### PR TITLE
Added new rule MiKo_3222 to simplify string comparisons

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -197,6 +197,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3216_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -302,6 +302,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_LogicalConditionsUsingTrueFalseCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_GetHashCodeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -12989,6 +12989,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Simplify comparison.
+        /// </summary>
+        internal static string MiKo_3222_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3222_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to String comparisons for equality can be simplified by using the specific methods provided by the .NET framework. This makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_3222_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3222_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to String comparison can be simplified.
+        /// </summary>
+        internal static string MiKo_3222_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3222_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to String comparisons can be simplified.
+        /// </summary>
+        internal static string MiKo_3222_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3222_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4574,6 +4574,18 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3221_Title" xml:space="preserve">
     <value>GetHashCode overrides should use 'HashCode.Combine'</value>
   </data>
+  <data name="MiKo_3222_CodeFixTitle" xml:space="preserve">
+    <value>Simplify comparison</value>
+  </data>
+  <data name="MiKo_3222_Description" xml:space="preserve">
+    <value>String comparisons for equality can be simplified by using the specific methods provided by the .NET framework. This makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_3222_MessageFormat" xml:space="preserve">
+    <value>String comparison can be simplified</value>
+  </data>
+  <data name="MiKo_3222_Title" xml:space="preserve">
+    <value>String comparisons can be simplified</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/InvertNegativeIfAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/InvertNegativeIfAnalyzer.cs
@@ -34,14 +34,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 case SyntaxKind.IsPatternExpression:
                 {
-                    var pattern = ((IsPatternExpressionSyntax)node).Pattern;
+                    var syntax = (IsPatternExpressionSyntax)node;
+                    var pattern = syntax.Pattern;
 
                     if (pattern.IsKind(SyntaxKind.NotPattern))
                     {
                         return true;
                     }
 
-                    return pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+                    return pattern.IsPatternCheckFor(SyntaxKind.FalseLiteralExpression);
                 }
 
                 default:
