### PR TITLE
Code cleaned up a bit

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
@@ -84,12 +84,9 @@ namespace MiKoSolutions.Analyzers
             return GetCommentElements(element, xmlTag);
         }
 
-        internal static IEnumerable<XElement> GetCommentElements(this XElement value, string xmlTag)
-        {
-            return value is null
-                   ? Enumerable.Empty<XElement>() // happens in case of an invalid character
-                   : value.Descendants(xmlTag);
-        }
+        internal static IEnumerable<XElement> GetCommentElements(this XElement value, string xmlTag) => value is null
+                                                                                                        ? Enumerable.Empty<XElement>() // happens in case of an invalid character
+                                                                                                        : value.Descendants(xmlTag);
 
         internal static IEnumerable<XElement> GetExceptionCommentElements(string commentXml)
         {

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -257,6 +257,7 @@ namespace MiKoSolutions.Analyzers
                     case IFieldSymbol _: return null;
 
                     default:
+                        // parameters might be part of properties or methods, so we have to do the loop here
                         symbol = symbol.ContainingSymbol;
 
                         break;

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -845,7 +845,7 @@ namespace MiKoSolutions.Analyzers
                     }
 
                     case BasePropertyDeclarationSyntax property:
-                        return property?.AccessorList?.Accessors.Any(_ => _.IsKind(SyntaxKind.SetAccessorDeclaration)) is true
+                        return property.AccessorList?.Accessors.Any(_ => _.IsKind(SyntaxKind.SetAccessorDeclaration)) is true
                                ? Constants.Names.DefaultPropertyParameterNames
                                : Array.Empty<string>();
                 }
@@ -899,7 +899,11 @@ namespace MiKoSolutions.Analyzers
         {
             var symbol = semanticModel.GetDeclaredSymbol(value);
 
+#if VS2022
+            return symbol;
+#else
             return symbol as IMethodSymbol;
+#endif
         }
 
         internal static ITypeSymbol GetTypeSymbol(this ArgumentSyntax value, Compilation compilation)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -28,8 +28,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var result = new string[orderedTerms.Count];
 
-            bool found;
             var resultIndex = 0;
+
+            // ReSharper disable once TooWideLocalVariableScope : it's done to have less memory pressure on garbage collector
+            bool found;
 
             while (orderedTerms.Count > 0)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
@@ -52,11 +52,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected IEnumerable<Diagnostic> AnalyzeParameters(IMethodSymbol symbol, string commentXml, DocumentationCommentTriviaSyntax comment)
         {
             var parameters = symbol.Parameters;
+            var parametersLength = parameters.Length;
 
-            if (parameters.Length > 0)
+            if (parametersLength > 0)
             {
-                foreach (var parameter in parameters)
+                for (var index = 0; index < parametersLength; index++)
                 {
+                    var parameter = parameters[index];
+
                     if (ShallAnalyzeParameter(parameter))
                     {
                         var parameterComment = comment.GetParameterComment(parameter.Name);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_PropertyChangeEventArgsViaCinchAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_PropertyChangeEventArgsViaCinchAnalyzer.cs
@@ -78,7 +78,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     properties.Add(Constants.AnalyzerCodeFixSharedData.PropertyTypeName, type.GetNameOnlyPart());
                 }
 
-                var issue = Issue(symbol?.Name, node, issueTemplate.FormatWith(propertyName), properties);
+                var issue = Issue(symbol.Name, node, issueTemplate.FormatWith(propertyName), properties);
+
                 ReportDiagnostics(context, issue);
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
@@ -157,7 +157,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (parent != null && parent.IsKind(SyntaxKind.ParenthesizedExpression))
             {
-                parent = parent?.Parent;
+                parent = parent.Parent;
             }
 
             return parent;
@@ -169,7 +169,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case SyntaxKind.UnaryMinusExpression:
                 case SyntaxKind.UnaryPlusExpression:
-                    return parent?.Parent;
+                    return parent.Parent;
 
                 default:
                     return parent;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1094_NamespaceAsClassSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1094_NamespaceAsClassSuffixAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
@@ -45,8 +45,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 #endif
         }
 
-        protected string GetNewName(Diagnostic diagnostic, ISymbol symbol) => diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.BetterName, out var betterName) ? betterName : symbol.Name;
-
         protected sealed override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => throw new NotSupportedException("This code fix provider does not modify the syntax");
+
+        private static string GetNewName(Diagnostic diagnostic, ISymbol symbol) => diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.BetterName, out var betterName) ? betterName : symbol.Name;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6002_AssertStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6002_AssertStatementSurroundedByBlankLinesAnalyzer.cs
@@ -23,12 +23,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 return false;
             }
 
-            if (typeName.EndsWith("Assert", StringComparison.Ordinal) is true)
+            if (typeName.EndsWith("Assert", StringComparison.Ordinal))
             {
                 return true;
             }
 
-            if (typeName.EndsWith("Assume", StringComparison.Ordinal) is true)
+            if (typeName.EndsWith("Assume", StringComparison.Ordinal))
             {
                 return true;
             }

--- a/MiKo.Analyzer.Tests/Rules/TestCaseData.cs
+++ b/MiKo.Analyzer.Tests/Rules/TestCaseData.cs
@@ -3,9 +3,9 @@ namespace MiKoSolutions.Analyzers.Rules
 {
     public sealed class TestCaseData
     {
-        public string Wrong { get; set; }
+        public string Wrong { get; init; }
 
-        public string Fixed { get; set; }
+        public string Fixed { get; init; }
 
         public override string ToString() => $"Wrong: {Wrong}   -   Fixed: {Fixed}";
     }

--- a/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
+// ReSharper disable once CheckNamespace
 namespace TestHelper
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 
 //// ncrunch: rdi off
 // ncrunch: no coverage start
+// ReSharper disable once CheckNamespace
 namespace TestHelper
 {
     /// <summary>


### PR DESCRIPTION
- Refactored several methods to use expression-bodied members and simplified logic by removing unnecessary null-conditional operators.
- Enhanced performance by replacing `foreach` loops with `for` loops and optimizing variable scope.
- Added conditional compilation for VS2022 and improved documentation with explanatory comments.
- Fixed potential bugs by removing null-conditional operators in method calls and node filtering.
- Updated properties to use `init` accessors for immutability.
- Removed unused `using` directives and added ReSharper directives to suppress warnings.