### PR TITLE
MiKo_5010 now detects 'Equals' methods with multiple parameters

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
@@ -205,9 +205,12 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             }
 
             // seems specific Equals, so let's see if it is the negative one
-            if (node.Parent.IsAnyKind(StrangeMarkers))
+            if (node.Parent.IsAnyKind(StrangeMarkers) && node.ArgumentList.Arguments.Count == 1)
             {
-                return Issue(nodeSymbol.Name, node.Expression, "Equals");
+                if (node.Expression is MemberAccessExpressionSyntax syntax)
+                {
+                    return Issue(nodeSymbol.Name, syntax, "Equals");
+                }
             }
 
             return null;

--- a/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5010_EqualsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5010_EqualsAnalyzerTests.cs
@@ -225,6 +225,23 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_non_object_Equals_method_with_multiple_parameters() => No_issue_is_reported_for(@"
+using System;
+using Microsoft.CodeAnalysis;
+
+public class TestMe
+{
+    public void DoSomething(IParameterSymbol parameter, ITypeSymbol argumentType)
+    {
+        if (parameter.Type.Equals(argumentType, SymbolEqualityComparer.Default) is false)
+        {
+            throw new ArgumentException();
+        }
+    }
+}
+");
+
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = "Would look strange otherwise.")]
         [Test]
         public void An_issue_is_reported_for_IEquatable_equals_method_inside_equality_operator_of_struct_that_invokes_object_Equals() => An_issue_is_reported_for(2, @"


### PR DESCRIPTION
MiKo_5010 now detects that there are specific methods named 'Equals' that have more than 1 parameter and ignores them (except for 'object.Equals')