### PR TITLE
added new MiKo_3120 rule that reports usage of 'It.Is<>(...)' matcher where a simple value would be sufficient

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -107,6 +107,12 @@ namespace MiKoSolutions.Analyzers
             internal const string VerifyAll = nameof(VerifyAll);
             internal const string Verify = nameof(Verify);
             internal const string Verifiable = nameof(Verifiable);
+
+            internal static class ConditionMatcher
+            {
+                internal const string It = nameof(It);
+                internal const string Is = nameof(Is);
+            }
         }
 
         internal static class FluentAssertions

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -182,6 +182,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3113_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3114_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3119_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3120_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -277,6 +277,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3119_TestMethodsDoNotReturnCompletedTaskAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12157,6 +12157,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use value directly instead of condition matcher.
+        /// </summary>
+        internal static string MiKo_3120_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3120_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Moq provides condition matchers to verify calls with given arguments. Those condition matchers exist to verify that parts of the argument match a specific criteria. They should not be used to test whether they match the exact value. For such cases the exact values should be provided instead of the condition matcher..
+        /// </summary>
+        internal static string MiKo_3120_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3120_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use value directly instead of condition matcher.
+        /// </summary>
+        internal static string MiKo_3120_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3120_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Moq mocks should use values instead of &apos;It.Is&lt;&gt;(...)&apos; condition matcher to verify exact values.
+        /// </summary>
+        internal static string MiKo_3120_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3120_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
         internal static string MiKo_3201_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4287,6 +4287,18 @@ For example, if the test uses 'Skip', it is unclear for the reader why the code 
   <data name="MiKo_3119_Title" xml:space="preserve">
     <value>Test methods should not simply return completed task</value>
   </data>
+  <data name="MiKo_3120_CodeFixTitle" xml:space="preserve">
+    <value>Use value directly instead of condition matcher</value>
+  </data>
+  <data name="MiKo_3120_Description" xml:space="preserve">
+    <value>Moq provides condition matchers to verify calls with given arguments. Those condition matchers exist to verify that parts of the argument match a specific criteria. They should not be used to test whether they match the exact value. For such cases the exact values should be provided instead of the condition matcher.</value>
+  </data>
+  <data name="MiKo_3120_MessageFormat" xml:space="preserve">
+    <value>Use value directly instead of condition matcher</value>
+  </data>
+  <data name="MiKo_3120_Title" xml:space="preserve">
+    <value>Moq mocks should use values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values</value>
+  </data>
   <data name="MiKo_3201_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer.cs
