### PR TITLE
MiKo_1300 now accepts 'failed' as identifier on lambda expressions

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
@@ -164,6 +164,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 case Constants.LambdaIdentifiers.Fallback3: // correct identifier (3rd fallback as there is already another identifier in the parent lambda expression)
                 case Constants.LambdaIdentifiers.Fallback4: // correct identifier (4th fallback as there is already another identifier in the parent lambda expression)
                 case Constants.LambdaIdentifiers.Fallback5: // correct identifier (5th fallback as there is already another identifier in the parent lambda expression)
+                case "failed": // result in ASP .NET core to indicate a failure
                     return null;
 
                 default:

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzerTests.cs
@@ -31,6 +31,7 @@ public class TestMe
         [TestCase("_3")]
         [TestCase("_4")]
         [TestCase("_5")]
+        [TestCase("failed")] // result to indicate an error in ASP .NET Core
         public void No_issue_is_reported_for_correctly_named_simple_lambda_identifier_(string identifier) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
@@ -58,6 +59,7 @@ public class TestMe
         [TestCase("_3")]
         [TestCase("_4")]
         [TestCase("_5")]
+        [TestCase("failed")] // result to indicate an error in ASP .NET Core
         public void No_issue_is_reported_for_correctly_named_parenthesized_lambda_identifier_(string identifier) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
In **_ASP .NET core_** developers might want to indicate that a specific operation was OK or failed.
In such case they want to use lambdas for the different cases where
- `_` would be the OK case
- `failed` the failure (such as the "not found") case