### PR TITLE
Code cleanup

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -219,6 +219,22 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ConcatenatedWith(this IEnumerable<string> values, string separator) => string.Join(separator, values);
 
+        public static string ConcatenatedWith(this char value, ReadOnlySpan<char> arg0)
+        {
+            var length = arg0.Length;
+
+            var chars = new char[length + 1];
+
+            if (length > 0)
+            {
+                arg0.CopyTo(chars.AsSpan(1));
+            }
+
+            chars[0] = value;
+
+            return new string(chars);
+        }
+
         public static string ConcatenatedWith(this string value, ReadOnlySpan<char> span)
         {
             var spanLength = span.Length;
@@ -279,6 +295,54 @@ namespace System
 
             value.CopyTo(chars);
             arg0?.CopyTo(0, chars, spanLength, length);
+
+            return new string(chars);
+        }
+
+        public static string ConcatenatedWith(this char value, string arg0, char arg1)
+        {
+            var length = arg0?.Length ?? 0;
+
+            var chars = new char[length + 2];
+
+            if (length > 0)
+            {
+                arg0.CopyTo(0, chars, 1, length);
+            }
+
+            chars[0] = value;
+            chars[length + 1] = arg1;
+
+            return new string(chars);
+        }
+
+        public static string ConcatenatedWith(this char value, ReadOnlySpan<char> arg0, char arg1)
+        {
+            var length = arg0.Length;
+
+            var chars = new char[length + 2];
+
+            if (length > 0)
+            {
+                arg0.CopyTo(chars.AsSpan(1));
+            }
+
+            chars[0] = value;
+            chars[length + 1] = arg1;
+
+            return new string(chars);
+        }
+
+        public static string ConcatenatedWith(this char value, string arg0, ReadOnlySpan<char> arg1)
+        {
+            var arg0Length = arg0?.Length ?? 0;
+            var arg1Length = arg1.Length;
+
+            var chars = new char[1 + arg0Length + arg1Length];
+
+            chars[0] = value;
+            arg0?.CopyTo(0, chars, 1, arg0Length);
+            arg1.CopyTo(chars.AsSpan(1 + arg0Length, arg1Length));
 
             return new string(chars);
         }
@@ -373,70 +437,6 @@ namespace System
             value.CopyTo(0, chars, 0, length);
             arg0.CopyTo(chars.AsSpan(length, arg0Length));
             arg1?.CopyTo(0, chars, length + arg0Length, arg1Length);
-
-            return new string(chars);
-        }
-
-        public static string ConcatenatedWith(this char value, ReadOnlySpan<char> arg0)
-        {
-            var length = arg0.Length;
-
-            var chars = new char[length + 1];
-
-            if (length > 0)
-            {
-                arg0.CopyTo(chars.AsSpan(1));
-            }
-
-            chars[0] = value;
-
-            return new string(chars);
-        }
-
-        public static string ConcatenatedWith(this char value, string arg0, char arg1)
-        {
-            var length = arg0?.Length ?? 0;
-
-            var chars = new char[length + 2];
-
-            if (length > 0)
-            {
-                arg0.CopyTo(0, chars, 1, length);
-            }
-
-            chars[0] = value;
-            chars[length + 1] = arg1;
-
-            return new string(chars);
-        }
-
-        public static string ConcatenatedWith(this char value, ReadOnlySpan<char> arg0, char arg1)
-        {
-            var length = arg0.Length;
-
-            var chars = new char[length + 2];
-
-            if (length > 0)
-            {
-                arg0.CopyTo(chars.AsSpan(1));
-            }
-
-            chars[0] = value;
-            chars[length + 1] = arg1;
-
-            return new string(chars);
-        }
-
-        public static string ConcatenatedWith(this char value, string arg0, ReadOnlySpan<char> arg1)
-        {
-            var arg0Length = arg0?.Length ?? 0;
-            var arg1Length = arg1.Length;
-
-            var chars = new char[1 + arg0Length + arg1Length];
-
-            chars[0] = value;
-            arg0?.CopyTo(0, chars, 1, arg0Length);
-            arg1.CopyTo(chars.AsSpan(1 + arg0Length, arg1Length));
 
             return new string(chars);
         }

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -7,15 +7,7 @@ namespace System
 {
     internal static class StringSplitExtensions
     {
-        public static IReadOnlyList<string> SplitBy(this string value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
-        {
-            if (value is null)
-            {
-                return Array.Empty<string>();
-            }
-
-            return SplitBy(value.AsSpan(), findings, comparison);
-        }
+        public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, ReadOnlySpan<char> separatorChars) => SplitBy(value, separatorChars, StringSplitOptions.None);
 
         public static IReadOnlyList<string> SplitBy(this ReadOnlySpan<char> value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
@@ -70,10 +62,18 @@ namespace System
             return results;
         }
 
-        public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, ReadOnlySpan<char> separatorChars) => SplitBy(value, separatorChars, StringSplitOptions.None);
-
         public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, ReadOnlySpan<char> separatorChars, StringSplitOptions options) => new SplitReadOnlySpanEnumerator(value, separatorChars, options);
 
         public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, char[] separatorChars, StringSplitOptions options) => SplitBy(value, separatorChars.AsSpan(), options);
-   }
+
+        public static IReadOnlyList<string> SplitBy(this string value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        {
+            if (value is null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return SplitBy(value.AsSpan(), findings, comparison);
+        }
+    }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3015_ArgumentExceptionThrownAtWrongPlaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3015_ArgumentExceptionThrownAtWrongPlaceAnalyzerTests.cs
@@ -18,11 +18,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                               nameof(ArgumentException),
                                                               nameof(ArgumentNullException),
                                                               nameof(ArgumentOutOfRangeException),
-                                                              "InvalidEnumArgumentException", // don't use nameof as the unit test framework will not find it (.NET CORE does not support System.ComponentModel)
+                                                              "InvalidEnumArgumentException", // do not use nameof as the unit test framework will not find it (.NET CORE does not support System.ComponentModel)
                                                               typeof(ArgumentException).FullName,
                                                               typeof(ArgumentNullException).FullName,
                                                               typeof(ArgumentOutOfRangeException).FullName,
-                                                              "System.ComponentModel.InvalidEnumArgumentException", // don't use typeof as the unit test framework will not find it (.NET CORE does not support System.ComponentModel)
+                                                              "System.ComponentModel.InvalidEnumArgumentException", // do not use typeof as the unit test framework will not find it (.NET CORE does not support System.ComponentModel)
                                                           ];
 
         [Test]

--- a/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
@@ -151,7 +151,7 @@ namespace TestHelper
                     break;
                 }
 
-                if (codeFixIndex != null)
+                if (codeFixIndex is not null)
                 {
                     document = ApplyFix(document, actions[(int)codeFixIndex]);
 


### PR DESCRIPTION
- Reordered multiple `ConcatenatedWith` methods in `StringExtensions.cs` for better code organization.
- Reordered the `SplitBy` methods in `StringSplitExtensions.cs` for better code organization.
- Updated comments in `MiKo_3015_ArgumentExceptionThrownAtWrongPlaceAnalyzerTests.cs` to use formal language.
- Improved null checks in `CodeFixVerifier.cs` by replacing `!=` with `is not`.

