### PR TITLE
Added new rule MiKo_6060 for switch casel labels to be on single line

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -367,6 +367,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -532,6 +532,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_TypeParameterConstraintClausesVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15879,5 +15879,41 @@ namespace MiKoSolutions.Analyzers {
                 return ResourceManager.GetString("MiKo_6058_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place switch case label on single line.
+        /// </summary>
+        internal static string MiKo_6060_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6060_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To ease reading, switch case labels should span a single line..
+        /// </summary>
+        internal static string MiKo_6060_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6060_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place switch case label on single line.
+        /// </summary>
+        internal static string MiKo_6060_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6060_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch case labels should be placed on same line.
+        /// </summary>
+        internal static string MiKo_6060_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6060_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5546,4 +5546,16 @@ Hence, their open brackets should be positioned at the same position where the c
   <data name="MiKo_6058_Title" xml:space="preserve">
     <value>Type parameter constraint clauses should be indented below parameter list</value>
   </data>
+  <data name="MiKo_6060_CodeFixTitle" xml:space="preserve">
+    <value>Place switch case label on single line</value>
+  </data>
+  <data name="MiKo_6060_Description" xml:space="preserve">
+    <value>To ease reading, switch case labels should span a single line.</value>
+  </data>
+  <data name="MiKo_6060_MessageFormat" xml:space="preserve">
+    <value>Place switch case label on single line</value>
+  </data>
+  <data name="MiKo_6060_Title" xml:space="preserve">
+    <value>Switch case labels should be placed on same line</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_CodeFixProvider.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6060_CodeFixProvider)), Shared]
+    public sealed class MiKo_6060_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6060";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => GetUpdatedSyntax(syntax);
+
+        private static T GetUpdatedSyntax<T>(T syntax) where T : SyntaxNode
+        {
+            switch (syntax)
+            {
+                case null:
+                    return null;
+
+                case CaseSwitchLabelSyntax label:
+                    return label.WithKeyword(label.Keyword.WithoutTrailingTrivia())
+                                .WithValue(GetUpdatedSyntax(label.Value).WithLeadingSpace().WithoutTrailingTrivia())
+                                .WithColonToken(label.ColonToken.WithoutLeadingTrivia()) as T;
+
+                case CasePatternSwitchLabelSyntax patternLabel:
+                    return patternLabel.WithKeyword(patternLabel.Keyword.WithoutTrailingTrivia())
+                                       .WithPattern(GetUpdatedSyntax(patternLabel.Pattern).WithLeadingSpace().WithoutTrailingTrivia())
+                                       .WithWhenClause(GetUpdatedSyntax(patternLabel.WhenClause))
+                                       .WithColonToken(patternLabel.ColonToken.WithoutLeadingTrivia()) as T;
+
+                case MemberAccessExpressionSyntax maes:
+                    return maes.WithName(maes.Name.WithoutTrivia())
+                               .WithOperatorToken(maes.OperatorToken.WithoutTrivia())
+                               .WithExpression(GetUpdatedSyntax(maes.Expression)) as T;
+
+                case BinaryExpressionSyntax binary:
+                    return binary.WithLeft(GetUpdatedSyntax(binary.Left))
+                                 .WithOperatorToken(binary.OperatorToken.WithLeadingSpace().WithoutTrailingTrivia())
+                                 .WithRight(GetUpdatedSyntax(binary.Right)) as T;
+
+                case IsPatternExpressionSyntax pattern:
+                    return pattern.WithPattern(GetUpdatedSyntax(pattern.Pattern))
+                                  .WithIsKeyword(pattern.IsKeyword.WithLeadingSpace().WithoutTrailingTrivia())
+                                  .WithExpression(GetUpdatedSyntax(pattern.Expression)) as T;
+
+                case InvocationExpressionSyntax invocation:
+                    return invocation.WithExpression(GetUpdatedSyntax(invocation.Expression))
+                                     .WithArgumentList(GetUpdatedSyntax(invocation.ArgumentList)) as T;
+
+                case WhenClauseSyntax clause:
+                    return clause?.WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
+                                  .WithCondition(GetUpdatedSyntax(clause.Condition)) as T;
+
+                case DeclarationPatternSyntax declaration:
+                    return declaration.WithType(declaration.Type.WithoutTrailingTrivia())
+                                      .WithDesignation(GetUpdatedSyntax(declaration.Designation)) as T;
+
+                case SingleVariableDesignationSyntax singleVariable:
+                    return singleVariable.WithIdentifier(singleVariable.Identifier.WithoutTrivia()) as T;
+
+                case ArgumentListSyntax argumentList:
+                    return argumentList.WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
+                                       .WithArguments(GetUpdatedSyntax(argumentList.Arguments))
+                                       .WithCloseParenToken(argumentList.CloseParenToken.WithoutTrivia())
+                                       .WithoutTrivia() as T;
+
+                case ArgumentSyntax argument:
+                    return argument.WithRefKindKeyword(argument.RefKindKeyword.WithoutLeadingTrivia().WithTrailingSpace())
+                                   .WithRefOrOutKeyword(argument.RefOrOutKeyword.WithoutLeadingTrivia().WithTrailingSpace())
+                                   .WithNameColon(GetUpdatedSyntax(argument.NameColon))
+                                   .WithExpression(GetUpdatedSyntax(argument.Expression)) as T;
+
+                default:
+                    return syntax.WithoutTrivia();
+            }
+        }
+
+        private static SeparatedSyntaxList<ArgumentSyntax> GetUpdatedSyntax(SeparatedSyntaxList<ArgumentSyntax> syntax)
+        {
+            var updatedItems = syntax.GetWithSeparators()
+                                     .Select(token =>
+                                                     {
+                                                         if (token.IsNode)
+                                                         {
+                                                             return GetUpdatedSyntax(token.AsNode());
+                                                         }
+
+                                                         if (token.IsToken)
+                                                         {
+                                                             return token.AsToken().WithLeadingSpace().WithoutTrailingTrivia();
+                                                         }
+
+                                                         return token;
+                                                     });
+
+            return SyntaxFactory.SeparatedList<ArgumentSyntax>(updatedItems);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6060_SwitchCasesAreOnSameLineAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6060";
+
+        private static readonly SyntaxKind[] SwitchLabels = { SyntaxKind.CaseSwitchLabel, SyntaxKind.CasePatternSwitchLabel };
+
+        public MiKo_6060_SwitchCasesAreOnSameLineAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SwitchLabels);
+
+        private static bool HasIssue(SyntaxNode node)
+        {
+            switch (node)
+            {
+                case CaseSwitchLabelSyntax label:
+                    return label.IsSpanningMultipleLines();
+
+                case CasePatternSwitchLabelSyntax pattern:
+                {
+                    if (pattern.WhenClause?.Condition is BinaryExpressionSyntax condition)
+                    {
+                        if (condition.Left is BinaryExpressionSyntax || condition.Right is BinaryExpressionSyntax)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return pattern.IsSpanningMultipleLines();
+                }
+
+                default:
+                    return false;
+            }
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var node = context.Node;
+
+            if (HasIssue(node))
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzerTests.cs
@@ -1,0 +1,1006 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6060_SwitchCasesAreOnSameLineAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_switch_case_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_if_value_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_if_value_is_spanning_multiple_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison
+                    .Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_if_colon_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal
+                :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_if_value_and_colon_are_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison.Ordinal
+                    :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_if_value_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_if_value_is_spanning_multiple_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison
+                    .Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_if_colon_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal
+                :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_if_value_and_colon_are_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case
+                StringComparison.Ordinal
+                    :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(StringComparison comparison)
+    {
+        switch (comparison)
+        {
+            case StringComparison.Ordinal:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void No_issue_is_reported_for_switch_case_pattern_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_switch_case_pattern_with_when_clause_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_switch_case_pattern_with_complex_when_clause_spanning_multiple_lines() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5
+                            && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_type_of_expression_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_instance_of_expression_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string
+                    s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_colon_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s
+                :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_when_clause_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s
+                    when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_expression_of_when_clause_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when
+                            s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_part_of_expression_of_when_clause_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s
+                                .Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_comparison_part_of_expression_of_when_clause_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length
+                                    > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_case_pattern_if_all_parts_are_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                string
+                    s
+                        when
+                            s
+                            .Length
+                                    > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_type_of_expression_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_instance_of_expression_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string
+                    s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_colon_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s
+                :
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_when_clause_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s
+                    when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_expression_of_when_clause_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when
+                            s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_part_of_expression_of_when_clause_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s
+                                .Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_comparison_part_of_expression_of_when_clause_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length
+                                    > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_all_parts_are_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                string
+                    s
+                        when
+                            s
+                            .Length
+                                    > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 5:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_argument_list_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                int i when i.ToString
+                                  (""D"") == ""42"":
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case int i when i.ToString(""D"") == ""42"":
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_case_pattern_if_all_arguments_are_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case
+                string s when s.Equals
+                                    (
+                                      ""D""
+                                        ,
+                                         StringComparison
+                                           .
+                                             Ordinal
+                                    )
+                                        is true:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Equals(""D"", StringComparison.Ordinal) is true:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6060_SwitchCasesAreOnSameLineAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6060_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 461 rules that are currently provided by the analyzer.
+The following tables lists all the 462 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -505,3 +505,5 @@ The following tables lists all the 461 rules that are currently provided by the 
 |MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
 |MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|
 |MiKo_6058|Type parameter constraint clauses should be indented below parameter list|&#x2713;|&#x2713;|
+|MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
+


### PR DESCRIPTION
- Introduced a new rule, MiKo_6060, to ensure switch case labels are placed on a single line for better readability.
- Implemented a code fix provider for automatically correcting switch case labels to be on a single line.
- Added comprehensive tests to verify the functionality of the MiKo_6060 rule and its code fix.
- Updated project configuration files to include the new analyzer and code fix provider.
- Updated the README to reflect the addition of the new rule.

(resolves #1059)