### PR TITLE
Added new rule MiKo_6050 that reports multi-line arguments to be positioned outdented right below method call

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -759,6 +759,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6047_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6048_LogicalConditionsAreOnSameLineAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6050_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -14096,5 +14096,41 @@ namespace MiKoSolutions.Analyzers {
                 return ResourceManager.GetString("MiKo_6049_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place argument outdented below method call.
+        /// </summary>
+        public static string MiKo_6050_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6050_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To easily spot the multi-line arguments of a method call, those arguments should be positioned outdented below the corresponding method call..
+        /// </summary>
+        public static string MiKo_6050_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6050_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place argument &apos;{0}&apos; outdented below method call.
+        /// </summary>
+        public static string MiKo_6050_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6050_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multi-line arguments are positioned outdented at end of method call.
+        /// </summary>
+        public static string MiKo_6050_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6050_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4938,4 +4938,16 @@ Hence, the open brace of the expression should be positioned directly below the 
   <data name="MiKo_6049_Title" xml:space="preserve">
     <value>Event (un-)registrations should be surrounded by blank lines</value>
   </data>
+  <data name="MiKo_6050_CodeFixTitle" xml:space="preserve">
+    <value>Place argument outdented below method call</value>
+  </data>
+  <data name="MiKo_6050_Description" xml:space="preserve">
+    <value>To easily spot the multi-line arguments of a method call, those arguments should be positioned outdented below the corresponding method call.</value>
+  </data>
+  <data name="MiKo_6050_MessageFormat" xml:space="preserve">
+    <value>Place argument '{0}' outdented below method call</value>
+  </data>
+  <data name="MiKo_6050_Title" xml:space="preserve">
+    <value>Multi-line arguments are positioned outdented at end of method call</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected override string Title => Resources.MiKo_6050_CodeFixTitle;
 
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ArgumentSyntax>().First();
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ArgumentSyntax>().FirstOrDefault();
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
         {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6050_CodeFixProvider)), Shared]
