### PR TITLE
Pluralization code in Verbalizer moved into Pluralizer

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -116,7 +116,7 @@ namespace System.Text
 
                 value.Remove(whitespacesBefore, word.Length);
 
-                var pluralWord = Verbalizer.MakePlural(word);
+                var pluralWord = Pluralizer.MakePluralName(word);
 
                 value.Insert(whitespacesBefore, pluralWord);
             }

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -67,7 +67,7 @@ namespace System
 
             if (HasFlag(handling, FirstWordHandling.MakePlural))
             {
-                word = Verbalizer.MakePlural(word);
+                word = Pluralizer.MakePluralName(word);
             }
 
             if (HasFlag(handling, FirstWordHandling.KeepLeadingSpace))

--- a/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
@@ -23,8 +23,46 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly string[] AllowedListNames = Constants.Markers.FieldPrefixes.SelectMany(_ => AllowedNames, (prefix, name) => prefix + name).ToArray();
 
+        /// <summary>
+        /// Create a plural name for a given name, but returns the same name in case if fails to do so.
+        /// </summary>
+        /// <param name="name">
+        /// The name to create a plural for.
+        /// </param>
+        /// <returns>
+        /// The plural for the given <paramref name="name"/>.
+        /// </returns>
+        public static string MakePluralName(string name) => GetPluralName(name, StringComparison.Ordinal) ?? name;
+
+        /// <summary>
+        /// Attempts to create a plural name for a given name, but (in contrast to <see cref="MakePluralName"/>) returns <see langword="null"/> in case if fails to do so.
+        /// </summary>
+        /// <param name="name">
+        /// The name to create a plural for.
+        /// </param>
+        /// <param name="comparison">
+        /// One of the <see cref="StringComparison"/> values that specifies the rules for comparison.
+        /// </param>
+        /// <returns>
+        /// The plural for the given <paramref name="name"/>.
+        /// </returns>
         public static string GetPluralName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase) => GetPluralName(name, name, comparison);
 
+        /// <summary>
+        /// Attempts to create a plural name for a given proposed name, but (in contrast to <see cref="MakePluralName"/>) returns <see langword="null"/> in case if fails to do so.
+        /// </summary>
+        /// <param name="name">
+        /// The name to create a plural for.
+        /// </param>
+        /// <param name="proposedName">
+        /// The proposed name to create the plural name for.
+        /// </param>
+        /// <param name="comparison">
+        /// One of the <see cref="StringComparison"/> values that specifies the rules for comparison.
+        /// </param>
+        /// <returns>
+        /// The plural for the given <paramref name="name"/>.
+        /// </returns>
         public static string GetPluralName(string name, string proposedName, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             if (name.EndsWith("trivia", comparison))
@@ -35,6 +73,21 @@ namespace MiKoSolutions.Analyzers.Linguistics
             return PluralNames.GetOrAdd(name, _ => CreatePluralName(proposedName.AsSpan(), comparison));
         }
 
+        /// <summary>
+        /// Attempts to create a plural name for a given name, but (in contrast to <see cref="MakePluralName"/>) returns <see langword="null"/> in case if fails to do so.
+        /// </summary>
+        /// <param name="name">
+        /// The name to create a plural for.
+        /// </param>
+        /// <param name="comparison">
+        /// One of the <see cref="StringComparison"/> values that specifies the rules for comparison.
+        /// </param>
+        /// <param name="suffixes">
+        /// The suffixes to remove from the plural name.
+        /// </param>
+        /// <returns>
+        /// The plural for the given <paramref name="name"/>.
+        /// </returns>
         public static string GetPluralName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params string[] suffixes)
         {
             if (IsAllowedListName(name, comparison))

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -24,8 +24,6 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly ConcurrentDictionary<string, string> InfiniteVerbs = new ConcurrentDictionary<string, string>();
 
-        private static readonly ConcurrentDictionary<string, string> Plurals = new ConcurrentDictionary<string, string>();
-
         private static readonly ConcurrentDictionary<string, string> ThirdPersonSingularVerbs = new ConcurrentDictionary<string, string>();
 
         private static readonly Pair[] Endings =
@@ -405,31 +403,6 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 }
 
                 return word;
-            }
-        }
-
-        public static string MakePlural(string value)
-        {
-            if (value.IsNullOrWhiteSpace())
-            {
-                return value;
-            }
-
-            return Plurals.GetOrAdd(value, CreatePlural);
-
-            string CreatePlural(string word)
-            {
-                if (word.EndsWith('s'))
-                {
-                    if (word.EndsWith("ss", StringComparison.Ordinal))
-                    {
-                        return word + "es";
-                    }
-
-                    return word;
-                }
-
-                return word.AsSpan().ConcatenatedWith('s');
             }
         }
 

--- a/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
@@ -34,5 +34,14 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("itemsToModel", ExpectedResult = "items")]
         [TestCase("itemModels", ExpectedResult = "items")]
         public static string Creates_correct_plural_name_(string singularName) => Pluralizer.GetPluralName(singularName);
+
+        [TestCase("access", ExpectedResult = "accesses")]
+        [TestCase("accesses", ExpectedResult = "accesses")]
+        [TestCase("Message", ExpectedResult = "Messages")]
+        [TestCase("Messages", ExpectedResult = "Messages")]
+        [TestCase("SyntaxTrivia", ExpectedResult = "SyntaxTrivia")]
+        [TestCase("Trivia", ExpectedResult = "Trivia")]
+        [TestCase("trivia", ExpectedResult = "trivia")]
+        public static string Makes_correct_plural_name_(string singularName) => Pluralizer.MakePluralName(singularName);
     }
 }

--- a/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
@@ -277,11 +277,5 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("shutting", ExpectedResult = true)]
         [TestCase("Shutting", ExpectedResult = true)]
         public static bool IsGerundVerb_detects_gerund_verb_(string name) => Verbalizer.IsGerundVerb(name);
-
-        [TestCase("access", ExpectedResult = "accesses")]
-        [TestCase("accesses", ExpectedResult = "accesses")]
-        [TestCase("Message", ExpectedResult = "Messages")]
-        [TestCase("Messages", ExpectedResult = "Messages")]
-        public static string MakePlural_finds_proper_plural(string name) => Verbalizer.MakePlural(name);
     }
 }


### PR DESCRIPTION
- Moved pluralization logic from `Verbalizer` to `Pluralizer` by introducing `MakePluralName` method.
- Added documentation for `Pluralizer`s methods `GetPluralName`.
- Updated `StringBuilderExtensions` and `StringExtensions` to use `Pluralizer` for pluralization.
- Removed `MakePlural` method and related dictionary from `Verbalizer`.
- Added new test cases for `Pluralizer.MakePluralName`.
- Removed obsolete test cases for `Verbalizer.MakePlural`.

