### PR TITLE
Code fix providers

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -138,11 +138,21 @@ namespace MiKoSolutions.Analyzers.Rules
         }
 
         [Test]
-        public static void CodeFixProviders_use_simplified_name_([ValueSource(nameof(AllCodeFixProviders))] CodeFixProvider provider)
+        public static void CodeFixProvider_uses_simplified_name_([ValueSource(nameof(AllCodeFixProviders))] CodeFixProvider provider)
         {
             var id = provider.FixableDiagnosticIds.First();
 
             Assert.That(provider.GetType().Name, Does.StartWith(id).And.EndsWith("_CodeFixProvider"));
+        }
+
+        [Test]
+        public static void CodeFixProvider_has_a_title_([ValueSource(nameof(AllCodeFixProviders))] CodeFixProvider provider)
+        {
+            var id = provider.FixableDiagnosticIds.First();
+
+            var title = provider.GetType().GetProperty("Title", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(provider).ToString();
+
+            Assert.That(title, Is.EqualTo(Resources.ResourceManager.GetString(id + "_CodeFixTitle")));
         }
 
         [Test, Ignore("Just to find gaps")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
@@ -102,6 +102,7 @@ public class TestMe
         [TestCase("This event is fired for", "Occurs for")]
         [TestCase("This event is raised for", "Occurs for")]
         [TestCase("This event occurs when", "Occurs when")]
+        [TestCase("When", "Occurs when")]
         public void Code_gets_fixed_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzerTests.cs
@@ -92,7 +92,7 @@ public sealed class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some documentation
 /// </summary>
@@ -101,7 +101,7 @@ public sealed class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some documentation
 /// This class cannot be inherited.
@@ -110,13 +110,13 @@ public sealed class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// This class cannot be inherited.
 /// Some documentation.
@@ -126,7 +126,7 @@ public sealed class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some documentation.
 /// This class cannot be inherited.
@@ -135,13 +135,13 @@ public sealed class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some text. This class cannot be inherited.
 /// Some documentation.
@@ -151,7 +151,7 @@ public sealed class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some text.
 /// Some documentation.
@@ -161,13 +161,13 @@ public sealed class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_all_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some text. This class cannot be inherited. Some documentation.
 /// </summary>
@@ -176,7 +176,7 @@ public sealed class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some text. Some documentation.
 /// This class cannot be inherited.
@@ -185,7 +185,7 @@ public sealed class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2010_SealedClassSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
@@ -105,7 +105,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some documentation.
 /// This class cannot be inherited.
@@ -115,7 +115,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some documentation.
 /// </summary>
@@ -123,13 +123,13 @@ public class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// This class cannot be inherited.
 /// Some documentation.
@@ -139,7 +139,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some documentation.
 /// </summary>
@@ -147,13 +147,13 @@ public class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some text. This class cannot be inherited.
 /// Some documentation.
@@ -163,7 +163,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some text.
 /// Some documentation.
@@ -172,13 +172,13 @@ public class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_all_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some text. This class cannot be inherited. Some documentation.
 /// </summary>
@@ -187,7 +187,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some text. Some documentation.
 /// </summary>
@@ -195,7 +195,7 @@ public class TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2011_UnsealedClassSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -81,7 +81,7 @@ public enum TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Something.
 /// </summary>
@@ -90,7 +90,7 @@ public enum TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Defines values that specify Something.
 /// </summary>
@@ -98,20 +98,20 @@ public enum TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>Something to do.</summary>
 public enum TestMe
 {
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Defines values that specify Something to do.
 /// </summary>
@@ -119,13 +119,13 @@ public enum TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_multiline()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Something
 /// to do.
@@ -135,7 +135,7 @@ public enum TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Defines values that specify Something
 /// to do.
@@ -144,13 +144,13 @@ public enum TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_seecref_multiline()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// <see cref=""TestMe""/>
 /// Something
@@ -161,7 +161,7 @@ public enum TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Defines values that specify <see cref=""TestMe""/>
 /// Something
@@ -171,20 +171,20 @@ public enum TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_seecref_on_single_line()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary><see cref=""TestMe""/> Something to do.</summary>
 public enum TestMe
 {
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Defines values that specify <see cref=""TestMe""/> Something to do.
 /// </summary>
@@ -192,7 +192,7 @@ public enum TestMe
 {
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2013_EnumSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzerTests.cs
@@ -148,7 +148,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_method_without_parameter()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe
@@ -160,7 +160,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe
@@ -172,13 +172,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_method_with_parameter()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe
@@ -191,7 +191,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe
@@ -206,7 +206,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2014_DisposeDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzerTests.cs
@@ -142,7 +142,7 @@ public class TestMe : ITestMe
         [Test]
         public void Code_gets_fixed_for_Checks_if_phrase()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -152,7 +152,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -162,7 +162,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2018_ChecksSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzerTests.cs
@@ -165,6 +165,32 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_Asynchronously_Checks_if_phrase()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Asynchronously checks if it is there.
+    /// </summary>
+    public bool IsSomething() => true;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Asynchronously determines whether it is there.
+    /// </summary>
+    public bool IsSomething() => true;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2018_ChecksSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2018_ChecksSummaryAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzerTests.cs
@@ -125,7 +125,7 @@ namespace Bla
         [Test]
         public void Code_gets_fixed_for_SerializationInfo()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Runtime.Serialization;
 
@@ -140,7 +140,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Runtime.Serialization;
 
@@ -157,13 +157,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_StreamingContext()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Runtime.Serialization;
 
@@ -178,7 +178,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Runtime.Serialization;
 
@@ -195,7 +195,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2029_InheritdocUsesWrongCrefAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2029_InheritdocUsesWrongCrefAnalyzerTests.cs
@@ -59,7 +59,7 @@ namespace Bla
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 namespace Bla
 {
     public class TestMe
@@ -70,7 +70,7 @@ namespace Bla
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 namespace Bla
 {
     public class TestMe
@@ -81,7 +81,7 @@ namespace Bla
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2029_InheritdocUsesWrongCrefAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -198,7 +198,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_array_type()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -211,7 +211,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -224,13 +224,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_byte_array_type()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -243,7 +243,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -256,7 +256,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [TestCase("Some integers.", "A collection of some integers.")]
@@ -321,7 +321,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_Task_with_generic_collection()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -339,7 +339,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -357,13 +357,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_Task_with_array()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -381,7 +381,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -399,13 +399,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_Task_with_byte_array()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -423,7 +423,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -441,7 +441,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzerTests.cs
@@ -119,7 +119,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_readonly_arrow_Command_property()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -131,7 +131,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -143,13 +143,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_readonly_Command_property()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -161,7 +161,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -173,13 +173,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_writeonly_Command_property()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -191,7 +191,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -203,13 +203,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_readwrite_Command_property()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -221,7 +221,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Windows.Input;
 
 public class TestMe
@@ -233,7 +233,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2037_CommandPropertySummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzerTests.cs
@@ -100,7 +100,7 @@ public interface ITestMe : ICommand
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Windows.Input;
 
@@ -117,7 +117,7 @@ public class TestMe : ICommand
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Windows.Input;
 
@@ -134,7 +134,7 @@ public class TestMe : ICommand
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2038_CommandTypeSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
@@ -61,7 +61,7 @@ public static class TestMeExtensions
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Doing something.
 /// </summary>
@@ -71,7 +71,7 @@ public static class TestMeExtensions
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Provides a set of <see langword=""static""/> methods for doing something.
 /// </summary>
@@ -81,7 +81,7 @@ public static class TestMeExtensions
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2042_BrParaAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2042_BrParaAnalyzerTests.cs
@@ -170,7 +170,7 @@ public sealed class TestMe
         [Test]
         public void Code_gets_fixed_for_BR_tag_on_type()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Does something.
 /// <br />
@@ -181,7 +181,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Does something.
 /// <para/>
@@ -192,13 +192,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_BR_tag_on_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -210,7 +210,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -222,13 +222,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_P_tag_on_type()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Does something.
 /// <p>
@@ -240,7 +240,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Does something.
 /// <para>
@@ -252,13 +252,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_P_tag_on_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -271,7 +271,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -284,7 +284,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2042_BrParaAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzerTests.cs
@@ -62,7 +62,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_tag_([Values("see", "seealso")] string tag)
         {
-            var originalText = @"
+            var originalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -72,7 +72,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -82,13 +82,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(originalText, FixedText);
+            VerifyCSharpFix(originalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_multiple_tags_([Values("see", "seealso")] string tag)
         {
-            var originalText = @"
+            var originalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -98,7 +98,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -108,7 +108,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(originalText, FixedText);
+            VerifyCSharpFix(originalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2044_InvalidSeeParameterInXmlAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzerTests.cs
@@ -68,7 +68,7 @@ public class TestMe : " + interfaceName + @"
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Windows.Data;
 
@@ -80,7 +80,7 @@ public class TestMe : IValueConverter
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Windows.Data;
 
@@ -92,7 +92,7 @@ public class TestMe : IValueConverter
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -219,7 +219,7 @@ public class TestMeFactory
         [Test]
         public void Code_gets_fixed_for_class_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Something.
 /// </summary>
@@ -229,7 +229,7 @@ public class TestMeFactory
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Provides support for creating something.
 /// </summary>
@@ -239,13 +239,13 @@ public class TestMeFactory
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMeFactory
 {
     /// <summary>
@@ -255,7 +255,7 @@ public class TestMeFactory
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMeFactory
 {
     /// <summary>
@@ -265,13 +265,13 @@ public class TestMeFactory
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_collection_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 using System.Collections.Generic;
 
@@ -284,7 +284,7 @@ public class TestMeFactory
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 using System.Collections.Generic;
 
@@ -297,7 +297,35 @@ public class TestMeFactory
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test] // https://github.com/dotnet/roslyn/issues/47550
+        public void Code_gets_fixed_working_around_Roslyn_bug_47550()
+        {
+            const string OriginalCode = @"
+internal interface IFactory
+{
+    /// <summary>
+    /// Blah <see cref=""Xyz""/> blah.
+    /// </summary>
+    /// <returns></returns>
+    IXyz Create();
+}
+";
+
+            const string FixedCode = @"
+internal interface IFactory
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref=""IXyz""/> type with blah <see cref=""Xyz""/> blah.
+    /// </summary>
+    /// <returns></returns>
+    IXyz Create();
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2060_FactoryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -221,7 +221,7 @@ public class TestMeFactory
         {
             const string OriginalCode = @"
 /// <summary>
-/// Something.
+/// Creates something.
 /// </summary>
 public class TestMeFactory
 {
@@ -236,6 +236,30 @@ public class TestMeFactory
 public class TestMeFactory
 {
     public string Create() => new string();
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_interface_summary()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// A factory that creates a <see cref=""Xyz"" /> for a given <see cref=""IXyz"" /> object.
+/// </summary>
+public interface ITestMeFactory
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Provides support for creating <see cref=""Xyz"" /> for a given <see cref=""IXyz"" /> object.
+/// </summary>
+public interface ITestMeFactory
+{
 }
 ";
 
@@ -301,7 +325,7 @@ public class TestMeFactory
         }
 
         [Test] // https://github.com/dotnet/roslyn/issues/47550
-        public void Code_gets_fixed_working_around_Roslyn_bug_47550()
+        public void Code_gets_fixed_working_around_Roslyn_issue_47550()
         {
             const string OriginalCode = @"
 internal interface IFactory
@@ -321,6 +345,32 @@ internal interface IFactory
     /// Creates a new instance of the <see cref=""IXyz""/> type with blah <see cref=""Xyz""/> blah.
     /// </summary>
     /// <returns></returns>
+    IXyz Create();
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_specific_method_summary()
+        {
+            const string OriginalCode = @"
+internal interface IFactory
+{
+    /// <summary>
+    /// Creates a <see cref=""Xyz""/> type.
+    /// </summary>
+    IXyz Create();
+}
+";
+
+            const string FixedCode = @"
+internal interface IFactory
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref=""IXyz""/> type with type.
+    /// </summary>
     IXyz Create();
 }
 ";

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzerTests.cs
@@ -111,7 +111,7 @@ public class TestMe : IEnumerable
         [Test]
         public void Code_gets_fixed_for_non_boolean_property_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -121,7 +121,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -131,13 +131,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_boolean_property_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -147,7 +147,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -157,13 +157,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_boolean_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -173,7 +173,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -183,13 +183,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_boolean_async_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -199,7 +199,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -209,13 +209,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_boolean_Task_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -227,7 +227,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -239,13 +239,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_non_boolean_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -255,7 +255,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -265,13 +265,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_non_boolean_async_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -281,7 +281,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -291,13 +291,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_non_boolean_Task_method_summary()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -309,7 +309,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -321,7 +321,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2070_ReturnsSummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2072_TrySummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2072_TrySummaryAnalyzerTests.cs
@@ -62,7 +62,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_([Values("Try to", "Tries to")] string startPhrase)
         {
-            var originalText = @"
+            var originalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -72,7 +72,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -82,13 +82,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(originalText, FixedText);
+            VerifyCSharpFix(originalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_Async()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -98,7 +98,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -108,13 +108,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_in_middle()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -124,7 +124,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -134,7 +134,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2072_TrySummaryAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzerTests.cs
@@ -88,7 +88,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -98,7 +98,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -108,13 +108,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_async_phrase()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -124,7 +124,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -134,13 +134,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_Determines_if_phrase()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -150,7 +150,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -160,7 +160,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
@@ -91,7 +91,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_simple_text()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -106,7 +106,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -121,13 +121,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_text_with_seeCref_and_ending_dot()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -142,7 +142,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -157,13 +157,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_text_with_seeCref_without_ending_dot()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -178,7 +178,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -193,13 +193,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_text_with_seeCref_on_same_line_without_ending_dot()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -212,7 +212,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -225,7 +225,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
@@ -79,7 +79,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 /// <summary>
 /// Some text
 /// </summary>
@@ -92,7 +92,7 @@ public sealed class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 /// <summary>
 /// Some text
 /// </summary>
@@ -105,7 +105,7 @@ public sealed class TestMe
     public readonly string m_field;
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2081_ReadOnlyFieldAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2090_EqualityOperatorAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2090_EqualityOperatorAnalyzerTests.cs
@@ -134,7 +134,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe
@@ -147,7 +147,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe
@@ -168,7 +168,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2090_EqualityOperatorAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2091_InequalityOperatorAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2091_InequalityOperatorAnalyzerTests.cs
@@ -135,7 +135,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe
@@ -148,7 +148,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe
@@ -169,7 +169,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2091_InequalityOperatorAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
@@ -154,7 +154,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 public class TestMe
 {
     /// <summary>
@@ -167,7 +167,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 public class TestMe
 {
     /// <summary>
@@ -180,7 +180,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2100_ExampleDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzerTests.cs
@@ -84,6 +84,18 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_comment_with_etc_period() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // some comment, etc.
+    }
+}
+");
+
         protected override string GetDiagnosticId() => MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -262,6 +262,9 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.AreEqualIgnoringCase(""abc"", s, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Is.EqualTo(""abc"").IgnoreCase, ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => CollectionAssert.IsSubsetOf(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Is.SubsetOf(""abc""), ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -235,6 +235,9 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.IsNullOrEmpty(o, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.That(o, Is.Null.Or.Empty, ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.IsNotNull(o, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.That(o, Is.Not.Null, ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -232,6 +232,9 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do() => Assert.LessOrEqual(42, 11, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do() => Assert.That(42, Is.LessThanOrEqualTo(11), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.IsNullOrEmpty(o, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.That(o, Is.Null.Or.Empty, ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -238,6 +239,15 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.IsNotNull(o, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(object o) => Assert.That(o, Is.Not.Null, ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.IsEmpty(s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Is.Empty, ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => CollectionAssert.AreEquivalent(e, a, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => Assert.That(a, Is.EquivalentTo(e), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => CollectionAssert.AreNotEquivalent(e, a, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => Assert.That(a, Is.Not.EquivalentTo(e), ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.CodeAnalysis.CodeFixes;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -260,6 +259,9 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.Contains(""abc"", s, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Does.Contain(""abc""), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.AreEqualIgnoringCase(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Is.EqualTo(""abc"").IgnoreCase, ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -248,6 +248,18 @@ namespace Bla
         [TestCase(
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => CollectionAssert.AreNotEquivalent(e, a, ""my message""); }",
              @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(IEnumerable e, IEnumerable a) => Assert.That(a, Is.Not.EquivalentTo(e), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.StartsWith(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Does.StartWith(""abc""), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.EndsWith(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Does.EndWith(""abc""), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.DoesNotContain(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Does.Not.Contain(""abc""), ""my message""); }")]
+        [TestCase(
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => StringAssert.Contains(""abc"", s, ""my message""); }",
+             @"using System; using NUnit.Framework; [TestFixture] class TestMe { [Test] void Do(string s) => Assert.That(s, Does.Contain(""abc""), ""my message""); }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
 
@@ -12,6 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("DoSomething")]
         [TestCase("Raise")]
         [TestCase("OnSomething")]
+        [TestCase("Notify")]
         public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
@@ -19,7 +21,6 @@ public class TestMe
 }
 ");
 
-        [TestCase("Notify")]
         [TestCase("NotifySomething")]
         [TestCase("OnNotify")]
         [TestCase("OnNotifySomething")]
@@ -30,8 +31,14 @@ public class TestMe
 }
 ");
 
+        [TestCase("class TestMe { void NotifySomething() { } }", "class TestMe { void OnSomething() { } }")]
+        [TestCase("class TestMe { void OnNotifySomething() { } }", "class TestMe { void OnSomething() { } }")]
+        public void Code_gets_fixed_for_method_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+
         protected override string GetDiagnosticId() => MiKo_1013_NotifyMethodsAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1013_NotifyMethodsAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1013_CodeFixProvider();
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
 
@@ -12,6 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("DoSomething")]
         [TestCase("CheckIn")]
         [TestCase("CheckOut")]
+        [TestCase("CheckAccess")]
         public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
@@ -40,8 +42,86 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void Code_gets_fixed_for_method_with_non_boolean_return_value()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public object CheckSomething() => 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public object FindSomething() => 42;
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_boolean_return_value()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public bool CheckSomething() => true;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public bool CanSomething() => true;
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_void_method_without_parameters()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public void CheckSomething() { }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public void VerifySomething() { }
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_void_method_with_parameters()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public void CheckSomething(object o) { }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public void ValidateSomething(object o) { }
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_1014_CheckMethodsAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1014_CheckMethodsAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1014_CodeFixProvider();
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
@@ -42,81 +42,13 @@ public class TestMe
 }
 ");
 
-        [Test]
-        public void Code_gets_fixed_for_method_with_non_boolean_return_value()
-        {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public object CheckSomething() => 42;
-}
-";
-
-            const string FixedCode = @"
-public class TestMe
-{
-    public object FindSomething() => 42;
-}
-";
-            VerifyCSharpFix(OriginalCode, FixedCode);
-        }
-
-        [Test]
-        public void Code_gets_fixed_for_method_with_boolean_return_value()
-        {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public bool CheckSomething() => true;
-}
-";
-
-            const string FixedCode = @"
-public class TestMe
-{
-    public bool CanSomething() => true;
-}
-";
-            VerifyCSharpFix(OriginalCode, FixedCode);
-        }
-
-        [Test]
-        public void Code_gets_fixed_for_void_method_without_parameters()
-        {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void CheckSomething() { }
-}
-";
-
-            const string FixedCode = @"
-public class TestMe
-{
-    public void VerifySomething() { }
-}
-";
-            VerifyCSharpFix(OriginalCode, FixedCode);
-        }
-
-        [Test]
-        public void Code_gets_fixed_for_void_method_with_parameters()
-        {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void CheckSomething(object o) { }
-}
-";
-
-            const string FixedCode = @"
-public class TestMe
-{
-    public void ValidateSomething(object o) { }
-}
-";
-            VerifyCSharpFix(OriginalCode, FixedCode);
-        }
+        [TestCase("class TestMe { object CheckSomething() => 42; }", "class TestMe { object FindSomething() => 42; }")]
+        [TestCase("class TestMe { bool CheckSomething() => true; }", "class TestMe { bool CanSomething() => true; }")]
+        [TestCase("class TestMe { bool CheckForSomething() => true; }", "class TestMe { bool HasSomething() => true; }")]
+        [TestCase("class TestMe { bool CheckFormat() => true; }", "class TestMe { bool HasFormat() => true; }")]
+        [TestCase("class TestMe { void CheckSomething() { } }", "class TestMe { void VerifySomething() { } }")]
+        [TestCase("class TestMe { void CheckSomething(object o) { } }", "class TestMe { void ValidateSomething(object o) { } }")]
+        public void Code_gets_fixed_for_method_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_1014_CheckMethodsAnalyzer.Id;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1016_FactoryMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1016_FactoryMethodsAnalyzerTests.cs
@@ -120,7 +120,7 @@ public class TestMeFactory : BaseFactory
         [Test]
         public void Code_gets_fixed_for_multiTypes_factory()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMeFactory
@@ -131,7 +131,7 @@ public class TestMeFactory
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMeFactory
@@ -141,13 +141,13 @@ public class TestMeFactory
     public string CreateString() => string.Empty;
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_single_type_factory()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe
@@ -160,7 +160,7 @@ public class TestMeFactory
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe
@@ -172,7 +172,7 @@ public class TestMeFactory
     public TestMe Create() => new TestMe();
 }
 ";
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_1016_FactoryMethodsAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1019_ClearRemoveMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1019_ClearRemoveMethodsAnalyzerTests.cs
@@ -62,6 +62,34 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_test_methods()
+        {
+            Assert.Multiple(() =>
+                                {
+                                    foreach (var test in Tests)
+                                    {
+                                        No_issue_is_reported_for(@"
+using System;
+using NUnit.Framework;
+
+public class TestMe
+{
+    [" + test + @"]
+    public void Clear(int i)
+    {
+    }
+
+    [" + test + @"]
+    public void Remove()
+    {
+    }
+}
+");
+                                    }
+                                });
+        }
+
+        [Test]
         public void No_issue_is_reported_for_Clears_method_with_parameters() => No_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -172,6 +172,19 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_strange_ref_usage() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(Guid guid1, Guid guid2)
+    {
+        ref var x = (guid1 == Guid.Empty) ? ref guid1 : ref guid2;
+    }
+}
+");
+
+        [Test]
         public void Code_gets_fixed_for_variable()
         {
             const string OriginalCode = @"

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzerTests.cs
@@ -212,7 +212,7 @@ public class TestMe : IDisposable
         [Test]
         public void Code_gets_fixed_for_interface_implementation_and_ctor_and_finalizer()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -227,7 +227,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -242,13 +242,13 @@ public class TestMe : IDisposable
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_ctor_and_finalizer()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -263,7 +263,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -278,13 +278,13 @@ public class TestMe : IDisposable
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_ctor_only()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -297,7 +297,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -310,13 +310,13 @@ public class TestMe : IDisposable
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_finalizer_only()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -329,7 +329,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -342,13 +342,13 @@ public class TestMe : IDisposable
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_no_ctor_or_finalizer()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -359,7 +359,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using System;
 
 public class TestMe : IDisposable
@@ -370,7 +370,7 @@ public class TestMe : IDisposable
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         //// TODO RKN: partial parts

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4101_TestSetUpMethodOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4101_TestSetUpMethodOrderingAnalyzerTests.cs
@@ -338,7 +338,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_test_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -355,7 +355,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -372,13 +372,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -395,7 +395,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -412,13 +412,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -435,7 +435,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -452,13 +452,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -475,7 +475,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -492,13 +492,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_full_fledged_test()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -530,7 +530,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -562,7 +562,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_4101_TestSetUpMethodOrderingAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4102_TestTearDownMethodOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4102_TestTearDownMethodOrderingAnalyzerTests.cs
@@ -368,7 +368,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_test_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -385,7 +385,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -402,13 +402,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -425,7 +425,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -442,13 +442,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -465,7 +465,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -482,13 +482,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -505,7 +505,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -522,13 +522,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_full_fledged_test()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -560,7 +560,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -592,7 +592,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_4102_TestTearDownMethodOrderingAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4103_TestOneTimeSetUpMethodOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4103_TestOneTimeSetUpMethodOrderingAnalyzerTests.cs
@@ -283,7 +283,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_test_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -300,7 +300,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -317,13 +317,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -340,7 +340,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -357,13 +357,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -380,7 +380,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -397,13 +397,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -420,7 +420,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -437,13 +437,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_full_fledged_test()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -475,7 +475,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -507,7 +507,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_4103_TestOneTimeSetUpMethodOrderingAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4104_TestOneTimeTearDownMethodOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4104_TestOneTimeTearDownMethodOrderingAnalyzerTests.cs
@@ -350,7 +350,7 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_test_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -367,7 +367,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -384,13 +384,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -407,7 +407,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -424,13 +424,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_test_cleanup_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -447,7 +447,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -464,13 +464,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_OneTime_test_initialization_method()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -487,7 +487,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -504,13 +504,13 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_full_fledged_test()
         {
-            const string OriginalText = @"
+            const string OriginalCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -542,7 +542,7 @@ public class TestMe
 }
 ";
 
-            const string FixedText = @"
+            const string FixedCode = @"
 using NUnit.Framework;
 
 public class TestMe
@@ -574,7 +574,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(OriginalText, FixedText);
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_4104_TestOneTimeTearDownMethodOrderingAnalyzer.Id;

--- a/MiKo.Analyzer/Extensions/SyntaxExtensions.cs
+++ b/MiKo.Analyzer/Extensions/SyntaxExtensions.cs
@@ -421,6 +421,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static SyntaxToken WithLeadingEndOfLine(this SyntaxToken token) => token.WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed); // use elastic one to allow formatting to be done automatically
 
+        internal static string WithoutXmlCommentExterior(this SyntaxNode syntaxNode) => syntaxNode.ToString().Replace("///", string.Empty).Trim();
+
         internal static bool HasLinqExtensionMethod(this SyntaxNode syntaxNode, SemanticModel semanticModel) => syntaxNode.LinqExtensionMethods(semanticModel).Any();
 
         internal static TRoot InsertNodeBefore<TRoot>(this TRoot root, SyntaxNode nodeInList, SyntaxNode newNode) where TRoot : SyntaxNode

--- a/MiKo.Analyzer/Resources.Designer.cs
+++ b/MiKo.Analyzer/Resources.Designer.cs
@@ -587,6 +587,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;Check&apos;.
+        /// </summary>
+        public static string MiKo_1014_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1014_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The term &apos;Check&apos; is ambiguous. If validation of parameters is meant, use something like &apos;Validate&apos; or &apos;Verify&apos;. If a check for a specific state is meant, use &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos; instead..
         /// </summary>
         public static string MiKo_1014_Description {

--- a/MiKo.Analyzer/Resources.Designer.cs
+++ b/MiKo.Analyzer/Resources.Designer.cs
@@ -171,6 +171,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename event argument.
+        /// </summary>
+        public static string MiKo_1001_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1001_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, parameters that inherit from &apos;System.EventArgs&apos; should be named &apos;e&apos; ..
         /// </summary>
         public static string MiKo_1001_Description {
@@ -203,6 +212,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1001_Title {
             get {
                 return ResourceManager.GetString("MiKo_1001_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename event argument.
+        /// </summary>
+        public static string MiKo_1002_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1002_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -243,6 +261,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename method according to event pattern.
+        /// </summary>
+        public static string MiKo_1003_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1003_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Event handlers should start with &apos;On&apos;, followed by the name of the event, to indicate that they handle events..
         /// </summary>
         public static string MiKo_1003_Description {
@@ -279,6 +306,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Event&apos; suffix.
+        /// </summary>
+        public static string MiKo_1004_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1004_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;Event&apos; as suffix in event names is noise and should be avoided..
         /// </summary>
         public static string MiKo_1004_Description {
@@ -302,6 +338,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1004_Title {
             get {
                 return ResourceManager.GetString("MiKo_1004_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename EventArgs variable.
+        /// </summary>
+        public static string MiKo_1005_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1005_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -388,6 +433,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename DependencyProperty event handler argument.
+        /// </summary>
+        public static string MiKo_1008_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1008_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To follow the .NET Framework Guidelines, parameters of DependencyProperty event handlers should be named &apos;d&apos; and &apos;e&apos;..
         /// </summary>
         public static string MiKo_1008_Description {
@@ -465,6 +519,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1011_Title {
             get {
                 return ResourceManager.GetString("MiKo_1011_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;fire&apos; to &apos;raise&apos;.
+        /// </summary>
+        public static string MiKo_1012_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1012_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -551,6 +614,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;Init&apos; to &apos;Initialize&apos;.
+        /// </summary>
+        public static string MiKo_1015_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1015_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The term &apos;Init&apos; is a lazy abbreviation and should not be used. &apos;Initialize&apos; should be used instead..
         /// </summary>
         public static string MiKo_1015_Description {
@@ -574,6 +646,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1015_Title {
             get {
                 return ResourceManager.GetString("MiKo_1015_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename factory method.
+        /// </summary>
+        public static string MiKo_1016_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1016_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -655,6 +736,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1018_Title {
             get {
                 return ResourceManager.GetString("MiKo_1018_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;Clear&apos; and &apos;Remove&apos;.
+        /// </summary>
+        public static string MiKo_1019_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1019_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -903,6 +993,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove base type indicator.
+        /// </summary>
+        public static string MiKo_1030_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1030_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indicating that a type is a base type by putting &apos;Abstract&apos; or &apos;Base&apos; in its name does not make sense. Every interface or class that is not sealed can act as a base class..
         /// </summary>
         public static string MiKo_1030_Description {
@@ -926,6 +1025,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1030_Title {
             get {
                 return ResourceManager.GetString("MiKo_1030_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1031_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1031_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -957,6 +1065,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1032_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1032_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indicating that a method deals with an entity by using &apos;Model&apos; in its name does not make sense..
         /// </summary>
         public static string MiKo_1032_Description {
@@ -980,6 +1097,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1032_Title {
             get {
                 return ResourceManager.GetString("MiKo_1032_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1033_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1033_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1011,6 +1137,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1034_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1034_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indicating that a field is an entity by using &apos;Model&apos; as its suffix does not make sense. Entities should not be suffixed at all. (eg. &apos;user&apos; instead of &apos;userModel&apos;).
         /// </summary>
         public static string MiKo_1034_Description {
@@ -1034,6 +1169,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1034_Title {
             get {
                 return ResourceManager.GetString("MiKo_1034_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1035_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1035_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1065,6 +1209,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
+        /// </summary>
+        public static string MiKo_1036_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1036_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indicating that an event deals with an entity by using &apos;Model&apos; in its name does not make sense..
         /// </summary>
         public static string MiKo_1036_Description {
@@ -1088,6 +1241,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1036_Title {
             get {
                 return ResourceManager.GetString("MiKo_1036_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Enum&apos; suffix.
+        /// </summary>
+        public static string MiKo_1037_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1037_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1119,6 +1281,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Suffix type with &apos;Extensions&apos;.
+        /// </summary>
+        public static string MiKo_1038_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1038_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, the names of classes that contain extension methods should end with the same suffix..
         /// </summary>
         public static string MiKo_1038_Description {
@@ -1142,6 +1313,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1038_Title {
             get {
                 return ResourceManager.GetString("MiKo_1038_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;this&apos; argument.
+        /// </summary>
+        public static string MiKo_1039_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1039_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1227,6 +1407,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;cancellationToken&apos;.
+        /// </summary>
+        public static string MiKo_1042_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1042_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, and being consistent with the .NET Framework classes, &apos;CancellationToken&apos; parameters should have a very specific name..
         /// </summary>
         public static string MiKo_1042_Description {
@@ -1250,6 +1439,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1042_Title {
             get {
                 return ResourceManager.GetString("MiKo_1042_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;token&apos;.
+        /// </summary>
+        public static string MiKo_1043_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1043_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1281,6 +1479,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Append &apos;Command&apos; suffix.
+        /// </summary>
+        public static string MiKo_1044_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1044_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, add the suffix &apos;Command&apos;..
         /// </summary>
         public static string MiKo_1044_Description {
@@ -1308,6 +1515,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Command&apos; suffix.
+        /// </summary>
+        public static string MiKo_1045_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1045_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, remove the suffix &apos;Command&apos; as the method itself is invoked by a command..
         /// </summary>
         public static string MiKo_1045_Description {
@@ -1331,6 +1547,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1045_Title {
             get {
                 return ResourceManager.GetString("MiKo_1045_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Append &apos;Async&apos; suffix.
+        /// </summary>
+        public static string MiKo_1046_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1046_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1371,6 +1596,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Async&apos; suffix.
+        /// </summary>
+        public static string MiKo_1047_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1047_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, methods that do not follow the Task-based Asynchronous Pattern (TAP) should not be suffixed with &apos;Async&apos; as that would indicate that they would follow the pattern..
         /// </summary>
         public static string MiKo_1047_Description {
@@ -1403,6 +1637,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1047_Title {
             get {
                 return ResourceManager.GetString("MiKo_1047_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Append &apos;Converter&apos; suffix.
+        /// </summary>
+        public static string MiKo_1048_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1048_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1461,6 +1704,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename return value.
+        /// </summary>
+        public static string MiKo_1050_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1050_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variables for return values should describe what data they contain and not what they technical are.
         ///So they should have better names than e.g. &apos;ret&apos;, &apos;retVal&apos; or &apos;returnValue&apos;..
         /// </summary>
@@ -1485,6 +1737,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1050_Title {
             get {
                 return ResourceManager.GetString("MiKo_1050_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;callback&apos;.
+        /// </summary>
+        public static string MiKo_1051_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1051_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1516,6 +1777,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;callback&apos;.
+        /// </summary>
+        public static string MiKo_1052_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1052_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suffixing delegate variables with their type is repetitive and provides no value. A more meaningful name (such as &apos;callback&apos;, &apos;filter&apos; or &apos;map&apos;) provides much more context..
         /// </summary>
         public static string MiKo_1052_Description {
@@ -1539,6 +1809,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1052_Title {
             get {
                 return ResourceManager.GetString("MiKo_1052_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename delegate field.
+        /// </summary>
+        public static string MiKo_1053_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1053_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1594,6 +1873,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1054_Title {
             get {
                 return ResourceManager.GetString("MiKo_1054_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename dependency property.
+        /// </summary>
+        public static string MiKo_1055_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1055_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1666,6 +1954,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1056_Title {
             get {
                 return ResourceManager.GetString("MiKo_1056_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename dependency property key.
+        /// </summary>
+        public static string MiKo_1057_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1057_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -1803,6 +2100,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename out parameter.
+        /// </summary>
+        public static string MiKo_1061_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1061_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If a &apos;TryXyz&apos; method has an [out] parameter, that [out] parameter shall be named specifically because it is the actual result of the method. The method&apos;s return value only exists to indicate a success or failure of the operation.
         ///
         ///- For a &apos;Try&apos; method, that parameter shall be named &apos;result&apos;.
@@ -1918,6 +2224,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename operator parameter.
+        /// </summary>
+        public static string MiKo_1065_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1065_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameters of operator overloads should have default names if there is no meaning to the parameters.
         ///For binary operator overloads use the names &apos;left&apos; and &apos;right&apos;, for unary operator overloads use the name &apos;value&apos;..
         /// </summary>
@@ -1951,6 +2266,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1065_Title {
             get {
                 return ResourceManager.GetString("MiKo_1065_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Perform&apos; from name.
+        /// </summary>
+        public static string MiKo_1067_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1067_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2033,6 +2357,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1069_Title {
             get {
                 return ResourceManager.GetString("MiKo_1069_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename variable into plural.
+        /// </summary>
+        public static string MiKo_1070_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1070_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2196,6 +2529,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove number.
+        /// </summary>
+        public static string MiKo_1081_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1081_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suffixing methods with a number makes it hard for the users of the methods to use them as it is unclear which one is the correct or whether they have to be used in conjunction. So instead of using a number suffix methods should have a proper descriptive name..
         /// </summary>
         public static string MiKo_1081_Description {
@@ -2219,6 +2561,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1081_Title {
             get {
                 return ResourceManager.GetString("MiKo_1081_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove number.
+        /// </summary>
+        public static string MiKo_1082_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1082_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2250,6 +2601,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove number.
+        /// </summary>
+        public static string MiKo_1083_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1083_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suffixing fields with a number (especially if their types have a number as well) makes them unnecessary difficult to read. Most times the number can simply be avoided, which in turn makes them easier to read (and they are to the point)..
         /// </summary>
         public static string MiKo_1083_Description {
@@ -2277,6 +2637,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove number.
+        /// </summary>
+        public static string MiKo_1084_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1084_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suffixing variables with a number (especially if their types have a number as well) makes them unnecessary difficult to read. Most times the number can simply be avoided, which in turn makes them easier to read (and they are to the point)..
         /// </summary>
         public static string MiKo_1084_Description {
@@ -2300,6 +2669,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1084_Title {
             get {
                 return ResourceManager.GetString("MiKo_1084_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove number.
+        /// </summary>
+        public static string MiKo_1085_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1085_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2358,6 +2736,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename parameter.
+        /// </summary>
+        public static string MiKo_1090_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1090_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Instead of suffixing a parameter with a specific type (such as xyzComparer, xyzView, or xyzItem), the parameter should be named so (comparer, view or item).
         ///
         ///The reason is that the type already states what the parameter is - so its name should not have that additional, redundant information..
@@ -2383,6 +2770,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1090_Title {
             get {
                 return ResourceManager.GetString("MiKo_1090_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove variable suffix.
+        /// </summary>
+        public static string MiKo_1091_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1091_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2416,6 +2812,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove suffix.
+        /// </summary>
+        public static string MiKo_1092_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1092_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Instead of suffixing an &apos;ability&apos; type with redundant information (such as &apos;ComparableItem&apos;), the redundant information should be left out of the name of the type (such as &apos;Comparable&apos;)..
         /// </summary>
         public static string MiKo_1092_Description {
@@ -2439,6 +2844,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1092_Title {
             get {
                 return ResourceManager.GetString("MiKo_1092_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove suffix &apos;Object&apos; or &apos;Struct&apos;.
+        /// </summary>
+        public static string MiKo_1093_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1093_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2526,6 +2940,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Append &apos;Tests&apos; suffix.
+        /// </summary>
+        public static string MiKo_1101_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1101_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A class that is marked as a unit test class should indicate that by the suffix &apos;Tests&apos; as it normally contains multiple tests..
         /// </summary>
         public static string MiKo_1101_Description {
@@ -2580,6 +3003,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename to &apos;PrepareTest&apos;.
+        /// </summary>
+        public static string MiKo_1103_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1103_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A method that is marked as unit test initialization method should be named &apos;PrepareTest&apos;..
         /// </summary>
         public static string MiKo_1103_Description {
@@ -2603,6 +3035,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1103_Title {
             get {
                 return ResourceManager.GetString("MiKo_1103_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename to &apos;CleanupTest&apos;.
+        /// </summary>
+        public static string MiKo_1104_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1104_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2634,6 +3075,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename to &apos;PrepareTestEnvironment&apos;.
+        /// </summary>
+        public static string MiKo_1105_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1105_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A method that is marked as one-time unit test initialization method should be named &apos;PrepareTestEnvironment&apos;..
         /// </summary>
         public static string MiKo_1105_Description {
@@ -2657,6 +3107,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1105_Title {
             get {
                 return ResourceManager.GetString("MiKo_1105_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename to &apos;CleanupTestEnvironment&apos;.
+        /// </summary>
+        public static string MiKo_1106_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1106_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2716,6 +3175,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove Mock suffix.
+        /// </summary>
+        public static string MiKo_1108_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1108_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For maintenance reasons, variables, parameters, properties and fields should be named about what they represent and not what they technically are.
         ///Hence naming them e.g. &apos;Mock&apos; or &apos;Stub&apos; does not provide any additional value and is just some cluttering noise. In addition, those names put the developer&apos;s attention and focus on the wrong thing..
         /// </summary>
@@ -2744,6 +3212,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefix with &apos;Testable&apos; instead of suffix &apos;Ut&apos;.
+        /// </summary>
+        public static string MiKo_1109_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1109_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sometimes types or some of their functionality cannot be tested directly due to wrong visibility. To work around that, a solution is to inherit from such types and use that special type during test. Additionally, additional methods or properties are added to such types to access the orginal, invisible method resp. property.
         ///Those specifically introduced types should be named as the original type, but prefixed with &apos;Testable&apos; - they should not be suffixed with the hard-to-understand &apos;Ut&apos; suffix..
         /// </summary>
@@ -2768,6 +3245,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1109_Title {
             get {
                 return ResourceManager.GetString("MiKo_1109_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Append underscore.
+        /// </summary>
+        public static string MiKo_1110_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1110_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2831,6 +3317,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;arbitrary&apos; from name.
+        /// </summary>
+        public static string MiKo_1112_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1112_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tests usually deal with arbitrary test data, hence there is no benefit in naming a field, parameter, variable (etc.) &apos;arbitrary&apos;. That phrase can be removed without losing any meaning..
         /// </summary>
         public static string MiKo_1112_Description {
@@ -2854,6 +3349,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1112_Title {
             get {
                 return ResourceManager.GetString("MiKo_1112_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename exception.
+        /// </summary>
+        public static string MiKo_1200_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1200_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -2885,6 +3389,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename exception.
+        /// </summary>
+        public static string MiKo_1201_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1201_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, exceptions as parameters should be named consistently..
         /// </summary>
         public static string MiKo_1201_Description {
@@ -2908,6 +3421,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_1201_Title {
             get {
                 return ResourceManager.GetString("MiKo_1201_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;_&apos;.
+        /// </summary>
+        public static string MiKo_1300_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1300_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3213,6 +3735,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start comment with &apos;Occurs &apos;.
+        /// </summary>
+        public static string MiKo_2001_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2001_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Events should be documented with &apos;Occurs ...&apos; to indicate that events actually occur..
         /// </summary>
         public static string MiKo_2001_Description {
@@ -3294,6 +3825,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix comment of event handler parameter.
+        /// </summary>
+        public static string MiKo_2004_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2004_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Event method parameters should define what exactly they are..
         /// </summary>
         public static string MiKo_2004_Description {
@@ -3348,6 +3888,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment to RoutedEvent.
+        /// </summary>
+        public static string MiKo_2006_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2006_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Routed events should be documented in the same way as they are documented by the .NET Framework..
         /// </summary>
         public static string MiKo_2006_Description {
@@ -3375,6 +3924,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Append sealed text to comment.
+        /// </summary>
+        public static string MiKo_2010_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2010_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease their usage when it comes to inheritance, sealed classes should document the fact that they are sealed..
         /// </summary>
         public static string MiKo_2010_Description {
@@ -3398,6 +3956,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2010_Title {
             get {
                 return ResourceManager.GetString("MiKo_2010_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove sealed text to comment.
+        /// </summary>
+        public static string MiKo_2011_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2011_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3457,6 +4024,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start comment with &apos;Defines values that specify &apos;.
+        /// </summary>
+        public static string MiKo_2013_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2013_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease their usage, enums should specify what kind of values they define..
         /// </summary>
         public static string MiKo_2013_Description {
@@ -3480,6 +4056,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2013_Title {
             get {
                 return ResourceManager.GetString("MiKo_2013_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply standard &apos;Dispose&apos; comment.
+        /// </summary>
+        public static string MiKo_2014_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2014_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3511,6 +4096,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace term &apos;fire&apos;.
+        /// </summary>
+        public static string MiKo_2015_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2015_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The term &apos;Fire&apos; is a negative term. Employees get fired (or guns), but not events or exceptions. Events get raised and exceptions get thrown..
         /// </summary>
         public static string MiKo_2015_Description {
@@ -3534,6 +4128,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2015_Title {
             get {
                 return ResourceManager.GetString("MiKo_2015_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start comment with &apos;Asynchronously &apos;.
+        /// </summary>
+        public static string MiKo_2016_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2016_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3565,6 +4168,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment to DependencyProperty.
+        /// </summary>
+        public static string MiKo_2017_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2017_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dependency properties should be documented in the same way as they are documented by the .NET Framework..
         /// </summary>
         public static string MiKo_2017_Description {
@@ -3588,6 +4200,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2017_Title {
             get {
                 return ResourceManager.GetString("MiKo_2017_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start summary with &apos;Determines whether&apos;.
+        /// </summary>
+        public static string MiKo_2018_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2018_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3646,6 +4267,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &lt;inheritdoc/&gt;.
+        /// </summary>
+        public static string MiKo_2020_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2020_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It does not make sense to use a &lt;summary&gt; documentation that only reference something else via &lt;see cref=&quot;...&quot; /&gt; as IntelliSense does not show these descriptions. For such a scenario &lt;inheritdoc /&gt; should be used..
         /// </summary>
         public static string MiKo_2020_Description {
@@ -3700,6 +4330,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix comment start of [out] parameter.
+        /// </summary>
+        public static string MiKo_2022_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2022_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of [out] parameters should start with the success case..
         /// </summary>
         public static string MiKo_2022_Description {
@@ -3723,6 +4362,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2022_Title {
             get {
                 return ResourceManager.GetString("MiKo_2022_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix comment start of Boolean parameter.
+        /// </summary>
+        public static string MiKo_2023_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2023_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3754,6 +4402,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix comment start of Enum parameter.
+        /// </summary>
+        public static string MiKo_2024_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2024_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of Enum parameters should start with a phrase that specifies what will be done with the Enum..
         /// </summary>
         public static string MiKo_2024_Description {
@@ -3777,6 +4434,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2024_Title {
             get {
                 return ResourceManager.GetString("MiKo_2024_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix comment start of CancellationToken.
+        /// </summary>
+        public static string MiKo_2025_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2025_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3835,6 +4501,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix comment start of parameter of serialization constructor.
+        /// </summary>
+        public static string MiKo_2027_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2027_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease the usage, the documentation of the parameters of the serialization constructors shall have a specific phrase that describes what they contain..
         /// </summary>
         public static string MiKo_2027_Description {
@@ -3885,6 +4560,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2028_Title {
             get {
                 return ResourceManager.GetString("MiKo_2028_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;cref&apos; value from &lt;inheritdoc/&gt;.
+        /// </summary>
+        public static string MiKo_2029_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2029_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -3943,6 +4627,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix return comment.
+        /// </summary>
+        public static string MiKo_2031_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2031_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a Task as return value should have a default (starting) phrase..
         /// </summary>
         public static string MiKo_2031_Description {
@@ -3997,6 +4690,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix return comment.
+        /// </summary>
+        public static string MiKo_2033_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2033_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a String as return value should have a specific phrase..
         /// </summary>
         public static string MiKo_2033_Description {
@@ -4024,6 +4726,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix return comment.
+        /// </summary>
+        public static string MiKo_2034_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2034_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of an Enum as return value should have a specific phrase..
         /// </summary>
         public static string MiKo_2034_Description {
@@ -4047,6 +4758,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2034_Title {
             get {
                 return ResourceManager.GetString("MiKo_2034_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix return comment.
+        /// </summary>
+        public static string MiKo_2035_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2035_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4105,6 +4825,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment to command property.
+        /// </summary>
+        public static string MiKo_2037_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2037_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a property that returns a command should start with a specific phrase that describes what command the property returns..
         /// </summary>
         public static string MiKo_2037_Description {
@@ -4132,6 +4861,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment to command.
+        /// </summary>
+        public static string MiKo_2038_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2038_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a command should start with a specific phrase that describes what the command does..
         /// </summary>
         public static string MiKo_2038_Description {
@@ -4155,6 +4893,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2038_Title {
             get {
                 return ResourceManager.GetString("MiKo_2038_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply standard extension methods comment to class.
+        /// </summary>
+        public static string MiKo_2039_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2039_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4249,6 +4996,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &lt;br/&gt; with &lt;para/&gt;.
+        /// </summary>
+        public static string MiKo_2042_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2042_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation should use the &apos;&lt;para/&gt;&apos; XML tags instead of &apos;&lt;br/&gt;&apos; or &apos;&lt;p/&gt;&apos; HTML tags..
         /// </summary>
         public static string MiKo_2042_Description {
@@ -4285,6 +5041,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start summary with &apos;Encapsulates a method that &apos;.
+        /// </summary>
+        public static string MiKo_2043_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2043_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a custom delegate should have a default starting phrase to indicate what the delegate encapsulates..
         /// </summary>
         public static string MiKo_2043_Description {
@@ -4308,6 +5073,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2043_Title {
             get {
                 return ResourceManager.GetString("MiKo_2043_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &lt;paramref&gt; tag for parameter.
+        /// </summary>
+        public static string MiKo_2044_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2044_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4420,6 +5194,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start comment with &apos;Represents a converter that converts &apos;.
+        /// </summary>
+        public static string MiKo_2048_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2048_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of a value converters should start with a specific phrase that describes what they convert..
         /// </summary>
         public static string MiKo_2048_Description {
@@ -4470,6 +5253,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2049_Title {
             get {
                 return ResourceManager.GetString("MiKo_2049_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply standard exception comment.
+        /// </summary>
+        public static string MiKo_2050_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2050_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4694,6 +5486,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment to factory.
+        /// </summary>
+        public static string MiKo_2060_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2060_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of factories should be uniform and consistent..
         /// </summary>
         public static string MiKo_2060_Description {
@@ -4717,6 +5518,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2060_Title {
             get {
                 return ResourceManager.GetString("MiKo_2060_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Return&apos; in comment.
+        /// </summary>
+        public static string MiKo_2070_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2070_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4776,6 +5586,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start summary with &apos;Attempts to&apos;.
+        /// </summary>
+        public static string MiKo_2072_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2072_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;Try&apos; methods attempt to achieve something. So their &lt;summary&gt; documentation should start with the phrase &apos;Attempts to &apos;..
         /// </summary>
         public static string MiKo_2072_Description {
@@ -4785,7 +5604,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Attempts to &apos;.
         /// </summary>
         public static string MiKo_2072_MessageFormat {
             get {
@@ -4803,6 +5622,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start summary with &apos;Determines whether&apos;.
+        /// </summary>
+        public static string MiKo_2073_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2073_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;Contain&apos; methods attempt to determine if something exists inside something else. So their &lt;summary&gt; documentation should start with the phrase &apos;Determines whether &apos;..
         /// </summary>
         public static string MiKo_2073_Description {
@@ -4812,7 +5640,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Start summary with &apos;Determines whether&apos;.
         /// </summary>
         public static string MiKo_2073_MessageFormat {
             get {
@@ -4826,6 +5654,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2073_Title {
             get {
                 return ResourceManager.GetString("MiKo_2073_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix comment of parameter.
+        /// </summary>
+        public static string MiKo_2074_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2074_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4857,6 +5694,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start field with default phrase.
+        /// </summary>
+        public static string MiKo_2080_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2080_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The documentation of fields should start with a default phrase..
         /// </summary>
         public static string MiKo_2080_Description {
@@ -4880,6 +5726,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2080_Title {
             get {
                 return ResourceManager.GetString("MiKo_2080_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Append read-only text.
+        /// </summary>
+        public static string MiKo_2081_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2081_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -4911,6 +5766,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment.
+        /// </summary>
+        public static string MiKo_2090_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2090_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease development and usage, the XML documentation for equality operators shall have a common default phrase..
         /// </summary>
         public static string MiKo_2090_Description {
@@ -4938,6 +5802,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply standard comment.
+        /// </summary>
+        public static string MiKo_2091_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2091_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To ease development and usage, the XML documentation for inequality operators shall have a common default phrase..
         /// </summary>
         public static string MiKo_2091_Description {
@@ -4961,6 +5834,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2091_Title {
             get {
                 return ResourceManager.GetString("MiKo_2091_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start comment with &apos;The following example demonstrates &apos;.
+        /// </summary>
+        public static string MiKo_2100_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2100_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -5073,6 +5955,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change &apos;id&apos; into &apos;identifier&apos;.
+        /// </summary>
+        public static string MiKo_2202_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2202_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The XML documentation should not use the abbreviation &apos;id&apos;. Instead, it should clearly document that this is an identifier. Hence, it should use the term &apos;identifier&apos; instead..
         /// </summary>
         public static string MiKo_2202_Description {
@@ -5096,6 +5987,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2202_Title {
             get {
                 return ResourceManager.GetString("MiKo_2202_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change &apos;GUID&apos; into &apos;unique identifier&apos;.
+        /// </summary>
+        public static string MiKo_2203_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2203_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -5302,6 +6202,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change &apos;info&apos; into &apos;information&apos;.
+        /// </summary>
+        public static string MiKo_2210_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2210_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The XML documentation should not use the abbreviation &apos;info&apos;. Instead, it should clearly document that this is an information. Hence, it should use the term &apos;information&apos; instead..
         /// </summary>
         public static string MiKo_2210_Description {
@@ -5325,6 +6234,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2210_Title {
             get {
                 return ResourceManager.GetString("MiKo_2210_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move remarks comment into summary.
+        /// </summary>
+        public static string MiKo_2211_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2211_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -5411,6 +6329,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_2300_Title {
             get {
                 return ResourceManager.GetString("MiKo_2300_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove obvious AAA comment.
+        /// </summary>
+        public static string MiKo_2301_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2301_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -6093,6 +7020,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;Task.CompletedTask&apos;.
+        /// </summary>
+        public static string MiKo_3020_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3020_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For performance reasons it&apos;s better to use &apos;Task.CompletedTask&apos; instead of &apos;Task.FromResult()&apos; as the returned task is internally cached..
         /// </summary>
         public static string MiKo_3020_Description {
@@ -6757,6 +7693,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make DependencyProperty &apos;public static readonly&apos;.
+        /// </summary>
+        public static string MiKo_3050_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3050_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fields that are the back of a DependencyProperty should be made &apos;public static readonly&apos; to allow the .NET framework and other clients to find and access those fields..
         /// </summary>
         public static string MiKo_3050_Description {
@@ -6826,6 +7771,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_3051_Title {
             get {
                 return ResourceManager.GetString("MiKo_3051_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make DependencyPropertyKey &apos;private static readonly&apos;.
+        /// </summary>
+        public static string MiKo_3052_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3052_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7115,6 +8069,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is false&apos; pattern.
+        /// </summary>
+        public static string MiKo_3081_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3081_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Logical NOT conditions are hard to recognize if they are coded using the &apos;!&apos; character. Code that uses &apos;is false&apos; is much easier to read and understand..
         /// </summary>
         public static string MiKo_3081_Description {
@@ -7138,6 +8101,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_3081_Title {
             get {
                 return ResourceManager.GetString("MiKo_3081_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is&apos; pattern.
+        /// </summary>
+        public static string MiKo_3082_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3082_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7169,6 +8141,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is null&apos; pattern.
+        /// </summary>
+        public static string MiKo_3083_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3083_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Null checks using the &apos;is&apos; pattern matching is more natural and therefore easier to read and understand than using the &apos;==&apos; operator..
         /// </summary>
         public static string MiKo_3083_Description {
@@ -7192,6 +8173,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_3083_Title {
             get {
                 return ResourceManager.GetString("MiKo_3083_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place constant value on right side.
+        /// </summary>
+        public static string MiKo_3084_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3084_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7471,6 +8461,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use hard-coded GUID.
+        /// </summary>
+        public static string MiKo_3103_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3103_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tests should be specific to make them reproducible and easy to maintain. A GUID that is generated is not reproducible at all and cannot be easily found in case a test fails.
         ///Therefore, a hard-coded GUID should be used instead..
         /// </summary>
@@ -7522,6 +8521,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_3104_Title {
             get {
                 return ResourceManager.GetString("MiKo_3104_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;Assert.That&apos;.
+        /// </summary>
+        public static string MiKo_3105_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3105_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7706,6 +8714,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place Dispose method after constructors and finalizers.
+        /// </summary>
+        public static string MiKo_4003_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4003_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ctors, finalizers and Dispose methods are all directly related to the lifetime of an object. Therefore, they belong together and should be placed side by side..
         /// </summary>
         public static string MiKo_4003_Description {
@@ -7729,6 +8746,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_4003_Title {
             get {
                 return ResourceManager.GetString("MiKo_4003_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place corresponding interface directly after type declaration.
+        /// </summary>
+        public static string MiKo_4004_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4004_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7760,6 +8786,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place test initialization method after [OneTimeSetUp] / [OneTimeTearDown] methods and before test cleanup and all other test methods.
+        /// </summary>
+        public static string MiKo_4101_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4101_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test initialization method define the most common parts that tests shall contain. So to ease their finding they should be ordered directly after all one-time methods and before all other methods..
         /// </summary>
         public static string MiKo_4101_Description {
@@ -7783,6 +8818,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_4101_Title {
             get {
                 return ResourceManager.GetString("MiKo_4101_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place test cleanup method after test initialization methods and before all test methods.
+        /// </summary>
+        public static string MiKo_4102_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4102_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7814,6 +8858,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place [OneTimeSetUp] method before all other methods.
+        /// </summary>
+        public static string MiKo_4103_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4103_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to One-Time test initialization method define the most common parts that the test environment shall have. So to ease their finding they should be ordered first..
         /// </summary>
         public static string MiKo_4103_Description {
@@ -7837,6 +8890,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_4103_Title {
             get {
                 return ResourceManager.GetString("MiKo_4103_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place [OneTimeTearDown] method directly after [OneTimeSetUp] method and before all other methods.
+        /// </summary>
+        public static string MiKo_4104_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4104_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7868,6 +8930,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place inside &apos;if&apos;.
+        /// </summary>
+        public static string MiKo_5001_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_5001_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For performance reasons, &apos;IsDebugEnabled&apos; should be invoked before the &apos;Debug&apos; or &apos;DebugFormat&apos; methods get invoked as those require messages to be created. That creation (and the garbage collection of them as well) is not needed if the &apos;Debug&apos; log level is not set..
         /// </summary>
         public static string MiKo_5001_Description {
@@ -7891,6 +8962,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_5001_Title {
             get {
                 return ResourceManager.GetString("MiKo_5001_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace with non-&apos;Format&apos; method.
+        /// </summary>
+        public static string MiKo_5002_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_5002_CodeFixTitle", resourceCulture);
             }
         }
         
@@ -7946,6 +9026,15 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_5003_Title {
             get {
                 return ResourceManager.GetString("MiKo_5003_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Equals&apos; by &apos;==&apos;.
+        /// </summary>
+        public static string MiKo_5010_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_5010_CodeFixTitle", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer/Resources.Designer.cs
+++ b/MiKo.Analyzer/Resources.Designer.cs
@@ -4213,7 +4213,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The terms &apos;Check&apos; or &apos;Test&apos; are ambiguous. If validation of parameters is meant, use something like &apos;Validates&apos; or &apos;Verifies&apos;. If a check for a specific state is meant, use &apos;Determines&apos; instead..
+        ///   Looks up a localized string similar to The terms &apos;Check&apos; or &apos;Test&apos; are ambiguous. If validation of parameters is meant, use something like &apos;Validates&apos; or &apos;Verifies&apos;. If a check for a specific state is meant, use &apos;Determines whether&apos; instead..
         /// </summary>
         public static string MiKo_2018_Description {
             get {
@@ -4222,7 +4222,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;{2}&apos; instead of ambiguous term &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Use &apos;{2}&apos; instead of &apos;{1}&apos;.
         /// </summary>
         public static string MiKo_2018_MessageFormat {
             get {

--- a/MiKo.Analyzer/Resources.Designer.cs
+++ b/MiKo.Analyzer/Resources.Designer.cs
@@ -8433,7 +8433,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; should contain tests.
+        ///   Looks up a localized string similar to Test class &apos;{0}&apos; should contain tests.
         /// </summary>
         public static string MiKo_3101_MessageFormat {
             get {

--- a/MiKo.Analyzer/Resources.Designer.cs
+++ b/MiKo.Analyzer/Resources.Designer.cs
@@ -559,6 +559,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;Notify&apos; to &apos;On&apos;.
+        /// </summary>
+        public static string MiKo_1013_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1013_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Many times, the term &apos;Notify&apos; indicates that an event shall be raised. In such case, the prefix &apos;On&apos; should be used instead.
         ///Example: Instead of &apos;NotifyPropertyChanged&apos; use &apos;OnPropertyChanged&apos;..
         /// </summary>

--- a/MiKo.Analyzer/Resources.resx
+++ b/MiKo.Analyzer/Resources.resx
@@ -2996,7 +2996,7 @@ This allows easy usage without any arbitrary using directives. It also mimics th
     <value>A class that is marked as a unit test class should contain unit tests.</value>
   </data>
   <data name="MiKo_3101_MessageFormat" xml:space="preserve">
-    <value>'{0}' should contain tests</value>
+    <value>Test class '{0}' should contain tests</value>
   </data>
   <data name="MiKo_3101_Title" xml:space="preserve">
     <value>Test classes should contain tests.</value>

--- a/MiKo.Analyzer/Resources.resx
+++ b/MiKo.Analyzer/Resources.resx
@@ -285,6 +285,9 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
   <data name="MiKo_1012_Title" xml:space="preserve">
     <value>Methods should not be named 'Fire'.</value>
   </data>
+  <data name="MiKo_1013_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'Notify' to 'On'</value>
+  </data>
   <data name="MiKo_1013_Description" xml:space="preserve">
     <value>Many times, the term 'Notify' indicates that an event shall be raised. In such case, the prefix 'On' should be used instead.
 Example: Instead of 'NotifyPropertyChanged' use 'OnPropertyChanged'.</value>

--- a/MiKo.Analyzer/Resources.resx
+++ b/MiKo.Analyzer/Resources.resx
@@ -155,6 +155,9 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   <data name="MiKo_0004_Title" xml:space="preserve">
     <value>Methods has too many parameters.</value>
   </data>
+  <data name="MiKo_1001_CodeFixTitle" xml:space="preserve">
+    <value>Rename event argument</value>
+  </data>
   <data name="MiKo_1001_Description" xml:space="preserve">
     <value>To ease maintenance, parameters that inherit from 'System.EventArgs' should be named 'e' .</value>
   </data>
@@ -166,6 +169,9 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   </data>
   <data name="MiKo_1001_Title" xml:space="preserve">
     <value>'System.EventArgs' parameters on methods should be named properly.</value>
+  </data>
+  <data name="MiKo_1002_CodeFixTitle" xml:space="preserve">
+    <value>Rename event argument</value>
   </data>
   <data name="MiKo_1002_Description" xml:space="preserve">
     <value>To follow the .NET Framework Guidelines, parameters of event handlers should be named 'sender' and 'e'.</value>
@@ -179,6 +185,9 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   <data name="MiKo_1002_Title" xml:space="preserve">
     <value>Parameter names do not follow .NET Framework Guidelines for event handlers.</value>
   </data>
+  <data name="MiKo_1003_CodeFixTitle" xml:space="preserve">
+    <value>Rename method according to event pattern</value>
+  </data>
   <data name="MiKo_1003_Description" xml:space="preserve">
     <value>Event handlers should start with 'On', followed by the name of the event, to indicate that they handle events.</value>
   </data>
@@ -191,6 +200,9 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   <data name="MiKo_1003_Title" xml:space="preserve">
     <value>Event handling method name does not follow the .NET Framework Best Practices.</value>
   </data>
+  <data name="MiKo_1004_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Event' suffix</value>
+  </data>
   <data name="MiKo_1004_Description" xml:space="preserve">
     <value>'Event' as suffix in event names is noise and should be avoided.</value>
   </data>
@@ -199,6 +211,9 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   </data>
   <data name="MiKo_1004_Title" xml:space="preserve">
     <value>Events should not contain term 'Event' in their names.</value>
+  </data>
+  <data name="MiKo_1005_CodeFixTitle" xml:space="preserve">
+    <value>Rename EventArgs variable</value>
   </data>
   <data name="MiKo_1005_Description" xml:space="preserve">
     <value>To ease maintenance, variables that are of type 'System.EventArgs' (or any inheritors) should be named 'e'.</value>
@@ -228,6 +243,9 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
   <data name="MiKo_1007_Title" xml:space="preserve">
     <value>Events and 'EventArgs' types shall be located in the same namespace.</value>
   </data>
+  <data name="MiKo_1008_CodeFixTitle" xml:space="preserve">
+    <value>Rename DependencyProperty event handler argument</value>
+  </data>
   <data name="MiKo_1008_Description" xml:space="preserve">
     <value>To follow the .NET Framework Guidelines, parameters of DependencyProperty event handlers should be named 'd' and 'e'.</value>
   </data>
@@ -254,6 +272,9 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
   </data>
   <data name="MiKo_1011_Title" xml:space="preserve">
     <value>Methods should not contain 'Do' in their names.</value>
+  </data>
+  <data name="MiKo_1012_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'fire' to 'raise'</value>
   </data>
   <data name="MiKo_1012_Description" xml:space="preserve">
     <value>The term 'Fire' is a negative term. Employees get fired (or guns), but not events. Events get raised. So use 'Raise' instead.</value>
@@ -283,6 +304,9 @@ Example: Instead of 'NotifyPropertyChanged' use 'OnPropertyChanged'.</value>
   <data name="MiKo_1014_Title" xml:space="preserve">
     <value>Methods should not be named 'Check'.</value>
   </data>
+  <data name="MiKo_1015_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'Init' to 'Initialize'</value>
+  </data>
   <data name="MiKo_1015_Description" xml:space="preserve">
     <value>The term 'Init' is a lazy abbreviation and should not be used. 'Initialize' should be used instead.</value>
   </data>
@@ -291,6 +315,9 @@ Example: Instead of 'NotifyPropertyChanged' use 'OnPropertyChanged'.</value>
   </data>
   <data name="MiKo_1015_Title" xml:space="preserve">
     <value>Methods should not be named 'Init'.</value>
+  </data>
+  <data name="MiKo_1016_CodeFixTitle" xml:space="preserve">
+    <value>Rename factory method</value>
   </data>
   <data name="MiKo_1016_Description" xml:space="preserve">
     <value>The method belongs to a factory and therefore its name should be started with 'Create'.</value>
@@ -318,6 +345,9 @@ Example: Instead of 'NotifyPropertyChanged' use 'OnPropertyChanged'.</value>
   </data>
   <data name="MiKo_1018_Title" xml:space="preserve">
     <value>Methods should not be suffixed with noun of a verb.</value>
+  </data>
+  <data name="MiKo_1019_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'Clear' and 'Remove'</value>
   </data>
   <data name="MiKo_1019_Description" xml:space="preserve">
     <value>Methods that are named 'Remove' and have no parameters should be named 'Clear' instead as they do not remove parameters.
@@ -401,6 +431,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1027_Title" xml:space="preserve">
     <value>Variable names in loops should be limited in length.</value>
   </data>
+  <data name="MiKo_1030_CodeFixTitle" xml:space="preserve">
+    <value>Remove base type indicator</value>
+  </data>
   <data name="MiKo_1030_Description" xml:space="preserve">
     <value>Indicating that a type is a base type by putting 'Abstract' or 'Base' in its name does not make sense. Every interface or class that is not sealed can act as a base class.</value>
   </data>
@@ -409,6 +442,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1030_Title" xml:space="preserve">
     <value>Types should not have an 'Abstract' or 'Base' marker to indicate that they are base types.</value>
+  </data>
+  <data name="MiKo_1031_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
   </data>
   <data name="MiKo_1031_Description" xml:space="preserve">
     <value>Indicating that a type is an entity by using 'Model' as its suffix does not make sense. Entities should not be suffixed at all. (eg. 'User' instead of 'UserModel')</value>
@@ -419,6 +455,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1031_Title" xml:space="preserve">
     <value>Entity types should not use a 'Model' suffix.</value>
   </data>
+  <data name="MiKo_1032_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
+  </data>
   <data name="MiKo_1032_Description" xml:space="preserve">
     <value>Indicating that a method deals with an entity by using 'Model' in its name does not make sense.</value>
   </data>
@@ -427,6 +466,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1032_Title" xml:space="preserve">
     <value>Methods dealing with entities should not use a 'Model' marker.</value>
+  </data>
+  <data name="MiKo_1033_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
   </data>
   <data name="MiKo_1033_Description" xml:space="preserve">
     <value>Indicating that a parameter is an entity by using 'Model' as its suffix does not make sense. Entities should not be suffixed at all. (eg. 'user' instead of 'userModel')</value>
@@ -437,6 +479,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1033_Title" xml:space="preserve">
     <value>Parameters representing entities should not use a 'Model' suffix.</value>
   </data>
+  <data name="MiKo_1034_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
+  </data>
   <data name="MiKo_1034_Description" xml:space="preserve">
     <value>Indicating that a field is an entity by using 'Model' as its suffix does not make sense. Entities should not be suffixed at all. (eg. 'user' instead of 'userModel')</value>
   </data>
@@ -445,6 +490,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1034_Title" xml:space="preserve">
     <value>Fields representing entities should not use a 'Model' suffix.</value>
+  </data>
+  <data name="MiKo_1035_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
   </data>
   <data name="MiKo_1035_Description" xml:space="preserve">
     <value>Indicating that a property deals with an entity by using 'Model' in its name does not make sense.</value>
@@ -455,6 +503,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1035_Title" xml:space="preserve">
     <value>Properties dealing with entities should not use a 'Model' marker.</value>
   </data>
+  <data name="MiKo_1036_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Model' indicator</value>
+  </data>
   <data name="MiKo_1036_Description" xml:space="preserve">
     <value>Indicating that an event deals with an entity by using 'Model' in its name does not make sense.</value>
   </data>
@@ -463,6 +514,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1036_Title" xml:space="preserve">
     <value>Events dealing with entities should not use a 'Model' marker.</value>
+  </data>
+  <data name="MiKo_1037_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Enum' suffix</value>
   </data>
   <data name="MiKo_1037_Description" xml:space="preserve">
     <value>Indicating that a type is an Enum by using 'Enum' as its suffix does not make sense.</value>
@@ -473,6 +527,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1037_Title" xml:space="preserve">
     <value>Types should not be suffixed with 'Enum'.</value>
   </data>
+  <data name="MiKo_1038_CodeFixTitle" xml:space="preserve">
+    <value>Suffix type with 'Extensions'</value>
+  </data>
   <data name="MiKo_1038_Description" xml:space="preserve">
     <value>To ease maintenance, the names of classes that contain extension methods should end with the same suffix.</value>
   </data>
@@ -481,6 +538,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1038_Title" xml:space="preserve">
     <value>Classes that contain extension methods should end with same suffix.</value>
+  </data>
+  <data name="MiKo_1039_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'this' argument</value>
   </data>
   <data name="MiKo_1039_Description" xml:space="preserve">
     <value>To ease maintenance, the 'this' parameter of extension methods should have a default name.</value>
@@ -509,6 +569,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1041_Title" xml:space="preserve">
     <value>Fields should not be suffixed with implementation details.</value>
   </data>
+  <data name="MiKo_1042_CodeFixTitle" xml:space="preserve">
+    <value>Name it 'cancellationToken'</value>
+  </data>
   <data name="MiKo_1042_Description" xml:space="preserve">
     <value>To ease maintenance, and being consistent with the .NET Framework classes, 'CancellationToken' parameters should have a very specific name.</value>
   </data>
@@ -517,6 +580,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1042_Title" xml:space="preserve">
     <value>'CancellationToken' parameters should have specific name.</value>
+  </data>
+  <data name="MiKo_1043_CodeFixTitle" xml:space="preserve">
+    <value>Name it 'token'</value>
   </data>
   <data name="MiKo_1043_Description" xml:space="preserve">
     <value>To ease maintenance, 'CancellationToken' variables should have a very specific name.</value>
@@ -527,6 +593,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1043_Title" xml:space="preserve">
     <value>'CancellationToken' variables should have specific name.</value>
   </data>
+  <data name="MiKo_1044_CodeFixTitle" xml:space="preserve">
+    <value>Append 'Command' suffix</value>
+  </data>
   <data name="MiKo_1044_Description" xml:space="preserve">
     <value>To ease maintenance, add the suffix 'Command'.</value>
   </data>
@@ -536,6 +605,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1044_Title" xml:space="preserve">
     <value>Commands should be suffixed with 'Command'.</value>
   </data>
+  <data name="MiKo_1045_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Command' suffix</value>
+  </data>
   <data name="MiKo_1045_Description" xml:space="preserve">
     <value>To ease maintenance, remove the suffix 'Command' as the method itself is invoked by a command.</value>
   </data>
@@ -544,6 +616,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1045_Title" xml:space="preserve">
     <value>Methods that are invoked by commands should not be suffixed with 'Command'.</value>
+  </data>
+  <data name="MiKo_1046_CodeFixTitle" xml:space="preserve">
+    <value>Append 'Async' suffix</value>
   </data>
   <data name="MiKo_1046_Description" xml:space="preserve">
     <value>To ease maintenance, methods that follow the Task-based Asynchronous Pattern (TAP) should be suffixed with 'Async'.</value>
@@ -557,6 +632,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1046_Title" xml:space="preserve">
     <value>Asynchronous methods should follow the Task-based Asynchronous Pattern (TAP).</value>
   </data>
+  <data name="MiKo_1047_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Async' suffix</value>
+  </data>
   <data name="MiKo_1047_Description" xml:space="preserve">
     <value>To ease maintenance, methods that do not follow the Task-based Asynchronous Pattern (TAP) should not be suffixed with 'Async' as that would indicate that they would follow the pattern.</value>
   </data>
@@ -568,6 +646,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   </data>
   <data name="MiKo_1047_Title" xml:space="preserve">
     <value>Methods not following the Task-based Asynchronous Pattern (TAP) should not lie about being asynchronous.</value>
+  </data>
+  <data name="MiKo_1048_CodeFixTitle" xml:space="preserve">
+    <value>Append 'Converter' suffix</value>
   </data>
   <data name="MiKo_1048_Description" xml:space="preserve">
     <value>Classes that are value converters should end with a specific suffix.</value>
@@ -587,6 +668,9 @@ Methods that are named 'Clear' and have parameters should be named 'Remove' inst
   <data name="MiKo_1049_Title" xml:space="preserve">
     <value>Do not use requirement terms such as 'Shall', 'Should', 'Must' or 'Need' for names.</value>
   </data>
+  <data name="MiKo_1050_CodeFixTitle" xml:space="preserve">
+    <value>Rename return value</value>
+  </data>
   <data name="MiKo_1050_Description" xml:space="preserve">
     <value>Variables for return values should describe what data they contain and not what they technical are.
 So they should have better names than e.g. 'ret', 'retVal' or 'returnValue'.</value>
@@ -597,6 +681,9 @@ So they should have better names than e.g. 'ret', 'retVal' or 'returnValue'.</va
   <data name="MiKo_1050_Title" xml:space="preserve">
     <value>Return values should have descriptive names.</value>
   </data>
+  <data name="MiKo_1051_CodeFixTitle" xml:space="preserve">
+    <value>Name it 'callback'</value>
+  </data>
   <data name="MiKo_1051_Description" xml:space="preserve">
     <value>Suffixing delegate parameters with their type is repetitive and provides no value. A more meaningful name (such as 'callback', 'filter' or 'map') provides much more context.</value>
   </data>
@@ -606,6 +693,9 @@ So they should have better names than e.g. 'ret', 'retVal' or 'returnValue'.</va
   <data name="MiKo_1051_Title" xml:space="preserve">
     <value>Do not suffix parameters with delegate types.</value>
   </data>
+  <data name="MiKo_1052_CodeFixTitle" xml:space="preserve">
+    <value>Name it 'callback'</value>
+  </data>
   <data name="MiKo_1052_Description" xml:space="preserve">
     <value>Suffixing delegate variables with their type is repetitive and provides no value. A more meaningful name (such as 'callback', 'filter' or 'map') provides much more context.</value>
   </data>
@@ -614,6 +704,9 @@ So they should have better names than e.g. 'ret', 'retVal' or 'returnValue'.</va
   </data>
   <data name="MiKo_1052_Title" xml:space="preserve">
     <value>Do not suffix variables with delegate types.</value>
+  </data>
+  <data name="MiKo_1053_CodeFixTitle" xml:space="preserve">
+    <value>Rename delegate field</value>
   </data>
   <data name="MiKo_1053_Description" xml:space="preserve">
     <value>Suffixing delegate fields with their type is repetitive and provides no value. A more meaningful name (such as 'callback', 'filter' or 'map') provides much more context.</value>
@@ -633,6 +726,9 @@ Types that are named so do not follow the Single Responsibility Principle (SRP);
   </data>
   <data name="MiKo_1054_Title" xml:space="preserve">
     <value>Do not name types 'Helper' or 'Utility'.</value>
+  </data>
+  <data name="MiKo_1055_CodeFixTitle" xml:space="preserve">
+    <value>Rename dependency property</value>
   </data>
   <data name="MiKo_1055_Description" xml:space="preserve">
     <value>To indicate that fields are the containers for specific dependency properties, those fields should be suffixed with 'Property' (similar as in the .NET Framework).</value>
@@ -657,6 +753,9 @@ Types that are named so do not follow the Single Responsibility Principle (SRP);
   </data>
   <data name="MiKo_1056_Title" xml:space="preserve">
     <value>Dependency properties should be prefixed with property names (as in the .NET Framework).</value>
+  </data>
+  <data name="MiKo_1057_CodeFixTitle" xml:space="preserve">
+    <value>Rename dependency property key</value>
   </data>
   <data name="MiKo_1057_Description" xml:space="preserve">
     <value>To indicate that fields are the keys for specific dependency properties, those fields should be suffixed with 'Key' (similar as in the .NET Framework).</value>
@@ -707,6 +806,9 @@ The same applies for 'XyzMissingException'. It is probably not missing (which me
   <data name="MiKo_1060_Title" xml:space="preserve">
     <value>Use '&lt;Entity&gt;NotFound' instead of 'Get&lt;Entity&gt;Failed' or '&lt;Entity&gt;Missing'.</value>
   </data>
+  <data name="MiKo_1061_CodeFixTitle" xml:space="preserve">
+    <value>Rename out parameter</value>
+  </data>
   <data name="MiKo_1061_Description" xml:space="preserve">
     <value>If a 'TryXyz' method has an [out] parameter, that [out] parameter shall be named specifically because it is the actual result of the method. The method's return value only exists to indicate a success or failure of the operation.
 
@@ -750,6 +852,9 @@ In addition, they distract the reader's attention as they have to translate the 
   <data name="MiKo_1064_Title" xml:space="preserve">
     <value>Parameter names reflect their meaning and not their type.</value>
   </data>
+  <data name="MiKo_1065_CodeFixTitle" xml:space="preserve">
+    <value>Rename operator parameter</value>
+  </data>
   <data name="MiKo_1065_Description" xml:space="preserve">
     <value>Parameters of operator overloads should have default names if there is no meaning to the parameters.
 For binary operator overloads use the names 'left' and 'right', for unary operator overloads use the name 'value'.</value>
@@ -762,6 +867,9 @@ For binary operator overloads use the names 'left' and 'right', for unary operat
   </data>
   <data name="MiKo_1065_Title" xml:space="preserve">
     <value>Parameter names do not follow .NET Framework Guidelines for operator overloads.</value>
+  </data>
+  <data name="MiKo_1067_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Perform' from name</value>
   </data>
   <data name="MiKo_1067_Description" xml:space="preserve">
     <value>The purpose of methods is to execute code, so it's useless and repetitive to have 'Perform' in their names.</value>
@@ -790,6 +898,9 @@ Hence, their methods should be named 'CanRun' or 'Run' (similar to commands wher
   </data>
   <data name="MiKo_1069_Title" xml:space="preserve">
     <value>Property names reflect their meaning and not their type.</value>
+  </data>
+  <data name="MiKo_1070_CodeFixTitle" xml:space="preserve">
+    <value>Rename variable into plural</value>
   </data>
   <data name="MiKo_1070_Description" xml:space="preserve">
     <value>Local variables for collections (that is any which is an 'IEnumerable') should have names in plural form. Their names should describe the contents of the collection; and not the collection itself.</value>
@@ -860,6 +971,9 @@ Example:
   <data name="MiKo_1080_Title" xml:space="preserve">
     <value>Names should contain numbers instead of their spellings.</value>
   </data>
+  <data name="MiKo_1081_CodeFixTitle" xml:space="preserve">
+    <value>Remove number</value>
+  </data>
   <data name="MiKo_1081_Description" xml:space="preserve">
     <value>Suffixing methods with a number makes it hard for the users of the methods to use them as it is unclear which one is the correct or whether they have to be used in conjunction. So instead of using a number suffix methods should have a proper descriptive name.</value>
   </data>
@@ -868,6 +982,9 @@ Example:
   </data>
   <data name="MiKo_1081_Title" xml:space="preserve">
     <value>Methods should not be suffixed with a number.</value>
+  </data>
+  <data name="MiKo_1082_CodeFixTitle" xml:space="preserve">
+    <value>Remove number</value>
   </data>
   <data name="MiKo_1082_Description" xml:space="preserve">
     <value>Suffixing properties with a number (especially if the type they return have a number as well) makes them unnecessary difficult to read. Most times the number can simply be avoided, which in turn makes them easier to read (and they are to the point).</value>
@@ -878,6 +995,9 @@ Example:
   <data name="MiKo_1082_Title" xml:space="preserve">
     <value>Properties should not be suffixed with a number if their types have number suffixes.</value>
   </data>
+  <data name="MiKo_1083_CodeFixTitle" xml:space="preserve">
+    <value>Remove number</value>
+  </data>
   <data name="MiKo_1083_Description" xml:space="preserve">
     <value>Suffixing fields with a number (especially if their types have a number as well) makes them unnecessary difficult to read. Most times the number can simply be avoided, which in turn makes them easier to read (and they are to the point).</value>
   </data>
@@ -887,6 +1007,9 @@ Example:
   <data name="MiKo_1083_Title" xml:space="preserve">
     <value>Fields should not be suffixed with a number if their types have number suffixes.</value>
   </data>
+  <data name="MiKo_1084_CodeFixTitle" xml:space="preserve">
+    <value>Remove number</value>
+  </data>
   <data name="MiKo_1084_Description" xml:space="preserve">
     <value>Suffixing variables with a number (especially if their types have a number as well) makes them unnecessary difficult to read. Most times the number can simply be avoided, which in turn makes them easier to read (and they are to the point).</value>
   </data>
@@ -895,6 +1018,9 @@ Example:
   </data>
   <data name="MiKo_1084_Title" xml:space="preserve">
     <value>Variables should not be suffixed with a number if their types have number suffixes.</value>
+  </data>
+  <data name="MiKo_1085_CodeFixTitle" xml:space="preserve">
+    <value>Remove number</value>
   </data>
   <data name="MiKo_1085_Description" xml:space="preserve">
     <value>Suffixing parameters with number provides no benefit. So instead of using a number suffix parameters should have a proper descriptive name.</value>
@@ -914,6 +1040,9 @@ Example:
   <data name="MiKo_1086_Title" xml:space="preserve">
     <value>Methods should not be named using numbers as slang.</value>
   </data>
+  <data name="MiKo_1090_CodeFixTitle" xml:space="preserve">
+    <value>Rename parameter</value>
+  </data>
   <data name="MiKo_1090_Description" xml:space="preserve">
     <value>Instead of suffixing a parameter with a specific type (such as xyzComparer, xyzView, or xyzItem), the parameter should be named so (comparer, view or item).
 
@@ -924,6 +1053,9 @@ The reason is that the type already states what the parameter is - so its name s
   </data>
   <data name="MiKo_1090_Title" xml:space="preserve">
     <value>Parameters should not be suffixed with specific types.</value>
+  </data>
+  <data name="MiKo_1091_CodeFixTitle" xml:space="preserve">
+    <value>Remove variable suffix</value>
   </data>
   <data name="MiKo_1091_Description" xml:space="preserve">
     <value>Instead of suffixing a variable with a specific type (such as xyzComparer, xyzView, or xyzItem), the variable should be named so (comparer, view or item).
@@ -936,6 +1068,9 @@ The reason is that the type already states what the variable is - so its name sh
   <data name="MiKo_1091_Title" xml:space="preserve">
     <value>Variables should not be suffixed with specific types.</value>
   </data>
+  <data name="MiKo_1092_CodeFixTitle" xml:space="preserve">
+    <value>Remove suffix</value>
+  </data>
   <data name="MiKo_1092_Description" xml:space="preserve">
     <value>Instead of suffixing an 'ability' type with redundant information (such as 'ComparableItem'), the redundant information should be left out of the name of the type (such as 'Comparable').</value>
   </data>
@@ -944,6 +1079,9 @@ The reason is that the type already states what the variable is - so its name sh
   </data>
   <data name="MiKo_1092_Title" xml:space="preserve">
     <value>'Ability' Types should not be suffixed with redundant information.</value>
+  </data>
+  <data name="MiKo_1093_CodeFixTitle" xml:space="preserve">
+    <value>Remove suffix 'Object' or 'Struct'</value>
   </data>
   <data name="MiKo_1093_Description" xml:space="preserve">
     <value>Identifiers should not have the term 'Object' or 'Struct' as suffix. Many times, a mcuh better name can be given that avoids the usage of the term 'Object' or 'Struct' at all (such as 'Identifier' instead of 'IdentificationObject').</value>
@@ -974,6 +1112,9 @@ The name should be constructed by having the name of the type under test as pref
   <data name="MiKo_1100_Title" xml:space="preserve">
     <value>Test classes should start with the name of the type under test.</value>
   </data>
+  <data name="MiKo_1101_CodeFixTitle" xml:space="preserve">
+    <value>Append 'Tests' suffix</value>
+  </data>
   <data name="MiKo_1101_Description" xml:space="preserve">
     <value>A class that is marked as a unit test class should indicate that by the suffix 'Tests' as it normally contains multiple tests.</value>
   </data>
@@ -992,6 +1133,9 @@ The name should be constructed by having the name of the type under test as pref
   <data name="MiKo_1102_Title" xml:space="preserve">
     <value>Test methods should not contain 'Test'.</value>
   </data>
+  <data name="MiKo_1103_CodeFixTitle" xml:space="preserve">
+    <value>Rename to 'PrepareTest'</value>
+  </data>
   <data name="MiKo_1103_Description" xml:space="preserve">
     <value>A method that is marked as unit test initialization method should be named 'PrepareTest'.</value>
   </data>
@@ -1000,6 +1144,9 @@ The name should be constructed by having the name of the type under test as pref
   </data>
   <data name="MiKo_1103_Title" xml:space="preserve">
     <value>Test initialization methods should be named 'PrepareTest'.</value>
+  </data>
+  <data name="MiKo_1104_CodeFixTitle" xml:space="preserve">
+    <value>Rename to 'CleanupTest'</value>
   </data>
   <data name="MiKo_1104_Description" xml:space="preserve">
     <value>A method that is marked as unit test cleanup method should be named 'CleanupTest'.</value>
@@ -1010,6 +1157,9 @@ The name should be constructed by having the name of the type under test as pref
   <data name="MiKo_1104_Title" xml:space="preserve">
     <value>Test cleanup methods should be named 'CleanupTest'.</value>
   </data>
+  <data name="MiKo_1105_CodeFixTitle" xml:space="preserve">
+    <value>Rename to 'PrepareTestEnvironment'</value>
+  </data>
   <data name="MiKo_1105_Description" xml:space="preserve">
     <value>A method that is marked as one-time unit test initialization method should be named 'PrepareTestEnvironment'.</value>
   </data>
@@ -1018,6 +1168,9 @@ The name should be constructed by having the name of the type under test as pref
   </data>
   <data name="MiKo_1105_Title" xml:space="preserve">
     <value>One-time test initialization methods should be named 'PrepareTestEnvironment'.</value>
+  </data>
+  <data name="MiKo_1106_CodeFixTitle" xml:space="preserve">
+    <value>Rename to 'CleanupTestEnvironment'</value>
   </data>
   <data name="MiKo_1106_Description" xml:space="preserve">
     <value>A method that is marked as one-time unit test cleanup method should be named 'CleanupTestEnvironment'.</value>
@@ -1038,6 +1191,9 @@ To ease reading, use underscores between the different words instead.</value>
   <data name="MiKo_1107_Title" xml:space="preserve">
     <value>Test methods should not be in Pascal-casing.</value>
   </data>
+  <data name="MiKo_1108_CodeFixTitle" xml:space="preserve">
+    <value>Remove Mock suffix</value>
+  </data>
   <data name="MiKo_1108_Description" xml:space="preserve">
     <value>For maintenance reasons, variables, parameters, properties and fields should be named about what they represent and not what they technically are.
 Hence naming them e.g. 'Mock' or 'Stub' does not provide any additional value and is just some cluttering noise. In addition, those names put the developer's attention and focus on the wrong thing.</value>
@@ -1048,6 +1204,9 @@ Hence naming them e.g. 'Mock' or 'Stub' does not provide any additional value an
   <data name="MiKo_1108_Title" xml:space="preserve">
     <value>Do not name variables, parameters, fields and properties 'Mock' or 'Stub'.</value>
   </data>
+  <data name="MiKo_1109_CodeFixTitle" xml:space="preserve">
+    <value>Prefix with 'Testable' instead of suffix 'Ut'</value>
+  </data>
   <data name="MiKo_1109_Description" xml:space="preserve">
     <value>Sometimes types or some of their functionality cannot be tested directly due to wrong visibility. To work around that, a solution is to inherit from such types and use that special type during test. Additionally, additional methods or properties are added to such types to access the orginal, invisible method resp. property.
 Those specifically introduced types should be named as the original type, but prefixed with 'Testable' - they should not be suffixed with the hard-to-understand 'Ut' suffix.</value>
@@ -1057,6 +1216,9 @@ Those specifically introduced types should be named as the original type, but pr
   </data>
   <data name="MiKo_1109_Title" xml:space="preserve">
     <value>Prefix testable types with 'Testable' instead of using the 'Ut' suffix.</value>
+  </data>
+  <data name="MiKo_1110_CodeFixTitle" xml:space="preserve">
+    <value>Append underscore</value>
   </data>
   <data name="MiKo_1110_Description" xml:space="preserve">
     <value>For maintenance reasons, parameterized test methods should be easy to read.
@@ -1081,6 +1243,9 @@ Example:
   <data name="MiKo_1111_Title" xml:space="preserve">
     <value>Test methods should be named in a fluent way.</value>
   </data>
+  <data name="MiKo_1112_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'arbitrary' from name</value>
+  </data>
   <data name="MiKo_1112_Description" xml:space="preserve">
     <value>Tests usually deal with arbitrary test data, hence there is no benefit in naming a field, parameter, variable (etc.) 'arbitrary'. That phrase can be removed without losing any meaning.</value>
   </data>
@@ -1089,6 +1254,9 @@ Example:
   </data>
   <data name="MiKo_1112_Title" xml:space="preserve">
     <value>Do not name test data 'arbitrary'.</value>
+  </data>
+  <data name="MiKo_1200_CodeFixTitle" xml:space="preserve">
+    <value>Rename exception</value>
   </data>
   <data name="MiKo_1200_Description" xml:space="preserve">
     <value>To ease maintenance, exceptions in catch blocks should be named consistently.</value>
@@ -1099,6 +1267,9 @@ Example:
   <data name="MiKo_1200_Title" xml:space="preserve">
     <value>Name exceptions in catch blocks consistently.</value>
   </data>
+  <data name="MiKo_1201_CodeFixTitle" xml:space="preserve">
+    <value>Rename exception</value>
+  </data>
   <data name="MiKo_1201_Description" xml:space="preserve">
     <value>To ease maintenance, exceptions as parameters should be named consistently.</value>
   </data>
@@ -1107,6 +1278,9 @@ Example:
   </data>
   <data name="MiKo_1201_Title" xml:space="preserve">
     <value>Name exceptions as parameters consistently.</value>
+  </data>
+  <data name="MiKo_1300_CodeFixTitle" xml:space="preserve">
+    <value>Name it '_'</value>
   </data>
   <data name="MiKo_1300_Description" xml:space="preserve">
     <value>To ease maintenance and avoid visual noise, unimportant identifiers in lambdas should be consistently named '_'.</value>
@@ -1211,6 +1385,9 @@ That allows an easy detection and use via IntelliSense.</value>
   <data name="MiKo_2000_Title" xml:space="preserve">
     <value>Documentation should be valid XML.</value>
   </data>
+  <data name="MiKo_2001_CodeFixTitle" xml:space="preserve">
+    <value>Start comment with 'Occurs '</value>
+  </data>
   <data name="MiKo_2001_Description" xml:space="preserve">
     <value>Events should be documented with 'Occurs ...' to indicate that events actually occur.</value>
   </data>
@@ -1238,6 +1415,9 @@ That allows an easy detection and use via IntelliSense.</value>
   <data name="MiKo_2003_Title" xml:space="preserve">
     <value>Documentation of event handlers should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2004_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment of event handler parameter</value>
+  </data>
   <data name="MiKo_2004_Description" xml:space="preserve">
     <value>Event method parameters should define what exactly they are.</value>
   </data>
@@ -1256,6 +1436,9 @@ That allows an easy detection and use via IntelliSense.</value>
   <data name="MiKo_2005_Title" xml:space="preserve">
     <value>Textual references to EventArgs should be documented properly.</value>
   </data>
+  <data name="MiKo_2006_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment to RoutedEvent</value>
+  </data>
   <data name="MiKo_2006_Description" xml:space="preserve">
     <value>Routed events should be documented in the same way as they are documented by the .NET Framework.</value>
   </data>
@@ -1265,6 +1448,9 @@ That allows an easy detection and use via IntelliSense.</value>
   <data name="MiKo_2006_Title" xml:space="preserve">
     <value>Routed events should be documented as done by the .NET Framework.</value>
   </data>
+  <data name="MiKo_2010_CodeFixTitle" xml:space="preserve">
+    <value>Append sealed text to comment</value>
+  </data>
   <data name="MiKo_2010_Description" xml:space="preserve">
     <value>To ease their usage when it comes to inheritance, sealed classes should document the fact that they are sealed.</value>
   </data>
@@ -1273,6 +1459,9 @@ That allows an easy detection and use via IntelliSense.</value>
   </data>
   <data name="MiKo_2010_Title" xml:space="preserve">
     <value>Sealed classes should document being sealed.</value>
+  </data>
+  <data name="MiKo_2011_CodeFixTitle" xml:space="preserve">
+    <value>Remove sealed text to comment</value>
   </data>
   <data name="MiKo_2011_Description" xml:space="preserve">
     <value>Unsealed classes should not report that they are sealed.</value>
@@ -1293,6 +1482,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2012_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation should describe its responsibility.</value>
   </data>
+  <data name="MiKo_2013_CodeFixTitle" xml:space="preserve">
+    <value>Start comment with 'Defines values that specify '</value>
+  </data>
   <data name="MiKo_2013_Description" xml:space="preserve">
     <value>To ease their usage, enums should specify what kind of values they define.</value>
   </data>
@@ -1301,6 +1493,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2013_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of Enums should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2014_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard 'Dispose' comment</value>
   </data>
   <data name="MiKo_2014_Description" xml:space="preserve">
     <value>Dispose methods should be documented in the same way as they are documented by the .NET Framework.</value>
@@ -1311,6 +1506,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2014_Title" xml:space="preserve">
     <value>Dispose methods should be documented as done by the .NET Framework.</value>
   </data>
+  <data name="MiKo_2015_CodeFixTitle" xml:space="preserve">
+    <value>Replace term 'fire'</value>
+  </data>
   <data name="MiKo_2015_Description" xml:space="preserve">
     <value>The term 'Fire' is a negative term. Employees get fired (or guns), but not events or exceptions. Events get raised and exceptions get thrown.</value>
   </data>
@@ -1319,6 +1517,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2015_Title" xml:space="preserve">
     <value>Documentation should use 'raise' or 'throw' instead of 'fire'.</value>
+  </data>
+  <data name="MiKo_2016_CodeFixTitle" xml:space="preserve">
+    <value>Start comment with 'Asynchronously '</value>
   </data>
   <data name="MiKo_2016_Description" xml:space="preserve">
     <value>Documentation for asynchronous methods should indicate that method is run asynchronously.</value>
@@ -1329,6 +1530,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2016_Title" xml:space="preserve">
     <value>Documentation for asynchronous methods should start with specific phrase.</value>
   </data>
+  <data name="MiKo_2017_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment to DependencyProperty</value>
+  </data>
   <data name="MiKo_2017_Description" xml:space="preserve">
     <value>Dependency properties should be documented in the same way as they are documented by the .NET Framework.</value>
   </data>
@@ -1337,6 +1541,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2017_Title" xml:space="preserve">
     <value>Dependency properties should be documented as done by the .NET Framework.</value>
+  </data>
+  <data name="MiKo_2018_CodeFixTitle" xml:space="preserve">
+    <value>Start summary with 'Determines whether'</value>
   </data>
   <data name="MiKo_2018_Description" xml:space="preserve">
     <value>The terms 'Check' or 'Test' are ambiguous. If validation of parameters is meant, use something like 'Validates' or 'Verifies'. If a check for a specific state is meant, use 'Determines' instead.</value>
@@ -1356,6 +1563,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2019_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation should start with a third person singular verb (for example "Provides ").</value>
   </data>
+  <data name="MiKo_2020_CodeFixTitle" xml:space="preserve">
+    <value>Use &lt;inheritdoc/&gt;</value>
+  </data>
   <data name="MiKo_2020_Description" xml:space="preserve">
     <value>It does not make sense to use a &lt;summary&gt; documentation that only reference something else via &lt;see cref="..." /&gt; as IntelliSense does not show these descriptions. For such a scenario &lt;inheritdoc /&gt; should be used.</value>
   </data>
@@ -1374,6 +1584,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2021_Title" xml:space="preserve">
     <value>Documentation of parameter should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2022_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment start of [out] parameter</value>
+  </data>
   <data name="MiKo_2022_Description" xml:space="preserve">
     <value>The documentation of [out] parameters should start with the success case.</value>
   </data>
@@ -1382,6 +1595,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2022_Title" xml:space="preserve">
     <value>Documentation of [out] parameters should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2023_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment start of Boolean parameter</value>
   </data>
   <data name="MiKo_2023_Description" xml:space="preserve">
     <value>The documentation of a Boolean as parameter should have a specific phrase that first describes the 'true' case and then the 'false' case.</value>
@@ -1392,6 +1608,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2023_Title" xml:space="preserve">
     <value>Documentation of Boolean parameters should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2024_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment start of Enum parameter</value>
+  </data>
   <data name="MiKo_2024_Description" xml:space="preserve">
     <value>The documentation of Enum parameters should start with a phrase that specifies what will be done with the Enum.</value>
   </data>
@@ -1400,6 +1619,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2024_Title" xml:space="preserve">
     <value>Documentation of Enum parameters should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2025_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment start of CancellationToken</value>
   </data>
   <data name="MiKo_2025_Description" xml:space="preserve">
     <value>The documentation of 'CancellationToken' parameters should start with a phrase that describes how it is used.</value>
@@ -1419,6 +1641,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2026_Title" xml:space="preserve">
     <value>Used parameters should not be documented to be unused.</value>
   </data>
+  <data name="MiKo_2027_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment start of parameter of serialization constructor</value>
+  </data>
   <data name="MiKo_2027_Description" xml:space="preserve">
     <value>To ease the usage, the documentation of the parameters of the serialization constructors shall have a specific phrase that describes what they contain.</value>
   </data>
@@ -1436,6 +1661,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2028_Title" xml:space="preserve">
     <value>Documentation of parameter should not just contain the name of the parameter.</value>
+  </data>
+  <data name="MiKo_2029_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'cref' value from &lt;inheritdoc/&gt;</value>
   </data>
   <data name="MiKo_2029_Description" xml:space="preserve">
     <value>Instead of faking an XML documentation by using &lt;inheritdoc&gt; with a 'cref' to itself, a well-written &lt;summary&gt; XML documentation should be used.</value>
@@ -1455,6 +1683,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2030_Title" xml:space="preserve">
     <value>Documentation of return value should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2031_CodeFixTitle" xml:space="preserve">
+    <value>Fix return comment</value>
+  </data>
   <data name="MiKo_2031_Description" xml:space="preserve">
     <value>The documentation of a Task as return value should have a default (starting) phrase.</value>
   </data>
@@ -1473,6 +1704,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2032_Title" xml:space="preserve">
     <value>Documentation of Boolean return value should have a specific phrase.</value>
   </data>
+  <data name="MiKo_2033_CodeFixTitle" xml:space="preserve">
+    <value>Fix return comment</value>
+  </data>
   <data name="MiKo_2033_Description" xml:space="preserve">
     <value>The documentation of a String as return value should have a specific phrase.</value>
   </data>
@@ -1482,6 +1716,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2033_Title" xml:space="preserve">
     <value>Documentation of String return value should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2034_CodeFixTitle" xml:space="preserve">
+    <value>Fix return comment</value>
+  </data>
   <data name="MiKo_2034_Description" xml:space="preserve">
     <value>The documentation of an Enum as return value should have a specific phrase.</value>
   </data>
@@ -1490,6 +1727,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2034_Title" xml:space="preserve">
     <value>Documentation of Enum return value should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2035_CodeFixTitle" xml:space="preserve">
+    <value>Fix return comment</value>
   </data>
   <data name="MiKo_2035_Description" xml:space="preserve">
     <value>The documentation of a collection as return value should have a specific phrase.</value>
@@ -1509,6 +1749,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2036_Title" xml:space="preserve">
     <value>Documentation of Boolean or Enum property shall describe the default value.</value>
   </data>
+  <data name="MiKo_2037_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment to command property</value>
+  </data>
   <data name="MiKo_2037_Description" xml:space="preserve">
     <value>The documentation of a property that returns a command should start with a specific phrase that describes what command the property returns.</value>
   </data>
@@ -1518,6 +1761,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2037_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of command properties should have a default starting phrase.</value>
   </data>
+  <data name="MiKo_2038_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment to command</value>
+  </data>
   <data name="MiKo_2038_Description" xml:space="preserve">
     <value>The documentation of a command should start with a specific phrase that describes what the command does.</value>
   </data>
@@ -1526,6 +1772,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2038_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of command should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2039_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard extension methods comment to class</value>
   </data>
   <data name="MiKo_2039_Description" xml:space="preserve">
     <value>The documentation of a class that contains extension methods should start with a specific phrase that describes what the class provides.</value>
@@ -1557,6 +1806,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2041_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation should not contain other documentation tags.</value>
   </data>
+  <data name="MiKo_2042_CodeFixTitle" xml:space="preserve">
+    <value>Replace &lt;br/&gt; with &lt;para/&gt;</value>
+  </data>
   <data name="MiKo_2042_Description" xml:space="preserve">
     <value>The documentation should use the '&lt;para/&gt;' XML tags instead of '&lt;br/&gt;' or '&lt;p/&gt;' HTML tags.</value>
   </data>
@@ -1569,6 +1821,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2042_Title" xml:space="preserve">
     <value>Documentation should use '&lt;para/&gt;' XML tags instead of '&lt;br/&gt;' HTML tags.</value>
   </data>
+  <data name="MiKo_2043_CodeFixTitle" xml:space="preserve">
+    <value>Start summary with 'Encapsulates a method that '</value>
+  </data>
   <data name="MiKo_2043_Description" xml:space="preserve">
     <value>The documentation of a custom delegate should have a default starting phrase to indicate what the delegate encapsulates.</value>
   </data>
@@ -1577,6 +1832,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2043_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of custom delegates should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2044_CodeFixTitle" xml:space="preserve">
+    <value>Use &lt;paramref&gt; tag for parameter</value>
   </data>
   <data name="MiKo_2044_Description" xml:space="preserve">
     <value>Method parameters should be referenced via &lt;paramref name="..."/&gt; inside the documentation.</value>
@@ -1614,6 +1872,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2047_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of Attributes should have a  default starting phrase.</value>
   </data>
+  <data name="MiKo_2048_CodeFixTitle" xml:space="preserve">
+    <value>Start comment with 'Represents a converter that converts '</value>
+  </data>
   <data name="MiKo_2048_Description" xml:space="preserve">
     <value>The documentation of a value converters should start with a specific phrase that describes what they convert.</value>
   </data>
@@ -1631,6 +1892,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2049_Title" xml:space="preserve">
     <value>Documentation should be more explicit and not use 'will be'.</value>
+  </data>
+  <data name="MiKo_2050_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard exception comment</value>
   </data>
   <data name="MiKo_2050_Description" xml:space="preserve">
     <value>The documentation of exceptions should follow the .NET Framework documentation.</value>
@@ -1708,6 +1972,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   <data name="MiKo_2057_Title" xml:space="preserve">
     <value>Types that are not disposable shall not throw an ObjectDisposedException.</value>
   </data>
+  <data name="MiKo_2060_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment to factory</value>
+  </data>
   <data name="MiKo_2060_Description" xml:space="preserve">
     <value>The documentation of factories should be uniform and consistent.</value>
   </data>
@@ -1716,6 +1983,9 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
   </data>
   <data name="MiKo_2060_Title" xml:space="preserve">
     <value>Factories should be documented in a uniform way.</value>
+  </data>
+  <data name="MiKo_2070_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Return' in comment</value>
   </data>
   <data name="MiKo_2070_Description" xml:space="preserve">
     <value>If a method comment starts with 'Returns', then it focuses on the return value but not on the purpose (responsibility) of the method.
@@ -1736,23 +2006,32 @@ Instead, the documentation should describe what the method is intended to do.</v
   <data name="MiKo_2071_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation for methods that return Enum types should not contain phrase for boolean type.</value>
   </data>
+  <data name="MiKo_2072_CodeFixTitle" xml:space="preserve">
+    <value>Start summary with 'Attempts to'</value>
+  </data>
   <data name="MiKo_2072_Description" xml:space="preserve">
     <value>'Try' methods attempt to achieve something. So their &lt;summary&gt; documentation should start with the phrase 'Attempts to '.</value>
   </data>
   <data name="MiKo_2072_MessageFormat" xml:space="preserve">
-    <value>Start &lt;summary&gt; with: '{1}'</value>
+    <value>Start &lt;summary&gt; with 'Attempts to '</value>
   </data>
   <data name="MiKo_2072_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation should not start with 'Try'.</value>
+  </data>
+  <data name="MiKo_2073_CodeFixTitle" xml:space="preserve">
+    <value>Start summary with 'Determines whether'</value>
   </data>
   <data name="MiKo_2073_Description" xml:space="preserve">
     <value>'Contain' methods attempt to determine if something exists inside something else. So their &lt;summary&gt; documentation should start with the phrase 'Determines whether '.</value>
   </data>
   <data name="MiKo_2073_MessageFormat" xml:space="preserve">
-    <value>Start &lt;summary&gt; with: '{1}'</value>
+    <value>Start summary with 'Determines whether'</value>
   </data>
   <data name="MiKo_2073_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of 'Contains' methods should start with 'Determines whether '.</value>
+  </data>
+  <data name="MiKo_2074_CodeFixTitle" xml:space="preserve">
+    <value>Fix comment of parameter</value>
   </data>
   <data name="MiKo_2074_Description" xml:space="preserve">
     <value>'Contain' methods attempt to determine if the value of a given parameter exists inside something. So the &lt;param&gt; documentation of the given parameter should end with the phrase ' to seek.'.</value>
@@ -1763,6 +2042,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   <data name="MiKo_2074_Title" xml:space="preserve">
     <value>Documentation of parameter of 'Contains' method should have a default ending phrase.</value>
   </data>
+  <data name="MiKo_2080_CodeFixTitle" xml:space="preserve">
+    <value>Start field with default phrase</value>
+  </data>
   <data name="MiKo_2080_Description" xml:space="preserve">
     <value>The documentation of fields should start with a default phrase.</value>
   </data>
@@ -1771,6 +2053,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   </data>
   <data name="MiKo_2080_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of fields should have a default starting phrase.</value>
+  </data>
+  <data name="MiKo_2081_CodeFixTitle" xml:space="preserve">
+    <value>Append read-only text</value>
   </data>
   <data name="MiKo_2081_Description" xml:space="preserve">
     <value>The documentation of a public-visible read-only field should indicate that it is read-only.</value>
@@ -1781,6 +2066,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   <data name="MiKo_2081_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation of public-visible read-only fields should have a default ending phrase.</value>
   </data>
+  <data name="MiKo_2090_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment</value>
+  </data>
   <data name="MiKo_2090_Description" xml:space="preserve">
     <value>To ease development and usage, the XML documentation for equality operators shall have a common default phrase.</value>
   </data>
@@ -1790,6 +2078,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   <data name="MiKo_2090_Title" xml:space="preserve">
     <value>Documentation for equality operator shall have default phrase.</value>
   </data>
+  <data name="MiKo_2091_CodeFixTitle" xml:space="preserve">
+    <value>Apply standard comment</value>
+  </data>
   <data name="MiKo_2091_Description" xml:space="preserve">
     <value>To ease development and usage, the XML documentation for inequality operators shall have a common default phrase.</value>
   </data>
@@ -1798,6 +2089,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   </data>
   <data name="MiKo_2091_Title" xml:space="preserve">
     <value>Documentation for inequality operator shall have default phrase.</value>
+  </data>
+  <data name="MiKo_2100_CodeFixTitle" xml:space="preserve">
+    <value>Start comment with 'The following example demonstrates '</value>
   </data>
   <data name="MiKo_2100_Description" xml:space="preserve">
     <value>To ease usage, the example documentation should start with a phrase that shortly describes what the given example demonstrates.</value>
@@ -1835,6 +2129,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   <data name="MiKo_2201_Title" xml:space="preserve">
     <value>Use a capitalized letter to start the sentences in the comment.</value>
   </data>
+  <data name="MiKo_2202_CodeFixTitle" xml:space="preserve">
+    <value>Change 'id' into 'identifier'</value>
+  </data>
   <data name="MiKo_2202_Description" xml:space="preserve">
     <value>The XML documentation should not use the abbreviation 'id'. Instead, it should clearly document that this is an identifier. Hence, it should use the term 'identifier' instead.</value>
   </data>
@@ -1843,6 +2140,9 @@ Instead, the documentation should describe what the method is intended to do.</v
   </data>
   <data name="MiKo_2202_Title" xml:space="preserve">
     <value>Documentation should use the term 'identifier' instead of 'id'.</value>
+  </data>
+  <data name="MiKo_2203_CodeFixTitle" xml:space="preserve">
+    <value>Change 'GUID' into 'unique identifier'</value>
   </data>
   <data name="MiKo_2203_Description" xml:space="preserve">
     <value>The XML documentation should not use the abbreviation 'guid'. Instead, it should clearly document that this is an unique identifier. Hence, it should use the term 'unique identifier' instead.</value>
@@ -1914,6 +2214,9 @@ By having a more concrete description it makes it easier for a developer to unde
   <data name="MiKo_2209_Title" xml:space="preserve">
     <value>Do not use double periods in documentation.</value>
   </data>
+  <data name="MiKo_2210_CodeFixTitle" xml:space="preserve">
+    <value>Change 'info' into 'information'</value>
+  </data>
   <data name="MiKo_2210_Description" xml:space="preserve">
     <value>The XML documentation should not use the abbreviation 'info'. Instead, it should clearly document that this is an information. Hence, it should use the term 'information' instead.</value>
   </data>
@@ -1922,6 +2225,9 @@ By having a more concrete description it makes it easier for a developer to unde
   </data>
   <data name="MiKo_2210_Title" xml:space="preserve">
     <value>Documentation should use the term 'information' instead of 'info'.</value>
+  </data>
+  <data name="MiKo_2211_CodeFixTitle" xml:space="preserve">
+    <value>Move remarks comment into summary</value>
   </data>
   <data name="MiKo_2211_Description" xml:space="preserve">
     <value>Unfortunately, tools such as Sandcastle cannot handle &lt;remarks&gt; sections on enum members. The resulting output (CHM, HTML, ...) does not contain any Remarks section.
@@ -1954,6 +2260,9 @@ They should not describe how it is achieved because that's what the code is for.
   </data>
   <data name="MiKo_2300_Title" xml:space="preserve">
     <value>Comments should explain the 'Why' and not the 'How'.</value>
+  </data>
+  <data name="MiKo_2301_CodeFixTitle" xml:space="preserve">
+    <value>Remove obvious AAA comment</value>
   </data>
   <data name="MiKo_2301_Description" xml:space="preserve">
     <value>Inside tests that follow the Arrange/Act/Assert style, the comments '// arrange', '// act' and '// assert' are obvious and provide no benefit. Therefore, they can be removed.</value>
@@ -2189,6 +2498,9 @@ That is they should return a Boolean and have the last parameter as [out] parame
   <data name="MiKo_3015_Title" xml:space="preserve">
     <value>Parameterless methods should throw InvalidOperationExceptions (instead of ArgumentExceptions or its subtypes) to indicate inappropriate states.</value>
   </data>
+  <data name="MiKo_3020_CodeFixTitle" xml:space="preserve">
+    <value>Use 'Task.CompletedTask'</value>
+  </data>
   <data name="MiKo_3020_Description" xml:space="preserve">
     <value>For performance reasons it's better to use 'Task.CompletedTask' instead of 'Task.FromResult()' as the returned task is internally cached.</value>
   </data>
@@ -2421,6 +2733,9 @@ Failures inside the delegate(s) are really hard to tackle down because an except
   <data name="MiKo_3049_Title" xml:space="preserve">
     <value>Enum members shall have the [Description] attribute applied.</value>
   </data>
+  <data name="MiKo_3050_CodeFixTitle" xml:space="preserve">
+    <value>Make DependencyProperty 'public static readonly'</value>
+  </data>
   <data name="MiKo_3050_Description" xml:space="preserve">
     <value>Fields that are the back of a DependencyProperty should be made 'public static readonly' to allow the .NET framework and other clients to find and access those fields.</value>
   </data>
@@ -2445,6 +2760,9 @@ In addition, the correct property names, property types and owing types should b
   </data>
   <data name="MiKo_3051_Title" xml:space="preserve">
     <value>DependencyProperty fields should be properly registered.</value>
+  </data>
+  <data name="MiKo_3052_CodeFixTitle" xml:space="preserve">
+    <value>Make DependencyPropertyKey 'private static readonly'</value>
   </data>
   <data name="MiKo_3052_Description" xml:space="preserve">
     <value>Fields that are the back of a DependencyPropertyKey should be made non-public, 'static readonly' to prevent clients to find and access those fields.</value>
@@ -2553,6 +2871,9 @@ Doing so allows to change the implementation of the return value whenever it's n
   <data name="MiKo_3073_Title" xml:space="preserve">
     <value>Do not leave objects partially initialized.</value>
   </data>
+  <data name="MiKo_3081_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is false' pattern</value>
+  </data>
   <data name="MiKo_3081_Description" xml:space="preserve">
     <value>Logical NOT conditions are hard to recognize if they are coded using the '!' character. Code that uses 'is false' is much easier to read and understand.</value>
   </data>
@@ -2561,6 +2882,9 @@ Doing so allows to change the implementation of the return value whenever it's n
   </data>
   <data name="MiKo_3081_Title" xml:space="preserve">
     <value>Pattern matching is preferred over a logical NOT condition.</value>
+  </data>
+  <data name="MiKo_3082_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is' pattern</value>
   </data>
   <data name="MiKo_3082_Description" xml:space="preserve">
     <value>Logical comparisons using the 'is' pattern matching are more natural and therefore easier to read and understand than using the '==' operator.</value>
@@ -2571,6 +2895,9 @@ Doing so allows to change the implementation of the return value whenever it's n
   <data name="MiKo_3082_Title" xml:space="preserve">
     <value>Pattern matching is preferred over a logical comparison with 'true' or 'false'.</value>
   </data>
+  <data name="MiKo_3083_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is null' pattern</value>
+  </data>
   <data name="MiKo_3083_Description" xml:space="preserve">
     <value>Null checks using the 'is' pattern matching is more natural and therefore easier to read and understand than using the '==' operator.</value>
   </data>
@@ -2579,6 +2906,9 @@ Doing so allows to change the implementation of the return value whenever it's n
   </data>
   <data name="MiKo_3083_Title" xml:space="preserve">
     <value>Pattern matching is preferred for null checks.</value>
+  </data>
+  <data name="MiKo_3084_CodeFixTitle" xml:space="preserve">
+    <value>Place constant value on right side</value>
   </data>
   <data name="MiKo_3084_Description" xml:space="preserve">
     <value>To increase readability, do not place constants on the left side of an operator. Instead, place it on the right side. This makes the code look more natural.</value>
@@ -2675,6 +3005,9 @@ So having a condition inside a test is a huge code smell.</value>
   <data name="MiKo_3102_Title" xml:space="preserve">
     <value>Test methods should not contain conditional statements such as 'if', 'switch', etc.</value>
   </data>
+  <data name="MiKo_3103_CodeFixTitle" xml:space="preserve">
+    <value>Use hard-coded GUID</value>
+  </data>
   <data name="MiKo_3103_Description" xml:space="preserve">
     <value>Tests should be specific to make them reproducible and easy to maintain. A GUID that is generated is not reproducible at all and cannot be easily found in case a test fails.
 Therefore, a hard-coded GUID should be used instead.</value>
@@ -2693,6 +3026,9 @@ Therefore, a hard-coded GUID should be used instead.</value>
   </data>
   <data name="MiKo_3104_Title" xml:space="preserve">
     <value>Use NUnit's [Combinatorial] attribute properly.</value>
+  </data>
+  <data name="MiKo_3105_CodeFixTitle" xml:space="preserve">
+    <value>Use 'Assert.That'</value>
   </data>
   <data name="MiKo_3105_Description" xml:space="preserve">
     <value>NUnit's fluent Assert approach is easier to understand. Following that approach, developers will most times not make the common mistake to mix up the 'actual' and 'expected' values.</value>
@@ -2760,6 +3096,9 @@ Such namespaces should be flattened.</value>
   <data name="MiKo_4002_Title" xml:space="preserve">
     <value>Methods with same name and accessibility should be placed side-by-side.</value>
   </data>
+  <data name="MiKo_4003_CodeFixTitle" xml:space="preserve">
+    <value>Place Dispose method after constructors and finalizers</value>
+  </data>
   <data name="MiKo_4003_Description" xml:space="preserve">
     <value>Ctors, finalizers and Dispose methods are all directly related to the lifetime of an object. Therefore, they belong together and should be placed side by side.</value>
   </data>
@@ -2768,6 +3107,9 @@ Such namespaces should be flattened.</value>
   </data>
   <data name="MiKo_4003_Title" xml:space="preserve">
     <value>Dispose methods should be placed directly after constructors and finalizers.</value>
+  </data>
+  <data name="MiKo_4004_CodeFixTitle" xml:space="preserve">
+    <value>Place corresponding interface directly after type declaration</value>
   </data>
   <data name="MiKo_4004_Description" xml:space="preserve">
     <value>To ease reading, the interface that gives the type its name should be listed as first interface. All the other implemented interfaces should be placed behind.</value>
@@ -2778,6 +3120,9 @@ Such namespaces should be flattened.</value>
   <data name="MiKo_4004_Title" xml:space="preserve">
     <value>The interface that gives a type its name should be placed directly after the type's declaration.</value>
   </data>
+  <data name="MiKo_4101_CodeFixTitle" xml:space="preserve">
+    <value>Place test initialization method after [OneTimeSetUp] / [OneTimeTearDown] methods and before test cleanup and all other test methods</value>
+  </data>
   <data name="MiKo_4101_Description" xml:space="preserve">
     <value>Test initialization method define the most common parts that tests shall contain. So to ease their finding they should be ordered directly after all one-time methods and before all other methods.</value>
   </data>
@@ -2786,6 +3131,9 @@ Such namespaces should be flattened.</value>
   </data>
   <data name="MiKo_4101_Title" xml:space="preserve">
     <value>Test initialization methods should be ordered directly after One-Time methods.</value>
+  </data>
+  <data name="MiKo_4102_CodeFixTitle" xml:space="preserve">
+    <value>Place test cleanup method after test initialization methods and before all test methods</value>
   </data>
   <data name="MiKo_4102_Description" xml:space="preserve">
     <value>Test cleanup methods define the common parts that shall be executed after any test has been finished. So to ease their finding they should be ordered before the test methods.</value>
@@ -2796,6 +3144,9 @@ Such namespaces should be flattened.</value>
   <data name="MiKo_4102_Title" xml:space="preserve">
     <value>Test cleanup methods should be ordered after test initialization methods and before test methods.</value>
   </data>
+  <data name="MiKo_4103_CodeFixTitle" xml:space="preserve">
+    <value>Place [OneTimeSetUp] method before all other methods</value>
+  </data>
   <data name="MiKo_4103_Description" xml:space="preserve">
     <value>One-Time test initialization method define the most common parts that the test environment shall have. So to ease their finding they should be ordered first.</value>
   </data>
@@ -2804,6 +3155,9 @@ Such namespaces should be flattened.</value>
   </data>
   <data name="MiKo_4103_Title" xml:space="preserve">
     <value>One-Time test initialization methods should be ordered before all other methods.</value>
+  </data>
+  <data name="MiKo_4104_CodeFixTitle" xml:space="preserve">
+    <value>Place [OneTimeTearDown] method directly after [OneTimeSetUp] method and before all other methods</value>
   </data>
   <data name="MiKo_4104_Description" xml:space="preserve">
     <value>One-Time test cleanup methods define the common parts that shall be executed after all tests have been finished, to clean up the test environment. So to ease their finding they should be ordered directly after the One-Time test initialization methods.</value>
@@ -2814,6 +3168,9 @@ Such namespaces should be flattened.</value>
   <data name="MiKo_4104_Title" xml:space="preserve">
     <value>One-Time test cleanup methods should be ordered directly after One-Time test initialization methods.</value>
   </data>
+  <data name="MiKo_5001_CodeFixTitle" xml:space="preserve">
+    <value>Place inside 'if'</value>
+  </data>
   <data name="MiKo_5001_Description" xml:space="preserve">
     <value>For performance reasons, 'IsDebugEnabled' should be invoked before the 'Debug' or 'DebugFormat' methods get invoked as those require messages to be created. That creation (and the garbage collection of them as well) is not needed if the 'Debug' log level is not set.</value>
   </data>
@@ -2822,6 +3179,9 @@ Such namespaces should be flattened.</value>
   </data>
   <data name="MiKo_5001_Title" xml:space="preserve">
     <value>'Debug' and 'DebugFormat' methods should be invoked only after 'IsDebugEnabled'.</value>
+  </data>
+  <data name="MiKo_5002_CodeFixTitle" xml:space="preserve">
+    <value>Replace with non-'Format' method</value>
   </data>
   <data name="MiKo_5002_Description" xml:space="preserve">
     <value>For performance reasons, 'xxxFormat' methods (such as 'DebugFormat') should be invoked only with arguments to format the string. Otherwise, the corresponding non-formatting methods (such as 'Debug') should be invoked.</value>
@@ -2841,6 +3201,9 @@ That allows the Log framework to log not only the name of the exception but also
   </data>
   <data name="MiKo_5003_Title" xml:space="preserve">
     <value>Correct Log methods should be invoked for exceptions.</value>
+  </data>
+  <data name="MiKo_5010_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Equals' by '=='</value>
   </data>
   <data name="MiKo_5010_Description" xml:space="preserve">
     <value>For performance reasons, it makes no sense to use 'object.Equals()' on value types. Value types get boxed and unboxed when being casted to objects. That puts unnecessary pressure on the garbage collector as temporary objects are created and immediately get garbage collected.

--- a/MiKo.Analyzer/Resources.resx
+++ b/MiKo.Analyzer/Resources.resx
@@ -1546,10 +1546,10 @@ It should not start with or contain a meaningless phrase like 'Used to'. Instead
     <value>Start summary with 'Determines whether'</value>
   </data>
   <data name="MiKo_2018_Description" xml:space="preserve">
-    <value>The terms 'Check' or 'Test' are ambiguous. If validation of parameters is meant, use something like 'Validates' or 'Verifies'. If a check for a specific state is meant, use 'Determines' instead.</value>
+    <value>The terms 'Check' or 'Test' are ambiguous. If validation of parameters is meant, use something like 'Validates' or 'Verifies'. If a check for a specific state is meant, use 'Determines whether' instead.</value>
   </data>
   <data name="MiKo_2018_MessageFormat" xml:space="preserve">
-    <value>Use '{2}' instead of ambiguous term '{1}'</value>
+    <value>Use '{2}' instead of '{1}'</value>
   </data>
   <data name="MiKo_2018_Title" xml:space="preserve">
     <value>Documentation should not use the ambiguous terms 'Check' or 'Test'.</value>

--- a/MiKo.Analyzer/Resources.resx
+++ b/MiKo.Analyzer/Resources.resx
@@ -295,6 +295,9 @@ Example: Instead of 'NotifyPropertyChanged' use 'OnPropertyChanged'.</value>
   <data name="MiKo_1013_Title" xml:space="preserve">
     <value>Methods should not be named 'Notify' or 'OnNotify'.</value>
   </data>
+  <data name="MiKo_1014_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'Check'</value>
+  </data>
   <data name="MiKo_1014_Description" xml:space="preserve">
     <value>The term 'Check' is ambiguous. If validation of parameters is meant, use something like 'Validate' or 'Verify'. If a check for a specific state is meant, use 'Is', 'Can' or 'Has' instead.</value>
   </data>

--- a/MiKo.Analyzer/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -305,7 +305,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlEmptyElementSyntax SeeCref(string typeName) => Cref(Constants.XmlTag.See, SyntaxFactory.ParseTypeName(typeName));
 
-        protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
+        // bug in Roslyn, see https://github.com/dotnet/roslyn/issues/47550
+        // protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
+        protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => SeeCref(type.ToString());
 
         protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type, NameSyntax member) => Cref(Constants.XmlTag.See, type, member);
 

--- a/MiKo.Analyzer/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -101,6 +101,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
             else
             {
+                index = Math.Max(0, index - 1);
                 continueText = SyntaxFactory.XmlText(commentContinue);
             }
 
@@ -305,17 +306,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlEmptyElementSyntax SeeCref(string typeName) => Cref(Constants.XmlTag.See, SyntaxFactory.ParseTypeName(typeName));
 
-        // bug in Roslyn, see https://github.com/dotnet/roslyn/issues/47550
-        // protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
-        protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => SeeCref(type.ToString());
+        protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
 
         protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type, NameSyntax member) => Cref(Constants.XmlTag.See, type, member);
 
-        protected static XmlEmptyElementSyntax Cref(string tag, TypeSyntax type) => Cref(tag, SyntaxFactory.TypeCref(type.WithoutTrailingTrivia()));
+        protected static XmlEmptyElementSyntax Cref(string tag, TypeSyntax type)
+        {
+            // fix trivia, to avoid situation as reported in https://github.com/dotnet/roslyn/issues/47550
+            return Cref(tag, SyntaxFactory.TypeCref(type.WithoutTrivia()));
+        }
 
         protected static XmlEmptyElementSyntax Cref(string tag, TypeSyntax type, NameSyntax member)
         {
-            return Cref(tag, SyntaxFactory.QualifiedCref(type, SyntaxFactory.NameMemberCref(member)));
+            // fix trivia, to avoid situation as reported in https://github.com/dotnet/roslyn/issues/47550
+            return Cref(tag, SyntaxFactory.QualifiedCref(type.WithoutTrivia(), SyntaxFactory.NameMemberCref(member.WithoutTrivia())));
         }
 
         private static XmlEmptyElementSyntax Cref(string tag, CrefSyntax syntax)

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2004_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2004_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2004_EventHandlerParametersAnalyzer.Id;
 
-        protected override string Title => "Fix comment of event handler parameter";
+        protected override string Title => Resources.MiKo_2004_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment to RoutedEvent";
+        protected override string Title => Resources.MiKo_2006_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2010_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2010_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2010_SealedClassSummaryAnalyzer.Id;
 
-        protected override string Title => "Append sealed text to comment";
+        protected override string Title => Resources.MiKo_2010_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2011_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2011_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2011_UnsealedClassSummaryAnalyzer.Id;
 
-        protected override string Title => "Remove sealed text to comment";
+        protected override string Title => Resources.MiKo_2011_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2014_DisposeDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Apply standard 'Dispose' comment";
+        protected override string Title => Resources.MiKo_2014_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2015_FireMethodsAnalyzer.Id;
 
-        protected override string Title => "Replace term 'fire'";
+        protected override string Title => Resources.MiKo_2015_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment to DependencyProperty";
+        protected override string Title => Resources.MiKo_2017_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         internal const string StartingPhrase = Constants.Comments.DeterminesWhetherPhrase;
 
-        private static readonly string[] Comments = { "Check ", "Checks ", "Test ", "Tests ", "Determines if " };
+        private static readonly string[] WrongPhrases = { "Check ", "Checks ", "Test ", "Tests ", "Determines if " };
 
         public MiKo_2018_ChecksSummaryAnalyzer() : base(Id, (SymbolKind)(-1))
         {
@@ -26,16 +26,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, IEnumerable<string> summaries)
         {
-            foreach (var summary in summaries
-                                        .Select(_ => _.Without(Constants.Comments.AsynchrounouslyStartingPhrase).Trim())
-                                        .Where(_ => _.StartsWithAny(Comments)))
+            foreach (var summary in summaries.Select(_ => _.Without(Constants.Comments.AsynchrounouslyStartingPhrase).Trim()))
             {
-                var wrongPhrase = summary.Substring(0, summary.IndexOf(" ", StringComparison.OrdinalIgnoreCase));
-
-                return new[] { Issue(symbol, wrongPhrase, StartingPhrase) };
+                foreach (var wrongPhrase in WrongPhrases.Where(_ => summary.StartsWith(_, StringComparison.OrdinalIgnoreCase)))
+                {
+                    yield return Issue(symbol, wrongPhrase, StartingPhrase);
+                }
             }
-
-            return Enumerable.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2020_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2020_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2020_InheritdocSummaryAnalyzer.Id;
 
-        protected override string Title => "Use <inheritdoc/>";
+        protected override string Title => Resources.MiKo_2020_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2022_OutParamDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment start of [out] parameter";
+        protected override string Title => Resources.MiKo_2022_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2023_BooleanParamDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment start of Boolean parameter";
+        protected override string Title => Resources.MiKo_2023_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2024_EnumParamDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment start of Enum parameter";
+        protected override string Title => Resources.MiKo_2024_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2025_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2025_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment start of CancellationToken";
+        protected override string Title => Resources.MiKo_2025_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2027_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2027_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment start of parameter of serialization ctor";
+        protected override string Title => Resources.MiKo_2027_CodeFixTitle;
 
         protected override IEnumerable<SyntaxNode> FittingSyntaxNodes(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ConstructorDeclarationSyntax>();
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2029_InheritdocUsesWrongCrefAnalyzer.Id;
 
-        protected override string Title => "Remove 'cref' value from <inheritdoc/>";
+        protected override string Title => Resources.MiKo_2029_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix return comment";
+        protected override string Title => Resources.MiKo_2031_CodeFixTitle;
 
         protected override SyntaxNode GenericComment(XmlElementSyntax comment, GenericNameSyntax returnType)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2033_StringReturnTypeDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix return comment";
+        protected override string Title => Resources.MiKo_2033_CodeFixTitle;
 
         protected override SyntaxNode GenericComment(XmlElementSyntax comment, GenericNameSyntax returnType)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2034_EnumReturnTypeDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix return comment";
+        protected override string Title => Resources.MiKo_2034_CodeFixTitle;
 
         protected override SyntaxNode GenericComment(XmlElementSyntax comment, GenericNameSyntax returnType)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix return comment";
+        protected override string Title => Resources.MiKo_2035_CodeFixTitle;
 
         protected override SyntaxNode GenericComment(XmlElementSyntax comment, GenericNameSyntax returnType)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2037_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2037_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2037_CommandPropertySummaryAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment to command property";
+        protected override string Title => Resources.MiKo_2037_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2038_CommandTypeSummaryAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment to command";
+        protected override string Title => Resources.MiKo_2038_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax) => CommentStartingWith((XmlElementSyntax)syntax, Constants.Comments.CommandSummaryStartingPhrase);
     }

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.Id;
 
-        protected override string Title => "Apply standard extension methods comment to class";
+        protected override string Title => Resources.MiKo_2039_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2042_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2042_CodeFixProvider.cs
@@ -3,7 +3,6 @@ using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -13,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2042_BrParaAnalyzer.Id;
 
-        protected override string Title => "Replace <br/> with <para/>";
+        protected override string Title => Resources.MiKo_2042_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2044_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2044_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2044_InvalidSeeParameterInXmlAnalyzer.Id;
 
-        protected override string Title => "Use <paramref> tag for parameter";
+        protected override string Title => Resources.MiKo_2044_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2050_ExceptionSummaryAnalyzer.Id;
 
-        protected override string Title => "Apply standard exception comment";
+        protected override string Title => Resources.MiKo_2050_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 
@@ -42,9 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (summary is null)
             {
                 var newSummary = Comment(SyntaxFactory.XmlSummaryElement(), Phrase).WithTrailingXmlComment();
-
-                var first = comment.Content.First();
-                return comment.InsertNodeAfter(first, newSummary);
+                return comment.InsertNodeAfter(comment.Content[0], newSummary);
             }
             else
             {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2060_FactoryAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment to factory";
+        protected override string Title => Resources.MiKo_2060_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -1,7 +1,11 @@
-﻿using System.Composition;
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -9,6 +13,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2060_CodeFixProvider)), Shared]
     public sealed class MiKo_2060_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
+        private static readonly Dictionary<string, string> TypeReplacementMap = new Dictionary<string, string>
+                                                                                {
+                                                                                    { "A factory that creates a ", string.Empty },
+                                                                                    { "A factory that creates ", string.Empty },
+                                                                                    { "A factory that ", string.Empty },
+                                                                                    { "Represents a factory that creates a ", string.Empty },
+                                                                                    { "Represents a factory that creates ", string.Empty },
+                                                                                    { "Represents a factory that ", string.Empty },
+                                                                                    { "Creates ", string.Empty },
+                                                                                };
+
+        private static readonly Dictionary<string, string> MethodReplacementMap = new Dictionary<string, string>
+                                                                                {
+                                                                                    { "Creates an instance of ", string.Empty },
+                                                                                    { "Creates an ", string.Empty },
+                                                                                    { "Creates a ", string.Empty },
+                                                                                };
+
         public override string FixableDiagnosticId => MiKo_2060_FactoryAnalyzer.Id;
 
         protected override string Title => Resources.MiKo_2060_CodeFixTitle;
@@ -22,10 +44,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 switch (ancestor)
                 {
                     case ClassDeclarationSyntax _:
-                        return CommentStartingWith(summary, Constants.Comments.FactorySummaryPhrase);
+                    case InterfaceDeclarationSyntax _:
+                    {
+                        var preparedComment = PrepareTypeComment(summary);
+                        return CommentStartingWith(preparedComment, Constants.Comments.FactorySummaryPhrase);
+                    }
 
                     case MethodDeclarationSyntax m:
                     {
+                        var preparedComment = PrepareMethodComment(summary);
+
                         var template = Constants.Comments.FactoryCreateMethodSummaryStartingPhraseTemplate;
                         var returnType = m.ReturnType;
 
@@ -37,12 +65,34 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         var parts = string.Format(template, '|').Split('|');
 
-                        return CommentStartingWith(summary, parts[0], SeeCref(returnType), parts[1]);
+                        return CommentStartingWith(preparedComment, parts[0], SeeCref(returnType), parts[1]);
                     }
                 }
             }
 
             return summary;
+        }
+
+        private static XmlElementSyntax PrepareTypeComment(XmlElementSyntax comment)
+        {
+            return Comment(comment, TypeReplacementMap.Select(_ => _.Key).ToList(), TypeReplacementMap);
+        }
+
+        private static XmlElementSyntax PrepareMethodComment(XmlElementSyntax comment)
+        {
+            var preparedComment = Comment(comment, MethodReplacementMap.Select(_ => _.Key).ToList(), MethodReplacementMap);
+
+            if (preparedComment.Content.Count > 2)
+            {
+                var content1 = preparedComment.Content[0];
+                var content2 = preparedComment.Content[1];
+                if (content2.IsKind(SyntaxKind.XmlEmptyElement) && content1.WithoutXmlCommentExterior().IsNullOrWhiteSpace())
+                {
+                    return preparedComment.RemoveNodes(new[] { content1, content2 }, SyntaxRemoveOptions.KeepNoTrivia);
+                }
+            }
+
+            return preparedComment;
         }
     }
 }

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2070_ReturnsSummaryAnalyzer.Id;
 
-        protected override string Title => "Replace 'Return' in comment";
+        protected override string Title => Resources.MiKo_2070_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -16,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2072_TrySummaryAnalyzer.Id;
 
-        protected override string Title => "Start summary with '" + MiKo_2072_TrySummaryAnalyzer.StartingPhrase + "'";
+        protected override string Title => Resources.MiKo_2072_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Start summary with '" + StartingPhrase + "'";
+        protected override string Title => Resources.MiKo_2073_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Fix comment of parameter";
+        protected override string Title => Resources.MiKo_2074_CodeFixTitle;
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, int index)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Composition;
 using System.Linq;
-using System.Threading;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -13,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.Id;
 
-        protected override string Title => "Start field with default phrase";
+        protected override string Title => Resources.MiKo_2080_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2081_ReadOnlyFieldAnalyzer.Id;
 
-        protected override string Title => "Append read-only text";
+        protected override string Title => Resources.MiKo_2081_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax)
         {

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2090_EqualityOperatorAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment";
+        protected override string Title => Resources.MiKo_2090_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2091_InequalityOperatorAnalyzer.Id;
 
-        protected override string Title => "Apply standard comment";
+        protected override string Title => Resources.MiKo_2091_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer.Id;
 
-        protected override string Title => "Move remarks comment into summary";
+        protected override string Title => Resources.MiKo_2211_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2301_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2301_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => MiKo_2301_TestArrangeActAssertCommentAnalyzer.Id;
 
-        protected override string Title => "Remove obvious AAA comment";
+        protected override string Title => Resources.MiKo_2301_CodeFixTitle;
 
         protected override bool IsTrivia => true;
 

--- a/MiKo.Analyzer/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer.cs
@@ -14,6 +14,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool CommentHasIssue(string comment, SemanticModel semanticModel) => comment.EndsWith(".", StringComparison.OrdinalIgnoreCase) && !comment.EndsWith("...", StringComparison.OrdinalIgnoreCase);
+        protected override bool CommentHasIssue(string comment, SemanticModel semanticModel) => comment.EndsWith(".", StringComparison.OrdinalIgnoreCase)
+                                                                                             && comment.EndsWith("...", StringComparison.OrdinalIgnoreCase) is false
+                                                                                             && comment.EndsWith("etc.", StringComparison.OrdinalIgnoreCase) is false;
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -30,20 +32,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
         }
 
-        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, string methodName, string methodName1)
+        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, params string[] methodNames)
         {
-            var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodName);
-            var method = SyntaxFactory.IdentifierName(methodName1);
+            var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodNames[0]);
 
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, start, method);
-        }
-
-        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, string methodName, string methodName1, string methodName2)
-        {
-            var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodName, methodName1);
-            var method = SyntaxFactory.IdentifierName(methodName2);
-
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, start, method);
+            var result = methodNames.Skip(1)
+                                    .Aggregate(start, (current, name) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, current, SyntaxFactory.IdentifierName(name)));
+            return result;
         }
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -32,12 +32,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
         }
 
+        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(ExpressionSyntax syntax, string name)
+        {
+            var identifierName = SyntaxFactory.IdentifierName(name);
+
+            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, syntax, identifierName);
+        }
+
         protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, params string[] methodNames)
         {
             var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodNames[0]);
 
-            var result = methodNames.Skip(1)
-                                    .Aggregate(start, (current, name) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, current, SyntaxFactory.IdentifierName(name)));
+            var result = methodNames.Skip(1).Aggregate(start, CreateSimpleMemberAccessExpressionSyntax);
             return result;
         }
     }

--- a/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -30,10 +30,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
         }
 
-        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, string methodName, string nextMethodName)
+        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, string methodName, string methodName1)
         {
             var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodName);
-            var method = SyntaxFactory.IdentifierName(nextMethodName);
+            var method = SyntaxFactory.IdentifierName(methodName1);
+
+            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, start, method);
+        }
+
+        protected static MemberAccessExpressionSyntax CreateSimpleMemberAccessExpressionSyntax(string typeName, string methodName, string methodName1, string methodName2)
+        {
+            var start = CreateSimpleMemberAccessExpressionSyntax(typeName, methodName, methodName1);
+            var method = SyntaxFactory.IdentifierName(methodName2);
 
             return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, start, method);
         }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3020_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3020_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3020_CompletedTaskAnalyzer.Id;
 
-        protected override string Title => "Use '" + nameof(Task) + "." + nameof(Task.CompletedTask) + "'";
+        protected override string Title => Resources.MiKo_3020_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<InvocationExpressionSyntax>().FirstOrDefault();
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3050_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3050_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3050_DependencyPropertyPublicStaticReadOnlyFieldAnalyzer.Id;
 
-        protected override string Title => "Make DependencyProperty 'public static readonly'";
+        protected override string Title => Resources.MiKo_3050_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<FieldDeclarationSyntax>().FirstOrDefault();
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3052_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3052_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3052_DependencyPropertyKeyNonPublicStaticReadOnlyFieldAnalyzer.Id;
 
-        protected override string Title => "Make DependencyPropertyKey 'private static readonly'";
+        protected override string Title => Resources.MiKo_3052_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<FieldDeclarationSyntax>().FirstOrDefault();
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3081_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3081_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer.Id;
 
-        protected override string Title => "Apply 'is false' pattern";
+        protected override string Title => Resources.MiKo_3081_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.First(_ => _.IsKind(SyntaxKind.LogicalNotExpression));
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3082_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3082_CodeFixProvider.cs
@@ -10,6 +10,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.Id;
 
-        protected override string Title => "Apply 'is' pattern";
+        protected override string Title => Resources.MiKo_3082_CodeFixTitle;
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3083_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3083_CodeFixProvider.cs
@@ -10,6 +10,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3083_UsePatternMatchingForNullEqualsExpressionAnalyzer.Id;
 
-        protected override string Title => "Apply 'is null' pattern";
+        protected override string Title => Resources.MiKo_3083_CodeFixTitle;
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3084_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3084_CodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         public override string FixableDiagnosticId => MiKo_3084_YodaExpressionAnalyzer.Id;
 
-        protected override string Title => "Place constant on right side";
+        protected override string Title => Resources.MiKo_3084_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.First(_ => Expressions.ContainsKey(_.Kind()));
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -38,6 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         case "IsNull": return FixAssertIsNull(original.ArgumentList.Arguments);
                         case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(original.ArgumentList.Arguments);
                         case "NotNull": return FixAssertNotNull(original.ArgumentList.Arguments);
+                        case "IsNotNull": return FixAssertIsNotNull(original.ArgumentList.Arguments);
                         case "IsNotEmpty": return FixAssertIsNotEmpty(original.ArgumentList.Arguments);
                         case "Greater": return FixAssertGreater(original.ArgumentList.Arguments);
                         case "GreaterOrEqual": return FixAssertGreaterOrEqual(original.ArgumentList.Arguments);
@@ -91,6 +92,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         }
 
         private static InvocationExpressionSyntax FixAssertNotNull(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[0], Is("Not", "Null"), 1, args);
+        }
+
+        private static InvocationExpressionSyntax FixAssertIsNotNull(SeparatedSyntaxList<ArgumentSyntax> args)
         {
             return AssertThat(args[0], Is("Not", "Null"), 1, args);
         }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -25,25 +25,34 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (original.Expression is MemberAccessExpressionSyntax maes && maes.Expression is IdentifierNameSyntax i)
             {
                 // for the moment only consider Assert and not StringAssert etc.
-                if (i.GetName() == "Assert")
+                switch (i.GetName())
                 {
-                    switch (maes.GetName())
+                    case "Assert":
+                    case "CollectionAssert":
                     {
-                        case "AreEqual": return FixAssertAreEqual(original.ArgumentList.Arguments);
-                        case "AreNotEqual": return FixAssertAreNotEqual(original.ArgumentList.Arguments);
-                        case "AreSame": return FixAssertAreSame(original.ArgumentList.Arguments);
-                        case "AreNotSame": return FixAssertAreNotSame(original.ArgumentList.Arguments);
-                        case "IsTrue": return FixAssertIsTrue(original.ArgumentList.Arguments);
-                        case "IsFalse": return FixAssertIsFalse(original.ArgumentList.Arguments);
-                        case "IsNull": return FixAssertIsNull(original.ArgumentList.Arguments);
-                        case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(original.ArgumentList.Arguments);
-                        case "NotNull": return FixAssertNotNull(original.ArgumentList.Arguments);
-                        case "IsNotNull": return FixAssertIsNotNull(original.ArgumentList.Arguments);
-                        case "IsNotEmpty": return FixAssertIsNotEmpty(original.ArgumentList.Arguments);
-                        case "Greater": return FixAssertGreater(original.ArgumentList.Arguments);
-                        case "GreaterOrEqual": return FixAssertGreaterOrEqual(original.ArgumentList.Arguments);
-                        case "Less": return FixAssertLess(original.ArgumentList.Arguments);
-                        case "LessOrEqual": return FixAssertLessOrEqual(original.ArgumentList.Arguments);
+                        switch (maes.GetName())
+                        {
+                            case "AreEqual": return FixAssertAreEqual(original.ArgumentList.Arguments);
+                            case "AreEquivalent": return FixCollectionAssertAreEquivalent(original.ArgumentList.Arguments);
+                            case "AreNotEqual": return FixAssertAreNotEqual(original.ArgumentList.Arguments);
+                            case "AreNotEquivalent": return FixCollectionAssertAreNotEquivalent(original.ArgumentList.Arguments);
+                            case "AreNotSame": return FixAssertAreNotSame(original.ArgumentList.Arguments);
+                            case "AreSame": return FixAssertAreSame(original.ArgumentList.Arguments);
+                            case "Greater": return FixAssertGreater(original.ArgumentList.Arguments);
+                            case "GreaterOrEqual": return FixAssertGreaterOrEqual(original.ArgumentList.Arguments);
+                            case "IsEmpty": return FixAssertIsEmpty(original.ArgumentList.Arguments);
+                            case "IsFalse": return FixAssertIsFalse(original.ArgumentList.Arguments);
+                            case "IsNotEmpty": return FixAssertIsNotEmpty(original.ArgumentList.Arguments);
+                            case "IsNotNull": return FixAssertIsNotNull(original.ArgumentList.Arguments);
+                            case "IsNull": return FixAssertIsNull(original.ArgumentList.Arguments);
+                            case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(original.ArgumentList.Arguments);
+                            case "IsTrue": return FixAssertIsTrue(original.ArgumentList.Arguments);
+                            case "Less": return FixAssertLess(original.ArgumentList.Arguments);
+                            case "LessOrEqual": return FixAssertLessOrEqual(original.ArgumentList.Arguments);
+                            case "NotNull": return FixAssertNotNull(original.ArgumentList.Arguments);
+                        }
+
+                        break;
                     }
                 }
             }
@@ -101,6 +110,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(args[0], Is("Not", "Null"), 1, args);
         }
 
+        private static InvocationExpressionSyntax FixAssertIsEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[0], Is("Empty"), 1, args);
+        }
+
         private static InvocationExpressionSyntax FixAssertIsNotEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
         {
             return AssertThat(args[0], Is("Not", "Empty"), 1, args);
@@ -124,6 +138,16 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static InvocationExpressionSyntax FixAssertLessOrEqual(SeparatedSyntaxList<ArgumentSyntax> args)
         {
             return AssertThat(args[0], Is("LessThanOrEqualTo", args[1]), 2, args);
+        }
+
+        private static InvocationExpressionSyntax FixCollectionAssertAreEquivalent(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Is("EquivalentTo", args[0]), 2, args);
+        }
+
+        private static InvocationExpressionSyntax FixCollectionAssertAreNotEquivalent(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Is("Not", "EquivalentTo", args[0]), 2, args);
         }
 
         private static InvocationExpressionSyntax AssertThat(ArgumentSyntax argument, ArgumentSyntax constraint, int skip, SeparatedSyntaxList<ArgumentSyntax> arguments)

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -138,16 +138,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ArgumentSyntax Is(string name) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name));
 
-        private static ArgumentSyntax Is(string name, string name1) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name, name1));
-
-        private static ArgumentSyntax Is(string name, string name1, string name2) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name, name1, name2));
-
-        private static ArgumentSyntax Is(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, arguments));
-
-        private static ArgumentSyntax Is(string name, string name1, params ArgumentSyntax[] arguments)
+        private static ArgumentSyntax Is(string name, string name1, ArgumentSyntax argument)
         {
             var expression = CreateSimpleMemberAccessExpressionSyntax("Is", name, name1);
-            return SyntaxFactory.Argument(CreateInvocationSyntax(expression, arguments));
+
+            return SyntaxFactory.Argument(CreateInvocationSyntax(expression, argument));
         }
+
+        private static ArgumentSyntax Is(params string[] names) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", names));
+
+        private static ArgumentSyntax Is(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, arguments));
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => MiKo_3105_TestMethodsUseAssertThatAnalyzer.Id;
 
-        protected override string Title => "Use 'Assert.That'";
+        protected override string Title => Resources.MiKo_3105_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<InvocationExpressionSyntax>().FirstOrDefault();
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -53,6 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             case "IsNotNull": return FixIsNotNull(args);
                             case "IsNull": return FixIsNull(args);
                             case "IsNullOrEmpty": return FixIsNullOrEmpty(args);
+                            case "IsSubsetOf": return FixIsSubsetOf(args);
                             case "IsTrue": return FixIsTrue(args);
                             case "Less": return FixLess(args);
                             case "LessOrEqual": return FixLessOrEqual(args);
@@ -103,6 +104,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static InvocationExpressionSyntax FixIsNull(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Null"), 1, args);
 
         private static InvocationExpressionSyntax FixIsNullOrEmpty(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Null", "Or", "Empty"), 1, args);
+
+        private static InvocationExpressionSyntax FixIsSubsetOf(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("SubsetOf", args[0]), 2, args);
 
         private static InvocationExpressionSyntax FixIsTrue(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("True"), 1, args);
 

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -36,6 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         case "IsTrue": return FixAssertIsTrue(original.ArgumentList.Arguments);
                         case "IsFalse": return FixAssertIsFalse(original.ArgumentList.Arguments);
                         case "IsNull": return FixAssertIsNull(original.ArgumentList.Arguments);
+                        case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(original.ArgumentList.Arguments);
                         case "NotNull": return FixAssertNotNull(original.ArgumentList.Arguments);
                         case "IsNotEmpty": return FixAssertIsNotEmpty(original.ArgumentList.Arguments);
                         case "Greater": return FixAssertGreater(original.ArgumentList.Arguments);
@@ -82,6 +83,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static InvocationExpressionSyntax FixAssertIsNull(SeparatedSyntaxList<ArgumentSyntax> args)
         {
             return AssertThat(args[0], Is("Null"), 1, args);
+        }
+
+        private static InvocationExpressionSyntax FixAssertIsNullOrEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[0], Is("Null", "Or", "Empty"), 1, args);
         }
 
         private static InvocationExpressionSyntax FixAssertNotNull(SeparatedSyntaxList<ArgumentSyntax> args)
@@ -132,13 +138,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ArgumentSyntax Is(string name) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name));
 
-        private static ArgumentSyntax Is(string name, string nextName) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name, nextName));
+        private static ArgumentSyntax Is(string name, string name1) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name, name1));
+
+        private static ArgumentSyntax Is(string name, string name1, string name2) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name, name1, name2));
 
         private static ArgumentSyntax Is(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, arguments));
 
-        private static ArgumentSyntax Is(string name, string nextName, params ArgumentSyntax[] arguments)
+        private static ArgumentSyntax Is(string name, string name1, params ArgumentSyntax[] arguments)
         {
-            var expression = CreateSimpleMemberAccessExpressionSyntax("Is", name, nextName);
+            var expression = CreateSimpleMemberAccessExpressionSyntax("Is", name, name1);
             return SyntaxFactory.Argument(CreateInvocationSyntax(expression, arguments));
         }
     }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -35,29 +35,29 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                         switch (maes.GetName())
                         {
-                            case "AreEqual": return FixAssertAreEqual(args);
-                            case "AreEqualIgnoringCase": return FixStringAssertAreEqualIgnoringCase(args);
-                            case "AreEquivalent": return FixCollectionAssertAreEquivalent(args);
-                            case "AreNotEqual": return FixAssertAreNotEqual(args);
-                            case "AreNotEquivalent": return FixCollectionAssertAreNotEquivalent(args);
-                            case "AreNotSame": return FixAssertAreNotSame(args);
-                            case "AreSame": return FixAssertAreSame(args);
-                            case "Contains": return FixStringAssertContains(args);
-                            case "DoesNotContain": return FixStringAssertDoesNotContain(args);
-                            case "EndsWith": return FixStringAssertEndsWith(args);
-                            case "Greater": return FixAssertGreater(args);
-                            case "GreaterOrEqual": return FixAssertGreaterOrEqual(args);
-                            case "IsEmpty": return FixAssertIsEmpty(args);
-                            case "IsFalse": return FixAssertIsFalse(args);
-                            case "IsNotEmpty": return FixAssertIsNotEmpty(args);
-                            case "IsNotNull": return FixAssertIsNotNull(args);
-                            case "IsNull": return FixAssertIsNull(args);
-                            case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(args);
-                            case "IsTrue": return FixAssertIsTrue(args);
-                            case "Less": return FixAssertLess(args);
-                            case "LessOrEqual": return FixAssertLessOrEqual(args);
-                            case "NotNull": return FixAssertNotNull(args);
-                            case "StartsWith": return FixStringAssertStartsWith(args);
+                            case "AreEqual": return FixAreEqual(args);
+                            case "AreEqualIgnoringCase": return FixAreEqualIgnoringCase(args);
+                            case "AreEquivalent": return FixAreEquivalent(args);
+                            case "AreNotEqual": return FixAreNotEqual(args);
+                            case "AreNotEquivalent": return FixAreNotEquivalent(args);
+                            case "AreNotSame": return FixAreNotSame(args);
+                            case "AreSame": return FixAreSame(args);
+                            case "Contains": return FixContains(args);
+                            case "DoesNotContain": return FixDoesNotContain(args);
+                            case "EndsWith": return FixEndsWith(args);
+                            case "Greater": return FixGreater(args);
+                            case "GreaterOrEqual": return FixGreaterOrEqual(args);
+                            case "IsEmpty": return FixIsEmpty(args);
+                            case "IsFalse": return FixIsFalse(args);
+                            case "IsNotEmpty": return FixIsNotEmpty(args);
+                            case "IsNotNull": return FixIsNotNull(args);
+                            case "IsNull": return FixIsNull(args);
+                            case "IsNullOrEmpty": return FixIsNullOrEmpty(args);
+                            case "IsTrue": return FixIsTrue(args);
+                            case "Less": return FixLess(args);
+                            case "LessOrEqual": return FixLessOrEqual(args);
+                            case "NotNull": return FixNotNull(args);
+                            case "StartsWith": return FixStartsWith(args);
                         }
 
                         break;
@@ -68,120 +68,51 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return original;
         }
 
-        private static InvocationExpressionSyntax FixAssertAreEqual(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("EqualTo", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixAreEqual(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("EqualTo", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertAreNotEqual(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("Not", "EqualTo", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixAreEqualIgnoringCase(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("EqualTo", args[0], "IgnoreCase"), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertAreSame(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("SameAs", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixAreEquivalent(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("EquivalentTo", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertAreNotSame(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("Not", "SameAs", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixAreNotEqual(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("Not", "EqualTo", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsTrue(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("True"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixAreNotEquivalent(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("Not", "EquivalentTo", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsFalse(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("False"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixAreNotSame(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("Not", "SameAs", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsNull(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Null"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixAreSame(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Is("SameAs", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsNullOrEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Null", "Or", "Empty"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixContains(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Does("Contain", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertNotNull(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Not", "Null"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixDoesNotContain(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Does("Not", "Contain", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsNotNull(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Not", "Null"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixEndsWith(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Does("EndWith", args[0]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Empty"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixGreater(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("GreaterThan", args[1]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertIsNotEmpty(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("Not", "Empty"), 1, args);
-        }
+        private static InvocationExpressionSyntax FixGreaterOrEqual(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("GreaterThanOrEqualTo", args[1]), 2, args);
 
-        private static InvocationExpressionSyntax FixAssertGreater(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("GreaterThan", args[1]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsEmpty(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Empty"), 1, args);
 
-        private static InvocationExpressionSyntax FixAssertGreaterOrEqual(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("GreaterThanOrEqualTo", args[1]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsFalse(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("False"), 1, args);
 
-        private static InvocationExpressionSyntax FixAssertLess(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("LessThan", args[1]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsNotEmpty(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Not", "Empty"), 1, args);
 
-        private static InvocationExpressionSyntax FixAssertLessOrEqual(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[0], Is("LessThanOrEqualTo", args[1]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsNotNull(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Not", "Null"), 1, args);
 
-        private static InvocationExpressionSyntax FixCollectionAssertAreEquivalent(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("EquivalentTo", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsNull(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Null"), 1, args);
 
-        private static InvocationExpressionSyntax FixCollectionAssertAreNotEquivalent(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("Not", "EquivalentTo", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsNullOrEmpty(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Null", "Or", "Empty"), 1, args);
 
-        private static InvocationExpressionSyntax FixStringAssertStartsWith(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Does("StartWith", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixIsTrue(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("True"), 1, args);
 
-        private static InvocationExpressionSyntax FixStringAssertEndsWith(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Does("EndWith", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixLess(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("LessThan", args[1]), 2, args);
 
-        private static InvocationExpressionSyntax FixStringAssertDoesNotContain(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Does("Not", "Contain", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixLessOrEqual(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("LessThanOrEqualTo", args[1]), 2, args);
 
-        private static InvocationExpressionSyntax FixStringAssertContains(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Does("Contain", args[0]), 2, args);
-        }
+        private static InvocationExpressionSyntax FixNotNull(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Is("Not", "Null"), 1, args);
 
-        private static InvocationExpressionSyntax FixStringAssertAreEqualIgnoringCase(SeparatedSyntaxList<ArgumentSyntax> args)
-        {
-            return AssertThat(args[1], Is("EqualTo", args[0], "IgnoreCase"), 2, args);
-        }
+        private static InvocationExpressionSyntax FixStartsWith(SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Does("StartWith", args[0]), 2, args);
 
         private static InvocationExpressionSyntax AssertThat(ArgumentSyntax argument, ArgumentSyntax constraint, int skip, SeparatedSyntaxList<ArgumentSyntax> arguments)
         {

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -29,27 +29,34 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     case "Assert":
                     case "CollectionAssert":
+                    case "StringAssert":
                     {
+                        var args = original.ArgumentList.Arguments;
+
                         switch (maes.GetName())
                         {
-                            case "AreEqual": return FixAssertAreEqual(original.ArgumentList.Arguments);
-                            case "AreEquivalent": return FixCollectionAssertAreEquivalent(original.ArgumentList.Arguments);
-                            case "AreNotEqual": return FixAssertAreNotEqual(original.ArgumentList.Arguments);
-                            case "AreNotEquivalent": return FixCollectionAssertAreNotEquivalent(original.ArgumentList.Arguments);
-                            case "AreNotSame": return FixAssertAreNotSame(original.ArgumentList.Arguments);
-                            case "AreSame": return FixAssertAreSame(original.ArgumentList.Arguments);
-                            case "Greater": return FixAssertGreater(original.ArgumentList.Arguments);
-                            case "GreaterOrEqual": return FixAssertGreaterOrEqual(original.ArgumentList.Arguments);
-                            case "IsEmpty": return FixAssertIsEmpty(original.ArgumentList.Arguments);
-                            case "IsFalse": return FixAssertIsFalse(original.ArgumentList.Arguments);
-                            case "IsNotEmpty": return FixAssertIsNotEmpty(original.ArgumentList.Arguments);
-                            case "IsNotNull": return FixAssertIsNotNull(original.ArgumentList.Arguments);
-                            case "IsNull": return FixAssertIsNull(original.ArgumentList.Arguments);
-                            case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(original.ArgumentList.Arguments);
-                            case "IsTrue": return FixAssertIsTrue(original.ArgumentList.Arguments);
-                            case "Less": return FixAssertLess(original.ArgumentList.Arguments);
-                            case "LessOrEqual": return FixAssertLessOrEqual(original.ArgumentList.Arguments);
-                            case "NotNull": return FixAssertNotNull(original.ArgumentList.Arguments);
+                            case "AreEqual": return FixAssertAreEqual(args);
+                            case "AreEquivalent": return FixCollectionAssertAreEquivalent(args);
+                            case "AreNotEqual": return FixAssertAreNotEqual(args);
+                            case "AreNotEquivalent": return FixCollectionAssertAreNotEquivalent(args);
+                            case "AreNotSame": return FixAssertAreNotSame(args);
+                            case "AreSame": return FixAssertAreSame(args);
+                            case "Contains": return FixStringAssertContains(args);
+                            case "DoesNotContain": return FixStringAssertDoesNotContain(args);
+                            case "EndsWith": return FixStringAssertEndsWith(args);
+                            case "Greater": return FixAssertGreater(args);
+                            case "GreaterOrEqual": return FixAssertGreaterOrEqual(args);
+                            case "IsEmpty": return FixAssertIsEmpty(args);
+                            case "IsFalse": return FixAssertIsFalse(args);
+                            case "IsNotEmpty": return FixAssertIsNotEmpty(args);
+                            case "IsNotNull": return FixAssertIsNotNull(args);
+                            case "IsNull": return FixAssertIsNull(args);
+                            case "IsNullOrEmpty": return FixAssertIsNullOrEmpty(args);
+                            case "IsTrue": return FixAssertIsTrue(args);
+                            case "Less": return FixAssertLess(args);
+                            case "LessOrEqual": return FixAssertLessOrEqual(args);
+                            case "NotNull": return FixAssertNotNull(args);
+                            case "StartsWith": return FixStringAssertStartsWith(args);
                         }
 
                         break;
@@ -150,6 +157,26 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(args[1], Is("Not", "EquivalentTo", args[0]), 2, args);
         }
 
+        private static InvocationExpressionSyntax FixStringAssertStartsWith(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Does("StartWith", args[0]), 2, args);
+        }
+
+        private static InvocationExpressionSyntax FixStringAssertEndsWith(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Does("EndWith", args[0]), 2, args);
+        }
+
+        private static InvocationExpressionSyntax FixStringAssertDoesNotContain(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Does("Not", "Contain", args[0]), 2, args);
+        }
+
+        private static InvocationExpressionSyntax FixStringAssertContains(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Does("Contain", args[0]), 2, args);
+        }
+
         private static InvocationExpressionSyntax AssertThat(ArgumentSyntax argument, ArgumentSyntax constraint, int skip, SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var args = new List<ArgumentSyntax>();
@@ -178,5 +205,16 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static ArgumentSyntax Is(params string[] names) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", names));
 
         private static ArgumentSyntax Is(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, arguments));
+
+        private static ArgumentSyntax Does(string name, string name1, ArgumentSyntax argument)
+        {
+            var expression = CreateSimpleMemberAccessExpressionSyntax("Does", name, name1);
+
+            return SyntaxFactory.Argument(CreateInvocationSyntax(expression, argument));
+        }
+
+        private static ArgumentSyntax Does(params string[] names) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Does", names));
+
+        private static ArgumentSyntax Does(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Does", name, arguments));
     }
 }

--- a/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -36,6 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         switch (maes.GetName())
                         {
                             case "AreEqual": return FixAssertAreEqual(args);
+                            case "AreEqualIgnoringCase": return FixStringAssertAreEqualIgnoringCase(args);
                             case "AreEquivalent": return FixCollectionAssertAreEquivalent(args);
                             case "AreNotEqual": return FixAssertAreNotEqual(args);
                             case "AreNotEquivalent": return FixCollectionAssertAreNotEquivalent(args);
@@ -177,6 +178,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(args[1], Does("Contain", args[0]), 2, args);
         }
 
+        private static InvocationExpressionSyntax FixStringAssertAreEqualIgnoringCase(SeparatedSyntaxList<ArgumentSyntax> args)
+        {
+            return AssertThat(args[1], Is("EqualTo", args[0], "IgnoreCase"), 2, args);
+        }
+
         private static InvocationExpressionSyntax AssertThat(ArgumentSyntax argument, ArgumentSyntax constraint, int skip, SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var args = new List<ArgumentSyntax>();
@@ -195,6 +201,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ArgumentSyntax Is(string name) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", name));
 
+        private static ArgumentSyntax Is(string name, ArgumentSyntax argument) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, argument));
+
         private static ArgumentSyntax Is(string name, string name1, ArgumentSyntax argument)
         {
             var expression = CreateSimpleMemberAccessExpressionSyntax("Is", name, name1);
@@ -202,9 +210,16 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return SyntaxFactory.Argument(CreateInvocationSyntax(expression, argument));
         }
 
+        private static ArgumentSyntax Is(string name, ArgumentSyntax argument, string name1)
+        {
+            var expression = CreateInvocationSyntax("Is", name, argument);
+
+            return SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax(expression, name1));
+        }
+
         private static ArgumentSyntax Is(params string[] names) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Is", names));
 
-        private static ArgumentSyntax Is(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Is", name, arguments));
+        private static ArgumentSyntax Does(string name, ArgumentSyntax argument) => SyntaxFactory.Argument(CreateInvocationSyntax("Does", name, argument));
 
         private static ArgumentSyntax Does(string name, string name1, ArgumentSyntax argument)
         {
@@ -214,7 +229,5 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         }
 
         private static ArgumentSyntax Does(params string[] names) => SyntaxFactory.Argument(CreateSimpleMemberAccessExpressionSyntax("Does", names));
-
-        private static ArgumentSyntax Does(string name, params ArgumentSyntax[] arguments) => SyntaxFactory.Argument(CreateInvocationSyntax("Does", name, arguments));
     }
 }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1001_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1001_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1001_EventArgsParameterAnalyzer.Id;
 
-        protected override string Title => "Rename event argument";
+        protected override string Title => Resources.MiKo_1001_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1001_EventArgsParameterAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1002_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1002_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1002_EventHandlingMethodParametersAnalyzer.Id;
 
-        protected override string Title => "Rename event argument";
+        protected override string Title => Resources.MiKo_1002_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1002_EventHandlingMethodParametersAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1003_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1003_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.Id;
 
-        protected override string Title => "Rename method according to event pattern";
+        protected override string Title => Resources.MiKo_1003_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1005_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1005_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1005_EventArgsLocalVariableAnalyzer.Id;
 
-        protected override string Title => "Rename EventArgs variable";
+        protected override string Title => Resources.MiKo_1005_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1005_EventArgsLocalVariableAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1008_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1008_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1008_DependencyPropertyEventHandlingMethodParametersAnalyzer.Id;
 
-        protected override string Title => "Rename DependencyProperty event handler argument";
+        protected override string Title => Resources.MiKo_1008_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1008_DependencyPropertyEventHandlingMethodParametersAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1012_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1012_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1012_FireMethodsAnalyzer.Id;
 
-        protected override string Title => "Rename 'fire' to 'raise'";
+        protected override string Title => Resources.MiKo_1012_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1012_FireMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1013_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1013_CodeFixProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1013_CodeFixProvider)), Shared]
+    public sealed class MiKo_1013_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_1013_NotifyMethodsAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_1013_CodeFixTitle;
+
+        protected override string GetNewName(ISymbol symbol) => MiKo_1013_NotifyMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
+
+        protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<MethodDeclarationSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
@@ -12,14 +12,31 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1013";
 
-        private static readonly string[] StartingPhrases = { "Notify", "OnNotify" };
+        private const string CorrectStartingPhrase = "On";
+        private const string StartingPhrase = "Notify";
+
+        private static readonly string[] StartingPhrases = { StartingPhrase, CorrectStartingPhrase + StartingPhrase };
 
         public MiKo_1013_NotifyMethodsAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol method) => method.Name.StartsWithAny(StartingPhrases, StringComparison.Ordinal)
-                                                                                            ? new[] { Issue(method) }
-                                                                                            : Enumerable.Empty<Diagnostic>();
+        internal static string FindBetterName(IMethodSymbol method) => method.Name
+                                                                             .Replace(StartingPhrase, CorrectStartingPhrase)
+                                                                             .Replace(CorrectStartingPhrase + CorrectStartingPhrase, CorrectStartingPhrase); // may happen for "OnNotifyXyz"
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol method)
+        {
+            if (method.Name.StartsWithAny(StartingPhrases))
+            {
+                // avoid situation that method has no name
+                if (method.Name.Without(StartingPhrase).Length != 0)
+                {
+                    return new[] { Issue(method) };
+                }
+            }
+
+            return Enumerable.Empty<Diagnostic>();
+        }
     }
 }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
@@ -12,10 +12,21 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1014";
 
-        private static readonly string[] StartingPhrases = { "CheckIn", "CheckOut" };
+        private const string Phrase = "Check";
+
+        private static readonly string[] StartingPhrases = { "CheckIn", "CheckOut", "CheckAccess" };
 
         public MiKo_1014_CheckMethodsAnalyzer() : base(Id)
         {
+        }
+
+        internal static string FindBetterName(IMethodSymbol method)
+        {
+            var prefix = method.ReturnsVoid
+                             ? method.Parameters.Any() ? "Validate" : "Verify"
+                             : method.ReturnType.IsBoolean() ? "Can" : "Find";
+
+            return prefix + method.Name.Substring(Phrase.Length);
         }
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod() is false;
@@ -23,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol method)
         {
             var methodName = method.Name;
-            var forbidden = methodName.StartsWith("Check", StringComparison.Ordinal) && methodName.StartsWithAny(StartingPhrases, StringComparison.Ordinal) is false;
+            var forbidden = methodName.StartsWith(Phrase, StringComparison.Ordinal) && methodName.StartsWithAny(StartingPhrases, StringComparison.Ordinal) is false;
             return forbidden
                        ? new[] { Issue(method) }
                        : Enumerable.Empty<Diagnostic>();

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1014_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1014_CodeFixProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1014_CodeFixProvider)), Shared]
+    public sealed class MiKo_1014_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_1014_CheckMethodsAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_1014_CodeFixTitle;
+
+        protected override string GetNewName(ISymbol symbol) => MiKo_1014_CheckMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
+
+        protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<MethodDeclarationSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1015_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1015_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1015_InitMethodsAnalyzer.Id;
 
-        protected override string Title => "Rename 'Init' to 'Initialize'";
+        protected override string Title => Resources.MiKo_1015_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1015_InitMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1016_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1016_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1016_FactoryMethodsAnalyzer.Id;
 
-        protected override string Title => "Rename factory method";
+        protected override string Title => Resources.MiKo_1016_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.First();
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1019_ClearRemoveMethodsAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1019_ClearRemoveMethodsAnalyzer.cs
@@ -23,20 +23,22 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                            ? method.Name.Replace(Clear, Remove)
                                                                            : method.Name.Replace(Remove, Clear);
 
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod() is false;
+
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol method)
         {
             var methodName = method.Name;
 
             const StringComparison Comparison = StringComparison.Ordinal;
 
-            if (methodName.StartsWith(Clear, Comparison) && !methodName.StartsWith(Clear + "s", Comparison))
+            if (methodName.StartsWith(Clear, Comparison) && methodName.StartsWith(Clear + "s", Comparison) is false)
             {
                 return method.Parameters.Any()
                        ? new[] { Issue(method, methodName.Replace(Clear, Remove)) }
                        : Enumerable.Empty<Diagnostic>();
             }
 
-            if (methodName.StartsWith(Remove, Comparison) && !methodName.StartsWith(Remove + "s", Comparison))
+            if (methodName.StartsWith(Remove, Comparison) && methodName.StartsWith(Remove + "s", Comparison) is false)
             {
                 return method.Parameters.Any()
                        ? Enumerable.Empty<Diagnostic>()

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1019_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1019_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1019_ClearRemoveMethodsAnalyzer.Id;
 
-        protected override string Title => "Rename 'Clear' and 'Remove'";
+        protected override string Title => Resources.MiKo_1019_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1019_ClearRemoveMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1030_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1030_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1030_BaseTypePrefixSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove base type indicator";
+        protected override string Title => Resources.MiKo_1030_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1030_BaseTypePrefixSuffixAnalyzer.FindBetterName((INamedTypeSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1031_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1031_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1031_TypeModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1031_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1031_TypeModelSuffixAnalyzer.FindBetterName((INamedTypeSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1032_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1032_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1032_MethodModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1032_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1032_MethodModelSuffixAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1033_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1033_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1033_ParameterModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1033_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1033_ParameterModelSuffixAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1034_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1034_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1034_FieldModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1034_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1034_FieldModelSuffixAnalyzer.FindBetterName((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1035_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1035_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1035_PropertyModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1035_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1035_PropertyModelSuffixAnalyzer.FindBetterName((IPropertySymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1036_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1036_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1036_EventModelSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Model' indicator";
+        protected override string Title => Resources.MiKo_1036_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1036_EventModelSuffixAnalyzer.FindBetterName((IEventSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1037_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1037_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1037_EnumSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove 'Enum' suffix";
+        protected override string Title => Resources.MiKo_1037_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1037_EnumSuffixAnalyzer.FindBetterName((INamedTypeSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1039_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1039_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1039_ExtensionMethodsParameterAnalyzer.Id;
 
-        protected override string Title => "Rename 'this' argument";
+        protected override string Title => Resources.MiKo_1039_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1039_ExtensionMethodsParameterAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1050_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1050_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1050_ReturnValueLocalVariableAnalyzer.Id;
 
-        protected override string Title => "Rename return value";
+        protected override string Title => Resources.MiKo_1050_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1050_ReturnValueLocalVariableAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1053_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1053_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1053_DelegateFieldNameSuffixAnalyzer.Id;
 
-        protected override string Title => "Rename delegate field";
+        protected override string Title => Resources.MiKo_1053_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1053_DelegateFieldNameSuffixAnalyzer.FindBetterName((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
@@ -13,12 +13,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1055_1056_CodeFixProvider : NamingCodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
-                                                                                         MiKo_1055_DependencyPropertyFieldSuffixAnalyzer.Id,
-                                                                                         MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.Id);
+                                                                                             MiKo_1055_DependencyPropertyFieldSuffixAnalyzer.Id,
+                                                                                             MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.Id);
 
-        public override string FixableDiagnosticId => MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.Id;
+        public override string FixableDiagnosticId => MiKo_1055_DependencyPropertyFieldSuffixAnalyzer.Id;
 
-        protected override string Title => "Rename dependency property";
+        protected override string Title => Resources.MiKo_1055_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.FindBetterName((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
@@ -16,9 +16,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                                              MiKo_1057_DependencyPropertyKeyFieldSuffixAnalyzer.Id,
                                                                                              MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzer.Id);
 
-        public override string FixableDiagnosticId => MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.Id;
+        public override string FixableDiagnosticId => MiKo_1057_DependencyPropertyKeyFieldSuffixAnalyzer.Id;
 
-        protected override string Title => "Rename dependency property key";
+        protected override string Title => Resources.MiKo_1057_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzer.FindBetterName((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1061_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1061_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1061_TryMethodOutParameterNameAnalyzer.Id;
 
-        protected override string Title => "Rename out parameter";
+        protected override string Title => Resources.MiKo_1061_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1061_TryMethodOutParameterNameAnalyzer.FindBetterName(symbol.GetEnclosingMethod());
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1065_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1065_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1065_OperatorParameterNameAnalyzer.Id;
 
-        protected override string Title => "Rename operator parameter";
+        protected override string Title => Resources.MiKo_1065_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1065_OperatorParameterNameAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1067_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1067_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1067_PerformMethodsAnalyzer.Id;
 
-        protected override string Title => "Remove 'Perform' from name";
+        protected override string Title => Resources.MiKo_1067_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1067_PerformMethodsAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1070_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1070_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1070_CollectionLocalVariableAnalyzer.Id;
 
-        protected override string Title => "Rename variable into plural";
+        protected override string Title => Resources.MiKo_1070_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1070_CollectionLocalVariableAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1081_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1081_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1081_MethodsWithNumberSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove number";
+        protected override string Title => Resources.MiKo_1081_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1081_MethodsWithNumberSuffixAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1082_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1082_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1082_PropertiesWithNumberSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove number";
+        protected override string Title => Resources.MiKo_1082_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1082_PropertiesWithNumberSuffixAnalyzer.FindBetterName((IPropertySymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1083_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1083_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1083_FieldsWithNumberSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove number";
+        protected override string Title => Resources.MiKo_1083_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1083_FieldsWithNumberSuffixAnalyzer.FindBetterName((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1084_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1084_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1084_VariablesWithNumberSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove number";
+        protected override string Title => Resources.MiKo_1084_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1084_VariablesWithNumberSuffixAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1085_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1085_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1085_ParametersWithNumberSuffixAnalyzer.Id;
 
-        protected override string Title => "Remove number";
+        protected override string Title => Resources.MiKo_1085_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1085_ParametersWithNumberSuffixAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1090_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1090_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1090_ParametersWrongSuffixedAnalyzer.Id;
 
-        protected override string Title => "Rename parameter";
+        protected override string Title => Resources.MiKo_1090_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1090_ParametersWrongSuffixedAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1091_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1091_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1091_VariableWrongSuffixedAnalyzer.Id;
 
-        protected override string Title => "Remove variable suffix";
+        protected override string Title => Resources.MiKo_1091_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1091_VariableWrongSuffixedAnalyzer.FindBetterName(symbol);
     }

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1092_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1092_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.Id;
 
-        protected override string Title => "Remove suffix";
+        protected override string Title => Resources.MiKo_1092_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.FindBetterName((INamedTypeSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1101_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1101_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1101_TestClassesSuffixAnalyzer.Id;
 
-        protected override string Title => "Append 'Tests' suffix";
+        protected override string Title => Resources.MiKo_1101_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1101_TestClassesSuffixAnalyzer.FindBetterName((INamedTypeSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1108_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1108_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1108_MockNamingAnalyzer.Id;
 
-        protected override string Title => "Remove Mock suffix";
+        protected override string Title => Resources.MiKo_1108_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1108_MockNamingAnalyzer.FindBetterName(symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1110_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1110_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1110_TestMethodsSuffixedWithUnderscoreAnalyzer.Id;
 
-        protected override string Title => "Append underscore";
+        protected override string Title => Resources.MiKo_1110_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1110_TestMethodsSuffixedWithUnderscoreAnalyzer.FindBetterName((IMethodSymbol)symbol);
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1200_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1200_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1200_ExceptionCatchBlockAnalyzer.Id;
 
-        protected override string Title => "Rename exception";
+        protected override string Title => Resources.MiKo_1200_CodeFixTitle;
 
         protected override string GetNewName(ISymbol symbol) => MiKo_1200_ExceptionCatchBlockAnalyzer.ExpectedName;
 

--- a/MiKo.Analyzer/Rules/Naming/MiKo_1201_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Naming/MiKo_1201_CodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public override string FixableDiagnosticId => MiKo_1201_ExceptionParameterAnalyzer.Id;
 
-        protected override string Title => "Rename exception";
+        protected override string Title => Resources.MiKo_1201_CodeFixTitle;
 
         protected override string FindBetterName(IParameterSymbol symbol) => MiKo_1201_ExceptionParameterAnalyzer.ExpectedName;
     }

--- a/MiKo.Analyzer/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer/Rules/Naming/NamingAnalyzer.cs
@@ -116,6 +116,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var semanticModel = context.SemanticModel;
             var type = node.Declaration.GetTypeSymbol(semanticModel);
 
+            if (type is null)
+            {
+                // may happen for a "ref var xyz" value
+                return;
+            }
+
             if (ShallAnalyze(type) is false)
             {
                 return;

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4003_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4003_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.Id;
 
-        protected override string Title => "Place Dispose method after ctors and finalizers";
+        protected override string Title => Resources.MiKo_4003_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4004_ImplementedInterfaceOrderedAfterClassAnalyzer.Id;
 
-        protected override string Title => "Place corresponding interface directly after type declaration";
+        protected override string Title => Resources.MiKo_4004_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4101_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4101_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4101_TestSetUpMethodOrderingAnalyzer.Id;
 
-        protected override string Title => Resources.MiKo_4101_MessageFormat;
+        protected override string Title => Resources.MiKo_4101_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4102_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4102_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4102_TestTearDownMethodOrderingAnalyzer.Id;
 
-        protected override string Title => Resources.MiKo_4102_MessageFormat;
+        protected override string Title => Resources.MiKo_4102_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4103_TestOneTimeSetUpMethodOrderingAnalyzer.Id;
 
-        protected override string Title => Resources.MiKo_4103_MessageFormat;
+        protected override string Title => Resources.MiKo_4103_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Ordering/MiKo_4104_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Ordering/MiKo_4104_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => MiKo_4104_TestOneTimeTearDownMethodOrderingAnalyzer.Id;
 
-        protected override string Title => Resources.MiKo_4104_MessageFormat;
+        protected override string Title => Resources.MiKo_4104_CodeFixTitle;
 
         protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax syntax)
         {

--- a/MiKo.Analyzer/Rules/Performance/MiKo_5001_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Performance/MiKo_5001_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
     {
         public override string FixableDiagnosticId => MiKo_5001_DebugLogIsEnabledAnalyzer.Id;
 
-        protected override string Title => "Place inside 'if'";
+        protected override string Title => Resources.MiKo_5001_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ExpressionStatementSyntax>().First();
 

--- a/MiKo.Analyzer/Rules/Performance/MiKo_5010_CodeFixProvider.cs
+++ b/MiKo.Analyzer/Rules/Performance/MiKo_5010_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
     {
         public override string FixableDiagnosticId => MiKo_5010_EqualsAnalyzer.Id;
 
-        protected override string Title => "Replace 'Equals' by '=='";
+        protected override string Title => Resources.MiKo_5010_CodeFixTitle;
 
         protected override SyntaxNode GetSyntax(IReadOnlyCollection<SyntaxNode> syntaxNodes)
         {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following tables list all the 281 rules that are currently provided by the a
 |MiKo_1010|Methods should not contain 'CanExecute' or 'Execute' in their names.|&#x2713;|\-|
 |MiKo_1011|Methods should not contain 'Do' in their names.|&#x2713;|\-|
 |MiKo_1012|Methods should not be named 'Fire'.|&#x2713;|&#x2713;|
-|MiKo_1013|Methods should not be named 'Notify' or 'OnNotify'.|&#x2713;|\-|
+|MiKo_1013|Methods should not be named 'Notify' or 'OnNotify'.|&#x2713;|&#x2713;|
 |MiKo_1014|Methods should not be named 'Check'.|&#x2713;|&#x2713;|
 |MiKo_1015|Methods should not be named 'Init'.|&#x2713;|&#x2713;|
 |MiKo_1016|Factory methods should be named 'Create'.|&#x2713;|&#x2713;|

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following tables list all the 281 rules that are currently provided by the a
 |MiKo_1011|Methods should not contain 'Do' in their names.|&#x2713;|\-|
 |MiKo_1012|Methods should not be named 'Fire'.|&#x2713;|&#x2713;|
 |MiKo_1013|Methods should not be named 'Notify' or 'OnNotify'.|&#x2713;|\-|
-|MiKo_1014|Methods should not be named 'Check'.|&#x2713;|\-|
+|MiKo_1014|Methods should not be named 'Check'.|&#x2713;|&#x2713;|
 |MiKo_1015|Methods should not be named 'Init'.|&#x2713;|&#x2713;|
 |MiKo_1016|Factory methods should be named 'Create'.|&#x2713;|&#x2713;|
 |MiKo_1017|Methods should not be prefixed with 'Get' or 'Set' if followed by 'Is', 'Can' or 'Has'.|&#x2713;|\-|


### PR DESCRIPTION
- New codefix provider for MiKo_1013 and MiKo_1014
- bugfixes, one for NRE caused by `ref var xyz` variable declarations
- codefix provider for MiKo_3105 now supports more Assert.xyz fixes
- MiKo_1019 analyzer now ignores test methods