### PR TITLE
MiKo_2013 better fixes types with 'Type', 'Enum' or 'Kind' in its name / summary

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/FirstWordHandling.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/FirstWordHandling.cs
@@ -19,18 +19,23 @@ namespace MiKoSolutions.Analyzers.Linguistics
         KeepLeadingSpace = 1 << 0,
 
         /// <summary>
-        /// Attempt to make it an infinite verb.
-        /// </summary>
-        MakeInfinite = 1 << 1,
-
-        /// <summary>
         /// Attempt to make the word starting with an upper case.
         /// </summary>
-        MakeUpperCase = 1 << 2,
+        MakeUpperCase = 1 << 1,
 
         /// <summary>
         /// Attempt to make the word starting with a lower case.
         /// </summary>
-        MakeLowerCase = 1 << 3,
+        MakeLowerCase = 1 << 2,
+
+        /// <summary>
+        /// Attempt to make it an infinite verb.
+        /// </summary>
+        MakeInfinite = 1 << 3,
+
+        /// <summary>
+        /// Attempt to make it a plural verb.
+        /// </summary>
+        MakePlural = 1 << 4,
     }
 }

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -24,6 +24,8 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly ConcurrentDictionary<string, string> InfiniteVerbs = new ConcurrentDictionary<string, string>();
 
+        private static readonly ConcurrentDictionary<string, string> Plurals = new ConcurrentDictionary<string, string>();
+
         private static readonly ConcurrentDictionary<string, string> ThirdPersonSingularVerbs = new ConcurrentDictionary<string, string>();
 
         private static readonly Pair[] Endings =
@@ -403,6 +405,31 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 }
 
                 return word;
+            }
+        }
+
+        public static string MakePlural(string value)
+        {
+            if (value.IsNullOrWhiteSpace())
+            {
+                return value;
+            }
+
+            return Plurals.GetOrAdd(value, CreatePlural);
+
+            string CreatePlural(string word)
+            {
+                if (word.EndsWith('s'))
+                {
+                    if (word.EndsWith("ss", StringComparison.Ordinal))
+                    {
+                        return word + "es";
+                    }
+
+                    return word;
+                }
+
+                return word.AsSpan().ConcatenatedWith('s');
             }
         }
 

--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -10,9 +10,10 @@ namespace MiKoSolutions.Analyzers.Extensions
     public static class StringBuilderExtensionsTests
     {
         private const int KeepLeadingSpace = 1 << 0;
-        private const int MakeInfinite = 1 << 1;
-        private const int MakeUpperCase = 1 << 2;
-        private const int MakeLowerCase = 1 << 3;
+        private const int MakeUpperCase = 1 << 1;
+        private const int MakeLowerCase = 1 << 2;
+        private const int MakeInfinite = 1 << 3;
+        private const int MakePlural = 1 << 4;
 
         [TestCase("", ExpectedResult = "")]
         [TestCase(" ", ExpectedResult = "")]
@@ -86,6 +87,10 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase(" represent", MakeInfinite | KeepLeadingSpace, " represent")]
         [TestCase("   represent", MakeInfinite, "represent")]
         [TestCase("   represent", MakeInfinite | KeepLeadingSpace, " represent")]
+        [TestCase("message", MakePlural, "messages")]
+        [TestCase("message", MakePlural | KeepLeadingSpace, "messages")]
+        [TestCase(" message", MakePlural | KeepLeadingSpace, " messages")]
+        [TestCase("   message", MakePlural | KeepLeadingSpace, " messages")]
         public static void AdjustFirstWordHandling(string s, int handling, string expectedResult)
         {
             var builder = new StringBuilder(s);

--- a/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
@@ -277,5 +277,11 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("shutting", ExpectedResult = true)]
         [TestCase("Shutting", ExpectedResult = true)]
         public static bool IsGerundVerb_detects_gerund_verb_(string name) => Verbalizer.IsGerundVerb(name);
+
+        [TestCase("access", ExpectedResult = "accesses")]
+        [TestCase("accesses", ExpectedResult = "accesses")]
+        [TestCase("Message", ExpectedResult = "Messages")]
+        [TestCase("Messages", ExpectedResult = "Messages")]
+        public static string MakePlural_finds_proper_plural(string name) => Verbalizer.MakePlural(name);
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -306,7 +306,7 @@ public enum TestMe
         [TestCase("Sets", "")]
         [TestCase("Gets or sets", "")]
         [TestCase("Gets or Sets", "")]
-        public void Code_gets_fixed_for_documentation_(string start, string expectedStart)
+        public void Code_gets_fixed_for_documentation_(string start, string fixedStart)
         {
             var originalCode = @"
 /// <summary>
@@ -319,9 +319,43 @@ public enum TestMe
 
             var fixedCode = @"
 /// <summary>
-/// Defines values that specify " + expectedStart + @"something to do.
+/// Defines values that specify " + fixedStart + @"something to do.
 /// </summary>
 public enum TestMe
+{
+}
+";
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [TestCase("Message", "messages")]
+        [TestCase("MessageEnum", "messages")]
+        [TestCase("MessageKind", "messages")]
+        [TestCase("MessageType", "messages")]
+        [TestCase("MessageTypes", "messages")]
+        [TestCase("MessageTypeKind", "messages")]
+        [TestCase("MessageTypeKinds", "messages")]
+        [TestCase("MessageTypeEnum", "messages")]
+        [TestCase("MessageTypeEnums", "messages")]
+        [TestCase("Direction", "directions")]
+        [TestCase("DirectionKind", "directions")]
+        [TestCase("ReferenceTypes", "references")]
+        public void Code_gets_fixed_for_special_documentation_(string typeName, string fixedEnding)
+        {
+            var originalCode = @"
+/// <summary>
+/// Gets or Sets " + typeName + @"
+/// </summary>
+public enum " + typeName + @"
+{
+}
+";
+
+            var fixedCode = @"
+/// <summary>
+/// Defines values that specify the different kinds of " + fixedEnding + @"
+/// </summary>
+public enum " + typeName + @"
 {
 }
 ";


### PR DESCRIPTION
- Enhanced `StringBuilderExtensions` and `StringExtensions` to support pluralization of words.
- Updated `FirstWordHandling` enum to include a `MakePlural` option.
- Added `MakePlural` method in `Verbalizer` to handle word pluralization.
- Improved `MiKo_2013_CodeFixProvider` to handle pluralization in XML comments.
- Added comprehensive tests for new pluralization features across different components.