### PR TITLE
Method signature is now aware of 'in' parameter

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -327,6 +327,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     case RefKind.Ref: return "ref ";
                     case RefKind.Out: return "out ";
+                    case RefKind.In: return "in ";
                     default: return string.Empty;
                 }
             }


### PR DESCRIPTION
('in' is same as 'ref readonly')