### PR TITLE
Added new rule MiKo_3046 that reports when using strings instead of 'nameof' on 'OnPropertyChanged' method invocations 

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -314,6 +314,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3045_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3045_EventManagerRegisterUsesNameofAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3046_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3047_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3047_ContentPropertyAttributeUsesNameofAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3048_ValueConverterHasAttributeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -9695,6 +9695,42 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
+        public static string MiKo_3046_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3046_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To prevent typos, any property raising method like &apos;OnPropertyChanged&apos; shall use &apos;nameof&apos; to define the property..
+        /// </summary>
+        public static string MiKo_3046_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3046_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;nameof&apos;.
+        /// </summary>
+        public static string MiKo_3046_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3046_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;nameof&apos; for property names of property raising methods.
+        /// </summary>
+        public static string MiKo_3046_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3046_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;nameof&apos;.
+        /// </summary>
         public static string MiKo_3047_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3047_CodeFixTitle", resourceCulture);

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3427,6 +3427,18 @@ Failures inside the delegate(s) are really hard to tackle down because an except
   <data name="MiKo_3045_Title" xml:space="preserve">
     <value>Use 'nameof' for EventManager event registrations</value>
   </data>
+  <data name="MiKo_3046_CodeFixTitle" xml:space="preserve">
+    <value>Use 'nameof'</value>
+  </data>
+  <data name="MiKo_3046_Description" xml:space="preserve">
+    <value>To prevent typos, any property raising method like 'OnPropertyChanged' shall use 'nameof' to define the property.</value>
+  </data>
+  <data name="MiKo_3046_MessageFormat" xml:space="preserve">
+    <value>Use 'nameof'</value>
+  </data>
+  <data name="MiKo_3046_Title" xml:space="preserve">
+    <value>Use 'nameof' for property names of property raising methods</value>
+  </data>
   <data name="MiKo_3047_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_CodeFixProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3046_CodeFixProvider)), Shared]
+    public sealed class MiKo_3046_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_3046_CodeFixTitle;
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<LiteralExpressionSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => NameOf((LiteralExpressionSyntax)syntax);
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3046";
+
+        private static readonly HashSet<string> ApplicableMethodNames = new HashSet<string>
+                                                                            {
+                                                                                "NotifyPropertyChanged",
+                                                                                "NotifyPropertyChanging",
+                                                                                "OnNotifyPropertyChanged",
+                                                                                "OnNotifyPropertyChanging",
+                                                                                "OnPropertyChanged",
+                                                                                "OnPropertyChanging",
+                                                                                "OnRaisePropertyChanged",
+                                                                                "OnRaisePropertyChanging",
+                                                                                "OnTriggerPropertyChanged",
+                                                                                "OnTriggerPropertyChanging",
+                                                                                "RaisePropertyChanged",
+                                                                                "RaisePropertyChanging",
+                                                                                "TriggerPropertyChanged",
+                                                                                "TriggerPropertyChanging",
+                                                                            };
+
+        public MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.StringLiteralExpression);
+
+        private static bool HasIssue(SyntaxNode node) => node.Parent is ArgumentSyntax a && a.Parent is ArgumentListSyntax al && al.Parent is InvocationExpressionSyntax i && ApplicableMethodNames.Contains(i.GetName());
+
+        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        {
+            var node = context.Node;
+
+            if (HasIssue(node))
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzerTests.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] MethodNames =
+                                                       {
+                                                           "NotifyPropertyChanged",
+                                                           "NotifyPropertyChanging",
+                                                           "OnNotifyPropertyChanged",
+                                                           "OnNotifyPropertyChanging",
+                                                           "OnPropertyChanged",
+                                                           "OnPropertyChanging",
+                                                           "OnRaisePropertyChanged",
+                                                           "OnRaisePropertyChanging",
+                                                           "OnTriggerPropertyChanged",
+                                                           "OnTriggerPropertyChanging",
+                                                           "RaisePropertyChanged",
+                                                           "RaisePropertyChanging",
+                                                           "TriggerPropertyChanged",
+                                                           "TriggerPropertyChanging",
+                                                       };
+
+        [Test]
+        public void No_issue_is_reported_for_method_with_nameof_applied_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public string MyProperty { get; set; }
+
+        private void DoSomething()
+        {
+            " + methodName + @"(nameof(MyProperty));
+        }
+
+        private void " + methodName + @"(string name)
+        { }
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_out_nameof_applied_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public string MyProperty { get; set; }
+
+        private void DoSomething()
+        {
+            " + methodName + @"(""MyProperty"");
+        }
+
+        private void " + methodName + @"(string name)
+        { }
+    }
+}");
+
+        [Test]
+        public void Code_gets_fixed_for_([ValueSource(nameof(MethodNames))] string methodName)
+        {
+            var originalCode = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public string MyProperty { get; set; }
+
+        private void DoSomething()
+        {
+            " + methodName + @"(""MyProperty"");
+        }
+
+        private void " + methodName + @"(string name)
+        { }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public string MyProperty { get; set; }
+
+        private void DoSomething()
+        {
+            " + methodName + @"(nameof(MyProperty));
+        }
+
+        private void " + methodName + @"(string name)
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3046_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 393 rules that are currently provided by the analyzer.
+The following tables list all the 394 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -313,6 +313,7 @@ The following tables list all the 393 rules that are currently provided by the a
 |MiKo_3043|Use 'nameof' for WeakEventManager event (de-)registrations|&#x2713;|&#x2713;|
 |MiKo_3044|Use 'nameof' to compare property names of 'PropertyChangingEventArgs' and 'PropertyChangedEventArgs'|&#x2713;|&#x2713;|
 |MiKo_3045|Use 'nameof' for EventManager event registrations|&#x2713;|&#x2713;|
+|MiKo_3046|Use 'nameof' for property names of property raising methods|&#x2713;|&#x2713;|
 |MiKo_3047|Use 'nameof' for applied [ContentProperty] attributes|&#x2713;|&#x2713;|
 |MiKo_3048|ValueConverters shall have the [ValueConversion] attribute applied|&#x2713;|\-|
 |MiKo_3049|Enum members shall have the [Description] attribute applied|&#x2713;|\-|


### PR DESCRIPTION
Resolves #540