+    public sealed class MiKo_6050_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_6050_CodeFixTitle;
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ArgumentSyntax>().First();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ArgumentSyntax argument)
+            {
+                var position = MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.GetOutdentedStartPosition(argument.FirstAncestor<ArgumentListSyntax>());
+                var spaces = position.Character;
+
+                return argument.WithLeadingSpaces(spaces);
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     // this is a new found line, so inspect start position
                     if (argumentPosition.Character != characterPosition)
                     {
-                        yield return Issue(argument.GetName(), argument);
+                        yield return Issue(argument.ToString(), argument);
                     }
                 }
                 else

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6050";
+
+        public MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer() : base(Id)
+        {
+        }
+
+        internal static LinePosition GetOutdentedStartPosition(ArgumentListSyntax argumentList)
+        {
+            var startPosition = argumentList.GetStartPosition();
+            var characterPosition = startPosition.Character + argumentList.OpenParenToken.Span.Length;
+
+            var arguments = argumentList.Arguments;
+
+            // inspect whether the first argument is on the same line as the method name itself, in such case we cannot outdent the arguments
+            if (arguments.Count > 0)
+            {
+                // hence we have to take the position of that very first argument
+                if (startPosition.Line != arguments[0].GetStartPosition().Line)
+                {
+                    characterPosition -= Constants.Indentation;
+                }
+            }
+
+            return new LinePosition(startPosition.Line, characterPosition);
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ArgumentList);
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ArgumentListSyntax argumentList && argumentList.Arguments.SeparatorCount > 0)
+            {
+                ReportDiagnostics(context, AnalyzeNode(argumentList));
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeNode(ArgumentListSyntax argumentList)
+        {
+            var startPosition = GetOutdentedStartPosition(argumentList);
+            var characterPosition = startPosition.Character;
+
+            var inspectedLines = new HashSet<int> { startPosition.Line };
+
+            foreach (var argument in argumentList.Arguments)
+            {
+                var argumentPosition = argument.GetStartPosition();
+
+                if (inspectedLines.Add(argumentPosition.Line))
+                {
+                    // this is a new found line, so inspect start position
+                    if (argumentPosition.Character != characterPosition)
+                    {
+                        yield return Issue(argument.GetName(), argument);
+                    }
+                }
+                else
+                {
+                    // line was already known, eg. due to a leading argument
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
@@ -1,0 +1,257 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_no_arguments() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        DoSomething();
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_1_argument() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x)
+    {
+        DoSomething(42);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_2_arguments_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y)
+    {
+        DoSomething(08, 15);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_2_arguments_where_2nd_argument_is_on_different_line_but_same_position_as_1st_argument() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y)
+    {
+        DoSomething(08,
+                    15);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_3_arguments_where_2nd_argument_is_on_different_line_but_same_position_as_1st_argument_and_3rd_argument_on_same_line_as_2nd_argument() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                    08, 15);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_3_arguments_where_3rd_argument_is_on_different_line_but_same_position_as_1st_argument_and_2nd_argument_on_same_line_as_3rd_argument() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(08, 15,
+                    42);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_3_arguments_where_2nd_and_3rd_argument_are_each_on_different_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                    08,
+                    15);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_call_with_3_arguments_where_all_arguments_each_are_on_different_line_and_outdented() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                123456,
+                789012,
+                -345678);
+    }
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:argumentMustNotSpanMultipleLines", Justification = "Would look strange otherwise.")]
+        [Test]
+        public void An_issue_is_reported_for_method_call_with_3_arguments_where_all_arguments_each_are_on_different_line_and_not_outdented() => An_issue_is_reported_for(3, @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                    42,
+                    08,
+                    15);
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_3_arguments_where_all_arguments_each_are_on_different_line_and_not_outdented()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                    123456,
+                    789012,
+                    -345678);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                123456,
+                789012,
+                -345678);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_3_arguments_where_all_arguments_each_are_on_different_line_and_messed_up_character_positions()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                  123456,
+                            789012,
+          -345678);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(
+                123456,
+                789012,
+                -345678);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_3_arguments_where_2nd_and_3rd_argument_are_each_on_different_line_and_messed_up_character_positions()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                08,
+                         15);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                    08,
+                    15);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6050_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
@@ -142,6 +142,37 @@ public class TestMe
 }
 ");
 
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:argumentMustNotSpanMultipleLines", Justification = "Would look strange otherwise.")]
+        [Test]
+        public void An_issue_is_reported_for_method_call_with_3_arguments_where_middle_one_is_ternary_operator() => An_issue_is_reported_for(3, @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, bool flag)
+    {
+        DoSomething(
+                    42,
+                    flag ? 08 : 15,
+                    flag);
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_call_with_3_arguments_where_last_is_incomplete() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42, 08,
+                    );
+    }
+}
+");
+
         [Test]
         public void Code_gets_fixed_for_method_with_3_arguments_where_all_arguments_each_are_on_different_line_and_not_outdented()
         {
@@ -241,6 +272,40 @@ public class TestMe
         DoSomething(42,
                     08,
                     15);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void CodeFixProvider_does_not_crash_when_attempting_to_fix_incomplete_code()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                08,
+                         );
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int x, int y, int z)
+    {
+        DoSomething(42,
+                    08,
+                         );
     }
 }
 ";

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 410 rules that are currently provided by the analyzer.
+The following tables list all the 411 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -454,3 +454,4 @@ The following tables list all the 410 rules that are currently provided by the a
 |MiKo_6047|Braces of switch expressions should be placed directly below the corresponding switch keyword|&#x2713;|&#x2713;|
 |MiKo_6048|Logical conditions should be placed on a single line|&#x2713;|&#x2713;|
 |MiKo_6049|Event (un-)registrations should be surrounded by blank lines|&#x2713;|&#x2713;|
+|MiKo_6050|Multi-line arguments are positioned outdented at end of method call|&#x2713;|&#x2713;|


### PR DESCRIPTION
(resolves #636)