### PR TITLE
MiKo_4004 codefix no longer crashs if properties, events and ctors come before ordinary methods

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             var methodSymbol = (IMethodSymbol)GetSymbol(document, disposeMethod);
             var typeSymbol = (INamedTypeSymbol)GetSymbol(document, typeSyntax);
 
-            var methods = typeSymbol.GetMethods().Except(methodSymbol);
+            var methods = typeSymbol.GetMethods(MethodKind.Ordinary).Except(methodSymbol);
             var method = methods.FirstOrDefault(_ => _.DeclaredAccessibility == methodSymbol.DeclaredAccessibility && _.IsStatic is false);
 
             if (method != null)

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzerTests.cs
@@ -450,6 +450,50 @@ public class TestMe : IDisposable
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_class_with_public_Dispose_method_after_other_methods_and_properties()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe : IDisposable
+{
+    public TestMe() { }
+
+    public string Name { get; set; }
+
+    public event EventHandler MyEvent;
+
+    public static void DoSomething() { }
+
+    public void A() { }
+
+    public void Dispose() { }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe : IDisposable
+{
+    public TestMe() { }
+
+    public string Name { get; set; }
+
+    public event EventHandler MyEvent;
+
+    public static void DoSomething() { }
+
+    public void Dispose() { }
+
+    public void A() { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         //// TODO RKN: partial parts
 
         protected override string GetDiagnosticId() => MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzer.Id;


### PR DESCRIPTION
(resolves #726)