### PR TITLE
Added rule MiKo_6057 that reports and fixes misaligned type parameter  constraint clauses

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -309,6 +309,26 @@ namespace System.Linq
             return count;
         }
 
+        internal static int Count(this SyntaxTriviaList value, Func<SyntaxTrivia, bool> filter)
+        {
+            // keep in local variable to avoid multiple requests (see Roslyn implementation)
+            var valueCount = value.Count;
+            var count = 0;
+
+            if (valueCount > 0)
+            {
+                for (var index = 0; index < valueCount; index++)
+                {
+                    if (filter(value[index]))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+
         internal static HashSet<T> Except<T>(this HashSet<T> source, IEnumerable<T> values) where T : class
         {
             source.ExceptWith(values);

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1791,6 +1791,14 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
+        internal static bool IsSpanningMultipleLines(this SyntaxNode value)
+        {
+            var startingLine = value.GetStartingLine();
+            var endingLine = value.GetEndingLine();
+
+            return startingLine != endingLine;
+        }
+
         internal static bool IsSeeLangword(this SyntaxNode value)
         {
             if (value is XmlEmptyElementSyntax syntax && syntax.GetName() == Constants.XmlTag.See)

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -107,6 +107,31 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsLocatedAt(this SyntaxToken value, Location location) => value.GetLocation().Equals(location);
 
+        internal static bool IsSpanningMultipleLines(this SyntaxToken value)
+        {
+            var foundLine = false;
+
+            var leadingTrivia = value.LeadingTrivia;
+
+            // keep in local variable to avoid multiple requests (see Roslyn implementation)
+            var count = leadingTrivia.Count;
+
+            for (var index = 0; index < count; index++)
+            {
+                if (leadingTrivia[index].IsComment())
+                {
+                    if (foundLine)
+                    {
+                        return true;
+                    }
+
+                    foundLine = true;
+                }
+            }
+
+            return false;
+        }
+
         internal static IReadOnlyList<SyntaxToken> OfKind(this SyntaxTokenList source, SyntaxKind kind)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -46,30 +46,7 @@ namespace MiKoSolutions.Analyzers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsSingleLineComment(this SyntaxTrivia value) => value.IsKind(SyntaxKind.SingleLineCommentTrivia);
 
-        internal static bool IsSpanningMultipleLines(this SyntaxTrivia value)
-        {
-            var foundLine = false;
-
-            var leadingTrivia = value.Token.LeadingTrivia;
-
-            // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var count = leadingTrivia.Count;
-
-            for (var index = 0; index < count; index++)
-            {
-                if (leadingTrivia[index].IsComment())
-                {
-                    if (foundLine)
-                    {
-                        return true;
-                    }
-
-                    foundLine = true;
-                }
-            }
-
-            return false;
-        }
+        internal static bool IsSpanningMultipleLines(this SyntaxTrivia value) => value.Token.IsSpanningMultipleLines();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsWhiteSpace(this SyntaxTrivia value) => value.IsKind(SyntaxKind.WhitespaceTrivia);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -353,6 +353,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6054_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6055_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -517,6 +517,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6054_LambdaArrowsAreOnSameLineAsParameterListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6055_SimpleAssignmentInBlockSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15392,5 +15392,41 @@ namespace MiKoSolutions.Analyzers {
                 return ResourceManager.GetString("MiKo_6056_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align type parameter constraint vertically along with others.
+        /// </summary>
+        internal static string MiKo_6057_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6057_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The code is easier to read if type parameter constraint clauses are aligned vertically..
+        /// </summary>
+        internal static string MiKo_6057_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6057_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align type parameter constraint vertically along with others.
+        /// </summary>
+        internal static string MiKo_6057_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6057_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type parameter constraint clauses should be aligned vertically.
+        /// </summary>
+        internal static string MiKo_6057_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6057_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5383,4 +5383,16 @@ Hence, their open brackets should be positioned at the same position where the c
   <data name="MiKo_6056_Title" xml:space="preserve">
     <value>Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned</value>
   </data>
+  <data name="MiKo_6057_CodeFixTitle" xml:space="preserve">
+    <value>Align type parameter constraint vertically along with others</value>
+  </data>
+  <data name="MiKo_6057_Description" xml:space="preserve">
+    <value>The code is easier to read if type parameter constraint clauses are aligned vertically.</value>
+  </data>
+  <data name="MiKo_6057_MessageFormat" xml:space="preserve">
+    <value>Align type parameter constraint vertically along with others</value>
+  </data>
+  <data name="MiKo_6057_Title" xml:space="preserve">
+    <value>Type parameter constraint clauses should be aligned vertically</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzer.cs
@@ -147,10 +147,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeBody(SyntaxNodeAnalysisContext context, SyntaxNode lambda)
         {
-            var startingLine = lambda.GetStartingLine();
-            var endingLine = lambda.GetEndingLine();
-
-            if (startingLine != endingLine && FitsOnSingleLine(lambda))
+            if (lambda.IsSpanningMultipleLines() && FitsOnSingleLine(lambda))
             {
                 ReportDiagnostics(context, Issue(lambda));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6057_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6057_CodeFixProvider.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6057_CodeFixProvider)), Shared]
+    public sealed class MiKo_6057_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6057";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeParameterConstraintClauseSyntax>().First();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is TypeParameterConstraintClauseSyntax node)
+            {
+                var spaces = GetProposedSpaces(issue);
+
+                return node.WithWhereKeyword(node.WhereKeyword.WithLeadingSpaces(spaces));
+            }
+
+            return base.GetUpdatedSyntax(document, syntax, issue);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6057";
+
+        private static readonly SyntaxList<TypeParameterConstraintClauseSyntax> Empty = SyntaxFactory.List<TypeParameterConstraintClauseSyntax>();
+
+        public MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeTypeParameterConstraintClause, SyntaxKind.TypeParameterConstraintClause);
+
+        private static SyntaxList<TypeParameterConstraintClauseSyntax> GetConstraintClauses(SyntaxNode node)
+        {
+            switch (node)
+            {
+                case ClassDeclarationSyntax c: return c.ConstraintClauses;
+                case InterfaceDeclarationSyntax i: return i.ConstraintClauses;
+                case RecordDeclarationSyntax r: return r.ConstraintClauses;
+                case StructDeclarationSyntax s: return s.ConstraintClauses;
+                case MethodDeclarationSyntax b: return b.ConstraintClauses;
+
+                default:
+                    return Empty;
+            }
+        }
+
+        private void AnalyzeTypeParameterConstraintClause(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is TypeParameterConstraintClauseSyntax node)
+            {
+                var issues = AnalyzeTypeParameterConstraintClause(node);
+
+                ReportDiagnostics(context, issues);
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeTypeParameterConstraintClause(TypeParameterConstraintClauseSyntax node)
+        {
+            var clauses = GetConstraintClauses(node.Parent);
+
+            if (clauses.Count <= 1)
+            {
+                // do not report the single one
+                yield break;
+            }
+
+            var reference = clauses[0];
+
+            if (node == reference)
+            {
+                // do not report for the first one
+                yield break;
+            }
+
+            var whereKeyword = node.WhereKeyword;
+
+            var referencePosition = reference.GetPositionWithinStartLine();
+            var position = whereKeyword.GetPositionWithinStartLine();
+
+            if (position != referencePosition || whereKeyword.LeadingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+            {
+                yield return Issue(whereKeyword, CreateProposalForSpaces(referencePosition));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzerTests.cs
@@ -1,0 +1,495 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] Types = ["class", "interface", "record", "struct"];
+
+        [Test]
+        public void No_issue_is_reported_for_method_without_type_parameter_constraint_clause() => No_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething() { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_type_without_type_parameter_constraint_clause_([ValueSource(nameof(Types))] string type) => No_issue_is_reported_for(@"
+public " + type + @" TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_type_with_type_parameter_constraint_clause_on_same_line_([ValueSource(nameof(Types))] string type) => No_issue_is_reported_for(@"
+public " + type + @" TestMe<T> where T : class
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_([ValueSource(nameof(Types))] string type) => No_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left() => An_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                      where T2 : class
+                                          where T3 : class
+    { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_right() => An_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                              where T2 : class
+                                          where T3 : class
+    { }
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_and_another_more_to_right() => An_issue_is_reported_for(2, @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                      where T2 : class
+                                              where T3 : class
+    { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between() => An_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_left() => An_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                      where T2 : class
+                                          where T3 : class
+    { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_right() => An_issue_is_reported_for(@"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                              where T2 : class
+                                          where T3 : class
+    { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                where T1 : class
+                            where T2 : class
+                                where T3 : class
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_right_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                    where T1 : class
+                                        where T2 : class
+                                    where T3 : class
+{
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_and_another_more_to_right_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(2, @"
+public " + type + @" TestMe<T1, T2, T3>
+                                    where T1 : class
+                                where T2 : class
+                                        where T3 : class
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                    where T1 : class
+
+                                    where T2 : class
+                                    where T3 : class
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_left_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                    where T1 : class
+
+                                where T2 : class
+                                    where T3 : class
+{
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_right_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+public " + type + @" TestMe<T1, T2, T3>
+                                    where T1 : class
+
+                                        where T2 : class
+                                    where T3 : class
+{
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                      where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_right()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                              where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_and_another_more_to_right()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                      where T2 : class
+                                              where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_left()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                      where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_right()
+        {
+            const string OriginalCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+
+                                              where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            const string FixedCode = @"
+public class class TestMe
+{
+    public void DoSomething<T1, T2, T3>() where T1 : class
+                                          where T2 : class
+                                          where T3 : class
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                            where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_right_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                    where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_aligned_more_to_left_and_another_more_to_right_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                            where T2 : class
+                                    where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_left_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+
+                            where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_multiple_type_parameter_constraint_clauses_aligned_vertically_and_one_has_empty_line_between_and_is_aligned_more_to_right_([ValueSource(nameof(Types))] string type)
+        {
+            const string OriginalCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+
+                                    where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            const string FixedCode = @"
+public ### TestMe<T1, T2, T3>
+                                where T1 : class
+                                where T2 : class
+                                where T3 : class
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", type), FixedCode.Replace("###", type));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6057_TypeParameterConstrainsClausesVerticallyAlignedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6057_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 447 rules that are currently provided by the analyzer.
+The following tables lists all the 448 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -491,3 +491,4 @@ The following tables lists all the 447 rules that are currently provided by the 
 |MiKo_6054|Lambda arrows shall be placed on same line as the parameter(s) of the lambda|&#x2713;|&#x2713;|
 |MiKo_6055|Assignment statements should be surrounded by blank lines|&#x2713;|&#x2713;|
 |MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
+|MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|


### PR DESCRIPTION
(resolves #976)