### PR TITLE
HashSet<SyntaxKind> replaced by SyntaxKind[] where set contains only a few elements

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -38,13 +38,12 @@ namespace MiKoSolutions.Analyzers
                                                                              ".Designer.cs",
                                                                          };
 
-        private static readonly HashSet<SyntaxKind> LocalFunctionContainerSyntaxKinds = new HashSet<SyntaxKind>
-                                                                                            {
-                                                                                                SyntaxKind.MethodDeclaration,
-                                                                                                SyntaxKind.Block,
-                                                                                                SyntaxKind.ConstructorDeclaration,
-                                                                                                SyntaxKind.LocalFunctionStatement,
-                                                                                            };
+        private static readonly SyntaxKind[] LocalFunctionContainerSyntaxKinds = {
+                                                                                     SyntaxKind.MethodDeclaration,
+                                                                                     SyntaxKind.Block,
+                                                                                     SyntaxKind.ConstructorDeclaration,
+                                                                                     SyntaxKind.LocalFunctionStatement,
+                                                                                 };
 
         internal static IEnumerable<IMethodSymbol> GetExtensionMethods(this ITypeSymbol value) => value.GetMethods().Where(_ => _.IsExtensionMethod);
 

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -38,7 +38,8 @@ namespace MiKoSolutions.Analyzers
                                                                              ".Designer.cs",
                                                                          };
 
