### PR TITLE
Added 'JetBrains.Profiler.Api' to profile tests

### DIFF
--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -131,9 +131,13 @@ namespace TestHelper
 
             foreach (var project in projects)
             {
+                JetBrains.Profiler.Api.MeasureProfiler.StartCollectingData();
+
                 var compilation = project.GetCompilationAsync().Result;
                 var compilationWithAnalyzers = compilation.WithAnalyzers([..analyzers]);
                 var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+
+                JetBrains.Profiler.Api.MeasureProfiler.SaveData();
 
                 foreach (var diag in diags)
                 {

--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />


### PR DESCRIPTION
- Integrated `JetBrains.Profiler.Api` into the diagnostic verification process to start and save profiling data.
- Added `JetBrains.Profiler.Api` as a package reference in the project file to enable profiling capabilities.
