### PR TITLE
MiKo analyzers now find API documentation separated by empty lines from code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator (IDE0100)

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -992,13 +992,17 @@ namespace MiKoSolutions.Analyzers
                         return null; // nothing more to do
                 }
 
-                var trivia = leadingTrivia[index];
-
-                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+                // just go reverse from the likely index to find any documentation that might be separated via (multiple) empty lines
+                for (; index >= 0; index--)
                 {
-                    if (trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
+                    var trivia = leadingTrivia[index];
+
+                    if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
                     {
-                        return syntax;
+                        if (trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
+                        {
+                            return syntax;
+                        }
                     }
                 }
             }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzerTests.cs
@@ -82,6 +82,20 @@ public class TestMe
 ");
 
         [Test]
+        public void An_issue_is_reported_for_property_with_obvious_documentation_and_empty_line_([ValueSource(nameof(ObviousStartingPhrases))] string obvious, [Values("", ".")] string ending) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// " + obvious + " Age" + ending + @"
+    /// </summary>
+
+    public int Age { get; set; }
+}
+");
+
+        [Test]
         public void Code_gets_fixed_for_property_with_obvious_documentation_([ValueSource(nameof(ObviousStartingPhrases))] string obvious, [Values("", ".")] string ending)
         {
             var originalCode = @"
@@ -92,6 +106,34 @@ public class TestMe
     /// <summary>
     /// " + obvious + " Age" + ending + @"
     /// </summary>
+    public int Age { get; set; }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int Age { get; set; }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_property_with_obvious_documentation_and_empty_line_([ValueSource(nameof(ObviousStartingPhrases))] string obvious, [Values("", ".")] string ending)
+        {
+            var originalCode = @"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// " + obvious + " Age" + ending + @"
+    /// </summary>
+
     public int Age { get; set; }
 }
 ";

--- a/MiKo.Analyzer.v3.ncrunchsolution
+++ b/MiKo.Analyzer.v3.ncrunchsolution
@@ -1,7 +1,7 @@
 ﻿<SolutionConfiguration>
   <Settings>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
-    <EnableRDI>True</EnableRDI>
+    <EnableRDI>False</EnableRDI>
     <FastLaneThreads>0</FastLaneThreads>
     <HotSpotsExclusionList>
       <Value>Rules\Analyzer.cs:MiKo.Analyzer\MiKo.Analyzer.csproj</Value>
@@ -15,7 +15,7 @@
     <PipelineOptimisationPriority>Throughput</PipelineOptimisationPriority>
     <RdiConfigured>True</RdiConfigured>
     <RestrictToString>False</RestrictToString>
-    <SlidingBuildDelayInMilliseconds>1000</SlidingBuildDelayInMilliseconds>
+    <SlidingBuildDelayInMilliseconds>2500</SlidingBuildDelayInMilliseconds>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
   <EngineModes>


### PR DESCRIPTION
Includes
- deactivation of RDI for NCrunch (as that takes too long to process and too much disk space)
- sliding build delay increase to 2.500ms
- deactivation of IDE0100 rule as that reports "xyz is false" to be fixed to "!xyz", which is unwanted