### PR TITLE
MiKo 2021 is now aware of "Determines", MiKo_6048 is now aware of semicolon

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
@@ -11,9 +11,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2021_CodeFixProvider)), Shared]
     public sealed class MiKo_2021_CodeFixProvider : ParameterDocumentationCodeFixProvider
     {
-        private static readonly string[] ReplacementMapKeys = { "Reference to the ", "Reference to a ", "Reference to an " };
+        private static readonly Pair[] ReplacementMap =
+                                                        {
+                                                            new Pair("Reference to a ", string.Empty),
+                                                            new Pair("Reference to an ", string.Empty),
+                                                            new Pair("Reference to the ", string.Empty),
+                                                            new Pair("Determines the ", string.Empty),
+                                                            new Pair("Determines to ", "value to "), // TODO RKN: new Pair("Determines to ", "value to "),
+                                                        };
 
-        private static readonly Pair[] ReplacementMap = ReplacementMapKeys.ToArray(_ => new Pair(_, string.Empty));
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.Select(_ => _.Key).ToArray();
 
         public override string FixableDiagnosticId => "MiKo_2021";
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -354,7 +354,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return new ConcreteMapInfo(mappedDataValue.ReplacementMapForOthers, mappedDataValue.ReplacementMapKeysForOthers, mappedDataValue.ReplacementMapKeysInUpperCaseForOthers);
         }
 
-        private ref struct ConcreteMapInfo
+        private readonly ref struct ConcreteMapInfo
         {
             public ConcreteMapInfo(ReadOnlySpan<Pair> map, string[] keys, string[] keysInUpperCase)
             {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6048_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6048_CodeFixProvider.cs
@@ -19,12 +19,44 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
         {
-            if (syntax.Parent is IfStatementSyntax statement)
+            switch (syntax.Parent)
             {
-                var updated = statement.WithOpenParenToken(statement.OpenParenToken.WithoutTrailingTrivia())
-                                       .WithCloseParenToken(statement.CloseParenToken.WithoutLeadingTrivia());
+                case IfStatementSyntax statement:
+                {
+                    var updated = statement.WithOpenParenToken(statement.OpenParenToken.WithoutTrailingTrivia())
+                                           .WithCloseParenToken(statement.CloseParenToken.WithoutLeadingTrivia());
 
-                return root.ReplaceNode(statement, updated);
+                    return root.ReplaceNode(statement, updated);
+                }
+
+                case ArrowExpressionClauseSyntax arrowClause:
+                {
+                    switch (arrowClause.Parent)
+                    {
+                        case BaseMethodDeclarationSyntax method:
+                        {
+                            var updatedMethod = method.WithSemicolonToken(method.SemicolonToken.WithoutLeadingTrivia());
+
+                            return root.ReplaceNode(method, updatedMethod);
+                        }
+
+                        case PropertyDeclarationSyntax property:
+                        {
+                            var updatedProperty = property.WithSemicolonToken(property.SemicolonToken.WithoutLeadingTrivia());
+
+                            return root.ReplaceNode(property, updatedProperty);
+                        }
+                    }
+
+                    break;
+                }
+
+                case ReturnStatementSyntax returnStatement:
+                {
+                    var updatedReturnStatement = returnStatement.WithSemicolonToken(returnStatement.SemicolonToken.WithoutLeadingTrivia());
+
+                    return root.ReplaceNode(returnStatement, updatedReturnStatement);
+                }
             }
 
             return base.GetUpdatedSyntaxRoot(document, root, syntax, annotationOfSyntax, issue);

--- a/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Attributes.cs
+++ b/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Attributes.cs
@@ -3,6 +3,7 @@
 using NUnit.Framework;
 
 //// ncrunch: rdi off
+// ReSharper disable CheckNamespace
 namespace TestHelper
 {
     public partial class CodeFixVerifier

--- a/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Contradictions.cs
+++ b/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Contradictions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 
 //// ncrunch: rdi off
+// ReSharper disable CheckNamespace
 namespace TestHelper
 {
     public partial class CodeFixVerifier

--- a/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Helper.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Simplification;
 
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
+// ReSharper disable CheckNamespace
 namespace TestHelper
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticResult.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticResult.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.CodeAnalysis;
 
 //// ncrunch: rdi off
+// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace TestHelper
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticResultLocation.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticResultLocation.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 
 //// ncrunch: rdi off
+// ReSharper disable CheckNamespace
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace TestHelper
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -25,6 +25,7 @@ using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
+// ReSharper disable CheckNamespace
 namespace TestHelper
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
@@ -81,17 +81,6 @@ public class TestMe
 }
 ");
 
-        [TestCase("whatever.")]
-        [TestCase("Whatever.")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
-public class TestMe
-{
-    /// <summary />
-    /// <param name='o'>" + comment + @"</param>
-    public void DoSomething(object o) { }
-}
-");
-
         [TestCase("<summary />")]
         [TestCase("<inheritdoc />")]
         [TestCase("<exclude />")]
@@ -99,6 +88,17 @@ public class TestMe
 public class TestMe
 {
     /// " + xmlElement + @"
+    public void DoSomething(object o) { }
+}
+");
+
+        [TestCase("whatever.")]
+        [TestCase("Whatever.")]
+        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>" + comment + @"</param>
     public void DoSomething(object o) { }
 }
 ");
@@ -155,6 +155,34 @@ public class TestMe
 }";
 
             VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [TestCase("Determines the", "The")]
+        [TestCase("Determines to which extend", "The value to which extend")]
+        [TestCase("Determines to what extend", "The value to what extend")]
+        public void Code_gets_fixed_for_parameter_with_Determines(string originalStart, string fixedStart)
+        {
+            var originalCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>
+    /// " + originalStart + @" stuff.
+    /// </param>
+    public void DoSomething(object o) { }
+}";
+
+            var fixedCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>
+    /// " + fixedStart + @" stuff.
+    /// </param>
+    public void DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(originalCode, fixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2021_ParamDefaultPhraseAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6048_LogicalConditionsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6048_LogicalConditionsAreOnSameLineAnalyzerTests.cs
@@ -311,7 +311,8 @@ public class TestMe : IEquatable<TestMe>
         && (
                         B == other.B
                         || (B != null
-        && B.Equals(other.B, StringComparison.Ordinal)));
+        && B.Equals(other.B, StringComparison.Ordinal)))
+        ;
     }
 }
 ";