@@ -90,7 +91,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                     case ParenthesizedExpressionSyntax parenthesized:
                     {
-                        condition = parenthesized.Expression;
+                        condition = parenthesized.WithoutParenthesis();
 
                         continue;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -204,7 +204,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             // remove parenthesis when possible
             if (operand is ParenthesizedExpressionSyntax syntax)
             {
-                var expression = syntax.Expression;
+                var expression = syntax.WithoutParenthesis();
 
                 switch (expression.Kind())
                 {
@@ -287,7 +287,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     if (pattern.IsKind(SyntaxKind.NotPattern))
                     {
-                        if (pattern.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.TrueLiteralExpression))
+                        if (pattern.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression))
                         {
                             var expression = condition.Expression;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
@@ -224,13 +224,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                     case InvocationExpressionSyntax i:
                     {
-                        var name = i.Expression.GetName();
+                        var name = i.GetName();
 
                         if (i.Expression is MemberAccessExpressionSyntax)
                         {
                             if (name.StartsWith("From", StringComparison.Ordinal))
                             {
-                                var typeName = i.GetName();
+                                var typeName = i.GetIdentifierName();
 
                                 switch (typeName)
                                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
@@ -28,13 +28,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case "AddHandler":
                 case "RemoveHandler":
                 {
-                    if (node.Parent is InvocationExpressionSyntax i)
+                    if (node.Parent is InvocationExpressionSyntax invocation)
                     {
-                        var typeName = i.GetName();
+                        var typeName = invocation.GetIdentifierName();
 
                         if (typeName == "WeakEventManager")
                         {
-                            var arguments = i.ArgumentList.Arguments;
+                            var arguments = invocation.ArgumentList.Arguments;
 
                             if (arguments.Count >= 2)
                             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
@@ -82,7 +82,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return name == nameof(Equals);
         }
 
-        private static bool IsPropertyName(ExpressionSyntax expression)
+        private static bool IsPropertyName(InvocationExpressionSyntax expression)
+        {
+            var name = expression.GetIdentifierName();
+
+            return name == "PropertyName";
+        }
+
+        private static bool IsPropertyName(MemberAccessExpressionSyntax expression)
         {
             var name = expression.GetName();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3087_AvoidComplexNegativeConditionsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3087_AvoidComplexNegativeConditionsAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool HasIssueInIsPattern(IsPatternExpressionSyntax pattern)
         {
-            if (pattern.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.FalseLiteralExpression))
+            if (pattern.IsPatternCheckFor(SyntaxKind.FalseLiteralExpression))
             {
                 switch (pattern.Expression)
                 {
@@ -62,7 +62,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case ParenthesizedExpressionSyntax parenthesizedExpression:
                 {
-                    if (parenthesizedExpression.Expression is IdentifierNameSyntax)
+                    if (parenthesizedExpression.WithoutParenthesis() is IdentifierNameSyntax)
                     {
                         // we have a (!(xyz)) condition
                         return false;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -24,15 +24,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var original = (InvocationExpressionSyntax)syntax;
 
-            if (original.Expression is MemberAccessExpressionSyntax maes && maes.Expression is IdentifierNameSyntax type)
-            {
-                var typeName = type.GetName();
+            var typeName = original.GetIdentifierName();
 
-                switch (typeName)
+            switch (typeName)
+            {
+                case "Assert":
+                case "CollectionAssert":
+                case "StringAssert":
                 {
-                    case "Assert":
-                    case "CollectionAssert":
-                    case "StringAssert":
+                    if (original.Expression is MemberAccessExpressionSyntax maes)
                     {
                         var args = original.ArgumentList;
                         var fixedArgs = UpdatedSyntax(maes, args);
@@ -41,9 +41,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         {
                             return original.ReplaceNode(args, fixedArgs);
                         }
-
-                        break;
                     }
+
+                    break;
                 }
             }
 
@@ -85,7 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 case InvocationExpressionSyntax method:
                 {
-                    var name = method.Expression.GetName();
+                    var name = method.GetName();
 
                     if (name == "Parse")
                     {
@@ -93,7 +93,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     }
 
                     return EnumerableMethods.Contains(name)
-                           ? method.GetName()
+                           ? method.GetIdentifierName()
                            : name;
                 }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -39,9 +39,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsFixableAssertionForLinqCall(InvocationExpressionSyntax invocation)
         {
-            if (invocation.GetName() == "Is")
+            if (invocation.GetIdentifierName() == "Is")
             {
-                switch (invocation.Expression.GetName())
+                switch (invocation.GetName())
                 {
                     case "EqualTo":
                     case "Zero":

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3202_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3202_CodeFixProvider.cs
@@ -143,9 +143,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ExpressionSyntax GetUpdatedCondition(Document document, ExpressionSyntax condition)
         {
-            var newCondition = condition is ParenthesizedExpressionSyntax parenthesized
-                               ? parenthesized.Expression
-                               : condition;
+            var newCondition = condition.WithoutParenthesis();
 
             return InvertCondition(document, newCondition).WithTriviaFrom(condition);
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3213_PublicDisposeMethodInvokesNonPublicDisposeMethodAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3213_PublicDisposeMethodInvokesNonPublicDisposeMethodAnalyzer.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.ThisExpression) is true && invocation.GetName() == nameof(GC) && invocation.Expression.GetName() == nameof(GC.SuppressFinalize))
+                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.ThisExpression) is true && invocation.GetIdentifierName() == nameof(GC) && invocation.GetName() == nameof(GC.SuppressFinalize))
                 {
                     return true;
                 }
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.TrueLiteralExpression) is true && invocation.Expression.GetName() == nameof(IDisposable.Dispose))
+                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.TrueLiteralExpression) is true && invocation.GetName() == nameof(IDisposable.Dispose))
                 {
                     return true;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3222_CodeFixProvider)), Shared]
+    public sealed class MiKo_3222_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3222";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            var node = syntaxNodes.OfType<BinaryExpressionSyntax>().FirstOrDefault();
+
+            if (node?.Parent is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression == node)
+            {
+                return parenthesized;
+            }
+
+            return node;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
+            {
+                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left)
+                {
+                    var arguments = binary.Right.FirstDescendant<ArgumentListSyntax>()?.Arguments;
+
+                    var argument1 = Argument(left.Left);
+                    var argument2 = Argument(left.Right);
+
+                    var access = SimpleMemberAccess(PredefinedType(SyntaxKind.StringKeyword), nameof(string.Equals));
+
+                    return arguments?.Count > 1
+                           ? Invocation(access, argument1, argument2, arguments.Value[1])
+                           : Invocation(access, argument1, argument2);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
@@ -39,9 +39,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                     var access = SimpleMemberAccess(PredefinedType(SyntaxKind.StringKeyword), nameof(string.Equals));
 
-                    return arguments?.Count > 1
-                           ? Invocation(access, argument1, argument2, arguments.Value[1])
-                           : Invocation(access, argument1, argument2);
+                    var updatedSyntax = arguments?.Count > 1
+                                        ? Invocation(access, argument1, argument2, arguments.Value[1])
+                                        : Invocation(access, argument1, argument2);
+
+                    return updatedSyntax.WithTriviaFrom(syntax);
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3222";
+
+        private static readonly SyntaxKind[] LogicalOr = { SyntaxKind.LogicalOrExpression };
+
+        public MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalOr);
+
+        private static bool TryGetBinaryExpression(ExpressionSyntax expression, out BinaryExpressionSyntax result)
+        {
+            if (expression.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+            {
+                result = left;
+
+                return true;
+            }
+
+            result = null;
+
+            return false;
+        }
+
+        private static bool TryGetInvocationExpression(ExpressionSyntax expression, out InvocationExpressionSyntax result)
+        {
+            result = null;
+
+            var syntax = expression.WithoutParenthesis();
+
+            switch (syntax)
+            {
+                // (a != null && a.Equals(b, StringComparison.Ordinal))
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
+                                                && b.Right.WithoutParenthesis() is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b, StringComparison.Ordinal) == true
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.EqualsExpression)
+                                                && b.Right.IsKind(SyntaxKind.TrueLiteralExpression)
+                                                && b.Left is ConditionalAccessExpressionSyntax c
+                                                && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b, StringComparison.Ordinal) is true
+                case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
+                                                   && p.Expression is ConditionalAccessExpressionSyntax c
+                                                   && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BinaryExpressionSyntax node)
+            {
+                var issues = AnalyzeLogicalExpressions(node, context);
+
+                ReportDiagnostics(context, issues);
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeLogicalExpressions(BinaryExpressionSyntax node, SyntaxNodeAnalysisContext context)
+        {
+            // "a == b || (a != null && a.Equals(b, StringComparison.Ordinal))"
+            // "a == b || a?.Equals(b, StringComparison.Ordinal) is true)"
+            // "left.A == right.A || (left.A != null && left.A.Equals(right.A, StringComparison.Ordinal))"
+            if (TryGetBinaryExpression(node.Left, out var left) && TryGetInvocationExpression(node.Right, out var invocation))
+            {
+                var arguments = invocation.ArgumentList.Arguments;
+
+                if (arguments.Count <= 0)
+                {
+                    // no arguments, so nothing to report here as simplifiable
+                    yield break;
+                }
+
+                var name = invocation.GetName();
+
+                if (name != nameof(Equals))
+                {
+                    // no Equals method, so nothing to report here as simplifiable
+                    yield break;
+                }
+
+                var semanticModel = context.SemanticModel;
+
+                // we might have properties, so we investigate the complete expression
+                if (invocation.GetIdentifierExpression().GetTypeSymbol(semanticModel).IsString())
+                {
+                    var partA = left.Left;
+                    var partB = left.Right;
+
+                    var nameA = partA.ToString();
+                    var nameB = partB.ToString();
+
+                    var argument = arguments[0];
+                    var argumentName = argument.ToString();
+
+                    if (nameB == argumentName || nameA == argumentName)
+                    {
+                        if (partA.GetTypeSymbol(semanticModel).IsString() && partB.GetTypeSymbol(semanticModel).IsString() && argument.GetTypeSymbol(semanticModel).IsString())
+                        {
+                            yield return Issue(node);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             var parent = invocation.Parent;
 
-            switch (parent.Kind())
+            switch (parent?.Kind())
             {
                 case SyntaxKind.ParenthesizedExpression when parent.Parent.IsKind(SyntaxKind.LogicalNotExpression):
                     return parent.Parent;
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
         {
             if (syntax is IsPatternExpressionSyntax pattern)
             {
-                var isFalsePattern = pattern.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+                var isFalsePattern = pattern.IsPatternCheckFor(SyntaxKind.FalseLiteralExpression);
 
                 return GetUpdatedSyntax(pattern.Expression, issue, isFalsePattern ? SyntaxKind.NotEqualsExpression : SyntaxKind.None).WithoutTrailingTrivia();
             }
@@ -124,7 +124,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
                     switch (child)
                     {
-                        case ParenthesizedExpressionSyntax p when p.Expression is InvocationExpressionSyntax pi:
+                        case ParenthesizedExpressionSyntax p when p.WithoutParenthesis() is InvocationExpressionSyntax pi:
                             return pi;
 
                         case InvocationExpressionSyntax i:

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -1054,7 +1055,7 @@ public class TestMe
                                    from boolean in booleans
                                    select " " + boolean + vc into end // we have lots of loops, so cache data to avoid unnecessary calculations
                                    from start in starts
-                                   select (start + end).Replace("   ", " ").Replace("  ", " ").Trim())
+                                   select new StringBuilder(start + end).Replace("   ", " ").Replace("  ", " ").Trim())
             {
                 results.Add(phrase.ToUpperCaseAt(0));
                 results.Add(phrase.ToLowerCaseAt(0));

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -749,9 +750,9 @@ internal interface IFactory
             var s = verbs.SelectMany(_ => phrases, (verb, phrase) => phrase + " " + verb).ToList();
 
             var startingPhrases = s.Concat(s.Select(_ => _.Replace("actory", "actory class"))).ToList();
-            var constructionPhrases = startingPhrases.Select(_ => _.Replace("creation", "construction").Replace("creating", "constructing").Replace("create", "construct")).ToList();
-            var buildingPhrases = startingPhrases.Select(_ => _.Replace("creation", "building").Replace("creating", "building").Replace("create", "build")).ToList();
-            var providingPhrases = startingPhrases.Select(_ => _.Replace("creation", "providing").Replace("creating", "providing").Replace("create", "provide")).ToList();
+            var constructionPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "construction").Replace("creating", "constructing").Replace("create", "construct").ToString()).ToList();
+            var buildingPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "building").Replace("creating", "building").Replace("create", "build").ToString()).ToList();
+            var providingPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "providing").Replace("creating", "providing").Replace("create", "provide").ToString()).ToList();
 
             var results = new HashSet<string>();
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3039_PropertyInvokesLinqAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3039_PropertyInvokesLinqAnalyzerTests.cs
@@ -265,7 +265,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_getter_as_arrow_clause_with_Linq_extension_and_elvis_operator() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_getter_as_arrow_clause_with_Linq_extension_and_conditional_access_operator() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -278,7 +278,7 @@ namespace Bla
 
         public IEnumerable<string> Bla
         {
-            get => _bla?.Select(_ => _).ToList();
+            get => _bla?.Select(_ => _);
         }
     }
 }
@@ -300,7 +300,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_as_arrow_clause_with_Linq_extension_and_elvis_operator() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_as_arrow_clause_with_Linq_extension_and_conditional_access_operator() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -311,7 +311,7 @@ namespace Bla
     {
         private IEnumerable<string> _bla;
 
-        public IEnumerable<string> Bla => _bla?.Select(_ => _).ToList();
+        public IEnumerable<string> Bla => _bla?.Select(_ => _);
     }
 }
 ");
@@ -404,7 +404,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_setter_as_arrow_clause_with_Linq_extension_and_elvis_operator() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_setter_as_arrow_clause_with_Linq_extension_and_conditional_access_operator() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -417,7 +417,7 @@ namespace Bla
 
         public IEnumerable<string> Bla
         {
-            set => _bla = value?.Select(_ => _).ToList();
+            set => _bla = value?.Select(_ => _);
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3093_StatementInsideLockTriggersActionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3093_StatementInsideLockTriggersActionAnalyzerTests.cs
@@ -49,7 +49,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_action_parameter_trigger_via_elvis_operator_in_code_block_of_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_action_parameter_trigger_via_conditional_access_operator_in_code_block_of_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -76,7 +76,7 @@ public class TestMe
 }");
 
         [Test]
-        public void An_issue_is_reported_for_action_parameter_trigger_via_elvis_operator_in_lock_statement_of_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_action_parameter_trigger_via_conditional_access_operator_in_lock_statement_of_method() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -57,7 +57,7 @@ public class TestMe
 
         [TestCase("""a == b || a?.ToString("D") is null""")]
         [TestCase("a == b || a?.GetHashCode() == 42")]
-        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is false")]
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) == false")]
         [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is false")]
         [TestCase("a == b || a?.Equals(b) == false")]
         [TestCase("a == b || a?.Equals(b) is false")]
@@ -348,6 +348,72 @@ public class TestMe
 
         if (string.Equals(left.A, right.A, Comparison))
         { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_multi_line_condition()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+    public object B { get; }
+    public string C { get; }
+
+    public bool Equals(TestMe other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return
+            (
+                A == other.A ||
+                A != null &&
+                A.Equals(other.A)
+            ) &&
+            (
+                B == other.B ||
+                B != null &&
+                B.Equals(other.B)
+            ) &&
+            (
+                C == other.C ||
+                C != null &&
+                C.Equals(other.C)
+            ) && base.Equals(other);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+    public object B { get; }
+    public string C { get; }
+
+    public bool Equals(TestMe other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return
+            string.Equals(A, other.A) &&
+            (
+                B == other.B ||
+                B != null &&
+                B.Equals(other.B)
+            ) &&
+            string.Equals(C, other.C) && base.Equals(other);
     }
 }
 ";

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -1,0 +1,364 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_logical_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null)
+        { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_logical_And_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null && o is string s)
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("a == b || (a?.Equals(b) is true)")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        public void No_issue_is_reported_for_non_string_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int? a, int? b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("""a == b || a?.ToString("D") is null""")]
+        [TestCase("a == b || a?.GetHashCode() == 42")]
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is false")]
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is false")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
+        [TestCase("a == b || c?.Equals(d, StringComparison.Ordinal) == true")]
+        [TestCase("a == b || c?.Equals(d, StringComparison.Ordinal) is true")]
+        [TestCase("a == b || c?.Equals(d) == true")]
+        [TestCase("a == b || c?.Equals(d) is true")]
+        [TestCase("a == b || (c != null && c.Equals(d, StringComparison.Ordinal))")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        public void No_issue_is_reported_for_condition_with_unrelated_condition_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b, string c, string d)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) == true")]
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b, StringComparison.Ordinal))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b, StringComparison.Ordinal))")]
+        [TestCase("(a == b || a?.Equals(b, StringComparison.Ordinal) == true)")]
+        [TestCase("(a == b || a?.Equals(b, StringComparison.Ordinal) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b, StringComparison.Ordinal)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b, StringComparison.Ordinal)))")]
+        [TestCase("(a == b || (a?.Equals(b, StringComparison.Ordinal) == true))")]
+        [TestCase("(a == b || (a?.Equals(b, StringComparison.Ordinal) is true))")]
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_condition_with_property() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A, StringComparison.Ordinal)))
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) == true")]
+        [TestCase("a == b || a?.Equals(b, StringComparison.Ordinal) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b, StringComparison.Ordinal))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b, StringComparison.Ordinal))")]
+        [TestCase("(a == b || a?.Equals(b, StringComparison.Ordinal) == true)")]
+        [TestCase("(a == b || a?.Equals(b, StringComparison.Ordinal) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b, StringComparison.Ordinal)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b, StringComparison.Ordinal)))")]
+        [TestCase("(a == b || (a?.Equals(b, StringComparison.Ordinal) == true))")]
+        [TestCase("(a == b || (a?.Equals(b, StringComparison.Ordinal) is true))")]
+        public void Code_gets_fixed_for_condition_with_StringComparison_(string condition)
+        {
+            var originalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b)
+    {
+        if (string.Equals(a, b, StringComparison.Ordinal))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void Code_gets_fixed_for_condition_without_StringComparison_(string condition)
+        {
+            var originalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string a, string b)
+    {
+        if (string.Equals(a, b))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_const_StringComparison()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private const StringComparison Comparison = StringComparison.Ordinal;
+
+    public void DoSomething(string a, string b)
+    {
+        if (a == b || (a != null && a.Equals(b, Comparison)))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private const StringComparison Comparison = StringComparison.Ordinal;
+
+    public void DoSomething(string a, string b)
+    {
+        if (string.Equals(a, b, Comparison))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_more_complex_condition_with_const_StringComparison()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private const StringComparison Comparison = StringComparison.Ordinal;
+
+    public void DoSomething(string a, string b, int i)
+    {
+        if (i == 42 || (a == b || (a != null && a.Equals(b, Comparison))))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private const StringComparison Comparison = StringComparison.Ordinal;
+
+    public void DoSomething(string a, string b, int i)
+    {
+        if (i == 42 || string.Equals(a, b, Comparison))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A, StringComparison.Ordinal)))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (string.Equals(left.A, right.A, StringComparison.Ordinal))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_property_and_const_StringComparison()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        const StringComparison Comparison = StringComparison.Ordinal;
+
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A, Comparison)))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        const StringComparison Comparison = StringComparison.Ordinal;
+
+        if (string.Equals(left.A, right.A, Comparison))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3222_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 460 rules that are currently provided by the analyzer.
+The following tables lists all the 461 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -412,6 +412,7 @@ The following tables lists all the 460 rules that are currently provided by the 
 |MiKo_3219|Public members should not be 'virtual'|&#x2713;|\-|
 |MiKo_3220|Logical '&amp;&amp;' or '&#124;&#124;' conditions using 'true' or 'false' should be simplified|&#x2713;|&#x2713;|
 |MiKo_3221|GetHashCode overrides should use 'HashCode.Combine'|&#x2713;|&#x2713;|
+|MiKo_3222|String comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
(resolves #1054)

- Added new rule MiKo_3222 to simplify string comparisons by using specific .NET methods.
- Implemented code fix provider for MiKo_3222 to automate simplification of string comparisons.
- Added tests for MiKo_3222 to verify the functionality of the new rule and code fix.
- Refactored existing code to use new methods for handling expressions and pattern checks.
- Updated documentation and project files to include the new rule.
