### PR TITLE
MiKo_3075 is now aware of global classes

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -38,7 +39,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return Enumerable.Empty<Diagnostic>();
             }
 
-            if (symbol.Name == "<Program>$") // TODO RKN: What about "$Program" ?
+            var node = symbol.GetSyntaxNodeInSource();
+
+            if (node is CompilationUnitSyntax)
             {
                 // nothing to report as we cannot use it anyway (such as the 'Program' class in the new C# global statement style)
                 return Enumerable.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzerTests.cs
@@ -12,6 +12,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     public sealed class MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzerTests : CodeFixVerifier
     {
         [Test]
+        public void No_issue_is_reported_for_top_level_class() => No_issue_is_reported_for(@"
+
+var str = ""some text"";
+
+");
+
+        [Test]
         public void No_issue_is_reported_for_abstract_class_with_accessibility_([Values("public", "internal", "protected", "private")] string accessibility) => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Enhanced the `MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzer` to handle global classes by checking for `CompilationUnitSyntax`.
- Added a new test case to ensure no issues are reported for top-level classes, verifying the new handling of global classes.
