### PR TITLE
MiKo_1046 now ignores the 'Main' method

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzer.cs
@@ -41,6 +41,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Enumerable.Empty<Diagnostic>();
             }
 
+            if (symbol.IsStatic && methodName == "Main")
+            {
+                // nothing to report here for the main method as that is the entry point of an application and as to be named 'Main'
+                return Enumerable.Empty<Diagnostic>();
+            }
+
             var betterName = symbol.Name + Constants.AsyncSuffix;
 
             return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
@@ -27,6 +27,26 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_static_async_Main_method() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public static async Task Main() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_static_async_Main_method() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public async Task Main() { }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_correctly_named_async_void_method() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
That 'Main' method acts as entry point to the application and therefore cannot be renamed.