### PR TITLE
Added new rule MiKo_3221 that reports 'GetHashCode()' implementation and fixes it to 'HashCode.Combine()'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -194,6 +194,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3215_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3216_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -297,6 +297,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3218_DoNotDefineExtensionMethodsInUnexpectedPlacesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_LogicalConditionsUsingTrueFalseCanBeSimplifiedAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_GetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12862,6 +12862,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;HashCode.Combine&apos;.
+        /// </summary>
+        internal static string MiKo_3221_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3221_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To improve the quality of the hash code returned by &apos;GetHashCode&apos;, developers should use &apos;HashCode.Combine&apos; (when the underlying data type is simple, for example, an integer value)..
+        /// </summary>
+        internal static string MiKo_3221_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3221_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;HashCode.Combine&apos; instead.
+        /// </summary>
+        internal static string MiKo_3221_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3221_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GetHashCode overrides should use &apos;HashCode.Combine&apos;.
+        /// </summary>
+        internal static string MiKo_3221_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3221_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4531,6 +4531,18 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3220_Title" xml:space="preserve">
     <value>Logical '&amp;&amp;' or '||' conditions using 'true' or 'false' should be simplified</value>
   </data>
+  <data name="MiKo_3221_CodeFixTitle" xml:space="preserve">
+    <value>Use 'HashCode.Combine'</value>
+  </data>
+  <data name="MiKo_3221_Description" xml:space="preserve">
+    <value>To improve the quality of the hash code returned by 'GetHashCode', developers should use 'HashCode.Combine' (when the underlying data type is simple, for example, an integer value).</value>
+  </data>
+  <data name="MiKo_3221_MessageFormat" xml:space="preserve">
+    <value>Use 'HashCode.Combine' instead</value>
+  </data>
+  <data name="MiKo_3221_Title" xml:space="preserve">
+    <value>GetHashCode overrides should use 'HashCode.Combine'</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3221_CodeFixProvider)), Shared]
+    public sealed class MiKo_3221_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3221";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<MethodDeclarationSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is MethodDeclarationSyntax method)
+            {
+                var nodes = new List<SyntaxNode>();
+
+                foreach (var expression in method.DescendantNodes<MemberAccessExpressionSyntax>())
+                {
+                    if (expression.Name.GetName() == nameof(GetHashCode))
+                    {
+                        switch (expression.Expression)
+                        {
+                            case IdentifierNameSyntax identifier:
+                                nodes.Add(identifier);
+                                break;
+
+                            case BaseExpressionSyntax _:
+                                nodes.Add(expression.Parent);
+                                break;
+                        }
+                    }
+                }
+
+                var count = nodes.Count;
+
+                if (count > 8)
+                {
+                    return GetUpdatedSyntaxWithHashCodeCreation(nodes, method);
+                }
+
+                if (count > 0)
+                {
+                    return GetUpdatedSyntaxWithHashCodeCombine(nodes, method);
+                }
+            }
+
+            return syntax;
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxWithHashCodeCreation(IEnumerable<SyntaxNode> nodes, MethodDeclarationSyntax method)
+        {
+            var statements = nodes.Select(_ => SyntaxFactory.ParseStatement("hash.Add(" + _ + ");")).ToList();
+            statements.Insert(0, SyntaxFactory.ParseStatement("var hash = new HashCode();"));
+            statements.Add(SyntaxFactory.ParseStatement("return hash.ToHashCode();"));
+
+            return method.WithBody(SyntaxFactory.Block(statements.Select(_ => _.WithIndentation().WithTrailingNewLine())))
+                         .WithExpressionBody(null)
+                         .WithSemicolonToken(default);
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxWithHashCodeCombine(IEnumerable<SyntaxNode> nodes, MethodDeclarationSyntax method)
+        {
+            var arguments = nodes.Select(_ => Argument(_.ToString())).ToArray();
+            var invocation = Invocation("HashCode", "Combine", arguments);
+
+            return method.WithBody(null)
+                         .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(invocation))
+                         .WithSemicolonToken(SyntaxKind.SemicolonToken.AsToken());
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3221_GetHashCodeAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3221";
+
+        private const string HashCode = "HashCode";
+        private const string Combine = "Combine";
+        private const string ToHashCode = "ToHashCode";
+
+        public MiKo_3221_GetHashCodeAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName("System." + HashCode) != null;
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsOverride && symbol.Name == nameof(GetHashCode);
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        {
+            if (symbol.GetSyntax<MethodDeclarationSyntax>() is MethodDeclarationSyntax method)
+            {
+                var expressionsCount = 0;
+                var expressions = method.DescendantNodes<MemberAccessExpressionSyntax>();
+
+                foreach (var expression in expressions)
+                {
+                    switch (expression.GetName())
+                    {
+                        case ToHashCode:
+                        case Combine when expression.Expression.GetName() == HashCode:
+                            yield break;
+                    }
+
+                    expressionsCount++;
+                }
+
+                if (expressionsCount == 0)
+                {
+                    // we do not have any members to combine
+                    yield break;
+                }
+
+                yield return Issue(method);
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzerTests.cs
@@ -1,0 +1,382 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3221_GetHashCodeAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_GetHashCode_method() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething() { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_GetHashCode_method_using_HashCode_Add() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8, m_field9;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(m_field1);
+        hash.Add(m_field2);
+        hash.Add(m_field3);
+        hash.Add(m_field4);
+        hash.Add(m_field5);
+        hash.Add(m_field6);
+        hash.Add(m_field7);
+        hash.Add(m_field8);
+        hash.Add(m_field9);
+        return hash.ToHashCode();
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_GetHashCode_body_method_using_HashCode_Combine() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(08, 15);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_GetHashCode_expression_body_method_using_HashCode_Combine() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public override int GetHashCode() => HashCode.Combine(08, 15);
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_GetHashCode_body_method_not_using_only_a_number() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public override int GetHashCode()
+    {
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_GetHashCode_expression_body_method_using_only_a_number() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public override int GetHashCode() => 42;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_GetHashCode_body_method_not_using_HashCode_Combine() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode()
+    {
+        return 42 ^ m_field.GetHashCode();
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_GetHashCode_expression_body_method_not_using_HashCode_Combine() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode() => 42 ^ m_field.GetHashCode();
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_expression_body_method_with_1_argument()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode() => m_field.GetHashCode();
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode() => HashCode.Combine(m_field);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_expression_body_method_with_2_arguments()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2;
+
+    public override int GetHashCode() => 42 * m_field1.GetHashCode() ^ m_field2.GetHashCode();
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2;
+
+    public override int GetHashCode() => HashCode.Combine(m_field1, m_field2);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_expression_body_method_with_8_arguments()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8;
+
+    public override int GetHashCode() => 42 * m_field1.GetHashCode() ^ m_field2.GetHashCode() ^ m_field3.GetHashCode() ^ m_field4.GetHashCode() ^ m_field5.GetHashCode() ^ m_field6.GetHashCode() ^ m_field7.GetHashCode() ^ m_field8.GetHashCode();
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8;
+
+    public override int GetHashCode() => HashCode.Combine(m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_expression_body_method_with_9_arguments()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8, m_field9;
+
+    public override int GetHashCode() => 42 * m_field1.GetHashCode() ^ m_field2.GetHashCode() ^ m_field3.GetHashCode() ^ m_field4.GetHashCode() ^ m_field5.GetHashCode() ^ m_field6.GetHashCode() ^ m_field7.GetHashCode() ^ m_field8.GetHashCode() ^ m_field9.GetHashCode();
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8, m_field9;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(m_field1);
+        hash.Add(m_field2);
+        hash.Add(m_field3);
+        hash.Add(m_field4);
+        hash.Add(m_field5);
+        hash.Add(m_field6);
+        hash.Add(m_field7);
+        hash.Add(m_field8);
+        hash.Add(m_field9);
+        return hash.ToHashCode();
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_body_method_with_1_argument()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode()
+    {
+        return m_field.GetHashCode();
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field;
+
+    public override int GetHashCode() => HashCode.Combine(m_field);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_body_method_with_9_arguments()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8, m_field9;
+
+    public override int GetHashCode()
+    {
+        var result = 42 * m_field1.GetHashCode()
+                        ^ m_field2.GetHashCode()
+                        ^ m_field3.GetHashCode()
+                        ^ m_field4.GetHashCode()
+                        ^ m_field5.GetHashCode()
+                        ^ m_field6.GetHashCode()
+                        ^ m_field7.GetHashCode()
+                        ^ m_field8.GetHashCode()
+                        ^ m_field9.GetHashCode();
+
+        return result;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private object m_field1, m_field2, m_field3, m_field4, m_field5, m_field6, m_field7, m_field8, m_field9;
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(m_field1);
+        hash.Add(m_field2);
+        hash.Add(m_field3);
+        hash.Add(m_field4);
+        hash.Add(m_field5);
+        hash.Add(m_field6);
+        hash.Add(m_field7);
+        hash.Add(m_field8);
+        hash.Add(m_field9);
+        return hash.ToHashCode();
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_GetHashCode_body_method_with_base_GetHashCode_argument()
+        {
+            const string OriginalCode = @"
+using System;
+
+public abstract class BaseClass
+{
+    public override int GetHashCode() => 42;
+}
+
+public class TestMe : BaseClass
+{
+    private readonly object m_field = new object();
+
+    public override int GetHashCode()
+    {
+        var hashCode = 339610899;
+        hashCode = hashCode * -1521134295 + base.GetHashCode();
+        hashCode = hashCode * -1521134295 + m_field.GetHashCode();
+        return hashCode;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public abstract class BaseClass
+{
+    public override int GetHashCode() => 42;
+}
+
+public class TestMe : BaseClass
+{
+    private readonly object m_field = new object();
+
+    public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), m_field);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode, allowNewCompilerDiagnostics: true); // needed as Compiler reports CS0103
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3221_GetHashCodeAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3221_GetHashCodeAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3221_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 455 rules that are currently provided by the analyzer.
+The following tables lists all the 456 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -408,6 +408,7 @@ The following tables lists all the 455 rules that are currently provided by the 
 |MiKo_3218|Do not define extension methods in unexpected places|&#x2713;|\-|
 |MiKo_3219|Public members should not be 'virtual'|&#x2713;|\-|
 |MiKo_3220|Logical '&amp;&amp;' or '&#124;&#124;' conditions using 'true' or 'false' should be simplified|&#x2713;|&#x2713;|
+|MiKo_3221|GetHashCode overrides should use 'HashCode.Combine'|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
(resolves #992)