### PR TITLE
Added new rule MiKo_6051 that reports and fixes colon tokens of ctor initializer calls

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -770,6 +770,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6048_LogicalConditionsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6050_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6051_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -14322,5 +14322,41 @@ namespace MiKoSolutions.Analyzers {
                 return ResourceManager.GetString("MiKo_6050_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place colon on same line as constructor call.
+        /// </summary>
+        public static string MiKo_6051_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6051_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The code is easier to read if the colons leading the calls of other constructors are placed on the same line as the calls themselves..
+        /// </summary>
+        public static string MiKo_6051_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6051_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place colon on same line as constructor call.
+        /// </summary>
+        public static string MiKo_6051_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6051_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Colon of constructor call shall be placed on same line as constructor call.
+        /// </summary>
+        public static string MiKo_6051_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6051_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5020,4 +5020,16 @@ Hence, the open brace of the expression should be positioned directly below the 
   <data name="MiKo_6050_Title" xml:space="preserve">
     <value>Multi-line arguments are positioned outdented at end of method call</value>
   </data>
+  <data name="MiKo_6051_CodeFixTitle" xml:space="preserve">
+    <value>Place colon on same line as constructor call</value>
+  </data>
+  <data name="MiKo_6051_Description" xml:space="preserve">
+    <value>The code is easier to read if the colons leading the calls of other constructors are placed on the same line as the calls themselves.</value>
+  </data>
+  <data name="MiKo_6051_MessageFormat" xml:space="preserve">
+    <value>Place colon on same line as constructor call</value>
+  </data>
+  <data name="MiKo_6051_Title" xml:space="preserve">
+    <value>Colon of constructor call shall be placed on same line as constructor call</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_CodeFixProvider.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6051_CodeFixProvider)), Shared]
+    public sealed class MiKo_6051_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_6051_CodeFixTitle;
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ConstructorInitializerSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ConstructorInitializerSyntax initializer)
+            {
+                var spaces = MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.GetSpaces(issue);
+
+                var updatedToken = initializer.ColonToken.WithLeadingSpaces(spaces).WithTrailingSpace();
+                var updatedKeyword = initializer.ThisOrBaseKeyword.WithoutLeadingTrivia();
+
+                return initializer.WithColonToken(updatedToken)
+                                  .WithThisOrBaseKeyword(updatedKeyword);
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_CodeFixProvider.cs
@@ -21,9 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (syntax is ConstructorInitializerSyntax initializer)
             {
-                var spaces = MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.GetSpaces(issue);
-
-                var updatedToken = initializer.ColonToken.WithLeadingSpaces(spaces).WithTrailingSpace();
+                var updatedToken = initializer.ColonToken.WithoutLeadingTrivia().WithTrailingSpace();
                 var updatedKeyword = initializer.ThisOrBaseKeyword.WithoutLeadingTrivia();
 
                 return initializer.WithColonToken(updatedToken)

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -19,9 +19,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = (ConstructorInitializerSyntax)context.Node;
+            var keyword = node.ThisOrBaseKeyword;
+
+            if (keyword.IsMissing)
+            {
+                // incomplete code
+                return;
+            }
 
             var startLine = node.ColonToken.GetStartingLine();
-            var rightPosition = node.ThisOrBaseKeyword.GetStartPosition();
+            var rightPosition = keyword.GetStartPosition();
 
             if (startLine != rightPosition.Line)
             {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -29,9 +29,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             var colonToken = node.ColonToken;
             var startLine = colonToken.GetStartingLine();
-            var rightPosition = keyword.GetStartPosition();
+            var keywordLine = keyword.GetStartingLine();
 
-            if (startLine != rightPosition.Line)
+            if (startLine != keywordLine)
             {
                 ReportDiagnostics(context, Issue(colonToken));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6051";
+
+        private const string Spaces = "SPACES";
+
+        public MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer() : base(Id)
+        {
+        }
+
+        internal static int GetSpaces(Diagnostic diagnostic) => int.Parse(diagnostic.Properties[Spaces]);
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.BaseConstructorInitializer, SyntaxKind.ThisConstructorInitializer);
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var node = (ConstructorInitializerSyntax)context.Node;
+
+            var startLine = node.ColonToken.GetStartingLine();
+            var rightPosition = node.ThisOrBaseKeyword.GetStartPosition();
+
+            if (startLine != rightPosition.Line)
+            {
+                ReportDiagnostics(context, Issue(node.ColonToken, new Dictionary<string, string> { { Spaces, rightPosition.Character.ToString("D") } }));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -27,12 +27,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 return;
             }
 
-            var startLine = node.ColonToken.GetStartingLine();
+            var colonToken = node.ColonToken;
+            var startLine = colonToken.GetStartingLine();
             var rightPosition = keyword.GetStartPosition();
 
             if (startLine != rightPosition.Line)
             {
-                ReportDiagnostics(context, Issue(node.ColonToken));
+                ReportDiagnostics(context, Issue(colonToken));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,13 +10,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
     {
         public const string Id = "MiKo_6051";
 
-        private const string Spaces = "SPACES";
-
         public MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer() : base(Id)
         {
         }
-
-        internal static int GetSpaces(Diagnostic diagnostic) => int.Parse(diagnostic.Properties[Spaces]);
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.BaseConstructorInitializer, SyntaxKind.ThisConstructorInitializer);
 
@@ -31,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             if (startLine != rightPosition.Line)
             {
-                ReportDiagnostics(context, Issue(node.ColonToken, new Dictionary<string, string> { { Spaces, rightPosition.Character.ToString("D") } }));
+                ReportDiagnostics(context, Issue(node.ColonToken));
             }
         }
     }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
@@ -12,6 +12,23 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
     public class MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests : CodeFixVerifier
     {
         [Test]
+        public void No_issue_is_reported_for_incomplete_ctor__when_colon_is_on_same_line() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public TestMe() :
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_incomplete_ctor__when_colon_is_on_other_line() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public TestMe()
+                :
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_ctor_calling_other_this_ctor_when_colon_is_on_same_line() => No_issue_is_reported_for(@"
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
@@ -81,6 +81,60 @@ public class TestMe : TestMeBase
 }
 ");
 
+        [Test]
+        public void Code_gets_fixed_for_ctor_calling_other_this_ctor_when_colon_is_on_other_line_than_invoked_ctor()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public TestMe() :
+                this(42) {}
+
+    public TestMe(int i) {}
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public TestMe() : this(42) {}
+
+    public TestMe(int i) {}
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ctor_calling_other_base_ctor_when_colon_is_on_other_line_than_invoked_ctor()
+        {
+            const string OriginalCode = @"
+public class TestMeBase
+{
+    public TestMeBase(int i) {}
+}
+public class TestMe : TestMeBase
+{
+    public TestMe() :
+                base(42) {}
+}
+";
+
+            const string FixedCode = @"
+public class TestMeBase
+{
+    public TestMeBase(int i) {}
+}
+public class TestMe : TestMeBase
+{
+    public TestMe() : base(42) {}
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public class MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_ctor_calling_other_this_ctor_when_colon_is_on_same_line() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public TestMe() : this(42) {}
+
+    public TestMe(int i) {}
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ctor_calling_other_base_ctor_when_colon_is_on_same_line() => No_issue_is_reported_for(@"
+public class TestMeBase
+{
+    public TestMeBase(int i) {}
+}
+public class TestMe : TestMeBase
+{
+    public TestMe() : base(42) {}
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ctor_calling_other_this_ctor_when_colon_is_on_same_line_but_below_ctor() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public TestMe()
+                : this(42) {}
+
+    public TestMe(int i) {}
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ctor_calling_other_base_ctor_when_colon_is_on_same_line_but_below_ctor() => No_issue_is_reported_for(@"
+public class TestMeBase
+{
+    public TestMeBase(int i) {}
+}
+public class TestMe : TestMeBase
+{
+    public TestMe()
+                : base(42) {}
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_ctor_calling_other_this_ctor_when_colon_is_on_other_line_than_invoked_ctor() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public TestMe() :
+                this(42) {}
+
+    public TestMe(int i) {}
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_ctor_calling_other_base_ctor_when_colon_is_on_other_line_than_invoked_ctor() => An_issue_is_reported_for(@"
+public class TestMeBase
+{
+    public TestMeBase(int i) {}
+}
+public class TestMe : TestMeBase
+{
+    public TestMe() :
+                base(42) {}
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6051_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 417 rules that are currently provided by the analyzer.
+The following tables list all the 418 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -461,3 +461,4 @@ The following tables list all the 417 rules that are currently provided by the a
 |MiKo_6048|Logical conditions should be placed on a single line|&#x2713;|\-|
 |MiKo_6049|Event (un-)registrations should be surrounded by blank lines|&#x2713;|&#x2713;|
 |MiKo_6050|Multi-line arguments are positioned outdented at end of method call|&#x2713;|&#x2713;|
+|MiKo_6051|Colon of constructor call shall be placed on same line as constructor call|&#x2713;|&#x2713;|


### PR DESCRIPTION
(resolves #689)