### PR TITLE
Added new rule MiKo_3118 that reports if test methods use ambiguous Linq calls (such as "Skip" or "FirstOrDefault")

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -399,6 +399,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3115_TestMethodsContainCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -7931,7 +7931,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use positive wording instead of negative.
+        ///   Looks up a localized string similar to Documentation should use positive wording instead of negative.
         /// </summary>
         public static string MiKo_2228_Title {
             get {
@@ -11615,6 +11615,35 @@ namespace MiKoSolutions.Analyzers {
         public static string MiKo_3117_Title {
             get {
                 return ResourceManager.GetString("MiKo_3117_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tests should be as explicit as possible.
+        ///Different Linq calls such as &apos;Skip&apos; or &apos;Take&apos; or &apos;FirstOrDefault&apos; help in production code but are not clear enough when used inside a tests.
+        ///For example, if the test uses &apos;Skip&apos;, it is unclear for the reader why the code should skip some values. Hence the reader needs to find out, which costs some time and could be easily avoided when the test would be more explicit here about the outcome..
+        /// </summary>
+        public static string MiKo_3118_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3118_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use ambiguous Linq call &apos;{0}&apos;.
+        /// </summary>
+        public static string MiKo_3118_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3118_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test methods should not use ambiguous Linq calls.
+        /// </summary>
+        public static string MiKo_3118_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3118_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4103,6 +4103,17 @@ It may even be that the contained code is commented out, leading to the question
   <data name="MiKo_3117_Title" xml:space="preserve">
     <value>Test cleanup methods should contain code</value>
   </data>
+  <data name="MiKo_3118_Description" xml:space="preserve">
+    <value>Tests should be as explicit as possible.
+Different Linq calls such as 'Skip' or 'Take' or 'FirstOrDefault' help in production code but are not clear enough when used inside a tests.
+For example, if the test uses 'Skip', it is unclear for the reader why the code should skip some values. Hence the reader needs to find out, which costs some time and could be easily avoided when the test would be more explicit here about the outcome.</value>
+  </data>
+  <data name="MiKo_3118_MessageFormat" xml:space="preserve">
+    <value>Do not use ambiguous Linq call '{0}'</value>
+  </data>
+  <data name="MiKo_3118_Title" xml:space="preserve">
+    <value>Test methods should not use ambiguous Linq calls</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3118";
+
+        private static readonly HashSet<string> ProblematicMethods = new HashSet<string>
+                                                                         {
+                                                                             nameof(Enumerable.Skip),
+                                                                             "SkipLast",
+                                                                             nameof(Enumerable.SkipWhile),
+                                                                             nameof(Enumerable.Take),
+                                                                             "TakeLast",
+                                                                             nameof(Enumerable.TakeWhile),
+                                                                             nameof(Enumerable.Single),
+                                                                             nameof(Enumerable.SingleOrDefault),
+                                                                             nameof(Enumerable.FirstOrDefault),
+                                                                             nameof(Enumerable.LastOrDefault),
+                                                                             nameof(Enumerable.Any),
+                                                                             nameof(Enumerable.All),
+                                                                         };
+
+        public MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsTestMethod();
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        {
+            var methodSyntax = symbol.GetSyntax();
+
+            foreach (var maes in methodSyntax.DescendantNodes<MemberAccessExpressionSyntax>(_ => _.Parent is InvocationExpressionSyntax))
+            {
+                var node = maes.Name;
+                var name = node.GetName();
+
+                if (ProblematicMethods.Contains(name))
+                {
+                    yield return Issue(name, node);
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzerTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_method() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_method_using_Linq() => No_issue_is_reported_for(@"
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public bool DoSomething(IEnumerable<int> values)
+    {
+         return values.Skip(1).Take(3).Any(_ => _ == 2);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_test_method() => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+public class TestMe
+{
+    [Test]
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_using_unproblematic_Linq() => No_issue_is_reported_for(@"
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+public class TestMe
+{
+    [Test]
+    public void DoSomething()
+    {
+        var result = Enumerable.Empty<int>();
+
+        Assert.That(result, Is.Empty);
+    }
+}
+");
+
+        [TestCase(nameof(Enumerable.Skip) + "(1)")]
+        [TestCase(nameof(Enumerable.SkipLast) + "()")]
+        [TestCase(nameof(Enumerable.SkipWhile) + "(true)")]
+        [TestCase(nameof(Enumerable.Take) + "(1)")]
+        [TestCase(nameof(Enumerable.TakeLast) + "()")]
+        [TestCase(nameof(Enumerable.TakeWhile) + "(true)")]
+        [TestCase(nameof(Enumerable.Any) + "(_ => _ == 2)")]
+        [TestCase(nameof(Enumerable.All) + "(_ => _ == 2)")]
+        [TestCase(nameof(Enumerable.FirstOrDefault) + "()")]
+        [TestCase(nameof(Enumerable.LastOrDefault) + "()")]
+        [TestCase(nameof(Enumerable.SingleOrDefault) + "()")]
+        [TestCase(nameof(Enumerable.Single) + "()")]
+        public void An_issue_is_reported_for_test_method_using_problematic_Linq_(string call) => An_issue_is_reported_for(@"
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+public class TestMe
+{
+    [Test]
+    public void DoSomething()
+    {
+        int[] values = { 1, 2, 3 };
+
+        var result = values." + call + @";
+
+        Assert.That(result, Is.Not.Null);
+    }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 403 rules that are currently provided by the analyzer.
+The following tables list all the 404 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -372,6 +372,7 @@ The following tables list all the 403 rules that are currently provided by the a
 |MiKo_3115|Test methods should contain code|&#x2713;|\-|
 |MiKo_3116|Test initialization methods should contain code|&#x2713;|\-|
 |MiKo_3117|Test cleanup methods should contain code|&#x2713;|\-|
+|MiKo_3118|Test methods should not use ambiguous Linq calls|&#x2713;|\-|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
resolves #599