-        private static readonly SyntaxKind[] LocalFunctionContainerSyntaxKinds = {
+        private static readonly SyntaxKind[] LocalFunctionContainerSyntaxKinds =
+                                                                                 {
                                                                                      SyntaxKind.MethodDeclaration,
                                                                                      SyntaxKind.Block,
                                                                                      SyntaxKind.ConstructorDeclaration,

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
@@ -10,14 +10,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     public abstract class MethodReturnsNullAnalyzer : MaintainabilityAnalyzer
     {
-        private static readonly HashSet<SyntaxKind> ImportantAncestors = new HashSet<SyntaxKind>
-                                                                             {
-                                                                                 SyntaxKind.VariableDeclaration,
-                                                                                 SyntaxKind.Parameter,
-                                                                                 SyntaxKind.IfStatement,
-                                                                                 SyntaxKind.ConditionalExpression,
-                                                                                 SyntaxKind.SwitchStatement,
-                                                                             };
+        private static readonly SyntaxKind[] ImportantAncestors =
+                                                                  {
+                                                                      SyntaxKind.VariableDeclaration,
+                                                                      SyntaxKind.Parameter,
+                                                                      SyntaxKind.IfStatement,
+                                                                      SyntaxKind.ConditionalExpression,
+                                                                      SyntaxKind.SwitchStatement,
+                                                                  };
 
         protected MethodReturnsNullAnalyzer(string diagnosticId) : base(diagnosticId)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
@@ -13,7 +13,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3021";
 
-        private static readonly SyntaxKind[] EnclosingInvocationSyntaxKinds = {
+        private static readonly SyntaxKind[] EnclosingInvocationSyntaxKinds =
+                                                                              {
                                                                                   SyntaxKind.AwaitExpression,
                                                                                   SyntaxKind.ReturnStatement,
                                                                                   SyntaxKind.VariableDeclarator,

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
@@ -13,13 +13,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3021";
 
-        private static readonly HashSet<SyntaxKind> EnclosingInvocationSyntaxKinds = new HashSet<SyntaxKind>
-                                                                                         {
-                                                                                             SyntaxKind.AwaitExpression,
-                                                                                             SyntaxKind.ReturnStatement,
-                                                                                             SyntaxKind.VariableDeclarator,
-                                                                                             SyntaxKind.ArrowExpressionClause,
-                                                                                         };
+        private static readonly SyntaxKind[] EnclosingInvocationSyntaxKinds = {
+                                                                                  SyntaxKind.AwaitExpression,
+                                                                                  SyntaxKind.ReturnStatement,
+                                                                                  SyntaxKind.VariableDeclarator,
+                                                                                  SyntaxKind.ArrowExpressionClause,
+                                                                              };
 
         public MiKo_3021_TaskRunAnalyzer() : base(Id)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -11,16 +9,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3082";
 
-        private static readonly HashSet<SyntaxKind> BooleanValues = new HashSet<SyntaxKind>
-                                                                        {
-                                                                            SyntaxKind.TrueLiteralExpression,
-                                                                            SyntaxKind.FalseLiteralExpression,
-                                                                        };
-
         public MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer() : base(Id)
         {
         }
 
-        protected override bool IsResponsibleNode(SyntaxKind kind) => BooleanValues.Contains(kind);
+        protected override bool IsResponsibleNode(SyntaxKind kind) => kind == SyntaxKind.TrueLiteralExpression || kind == SyntaxKind.FalseLiteralExpression;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
@@ -13,7 +13,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3084";
 
-        private static readonly SyntaxKind[] ExpressionValues = {
+        private static readonly SyntaxKind[] ExpressionValues =
+                                                                {
                                                                     SyntaxKind.TrueLiteralExpression,
                                                                     SyntaxKind.FalseLiteralExpression,
                                                                     SyntaxKind.NullLiteralExpression,
@@ -21,7 +22,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                     SyntaxKind.StringLiteralExpression,
                                                                 };
 
-        private static readonly SyntaxKind[] Expressions = {
+        private static readonly SyntaxKind[] Expressions =
+                                                           {
                                                                SyntaxKind.EqualsExpression,
                                                                SyntaxKind.NotEqualsExpression,
                                                                SyntaxKind.LessThanExpression,

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
@@ -13,17 +13,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3084";
 
-        private static readonly HashSet<SyntaxKind> ExpressionValues = new HashSet<SyntaxKind>
-                                                                           {
-                                                                               SyntaxKind.TrueLiteralExpression,
-                                                                               SyntaxKind.FalseLiteralExpression,
-                                                                               SyntaxKind.NullLiteralExpression,
-                                                                               SyntaxKind.NumericLiteralExpression,
-                                                                               SyntaxKind.StringLiteralExpression,
-                                                                           };
+        private static readonly SyntaxKind[] ExpressionValues = {
+                                                                    SyntaxKind.TrueLiteralExpression,
+                                                                    SyntaxKind.FalseLiteralExpression,
+                                                                    SyntaxKind.NullLiteralExpression,
+                                                                    SyntaxKind.NumericLiteralExpression,
+                                                                    SyntaxKind.StringLiteralExpression,
+                                                                };
 
-        private static readonly SyntaxKind[] Expressions =
-                                                           {
+        private static readonly SyntaxKind[] Expressions = {
                                                                SyntaxKind.EqualsExpression,
                                                                SyntaxKind.NotEqualsExpression,
                                                                SyntaxKind.LessThanExpression,

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
@@ -14,7 +14,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3094";
 
-        private static readonly SyntaxKind[] AccessOrInvocations = {
+        private static readonly SyntaxKind[] AccessOrInvocations =
+                                                                   {
                                                                        SyntaxKind.ConditionalAccessExpression,
                                                                        SyntaxKind.InvocationExpression,
                                                                        SyntaxKind.MemberBindingExpression,

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
@@ -14,13 +14,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3094";
 
-        private static readonly HashSet<SyntaxKind> AccessOrInvocations = new HashSet<SyntaxKind>
-                                                                              {
-                                                                                  SyntaxKind.ConditionalAccessExpression,
-                                                                                  SyntaxKind.InvocationExpression,
-                                                                                  SyntaxKind.MemberBindingExpression,
-                                                                                  SyntaxKind.SimpleMemberAccessExpression,
-                                                                              };
+        private static readonly SyntaxKind[] AccessOrInvocations = {
+                                                                       SyntaxKind.ConditionalAccessExpression,
+                                                                       SyntaxKind.InvocationExpression,
+                                                                       SyntaxKind.MemberBindingExpression,
+                                                                       SyntaxKind.SimpleMemberAccessExpression,
+                                                                   };
 
         public MiKo_3094_StatementInsideLockCallsParameterAnalyzer() : base(Id, (SymbolKind)(-1))
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
@@ -15,18 +15,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private const int MaximumAllowedFollowUpStatements = 3;
 
-        private static readonly HashSet<SyntaxKind> ForbiddenFollowUps = new HashSet<SyntaxKind>
-                                                                             {
-                                                                                 SyntaxKind.DoStatement,
-                                                                                 SyntaxKind.WhileStatement,
-                                                                                 SyntaxKind.ForStatement,
-                                                                                 SyntaxKind.ForEachStatement,
-                                                                                 SyntaxKind.SwitchStatement,
-                                                                                 SyntaxKind.IfStatement,
-                                                                                 SyntaxKind.UsingStatement,
-                                                                                 SyntaxKind.TryStatement,
-                                                                                 SyntaxKind.LocalFunctionStatement,
-                                                                             };
+        private static readonly ISet<SyntaxKind> ForbiddenFollowUps = new HashSet<SyntaxKind>
+                                                                          {
+                                                                              SyntaxKind.DoStatement,
+                                                                              SyntaxKind.WhileStatement,
+                                                                              SyntaxKind.ForStatement,
+                                                                              SyntaxKind.ForEachStatement,
+                                                                              SyntaxKind.SwitchStatement,
+                                                                              SyntaxKind.IfStatement,
+                                                                              SyntaxKind.UsingStatement,
+                                                                              SyntaxKind.TryStatement,
+                                                                              SyntaxKind.LocalFunctionStatement,
+                                                                          };
 
         private static readonly ISet<SyntaxKind> ForbiddenInsides = new HashSet<SyntaxKind>
                                                                         {


### PR DESCRIPTION
Benchmarking shows that the HashSet lookup is faster than iterating over the array only in case it contains above 7-10 elements 