### PR TITLE
MiKo_6043 is now aware of lambdas containing conditional access calls

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_CodeFixProvider.cs
@@ -89,6 +89,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                 .WithCloseBraceToken(aoces.CloseBraceToken.WithoutTrivia().WithLeadingSpace()) // remove the spaces or line breaks around the closing bracket
                                 .WithInitializers(GetUpdatedSyntax(aoces.Initializers, Constants.Indentation));
 
+                case ConditionalAccessExpressionSyntax conditional:
+                    return conditional.WithoutTrivia()
+                                      .WithOperatorToken(conditional.OperatorToken.WithoutTrivia())
+                                      .WithWhenNotNull(GetUpdatedSyntax(conditional.WhenNotNull))
+                                      .WithExpression(GetUpdatedSyntax(conditional.Expression));
+
                 case ParenthesizedLambdaExpressionSyntax p: return GetUpdatedSyntax(p);
                 case SimpleLambdaExpressionSyntax s: return GetUpdatedSyntax(s);
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzerTests.cs
@@ -1275,6 +1275,53 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_parenthesized_lambda_expression_body_with_conditional_access_that_spans_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public static string DoSomething()
+        {
+            return DoSomethingCore((someValue) => someValue
+                                                    ?.ToString());
+        }
+
+        private static string DoSomethingCore(Func<int, string> callback, bool flag)
+        {
+            return callback(42);
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public static string DoSomething()
+        {
+            return DoSomethingCore((someValue) => someValue?.ToString());
+        }
+
+        private static string DoSomethingCore(Func<int, string> callback, bool flag)
+        {
+            return callback(42);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6043_LambdaExpressionBodiesAreOnSameLineAnalyzer();


### PR DESCRIPTION
- Enhanced the `GetUpdatedSyntax` method to handle `ConditionalAccessExpressionSyntax`, ensuring correct formatting by removing unnecessary trivia.
- Added a new test case to verify the code fix for parenthesized lambda expressions containing conditional access that spans multiple lines.
