### PR TITLE
MiKo_4001 no longer crashes on ctors that do not exist in source code

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
@@ -29,9 +29,9 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             // handle each accessibility separately, to avoid situations such as that private methods suddenly get sorted before other public methods
             foreach (var nodes in methodsOrderedByParameters.GroupBy(_ => _.DeclaredAccessibility))
             {
-                var methodNodes = nodes.Select(_ => _.GetSyntax()).ToList();
+                var methodNodes = nodes.Select(_ => _.GetSyntax()).Where(_ => _ != null).ToList();
 
-                if (methodNodes.Count == 1)
+                if (methodNodes.Count <= 1)
                 {
                     // ignore those that have only one occurrence
                     continue;

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzerTests.cs
@@ -586,6 +586,30 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_ctors_on_structs_that_do_not_have_a_parameterless_ctor()
+        {
+            const string OriginalCode = @"
+public readonly struct TestMe
+{
+    public TestMe(string s1, string s2) { }
+
+    public TestMe(string s) { }
+}
+";
+
+            const string FixedCode = @"
+public readonly struct TestMe
+{
+    public TestMe(string s) { }
+
+    public TestMe(string s1, string s2) { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer();


### PR DESCRIPTION
(such as parameterless ctors on structs)