### PR TITLE
MiKo_6037 is now able to fix parenthesis that are placed on different lines as well

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -959,6 +959,9 @@ namespace System.Linq
         internal static SyntaxList<T> ToSyntaxList<T>(this IEnumerable<T> source) where T : SyntaxNode => SyntaxFactory.List(source);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static SeparatedSyntaxList<T> ToSeparatedSyntaxList<T>(this T value) where T : SyntaxNode => new[] { value }.ToSeparatedSyntaxList();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SeparatedSyntaxList<T> ToSeparatedSyntaxList<T>(this IEnumerable<T> source) where T : SyntaxNode => SyntaxFactory.SeparatedList(source);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3034_CodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var name = SyntaxFactory.ParseName("CallerMemberName");
             var attribute = SyntaxFactory.Attribute(name);
-            var attributeList = SyntaxFactory.AttributeList(new[] { attribute }.ToSeparatedSyntaxList());
+            var attributeList = SyntaxFactory.AttributeList(attribute.ToSeparatedSyntaxList());
 
             return parameter.WithAttributeLists(new SyntaxList<AttributeListSyntax>(attributeList))
                             .WithDefault(SyntaxFactory.EqualsValueClause(NullLiteral()));

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var variableDeclarator = SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(identifier), default, SyntaxFactory.EqualsValueClause(assignment));
 
             var type = SyntaxFactory.ParseTypeName(Constants.DependencyProperty.TypeName);
-            var variableDeclaration = SyntaxFactory.VariableDeclaration(type, new[] { variableDeclarator }.ToSeparatedSyntaxList());
+            var variableDeclaration = SyntaxFactory.VariableDeclaration(type, variableDeclarator.ToSeparatedSyntaxList());
 
             var field = SyntaxFactory.FieldDeclaration(default, PublicStaticReadOnly.ToTokenList(), variableDeclaration);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_CodeFixProvider.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
@@ -23,42 +22,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             if (syntax is InvocationExpressionSyntax invocation)
             {
                 return invocation.WithArgumentList(invocation.ArgumentList.WithoutLeadingTrivia())
-                                 .WithExpression(GetUpdatedExpression(invocation.Expression).WithoutTrailingTrivia());
+                                 .WithExpression(GetUpdatedExpressionPlacedOnSameLine(invocation.Expression).WithoutTrailingTrivia());
             }
 
             return syntax;
-        }
-
-        private static ExpressionSyntax GetUpdatedExpression(ExpressionSyntax expression)
-        {
-            switch (expression)
-            {
-                case MemberAccessExpressionSyntax maes:
-                {
-                    return maes.WithName((SimpleNameSyntax)GetUpdatedExpression(maes.Name));
-                }
-
-                case GenericNameSyntax genericName:
-                {
-                    var types = genericName.TypeArgumentList;
-                    var arguments = types.Arguments;
-
-                    var separators = Enumerable.Repeat(arguments.GetSeparator(0).WithoutTrivia().WithTrailingSpace(), arguments.Count - 1);
-
-                    var updatedTypes = types.WithoutTrivia()
-                                            .WithArguments(SyntaxFactory.SeparatedList(arguments.Select(_ => _.WithoutTrivia()), separators))
-                                            .WithGreaterThanToken(types.GreaterThanToken.WithoutTrivia())
-                                            .WithLessThanToken(types.LessThanToken.WithoutTrivia());
-
-                    return genericName.WithIdentifier(genericName.Identifier.WithoutTrailingTrivia())
-                                      .WithTypeArgumentList(updatedTypes);
-                }
-
-                default:
-                {
-                    return expression;
-                }
-            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
@@ -21,7 +21,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (syntax is InvocationExpressionSyntax invocation)
             {
-                return invocation.WithArgumentList(GetUpdatedArgumentList(invocation.ArgumentList));
+                return invocation.WithArgumentList(GetUpdatedArgumentList(invocation.ArgumentList))
+                                 .WithExpression(GetUpdatedExpressionPlacedOnSameLine(invocation.Expression).WithoutTrailingTrivia());
             }
 
             return syntax;
@@ -31,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             var argumentSyntax = argumentList.Arguments.First();
 
-            return argumentList.WithArguments(new[] { argumentSyntax.WithoutTrivia() }.ToSeparatedSyntaxList())
+            return argumentList.WithArguments(argumentSyntax.WithoutTrivia().ToSeparatedSyntaxList())
                                .WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
                                .WithCloseParenToken(argumentList.CloseParenToken.WithoutLeadingTrivia());
         }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzerTests.cs
@@ -177,6 +177,90 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_if_complete_Linq_call_spanning_multiple_lines_with_single_argument_with_surrounding_parenthesis_on_separate_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var items = new List<int>();
+
+        var results = items.Select(_ => _.ToString())
+                           .OrderBy
+                                (_ => _)
+                           .ToList();
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var items = new List<int>();
+
+        var results = items.Select(_ => _.ToString())
+                           .OrderBy(_ => _)
+                           .ToList();
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_complete_Linq_call_spanning_multiple_lines_with_single_argument_with_generic_bracket_on_separate_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var items = new List<int>();
+
+        var results = items.Select<int, string
+                                        >(_ => _.ToString())
+                           .ToList();
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var items = new List<int>();
+
+        var results = items.Select<int, string>(_ => _.ToString())
+                           .ToList();
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer();


### PR DESCRIPTION
- includes refactoring to use new method 'ToSeparatedSyntaxList' for single value