@@ -8,6 +8,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
+    /// <inheritdoc/>
+    /// <seealso cref="MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer"/>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer : ObjectCreationExpressionMaintainabilityAnalyzer
     {
@@ -46,11 +48,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsConditionMatcher(MemberAccessExpressionSyntax node)
         {
-            if (node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() == "It")
+            if (node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() == Constants.Moq.ConditionMatcher.It)
             {
                 switch (node.GetName())
                 {
-                    case "Is":
+                    case Constants.Moq.ConditionMatcher.Is:
                     case "IsAny":
                     case "IsIn":
                     case "IsInRange":

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_CodeFixProvider.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3120_CodeFixProvider)), Shared]
+    public sealed class MiKo_3120_CodeFixProvider : UnitTestCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3120";
+
+        protected override string Title => Resources.MiKo_3120_CodeFixTitle;
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ArgumentSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ArgumentSyntax argument && argument.Expression is InvocationExpressionSyntax i && i.ArgumentList.Arguments.FirstOrDefault()?.Expression is LambdaExpressionSyntax lambda)
+            {
+                switch (lambda.ExpressionBody)
+                {
+                    case BinaryExpressionSyntax binary:
+                        return Argument(binary.Right);
+
+                    case IsPatternExpressionSyntax pattern when pattern.Expression is IdentifierNameSyntax && pattern.Pattern is ConstantPatternSyntax c && c.Expression is LiteralExpressionSyntax literal:
+                        return Argument(literal);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    /// <inheritdoc/>
+    /// <seealso cref="MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer"/>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3120";
+
+        public MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName(Constants.Moq.MockFullQualified) != null;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context)
+        {
+            base.InitializeCore(context);
+
+            context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
+        }
+
+        private static bool IsMoqConditionMatcher(InvocationExpressionSyntax node) => node.Expression is MemberAccessExpressionSyntax maes
+                                                                                      && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression)
+                                                                                      && maes.Expression is IdentifierNameSyntax invokedType
+                                                                                      && invokedType.GetName() == Constants.Moq.ConditionMatcher.It
+                                                                                      && maes.GetName() == Constants.Moq.ConditionMatcher.Is;
+
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax node)
+            {
+                var arguments = node.ArgumentList.Arguments;
+
+                if (arguments.Count == 1)
+                {
+                    var issues = AnalyzeSimpleMemberAccessExpression(node, arguments[0]);
+
+                    ReportDiagnostics(context, issues);
+                }
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeSimpleMemberAccessExpression(InvocationExpressionSyntax node, ArgumentSyntax argument)
+        {
+            if (IsMoqConditionMatcher(node) && argument.Expression is LambdaExpressionSyntax lambda)
+            {
+                switch (lambda.ExpressionBody)
+                {
+                    case BinaryExpressionSyntax binary when binary.OperatorToken.IsKind(SyntaxKind.EqualsEqualsToken) && binary.Left is IdentifierNameSyntax && binary.Right is LiteralExpressionSyntax:
+                        return new[] { Issue(node) };
+
+                    case IsPatternExpressionSyntax pattern when pattern.Expression is IdentifierNameSyntax && pattern.Pattern is ConstantPatternSyntax c && c.Expression is LiteralExpressionSyntax:
+                        return new[] { Issue(node) };
+                }
+            }
+
+            return Enumerable.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -232,6 +232,12 @@ namespace MiKoSolutions.Analyzers.Rules
         }
 
         [Test]
+        public static void Analyzers_are_available() => Assert.That(AllAnalyzers.Length, Is.Not.Zero);
+
+        [Test]
+        public static void CodeFixProviders_are_available() => Assert.That(AllCodeFixProviders.Length, Is.Not.Zero);
+
+        [Test]
         public static void CodeFixProvider_are_marked_with_ExportCodeFixProvider_attribute()
         {
             Assert.Multiple(() =>
@@ -343,7 +349,7 @@ namespace MiKoSolutions.Analyzers.Rules
         {
             var markdownBuilder = new StringBuilder().AppendLine()
                                                      .AppendLine("## Available Rules")
-                                                     .AppendLine(CultureInfo.CurrentCulture, $"The following tables list all the {AllAnalyzers.Length} rules that are currently provided by the analyzer.");
+                                                     .AppendLine(CultureInfo.CurrentCulture, $"The following tables lists all the {AllAnalyzers.Length} rules that are currently provided by the analyzer.");
 
             var category = string.Empty;
             var tableFormat = "|{0}|{1}|{2}|{3}|" + Environment.NewLine;
@@ -369,7 +375,7 @@ namespace MiKoSolutions.Analyzers.Rules
                                          CultureInfo.CurrentCulture,
                                          tableFormat,
                                          descriptor.Id,
-                                         descriptor.Title.ToString(CultureInfo.CurrentCulture).Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("|", "&#124;").Replace("\"", "&quot;").Replace("'", "&apos;").Replace("#", "&num;"),
+                                         descriptor.Title.ToString(CultureInfo.CurrentCulture).Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("#", "&num;").Replace("|", "&#124;"), // .Replace("\"", "&quot;").Replace("'", "&apos;")
                                          descriptor.IsEnabledByDefault ? Check : NoCheck,
                                          codeFixProviders.Contains(descriptor.Id) ? Check : NoCheck);
             }
@@ -410,11 +416,11 @@ namespace MiKoSolutions.Analyzers.Rules
         {
             var baseType = typeof(CodeFixProvider);
 
-            var allAnalyzers = typeof(Analyzer).Assembly.GetExportedTypes()
-                                               .Where(_ => _.IsAbstract is false && baseType.IsAssignableFrom(_))
-                                               .Select(_ => (CodeFixProvider)_.GetConstructor(Type.EmptyTypes).Invoke(null))
-                                               .OrderBy(_ => _.GetType().Name)
-                                               .ToArray();
+            var allAnalyzers = typeof(MiKoCodeFixProvider).Assembly.GetExportedTypes()
+                                                          .Where(_ => _.IsAbstract is false && baseType.IsAssignableFrom(_))
+                                                          .Select(_ => (CodeFixProvider)_.GetConstructor(Type.EmptyTypes).Invoke(null))
+                                                          .OrderBy(_ => _.GetType().Name)
+                                                          .ToArray();
 
             return allAnalyzers;
         }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzerTests.cs
@@ -1,0 +1,205 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_method() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_recursive_method() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        DoSomething();
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_mock_method_invocation_([Values("IsAny", "IsIn", "IsNotIn", "IsInRange", "IsNotNull", "IsRegex")] string method) => No_issue_is_reported_for(@"
+using System;
+
+using Moq;
+
+namespace Bla
+{
+    public interface ITestMe
+    {
+        void DoSomething(string text);
+    }
+
+    public class TestMeTests
+    {
+        private Mock<ITestMe> ObjectUnderTest { get; set; }
+
+        public void PrepareTest()
+        {
+            ObjectUnderTest = new Mock<ITestMe>();
+
+            ObjectUnderTest.Setup(_ => _.DoSomething(It." + method + @"<string>(_ => _ == ""42"")).Returns(true);
+            ObjectUnderTest.Verify(_ => _.DoSomething(It." + method + @"<string>(_ => _ == ""42""), Times.Once);
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_mock_method_invocation_using_property() => No_issue_is_reported_for(@"
+using System;
+
+using Moq;
+
+namespace Bla
+{
+    public record Dto(string Name)
+    {
+    }
+
+    public interface ITestMe
+    {
+        void DoSomething(Dto dto);
+    }
+
+    public class TestMeTests
+    {
+        private Mock<ITestMe> ObjectUnderTest { get; set; }
+
+        public void PrepareTest()
+        {
+            ObjectUnderTest = new Mock<ITestMe>();
+
+            ObjectUnderTest.Setup(_ => _.DoSomething(It.Is<Dto>(_ => _.Name == ""42""))).Returns(true);
+            ObjectUnderTest.Verify(_ => _.DoSomething(It.Is<Dto>(_ => _.Name == ""42"")), Times.Once);
+        }
+    }
+}
+");
+
+        [TestCase("object", "is", "null")]
+        [TestCase("bool", "is", "true")]
+        [TestCase("bool", "is", "false")]
+        [TestCase("object", "==", "null")]
+        [TestCase("bool", "==", "true")]
+        [TestCase("bool", "==", "false")]
+        [TestCase("string", "==", @"""42""")]
+        public void An_issue_is_reported_for_mock_method_invocation_using_direct_comparison_(string type, string comparison, string value) => An_issue_is_reported_for(@"
+using System;
+
+using Moq;
+
+namespace Bla
+{
+    public interface ITestMe
+    {
+        void DoSomething(" + type + @" data);
+    }
+
+    public class TestMeTests
+    {
+        private Mock<ITestMe> ObjectUnderTest { get; set; }
+
+        public void PrepareTest()
+        {
+            ObjectUnderTest = new Mock<ITestMe>();
+
+            ObjectUnderTest.Verify(_ => _.DoSomething(It.Is<" + type + @">(_ => _ " + comparison + " " + value + @")), Times.Once);
+        }
+    }
+}
+");
+
+        [TestCase("object", "is", "null")]
+        [TestCase("bool", "is", "true")]
+        [TestCase("bool", "is", "false")]
+        [TestCase("object", "==", "null")]
+        [TestCase("bool", "==", "true")]
+        [TestCase("bool", "==", "false")]
+        [TestCase("string", "==", @"""42""")]
+        public void Code_gets_fixed_for_mock_method_invocation_using_direct_comparison_(string type, string comparison, string value)
+        {
+            const string OriginalCode = @"
+using System;
+
+using Moq;
+
+namespace Bla
+{
+    public interface ITestMe
+    {
+        void DoSomething(#1# text);
+    }
+
+    public class TestMeTests
+    {
+        private Mock<ITestMe> ObjectUnderTest { get; set; }
+
+        public void PrepareTest()
+        {
+            ObjectUnderTest = new Mock<ITestMe>();
+
+            ObjectUnderTest.Verify(_ => _.DoSomething(It.Is<#1#>(_ => _ #2# #3#)), Times.Once);
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using Moq;
+
+namespace Bla
+{
+    public interface ITestMe
+    {
+        void DoSomething(#1# text);
+    }
+
+    public class TestMeTests
+    {
+        private Mock<ITestMe> ObjectUnderTest { get; set; }
+
+        public void PrepareTest()
+        {
+            ObjectUnderTest = new Mock<ITestMe>();
+
+            ObjectUnderTest.Verify(_ => _.DoSomething(#3#), Times.Once);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("#1#", type).Replace("#2#", comparison).Replace("#3#", value), FixedCode.Replace("#1#", type).Replace("#3#", value));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3120_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 445 rules that are currently provided by the analyzer.
+The following tables lists all the 446 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -387,6 +387,7 @@ The following tables lists all the 445 rules that are currently provided by the 
 |MiKo_3117|Test cleanup methods should contain code|&#x2713;|\-|
 |MiKo_3118|Test methods should not use ambiguous Linq calls|&#x2713;|\-|
 |MiKo_3119|Test methods should not simply return completed task|&#x2713;|&#x2713;|
+|MiKo_3120|Moq mocks should use values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values|&#x2713;|&#x2713;|
 |MiKo_3201|If statements can be inverted in short methods|&#x2713;|&#x2713;|
 |MiKo_3202|Use positive conditions when returning in all paths|&#x2713;|&#x2713;|
 |MiKo_3203|If-continue statements can be inverted when followed by single line|&#x2713;|&#x2713;|


### PR DESCRIPTION
(resolves  #942)