### PR TITLE
Added new rule MiKo_3214 that reports scope defining method such as 'BeginUpdate/EndUpdate' or 'EnterSomething/ExitSomething'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -419,6 +419,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3211_PublicTypesShouldNotHaveFinalizerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3212_DoNotProvideUnexpectedDisposeMethodsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3213_PublicDisposeMethodInvokesNonPublicDisposeMethodAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3214_BeginEndScopeMethodsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12130,7 +12130,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename scope-defining method to not start with &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Rename scope-defining method to not start with &apos;{1}&apos;.
         /// </summary>
         public static string MiKo_3214_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12119,6 +12119,35 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If methods start with &apos;Begin&apos; or &apos;Enter&apos; they probably have counterparts that start with &apos;End&apos; or &apos;Exit&apos;. Such methods are considered to define some kind of scope (for example, &apos;BeginUpdate&apos; and &apos;EndUpdate&apos; defines a scope for an update operation).
+        ///As it is prone to errors to forget or not correctly invoke the &apos;End&apos; methods (eg. due to exceptions being thrown), those methods should not be made available to the public.
+        ///Instead, a method should be made available that returns an &apos;IDisposable&apos; to define that  [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string MiKo_3214_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3214_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename scope-defining method to not start with &apos;{0}&apos;.
+        /// </summary>
+        public static string MiKo_3214_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3214_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interfaces do not contain &apos;Begin/End&apos; or &apos;Enter/Exit&apos; scope-defining methods.
+        /// </summary>
+        public static string MiKo_3214_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3214_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         public static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4286,7 +4286,7 @@ Instead, a method should be made available that returns an 'IDisposable' to defi
 By doing so developers can simply place the call inside a 'using' to guarantee that the 'End' method is invoked in all cases.</value>
   </data>
   <data name="MiKo_3214_MessageFormat" xml:space="preserve">
-    <value>Rename scope-defining method to not start with '{0}'</value>
+    <value>Rename scope-defining method to not start with '{1}'</value>
   </data>
   <data name="MiKo_3214_Title" xml:space="preserve">
     <value>Interfaces do not contain 'Begin/End' or 'Enter/Exit' scope-defining methods</value>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4279,6 +4279,18 @@ All the other calls should be invoked from the 'Dispose(bool disposing)' method.
   <data name="MiKo_3213_Title" xml:space="preserve">
     <value>Parameterless Dispose method follows Basic Dispose pattern</value>
   </data>
+  <data name="MiKo_3214_Description" xml:space="preserve">
+    <value>If methods start with 'Begin' or 'Enter' they probably have counterparts that start with 'End' or 'Exit'. Such methods are considered to define some kind of scope (for example, 'BeginUpdate' and 'EndUpdate' defines a scope for an update operation).
+As it is prone to errors to forget or not correctly invoke the 'End' methods (eg. due to exceptions being thrown), those methods should not be made available to the public.
+Instead, a method should be made available that returns an 'IDisposable' to define that scope.
+By doing so developers can simply place the call inside a 'using' to guarantee that the 'End' method is invoked in all cases.</value>
+  </data>
+  <data name="MiKo_3214_MessageFormat" xml:space="preserve">
+    <value>Rename scope-defining method to not start with '{0}'</value>
+  </data>
+  <data name="MiKo_3214_Title" xml:space="preserve">
+    <value>Interfaces do not contain 'Begin/End' or 'Enter/Exit' scope-defining methods</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzer.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3214_BeginEndScopeMethodsAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3214";
+
+        private static readonly string[] ScopeIndicators = { "Begin", "End", "Enter", "Exit", "Leave" };
+
+        public MiKo_3214_BeginEndScopeMethodsAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInterface, SyntaxKind.InterfaceDeclaration);
+
+        private void AnalyzeInterface(SyntaxNodeAnalysisContext context)
+        {
+            var issues = Analyze((InterfaceDeclarationSyntax)context.Node);
+
+            ReportDiagnostics(context, issues);
+        }
+
+        private IEnumerable<Diagnostic> Analyze(TypeDeclarationSyntax syntax)
+        {
+            foreach (var method in syntax.Members.OfType<MethodDeclarationSyntax>())
+            {
+                var identifier = method.Identifier;
+                var name = identifier.ValueText;
+
+                var indicator = ScopeIndicators.FirstOrDefault(_ => name.StartsWith(_, StringComparison.OrdinalIgnoreCase));
+
+                if (indicator != null)
+                {
+                    yield return Issue(identifier, indicator);
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0003_LinesOfCodeInClassAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0003_LinesOfCodeInClassAnalyzer.cs
@@ -48,14 +48,8 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
             {
                 switch (member)
                 {
-                    case ConstructorDeclarationSyntax _:
-                    case DestructorDeclarationSyntax _:
-                    case IndexerDeclarationSyntax _:
-                    case PropertyDeclarationSyntax _:
-                    case EventDeclarationSyntax _:
-                    case MethodDeclarationSyntax _:
-                    case ConversionOperatorDeclarationSyntax _:
-                    case OperatorDeclarationSyntax _:
+                    case BaseMethodDeclarationSyntax _:
+                    case BasePropertyDeclarationSyntax _:
                     {
                         foreach (var block in member.DescendantNodes<BlockSyntax>())
                         {

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzerTests.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3214_BeginEndScopeMethodsAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_scope_methods_in_([Values("class", "struct", "record")] string type) => No_issue_is_reported_for(@"
+public " + type + @" TestMe
+{
+    public void BeginUpdate() { }
+
+    public void EndUpdate() { }
+
+    public void EnterMethod() { }
+
+    public void ExitMethod() { }
+
+    public void LeaveMethod() { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_interface_with_no_scope_method() => No_issue_is_reported_for(@"
+public interface TestMe
+{
+    public void Update() { }
+}
+");
+
+        [TestCase("BeginUpdate")]
+        [TestCase("EndUpdate")]
+        [TestCase("EnterMethod")]
+        [TestCase("ExitMethod")]
+        [TestCase("LeaveMethod")]
+        public void An_issue_is_reported_for_interface_with_scope_method_(string methodName) => An_issue_is_reported_for(@"
+public interface TestMe
+{
+    public void " + methodName + @"() { }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3214_BeginEndScopeMethodsAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3214_BeginEndScopeMethodsAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 424 rules that are currently provided by the analyzer.
+The following tables list all the 425 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -387,6 +387,7 @@ The following tables list all the 424 rules that are currently provided by the a
 |MiKo_3211|Public types should not have finalizers|&#x2713;|\-|
 |MiKo_3212|Do not confuse developers by providing other Dispose methods|&#x2713;|\-|
 |MiKo_3213|Parameterless Dispose method follows Basic Dispose pattern|&#x2713;|\-|
+|MiKo_3214|Interfaces do not contain 'Begin/End' or 'Enter/Exit' scope-defining methods|&#x2713;|\-|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
(resolves #659)