### PR TITLE
Added new rule MiKo_1075 that reports and fixes types suffixed with 'EventArgs' but not inheriting from 'EventArgs'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -562,6 +562,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1073_BooleanFieldNamedAsQuestionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1074_LockIdentifiersAreSuffixedWithLockAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1075_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1081_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1081_MethodsWithNumberSuffixAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -2828,6 +2828,43 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove suffix &apos;EventArgs&apos;.
+        /// </summary>
+        public static string MiKo_1075_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1075_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Event argument types should follow the pattern that they inherit from &apos;System.EventArgs&apos; and their names end with &apos;EventArgs&apos;.
+        ///Types that end their names with &apos;EventArgs&apos; but do not follow that pattern lie about being event arguments types. Such types should not end their names with &apos;EventArgs&apos; at all..
+        /// </summary>
+        public static string MiKo_1075_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1075_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
+        /// </summary>
+        public static string MiKo_1075_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1075_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-&apos;System.EventArgs&apos; types should not be suffixed with &apos;EventArgs&apos;.
+        /// </summary>
+        public static string MiKo_1075_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1075_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It is much easier to read a number inside a name if it is written as number and not its spelling (e.g. &apos;issue42&apos; in contrast to &apos;issueFortyTwo&apos;)..
         /// </summary>
         public static string MiKo_1080_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1072,6 +1072,19 @@ Example:
   <data name="MiKo_1074_Title" xml:space="preserve">
     <value>Objects used to lock on should be suffixed with 'Lock'</value>
   </data>
+  <data name="MiKo_1075_CodeFixTitle" xml:space="preserve">
+    <value>Remove suffix 'EventArgs'</value>
+  </data>
+  <data name="MiKo_1075_Description" xml:space="preserve">
+    <value>Event argument types should follow the pattern that they inherit from 'System.EventArgs' and their names end with 'EventArgs'.
+Types that end their names with 'EventArgs' but do not follow that pattern lie about being event arguments types. Such types should not end their names with 'EventArgs' at all.</value>
+  </data>
+  <data name="MiKo_1075_MessageFormat" xml:space="preserve">
+    <value>Name it '{1}' instead</value>
+  </data>
+  <data name="MiKo_1075_Title" xml:space="preserve">
+    <value>Non-'System.EventArgs' types should not be suffixed with 'EventArgs'</value>
+  </data>
   <data name="MiKo_1080_Description" xml:space="preserve">
     <value>It is much easier to read a number inside a name if it is written as number and not its spelling (e.g. 'issue42' in contrast to 'issueFortyTwo').</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_CodeFixProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1075_CodeFixProvider)), Shared]
+    public sealed class MiKo_1075_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.Id;
+
+        protected override string Title => Resources.MiKo_1075_CodeFixTitle;
+
+        protected override string GetNewName(Diagnostic diagnostic, ISymbol symbol) => MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.FindBetterName(symbol, diagnostic);
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ClassDeclarationSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1075";
+
+        public MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer() : base(Id, SymbolKind.NamedType)
+        {
+        }
+
+        internal static string FindBetterName(ISymbol symbol, Diagnostic diagnostic) => FindBetterName(symbol);
+
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.TypeKind == TypeKind.Class && symbol.Name.EndsWith(nameof(EventArgs), StringComparison.Ordinal);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => symbol.IsEventArgs()
+                                                                                                                    ? Enumerable.Empty<Diagnostic>()
+                                                                                                                    : new[] { Issue(symbol, FindBetterName(symbol)) };
+
+        private static string FindBetterName(ISymbol symbol) => symbol.Name.Without(nameof(EventArgs));
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzerTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_class() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_EventArgs_type_not_named_EventArgs() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe : EventArgs
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_EventArgs_type_named_EventArgs() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMeEventArgs : EventArgs
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_EventArgs_type_incorrectly_named_EventArgs() => An_issue_is_reported_for(@"
+using System;
+
+public class MyEventArgs
+{
+}
+");
+
+        [TestCase("using System; class TestMeEventArgs { }", "using System; class TestMe { }")]
+        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+
+        protected override string GetDiagnosticId() => MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1075_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 421 rules that are currently provided by the analyzer.
+The following tables list all the 422 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -105,6 +105,7 @@ The following tables list all the 421 rules that are currently provided by the a
 |MiKo_1072|Boolean properties or methods should be named as statements and not as questions|&#x2713;|\-|
 |MiKo_1073|Boolean fields should be named as statements and not as questions|&#x2713;|\-|
 |MiKo_1074|Objects used to lock on should be suffixed with 'Lock'|&#x2713;|\-|
+|MiKo_1075|Non-'System.EventArgs' types should not be suffixed with 'EventArgs'|&#x2713;|&#x2713;|
 |MiKo_1080|Names should contain numbers instead of their spellings|&#x2713;|\-|
 |MiKo_1081|Methods should not be suffixed with a number|&#x2713;|&#x2713;|
 |MiKo_1082|Properties should not be suffixed with a number if their types have number suffixes|&#x2713;|&#x2713;|


### PR DESCRIPTION
(resolves #639)