### PR TITLE
Added new rule MiKo_2229 that detects and removes left over XML fragments '/>' or '</'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -64,6 +64,14 @@ namespace MiKoSolutions.Analyzers
 
 //// ncrunch: collect values off
 
+        internal static SyntaxToken FindToken<T>(this T value, Diagnostic diagnostic) where T : SyntaxNode
+        {
+            var position = diagnostic.Location.SourceSpan.Start;
+            var token = value.FindToken(position, true);
+
+            return token;
+        }
+
         internal static T FirstAncestor<T>(this SyntaxNode value) where T : SyntaxNode => value.Ancestors<T>().FirstOrDefault();
 
         internal static T FirstAncestor<T>(this SyntaxNode value, Func<T, bool> predicate) where T : SyntaxNode => value.Ancestors<T>().FirstOrDefault(predicate);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -227,6 +227,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_XmlFragmentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -7988,6 +7988,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete XML fragment.
+        /// </summary>
+        public static string MiKo_2229_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2229_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XML fragments in XML documentation are a left over and were not recognized by the developer. However, they may end up in documentation that is available to everybody and therefore should be avoided..
+        /// </summary>
+        public static string MiKo_2229_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2229_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete XML fragment &apos;{0}&apos;.
+        /// </summary>
+        public static string MiKo_2229_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2229_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should not contain left-over XML fragments.
+        /// </summary>
+        public static string MiKo_2229_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2229_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should explain the deeper reasons behind the code to understand why the code is written in that way.
         ///They should not describe how it is achieved because that&apos;s what the code is for..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2838,6 +2838,18 @@ Positive wording is much easier to understand as it is straight forward and come
   <data name="MiKo_2228_Title" xml:space="preserve">
     <value>Documentation should use positive wording instead of negative</value>
   </data>
+  <data name="MiKo_2229_CodeFixTitle" xml:space="preserve">
+    <value>Delete XML fragment</value>
+  </data>
+  <data name="MiKo_2229_Description" xml:space="preserve">
+    <value>XML fragments in XML documentation are a left over and were not recognized by the developer. However, they may end up in documentation that is available to everybody and therefore should be avoided.</value>
+  </data>
+  <data name="MiKo_2229_MessageFormat" xml:space="preserve">
+    <value>Delete XML fragment '{0}'</value>
+  </data>
+  <data name="MiKo_2229_Title" xml:space="preserve">
+    <value>Documentation should not contain left-over XML fragments</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should explain the deeper reasons behind the code to understand why the code is written in that way.
 They should not describe how it is achieved because that's what the code is for.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2229_CodeFixProvider)), Shared]
+    public sealed class MiKo_2229_CodeFixProvider : OverallDocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_2229_XmlFragmentAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_2229_CodeFixTitle;
+
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        {
+            var token = syntax.FindToken(diagnostic);
+            var fragment = diagnostic.Location.GetText();
+
+            return syntax.ReplaceToken(token, token.WithText(token.Text.Without(fragment)));
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2229_XmlFragmentAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2229";
+
+        internal static readonly string[] Phrases = { "</", "/>", "/ >" };
+
+        public MiKo_2229_XmlFragmentAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        {
+            foreach (var token in comment.DescendantTokens(SyntaxKind.XmlTextLiteralToken))
+            {
+                foreach (var location in GetAllLocations(token, Phrases))
+                {
+                    yield return Issue(location);
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzerTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2229_XmlFragmentAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_correct_XML() => No_issue_is_reported_for(@"
+/// <summary>
+/// Some text
+/// </summary>
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrect_XML_([Values("</", "/>", "/ >")] string fragment) => An_issue_is_reported_for(@"
+/// <summary>
+/// Some text
+/// </summary>" + fragment + @"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_incorrect_XML_([Values("</", "/>", "/ >")] string fragment)
+        {
+            const string Template = @"
+/// <summary>
+/// Some text
+/// </summary>###
+public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", fragment), Template.Replace("###", string.Empty));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2229_XmlFragmentAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2229_XmlFragmentAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2229_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 419 rules that are currently provided by the analyzer.
+The following tables list all the 420 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -257,6 +257,7 @@ The following tables list all the 419 rules that are currently provided by the a
 |MiKo_2226|Documentation should explain the 'Why' and not the 'That'|&#x2713;|\-|
 |MiKo_2227|Documentation should not contain ReSharper suppressions|&#x2713;|\-|
 |MiKo_2228|Documentation should use positive wording instead of negative|&#x2713;|\-|
+|MiKo_2229|Documentation should not contain left-over XML fragments|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
(resolves #684)