### PR TITLE
MiKo_2013 is now aware of sentence ending for special kinds

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -109,7 +109,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     existingText = existingText.WithoutFirstWord();
                 }
 
-                var continuation = new StringBuilder(existingText.Trim().ToString()).ReplaceAllWithCheck(EnumStartingPhrases, string.Empty).ToString();
+                // fix sentence ending
+                var trimmedExistingText = existingText.Trim();
+                var trimmedExistingTextEnd = ReadOnlySpan<char>.Empty;
+
+                if (trimmedExistingText.EndsWithAny(Constants.SentenceMarkers))
+                {
+                    var end = trimmedExistingText.Length - 1;
+
+                    trimmedExistingTextEnd = trimmedExistingText.Slice(end);
+                    trimmedExistingText = trimmedExistingText.Slice(0, end);
+                }
+
+                var continuation = new StringBuilder(trimmedExistingText.ToString()).ReplaceAllWithCheck(EnumStartingPhrases, string.Empty).ToString();
 
                 if (continuation.IsSingleWord())
                 {
@@ -129,7 +141,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
 
                 textTokens.RemoveAt(0);
-                textTokens.Insert(0, XmlTextToken(startingPhrase + continuation));
+                textTokens.Insert(0, XmlTextToken(startingPhrase.ConcatenatedWith(continuation, trimmedExistingTextEnd)));
             }
             else
             {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -362,6 +362,40 @@ public enum " + typeName + @"
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [TestCase("Message", "messages")]
+        [TestCase("MessageEnum", "messages")]
+        [TestCase("MessageKind", "messages")]
+        [TestCase("MessageType", "messages")]
+        [TestCase("MessageTypes", "messages")]
+        [TestCase("MessageTypeKind", "messages")]
+        [TestCase("MessageTypeKinds", "messages")]
+        [TestCase("MessageTypeEnum", "messages")]
+        [TestCase("MessageTypeEnums", "messages")]
+        [TestCase("Direction", "directions")]
+        [TestCase("DirectionKind", "directions")]
+        [TestCase("ReferenceTypes", "references")]
+        public void Code_gets_fixed_for_sentenced_with_special_documentation_(string typeName, string fixedEnding)
+        {
+            var originalCode = @"
+/// <summary>
+/// Gets or Sets " + typeName + @".
+/// </summary>
+public enum " + typeName + @"
+{
+}
+";
+
+            var fixedCode = @"
+/// <summary>
+/// Defines values that specify the different kinds of " + fixedEnding + @".
+/// </summary>
+public enum " + typeName + @"
+{
+}
+";
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2013_EnumSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2013_EnumSummaryAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_2013_CodeFixProvider` to handle sentence endings in XML comments for special kinds.
- Implemented logic to trim existing text and check for sentence markers, ensuring proper sentence continuation.
- Updated the insertion of text tokens to concatenate with sentence endings.
- Added new test cases in `MiKo_2013_EnumSummaryAnalyzerTests` to verify the handling of sentence endings for various enum types.
