### PR TITLE
Profiling made configurable to avoid thousands of windows popping up when profiling all tests at once

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules
             var files = GetDocuments(path).ToList();
             var sources = files.Select(File.ReadAllText).ToArray();
 
-            var results = DiagnosticVerifier.GetDiagnostics(sources, LanguageVersion.LatestMajor, AllAnalyzers.Cast<DiagnosticAnalyzer>().ToArray());
+            var results = DiagnosticVerifier.GetDiagnostics(sources, LanguageVersion.LatestMajor, AllAnalyzers.Cast<DiagnosticAnalyzer>().ToArray(), true);
 
             Assert.That(results.Count, Is.Zero);
 

--- a/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -22,7 +22,7 @@ namespace TestHelper
     {
         private static readonly string[] Placeholders = Enumerable.Range(0, 10).Select(_ => "{" + _ + "}").ToArray();
 
-        internal static Diagnostic[] GetDiagnostics(ReadOnlySpan<string> sources, LanguageVersion languageVersion, ReadOnlySpan<DiagnosticAnalyzer> analyzers) => GetSortedDiagnostics(sources, languageVersion, analyzers);
+        internal static Diagnostic[] GetDiagnostics(ReadOnlySpan<string> sources, LanguageVersion languageVersion, ReadOnlySpan<DiagnosticAnalyzer> analyzers, bool profileAnalysis) => GetSortedDiagnostics(sources, languageVersion, analyzers, profileAnalysis);
 
         /// <summary>
         /// Gets the CSharp analyzer being tested - to be implemented in non-abstract class.
@@ -189,6 +189,6 @@ namespace TestHelper
         /// <returns>
         /// An array of Diagnostics that surfaced in the source code, sorted by Location.
         /// </returns>
-        private Diagnostic[] GetDiagnostics(ReadOnlySpan<string> sources, LanguageVersion languageVersion) => GetSortedDiagnostics(sources, languageVersion, [GetObjectUnderTest()]);
+        private Diagnostic[] GetDiagnostics(ReadOnlySpan<string> sources, LanguageVersion languageVersion) => GetSortedDiagnostics(sources, languageVersion, [GetObjectUnderTest()], false);
     }
 }


### PR DESCRIPTION
- Introduced a `profileAnalysis` parameter to control whether profiling data is collected during diagnostic analysis.
- Updated diagnostic methods to conditionally start and save profiling data based on the `profileAnalysis` flag.
- Enabled profiling in specific test scenarios to gather performance data.

