### PR TITLE
MiKo_3081 is now aware of directives

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -57,9 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if NCRUNCH
-        // do not define a static ctor to speed up tests
-#else
+#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
         static MiKo_2023_CodeFixProvider() => LoadData(); // ensure that we have the object available
 #endif
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -18,9 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] TaskParts = Constants.Comments.GenericTaskReturnTypeStartingPhraseTemplate.FormatWith("task", '|').Split('|');
 
-#if NCRUNCH
-        // do not define a static ctor to speed up tests
-#else
+#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
         static MiKo_2035_CodeFixProvider() => LoadData(); // ensure that we have the object available
 #endif
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -17,9 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         internal static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if NCRUNCH
-        // do not define a static ctor to speed up tests
-#else
+#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
         static MiKo_2060_CodeFixProvider() => LoadData(); // ensure that we have the object available
 #endif
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -16,9 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if NCRUNCH
-        // do not define a static ctor to speed up tests
-#else
+#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
         static MiKo_2080_CodeFixProvider() => LoadData(); // ensure that we have the object available
 #endif
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer.cs
@@ -18,26 +18,27 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var node = (PrefixUnaryExpressionSyntax)context.Node;
 
-            if (node.Operand is IdentifierNameSyntax right && node.Parent is AssignmentExpressionSyntax assignment && assignment.Left is IdentifierNameSyntax left)
+            if (node.Operand is IdentifierNameSyntax right)
             {
-                if (right.Identifier.ValueText == left.Identifier.ValueText)
+                switch (node.Parent)
                 {
-                    // same identifier, do not report
-                    return;
+                    case IfDirectiveTriviaSyntax _: // ignore directives
+                    case AssignmentExpressionSyntax assignment when assignment.Left is IdentifierNameSyntax left && left.Identifier.ValueText == right.Identifier.ValueText: // same identifier, do not report
+                        return;
                 }
             }
 
             var semanticModel = context.SemanticModel;
 
-            if (node.IsExpression(semanticModel))
-            {
-                // ignore expression trees
-                return;
-            }
-
             if (node.Operand.GetSymbol(semanticModel) is IFieldSymbol f && f.IsConst)
             {
                 // ignore constants
+                return;
+            }
+
+            if (node.IsExpression(semanticModel))
+            {
+                // ignore expression trees
                 return;
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests.cs
@@ -12,6 +12,22 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     public sealed class MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests : CodeFixVerifier
     {
         [Test]
+        public void No_issue_is_reported_for_directive() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool a)
+    {
+#if !DEBUG
+        a = false;
+#endif
+        return a;
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_logical_condition() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Enhanced `MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer` to properly handle directives and reordered checks for constants and expression trees.
- Added a new test to verify that no issues are reported for directives in `MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests`.
- Changed preprocessor directives in multiple `CodeFixProvider` classes to ensure compatibility with NCrunch by using `#if !NCRUNCH`.
