### PR TITLE
Added new rules MiKo_3116 and MiKo_3117 that report empty test initialization or cleanup methods as unneeded 

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -389,6 +389,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3114_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3114_UseMockOfInsteadMockObjectAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3115_TestMethodsContainCodeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -11364,6 +11364,60 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Methods that are marked as unit test initialization methods but are empty are not needed and clutter only the code base. Hence such methods can be removed without fear..
+        /// </summary>
+        public static string MiKo_3116_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3116_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete empty test initialization method.
+        /// </summary>
+        public static string MiKo_3116_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3116_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test initialization methods should contain code.
+        /// </summary>
+        public static string MiKo_3116_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3116_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Methods that are marked as unit test cleanup methods but are empty are not needed and clutter only the code base. Hence such methods can be removed without fear..
+        /// </summary>
+        public static string MiKo_3117_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3117_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete empty test cleanup method.
+        /// </summary>
+        public static string MiKo_3117_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3117_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test cleanup methods should contain code.
+        /// </summary>
+        public static string MiKo_3117_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3117_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         public static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4016,6 +4016,24 @@ It may even be that the contained code is commented out, leading to the question
   <data name="MiKo_3115_Title" xml:space="preserve">
     <value>Test methods should contain code</value>
   </data>
+  <data name="MiKo_3116_Description" xml:space="preserve">
+    <value>Methods that are marked as unit test initialization methods but are empty are not needed and clutter only the code base. Hence such methods can be removed without fear.</value>
+  </data>
+  <data name="MiKo_3116_MessageFormat" xml:space="preserve">
+    <value>Delete empty test initialization method</value>
+  </data>
+  <data name="MiKo_3116_Title" xml:space="preserve">
+    <value>Test initialization methods should contain code</value>
+  </data>
+  <data name="MiKo_3117_Description" xml:space="preserve">
+    <value>Methods that are marked as unit test cleanup methods but are empty are not needed and clutter only the code base. Hence such methods can be removed without fear.</value>
+  </data>
+  <data name="MiKo_3117_MessageFormat" xml:space="preserve">
+    <value>Delete empty test cleanup method</value>
+  </data>
+  <data name="MiKo_3117_Title" xml:space="preserve">
+    <value>Test cleanup methods should contain code</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3116_TestSetUpMethodsContainCodeAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3116";
+
+        public MiKo_3116_TestSetUpMethodsContainCodeAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+
+        private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            var method = (MethodDeclarationSyntax)context.Node;
+            var methodBody = method.Body;
+
+            if (methodBody != null && methodBody.Statements.Count == 0 && method.IsTestSetUpMethod() && method.IsAbstract() is false)
+            {
+                ReportDiagnostics(context, Issue(method));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3117_TestTearDownMethodsContainCodeAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3117";
+
+        public MiKo_3117_TestTearDownMethodsContainCodeAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+
+        private void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            var method = (MethodDeclarationSyntax)context.Node;
+            var methodBody = method.Body;
+
+            if (methodBody != null && methodBody.Statements.Count == 0 && method.IsTestTearDownMethod() && method.IsAbstract() is false)
+            {
+                ReportDiagnostics(context, Issue(method));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzerTests.cs
@@ -7,10 +7,10 @@ using TestHelper;
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [TestFixture]
-    public sealed class MiKo_3115_TestMethodsContainCodeAnalyzerTests : CodeFixVerifier
+    public sealed class MiKo_3116_TestSetUpMethodsContainCodeAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_empty_non_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_non_test_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -23,7 +23,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_empty_non_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_empty_non_test_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -39,7 +39,58 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_test_setup_or_teardown_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_test_or_teardown_method() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething() { }
+
+        [TearDown]
+        public void CleanupTest() { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_setup_method_that_contains_only_a_single_line_comment() => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            // some comment
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_setup_method_that_contains_only_a_multi_line_comment() => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            /* some comment */
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_empty_test_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -49,57 +100,6 @@ namespace Bla
     public class TestMe
     {
         [SetUp]
-        public void PrepareTest() { }
-
-        [TearDown]
-        public void CleanupTest() { }
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_non_test_method_that_contains_only_a_single_line_comment() => No_issue_is_reported_for(@"
-using System;
-
-namespace Bla
-{
-    public class TestMe
-    {
-        public void DoSomething()
-        {
-            // some comment
-        }
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_non_test_method_that_contains_only_a_multi_line_comment() => No_issue_is_reported_for(@"
-using System;
-
-namespace Bla
-{
-    public class TestMe
-    {
-        public void DoSomething()
-        {
-            /* some comment */
-        }
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_non_empty_test_method() => No_issue_is_reported_for(@"
-using System;
-
-using NUnit.Framework;
-
-namespace Bla
-{
-    public class TestMe
-    {
-        [Test]
         public void DoSomething()
         {
             var x = 0;
@@ -109,7 +109,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_abstract_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_abstract_test_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -118,14 +118,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [SetUp]
         public abstract void DoSomething();
     }
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_expression_body_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_expression_body_test_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -134,14 +134,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [SetUp]
         public void DoSomething() => Assert.Fail();
     }
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_empty_test_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_test_setup_method() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -150,14 +150,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [SetUp]
         public void DoSomething() { }
     }
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_that_contains_only_a_single_line_comment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_setup_method_that_contains_only_a_single_line_comment() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -166,7 +166,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [SetUp]
         public void DoSomething()
         {
             // some comment
@@ -176,7 +176,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_that_contains_only_a_multi_line_comment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_setup_method_that_contains_only_a_multi_line_comment() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -185,7 +185,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [SetUp]
         public void DoSomething()
         {
             /* some comment */
@@ -194,8 +194,8 @@ namespace Bla
 }
 ");
 
-        protected override string GetDiagnosticId() => MiKo_3115_TestMethodsContainCodeAnalyzer.Id;
+        protected override string GetDiagnosticId() => MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.Id;
 
-        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3115_TestMethodsContainCodeAnalyzer();
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3116_TestSetUpMethodsContainCodeAnalyzer();
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzerTests.cs
@@ -7,10 +7,10 @@ using TestHelper;
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [TestFixture]
-    public sealed class MiKo_3115_TestMethodsContainCodeAnalyzerTests : CodeFixVerifier
+    public sealed class MiKo_3117_TestTearDownMethodsContainCodeAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_empty_non_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_non_test_teardown_method() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -23,7 +23,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_empty_non_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_empty_non_test_teardown_method() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -39,7 +39,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_test_setup_or_teardown_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_test_or_setup_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -51,14 +51,14 @@ namespace Bla
         [SetUp]
         public void PrepareTest() { }
 
-        [TearDown]
-        public void CleanupTest() { }
+        [Test]
+        public void DoSomething() { }
     }
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_test_method_that_contains_only_a_single_line_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_test_teardown_method_that_contains_only_a_single_line_comment() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -74,7 +74,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_test_method_that_contains_only_a_multi_line_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_test_teardown_method_that_contains_only_a_multi_line_comment() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -90,7 +90,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_empty_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_empty_test_teardown_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -99,7 +99,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public void DoSomething()
         {
             var x = 0;
@@ -109,7 +109,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_abstract_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_abstract_test_teardown_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -118,14 +118,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public abstract void DoSomething();
     }
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_expression_body_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_expression_body_test_teardown_method() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -134,14 +134,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public void DoSomething() => Assert.Fail();
     }
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_empty_test_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_test_teardown_method() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -150,14 +150,14 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public void DoSomething() { }
     }
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_that_contains_only_a_single_line_comment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_teardown_method_that_contains_only_a_single_line_comment() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -166,7 +166,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public void DoSomething()
         {
             // some comment
@@ -176,7 +176,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_that_contains_only_a_multi_line_comment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_teardown_method_that_contains_only_a_multi_line_comment() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;
@@ -185,7 +185,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [Test]
+        [TearDown]
         public void DoSomething()
         {
             /* some comment */
@@ -194,8 +194,8 @@ namespace Bla
 }
 ");
 
-        protected override string GetDiagnosticId() => MiKo_3115_TestMethodsContainCodeAnalyzer.Id;
+        protected override string GetDiagnosticId() => MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.Id;
 
-        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3115_TestMethodsContainCodeAnalyzer();
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3117_TestTearDownMethodsContainCodeAnalyzer();
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 391 rules that are currently provided by the analyzer.
+The following tables list all the 393 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -363,6 +363,8 @@ The following tables list all the 391 rules that are currently provided by the a
 |MiKo_3113|Do not use FluentAssertions|&#x2713;|&#x2713;|
 |MiKo_3114|Use &apos;Mock.Of&lt;T&gt;()&apos; instead of &apos;new Mock&lt;T&gt;().Object&apos;|&#x2713;|&#x2713;|
 |MiKo_3115|Test methods should contain code|&#x2713;|\-|
+|MiKo_3116|Test initialization methods should contain code|&#x2713;|\-|
+|MiKo_3117|Test cleanup methods should contain code|&#x2713;|\-|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
(resolves #538)