### PR TITLE
Added new rule MiKo_3218 that reports extension methods defined in unexpected places

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -431,6 +431,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3216_AssignedStaticFieldsAreReadOnlyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3216_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3217_DoNotUseGenericsWithGenericsWithGenericsAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12393,6 +12393,33 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Extension methods are a great way to extend types with additional functionality. Such extension methods are defined in static types specifically designed for that. However, other types that are not intended to contain extension methods should not unexpectedly contain them..
+        /// </summary>
+        public static string MiKo_3218_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3218_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change from extension method into normal static method.
+        /// </summary>
+        public static string MiKo_3218_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3218_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not define extension methods in unexpected places.
+        /// </summary>
+        public static string MiKo_3218_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3218_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         public static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4374,6 +4374,15 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3217_Title" xml:space="preserve">
     <value>Do not use generic types that have other generic types as type arguments</value>
   </data>
+  <data name="MiKo_3218_Description" xml:space="preserve">
+    <value>Extension methods are a great way to extend types with additional functionality. Such extension methods are defined in static types specifically designed for that. However, other types that are not intended to contain extension methods should not unexpectedly contain them.</value>
+  </data>
+  <data name="MiKo_3218_MessageFormat" xml:space="preserve">
+    <value>Change from extension method into normal static method</value>
+  </data>
+  <data name="MiKo_3218_Title" xml:space="preserve">
+    <value>Do not define extension methods in unexpected places</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3218";
+
+        public MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsExtensionMethod;
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation) => symbol.ContainingType.Name.Contains("Extension")
+                                                                                                             ? Enumerable.Empty<Diagnostic>()
+                                                                                                             : new[] { Issue(symbol) };
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzerTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: collect values off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] Visibilities = { "private", "protected", "internal", "public" };
+
+        [Test]
+        public void No_issue_is_reported_for_empty_type() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_valid_extension_method_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+public class TestMeExtensions
+{
+    " + visibility + @" static int ExtendMe(this int value) => value;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_valid_static_method_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    " + visibility + @" static int ExtendMe(int value) => value;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_extension_method_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => An_issue_is_reported_for(@"
+public class TestMe
+{
+    " + visibility + @" static int ExtendMe(this int value) => value;
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables list all the 432 rules that are currently provided by the analyzer.
+The following tables list all the 433 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -395,6 +395,7 @@ The following tables list all the 432 rules that are currently provided by the a
 |MiKo_3215|Callbacks should be 'Func&lt;T, bool&gt;' instead of 'Predicate&lt;bool&gt;'|&#x2713;|&#x2713;|
 |MiKo_3216|Static fields with initializers should be read-only|&#x2713;|&#x2713;|
 |MiKo_3217|Do not use generic types that have other generic types as type arguments|&#x2713;|\-|
+|MiKo_3218|Do not define extension methods in unexpected places|&#x2713;|\-|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
such as private methods in "normal" types

(resolves #776)