### PR TITLE
Naming analyzer are now aware of Json constructor arguments

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1033_ParameterModelSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1033_ParameterModelSuffixAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IParameterSymbol symbol) => symbol.GetEnclosingMethod().IsInterfaceImplementation() is false;
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => base.ShallAnalyze(symbol) && symbol.GetEnclosingMethod().IsInterfaceImplementation() is false;
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation) => AnalyzeEntityMarkers(symbol);
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -122,7 +122,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected virtual bool ShallAnalyze(IFieldSymbol symbol) => symbol.IsOverride is false;
 
-        protected virtual bool ShallAnalyze(IParameterSymbol symbol) => symbol.IsOverride is false;
+        protected virtual bool ShallAnalyze(IParameterSymbol symbol)
+        {
+            if (symbol.IsOverride)
+            {
+                return false;
+            }
+
+            if (symbol.ContainingSymbol is IMethodSymbol method && method.IsConstructor())
+            {
+                if (method.HasAttributeApplied("System.Text.Json.Serialization.JsonConstructorAttribute")
+                 || method.HasAttributeApplied("Newtonsoft.Json.JsonConstructorAttribute"))
+                {
+                    // ignore Json constructors
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         protected virtual bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => false;
 

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Windows.Input;
 using System.Xml;
@@ -49,6 +50,7 @@ namespace TestHelper
         private static readonly MetadataReference SystemLinqReference = MetadataReference.CreateFromFile(typeof(Expression).Assembly.Location);
         private static readonly MetadataReference SystemRuntimeReference = MetadataReference.CreateFromFile(typeof(DataContractAttribute).Assembly.Location); // needed also for other attributes
         private static readonly MetadataReference SystemTextReference = MetadataReference.CreateFromFile(typeof(Regex).Assembly.Location);
+        private static readonly MetadataReference SystemTextJsonReference = MetadataReference.CreateFromFile(typeof(JsonConstructorAttribute).Assembly.Location);
         private static readonly MetadataReference SystemWindowsInputReference = MetadataReference.CreateFromFile(typeof(ICommand).Assembly.Location);
         private static readonly MetadataReference SystemXmlReference = MetadataReference.CreateFromFile(typeof(XmlNode).Assembly.Location);
 
@@ -235,6 +237,7 @@ namespace TestHelper
                                                .AddMetadataReference(projectId, SystemRuntimeNetStandardReference)
                                                .AddMetadataReference(projectId, SystemLinqReference)
                                                .AddMetadataReference(projectId, SystemTextReference)
+                                               .AddMetadataReference(projectId, SystemTextJsonReference)
                                                .AddMetadataReference(projectId, SystemXmlReference);
 
             var count = 0;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -287,6 +287,39 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_Json_constructor([ValueSource(nameof(BadPrefixes))] string name) => No_issue_is_reported_for(@"
+using System;
+using System.Text.Json.Serialization;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [JsonConstructor]
+        public TestMe(int " + name + @")
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Newtonsoft_Json_constructor([ValueSource(nameof(BadPrefixes))] string name) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Newtonsoft.Json.JsonConstructorAttribute]
+        public TestMe(int " + name + @")
+        {
+        }
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_extern_method_([ValueSource(nameof(BadPrefixes))] string part) => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
Those arguments get ignored as they have to match the entries within Json.