@@ -351,7 +352,8 @@ B == other.B || (B != null && B.Equals(other.B, StringComparison.Ordinal)))
 && (
 C == other.C || (C != null && C.Equals(other.C)))
 && (
-D == other.D || (D != null && D.Equals(other.D, StringComparison.Ordinal))) && base.Equals(other);
+D == other.D || (D != null && D.Equals(other.D, StringComparison.Ordinal))) && base.Equals(other)
+;
 }
 ";
 
@@ -387,7 +389,8 @@ public class TestMe : IEquatable<TestMe>
         && (
                         B == other.B
                         || (B != null
-        && B.Equals(other.B, StringComparison.Ordinal)));
+        && B.Equals(other.B, StringComparison.Ordinal)))
+        ;
 }
 ";
 
@@ -399,6 +402,46 @@ public class TestMe : IEquatable<TestMe>
     public string A, B;
 
     public bool Equals(TestMe other) => (A == other.A || (A != null && A.Equals(other.A, StringComparison.Ordinal))) && (B == other.B || (B != null && B.Equals(other.B, StringComparison.Ordinal)));
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_parenthesized_logical_condition_parts_are_all_on_their_own_lines_and_parenthesis_are_on_separate_lines_for_arrow_clause_on_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private TestMe other;
+
+    public string A, B;
+
+    public bool Equality => (
+                A == other.A
+                || (A != null
+        && A.Equals(other.A, StringComparison.Ordinal)))
+        && (
+                        B == other.B
+                        || (B != null
+        && B.Equals(other.B, StringComparison.Ordinal)))
+        ;
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private TestMe other;
+
+    public string A, B;
+
+    public bool Equality => (A == other.A || (A != null && A.Equals(other.A, StringComparison.Ordinal))) && (B == other.B || (B != null && B.Equals(other.B, StringComparison.Ordinal)));
 }
 ";
 


### PR DESCRIPTION
- Enhanced the `MiKo_2021_CodeFixProvider` to handle phrases starting with "Determines".
- Made `ConcreteMapInfo` struct readonly in `MiKo_2023_CodeFixProvider`.
- Improved spacing logic in `MiKo_6048_CodeFixProvider` for various syntax nodes.
- Added new test cases for handling "Determines" phrases in documentation.
- Disabled ReSharper namespace checks and IDE0130 warnings in test helper files.

