### PR TITLE
Added new rule MiKo_6059 for switch expression arms to be on single lines

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -894,9 +894,9 @@ namespace MiKoSolutions.Analyzers
         internal static class LambdaIdentifiers
         {
             internal const string Default = "_";
-            internal const string Fallback2Underscores = "__";
-            internal const string Fallback3Underscores = "___";
-            internal const string Fallback4Underscores = "____";
+            internal const string FallbackUnderscores2 = "__";
+            internal const string FallbackUnderscores3 = "___";
+            internal const string FallbackUnderscores4 = "____";
             internal const string Fallback0 = "_0";
             internal const string Fallback1 = "_1";
             internal const string Fallback2 = "_2";

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -1129,6 +1129,7 @@ namespace System.Linq
             switch (source)
             {
                 case TSource[] array: return ToArray(array, keySelector);
+                case ImmutableArray<TSource> array: return ToArray(array, keySelector);
                 case IReadOnlyList<TSource> list: return ToArray(list, keySelector);
                 case IReadOnlyCollection<TSource> collection: return ToArray(collection, keySelector);
                 default:
@@ -1156,6 +1157,7 @@ namespace System.Linq
             {
                 case TSource[] array: return array.ToHashSet(selector);
                 case List<TSource> list: return list.ToHashSet(selector);
+                case ImmutableArray<TSource> array: return array.ToHashSet(selector);
             }
 
             var result = new HashSet<TResult>();
@@ -1173,9 +1175,12 @@ namespace System.Linq
             var result = new HashSet<TResult>();
             var length = source.Count;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                result.Add(selector(source[index]));
+                for (var index = 0; index < length; index++)
+                {
+                    result.Add(selector(source[index]));
+                }
             }
 
             return result;
@@ -1186,9 +1191,12 @@ namespace System.Linq
             var result = new HashSet<TResult>();
             var length = source.Length;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                result.Add(selector(source[index]));
+                for (var index = 0; index < length; index++)
+                {
+                    result.Add(selector(source[index]));
+                }
             }
 
             return result;
@@ -1199,9 +1207,12 @@ namespace System.Linq
             var result = new HashSet<TResult>();
             var length = source.Count;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                result.Add(selector(source[index]));
+                for (var index = 0; index < length; index++)
+                {
+                    result.Add(selector(source[index]));
+                }
             }
 
             return result;
@@ -1212,9 +1223,12 @@ namespace System.Linq
             var result = new HashSet<TResult>();
             var length = source.Count;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                result.Add(selector(source[index]));
+                for (var index = 0; index < length; index++)
+                {
+                    result.Add(selector(source[index]));
+                }
             }
 
             return result;
@@ -1225,9 +1239,12 @@ namespace System.Linq
             var result = new HashSet<TResult>();
             var length = source.Length;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                result.Add(selector(source[index]));
+                for (var index = 0; index < length; index++)
+                {
+                    result.Add(selector(source[index]));
+                }
             }
 
             return result;

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -367,6 +367,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -532,6 +532,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_TypeParameterConstraintClausesVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15881,6 +15881,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place switch expression arm on single line.
+        /// </summary>
+        internal static string MiKo_6059_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6059_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To ease reading, switch expression arms should span a single line..
+        /// </summary>
+        internal static string MiKo_6059_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6059_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place switch expression arm on single line.
+        /// </summary>
+        internal static string MiKo_6059_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6059_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch expression arms should be placed on same line.
+        /// </summary>
+        internal static string MiKo_6059_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6059_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Place switch case label on single line.
         /// </summary>
         internal static string MiKo_6060_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5546,6 +5546,18 @@ Hence, their open brackets should be positioned at the same position where the c
   <data name="MiKo_6058_Title" xml:space="preserve">
     <value>Type parameter constraint clauses should be indented below parameter list</value>
   </data>
+  <data name="MiKo_6059_CodeFixTitle" xml:space="preserve">
+    <value>Place switch expression arm on single line</value>
+  </data>
+  <data name="MiKo_6059_Description" xml:space="preserve">
+    <value>To ease reading, switch expression arms should span a single line.</value>
+  </data>
+  <data name="MiKo_6059_MessageFormat" xml:space="preserve">
+    <value>Place switch expression arm on single line</value>
+  </data>
+  <data name="MiKo_6059_Title" xml:space="preserve">
+    <value>Switch expression arms should be placed on same line</value>
+  </data>
   <data name="MiKo_6060_CodeFixTitle" xml:space="preserve">
     <value>Place switch case label on single line</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -92,9 +92,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 case Constants.LambdaIdentifiers.Fallback3:
                 case Constants.LambdaIdentifiers.Fallback4:
                 case Constants.LambdaIdentifiers.Fallback5:
-                case Constants.LambdaIdentifiers.Fallback2Underscores:
-                case Constants.LambdaIdentifiers.Fallback3Underscores:
-                case Constants.LambdaIdentifiers.Fallback4Underscores:
+                case Constants.LambdaIdentifiers.FallbackUnderscores2:
+                case Constants.LambdaIdentifiers.FallbackUnderscores3:
+                case Constants.LambdaIdentifiers.FallbackUnderscores4:
                 case "map":
                 case "set":
                 case "list":

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
@@ -87,13 +87,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     return Constants.LambdaIdentifiers.Default;
 
                 case 2:
-                    return Constants.LambdaIdentifiers.Fallback2Underscores;
+                    return Constants.LambdaIdentifiers.FallbackUnderscores2;
 
                 case 3:
-                    return Constants.LambdaIdentifiers.Fallback3Underscores;
+                    return Constants.LambdaIdentifiers.FallbackUnderscores3;
 
                 case 4:
-                    return Constants.LambdaIdentifiers.Fallback4Underscores;
+                    return Constants.LambdaIdentifiers.FallbackUnderscores4;
 
                 case 5:
                     return Constants.LambdaIdentifiers.Fallback4;
@@ -155,9 +155,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 case null: // we do not have one
                 case Constants.LambdaIdentifiers.Default: // correct identifier (default one)
-                case Constants.LambdaIdentifiers.Fallback2Underscores: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
-                case Constants.LambdaIdentifiers.Fallback3Underscores: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
-                case Constants.LambdaIdentifiers.Fallback4Underscores: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
+                case Constants.LambdaIdentifiers.FallbackUnderscores2: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
+                case Constants.LambdaIdentifiers.FallbackUnderscores3: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
+                case Constants.LambdaIdentifiers.FallbackUnderscores4: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
                 case Constants.LambdaIdentifiers.Fallback0: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
                 case Constants.LambdaIdentifiers.Fallback1: // correct identifier (fallback as there is already another identifier in the parent lambda expression)
                 case Constants.LambdaIdentifiers.Fallback2: // correct identifier (2nd fallback as there is already another identifier in the parent lambda expression)

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_CodeFixProvider.cs
@@ -19,8 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (syntax is InvocationExpressionSyntax invocation)
             {
-                return invocation.WithArgumentList(invocation.ArgumentList.WithoutLeadingTrivia())
-                                 .WithExpression(GetUpdatedExpressionPlacedOnSameLine(invocation.Expression).WithoutTrailingTrivia());
+                return PlacedOnSameLine(invocation).WithLeadingTriviaFrom(invocation);
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
@@ -19,20 +19,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (syntax is InvocationExpressionSyntax invocation)
             {
-                return invocation.WithArgumentList(GetUpdatedArgumentList(invocation.ArgumentList))
-                                 .WithExpression(GetUpdatedExpressionPlacedOnSameLine(invocation.Expression).WithoutTrailingTrivia());
+                return invocation.WithArgumentList(PlacedOnSameLine(invocation.ArgumentList))
+                                 .WithExpression(PlacedOnSameLine(invocation.Expression))
+                                 .WithTrailingTriviaFrom(invocation);
             }
 
             return syntax;
         }
 
-        private static ArgumentListSyntax GetUpdatedArgumentList(ArgumentListSyntax argumentList)
-        {
-            var argumentSyntax = argumentList.Arguments.First();
-
-            return argumentList.WithArguments(argumentSyntax.WithoutTrivia().ToSeparatedSyntaxList())
-                               .WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
-                               .WithCloseParenToken(argumentList.CloseParenToken.WithoutLeadingTrivia());
-        }
+        private static ExpressionSyntax PlacedOnSameLine(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax maes
+                                                                                         ? maes.WithName(SpacingCodeFixProvider.PlacedOnSameLine(maes.Name))
+                                                                                         : expression;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_CodeFixProvider.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6059_CodeFixProvider)), Shared]
+    public sealed class MiKo_6059_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6059";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<SwitchExpressionSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is SwitchExpressionSyntax switchExpression)
+            {
+                var arms = switchExpression.Arms;
+
+                var updatedArms = arms.GetWithSeparators()
+                                      .Select(token =>
+                                                      {
+                                                          if (token.IsNode)
+                                                          {
+                                                              var node = token.AsNode();
+
+                                                              return PlacedOnSameLine(node).WithLeadingTriviaFrom(node);
+                                                          }
+
+                                                          if (token.IsToken)
+                                                          {
+                                                              return token.AsToken().WithoutLeadingTrivia();
+                                                          }
+
+                                                          return token;
+                                                      });
+
+                return switchExpression.WithArms(SyntaxFactory.SeparatedList<SwitchExpressionArmSyntax>(updatedArms));
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var index = arms.IndexOf(arm);
 
                 // be aware that the last arm might have no separator
-                if (index < arms.Count - 1)
+                if (index < arms.SeparatorCount)
                 {
                     var token = arms.GetSeparator(index);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -22,7 +24,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (arm.IsSpanningMultipleLines())
             {
-                return true;
+                // maybe we have an initializer, so check for that
+                return arm.DescendantNodes<InitializerExpressionSyntax>().None();
             }
 
             // maybe the comma is not placed at same line, so let's find out

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6059";
+
+        private static readonly SyntaxKind[] SwitchArms = { SyntaxKind.SwitchExpressionArm };
+
+        public MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SwitchArms);
+
+        private static bool HasIssue(SwitchExpressionArmSyntax arm)
+        {
+            if (arm.IsSpanningMultipleLines())
+            {
+                return true;
+            }
+
+            // maybe the comma is not placed at same line, so let's find out
+            if (arm.Parent is SwitchExpressionSyntax switchExpression)
+            {
+                var arms = switchExpression.Arms;
+
+                var index = arms.IndexOf(arm);
+
+                // be aware that the last arm might have no separator
+                if (index < arms.Count - 1)
+                {
+                    var token = arms.GetSeparator(index);
+
+                    if (token.GetStartingLine() != arm.GetStartingLine())
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is SwitchExpressionArmSyntax arm && HasIssue(arm))
+            {
+                ReportDiagnostics(context, Issue(arm));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_CodeFixProvider.cs
@@ -4,8 +4,6 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
@@ -16,92 +14,6 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => GetUpdatedSyntax(syntax);
-
-        private static T GetUpdatedSyntax<T>(T syntax) where T : SyntaxNode
-        {
-            switch (syntax)
-            {
-                case null:
-                    return null;
-
-                case CaseSwitchLabelSyntax label:
-                    return label.WithKeyword(label.Keyword.WithoutTrailingTrivia())
-                                .WithValue(GetUpdatedSyntax(label.Value).WithLeadingSpace().WithoutTrailingTrivia())
-                                .WithColonToken(label.ColonToken.WithoutLeadingTrivia()) as T;
-
-                case CasePatternSwitchLabelSyntax patternLabel:
-                    return patternLabel.WithKeyword(patternLabel.Keyword.WithoutTrailingTrivia())
-                                       .WithPattern(GetUpdatedSyntax(patternLabel.Pattern).WithLeadingSpace().WithoutTrailingTrivia())
-                                       .WithWhenClause(GetUpdatedSyntax(patternLabel.WhenClause))
-                                       .WithColonToken(patternLabel.ColonToken.WithoutLeadingTrivia()) as T;
-
-                case MemberAccessExpressionSyntax maes:
-                    return maes.WithName(maes.Name.WithoutTrivia())
-                               .WithOperatorToken(maes.OperatorToken.WithoutTrivia())
-                               .WithExpression(GetUpdatedSyntax(maes.Expression)) as T;
-
-                case BinaryExpressionSyntax binary:
-                    return binary.WithLeft(GetUpdatedSyntax(binary.Left))
-                                 .WithOperatorToken(binary.OperatorToken.WithLeadingSpace().WithoutTrailingTrivia())
-                                 .WithRight(GetUpdatedSyntax(binary.Right)) as T;
-
-                case IsPatternExpressionSyntax pattern:
-                    return pattern.WithPattern(GetUpdatedSyntax(pattern.Pattern))
-                                  .WithIsKeyword(pattern.IsKeyword.WithLeadingSpace().WithoutTrailingTrivia())
-                                  .WithExpression(GetUpdatedSyntax(pattern.Expression)) as T;
-
-                case InvocationExpressionSyntax invocation:
-                    return invocation.WithExpression(GetUpdatedSyntax(invocation.Expression))
-                                     .WithArgumentList(GetUpdatedSyntax(invocation.ArgumentList)) as T;
-
-                case WhenClauseSyntax clause:
-                    return clause?.WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
-                                  .WithCondition(GetUpdatedSyntax(clause.Condition)) as T;
-
-                case DeclarationPatternSyntax declaration:
-                    return declaration.WithType(declaration.Type.WithoutTrailingTrivia())
-                                      .WithDesignation(GetUpdatedSyntax(declaration.Designation)) as T;
-
-                case SingleVariableDesignationSyntax singleVariable:
-                    return singleVariable.WithIdentifier(singleVariable.Identifier.WithoutTrivia()) as T;
-
-                case ArgumentListSyntax argumentList:
-                    return argumentList.WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
-                                       .WithArguments(GetUpdatedSyntax(argumentList.Arguments))
-                                       .WithCloseParenToken(argumentList.CloseParenToken.WithoutTrivia())
-                                       .WithoutTrivia() as T;
-
-                case ArgumentSyntax argument:
-                    return argument.WithRefKindKeyword(argument.RefKindKeyword.WithoutLeadingTrivia().WithTrailingSpace())
-                                   .WithRefOrOutKeyword(argument.RefOrOutKeyword.WithoutLeadingTrivia().WithTrailingSpace())
-                                   .WithNameColon(GetUpdatedSyntax(argument.NameColon))
-                                   .WithExpression(GetUpdatedSyntax(argument.Expression)) as T;
-
-                default:
-                    return syntax.WithoutTrivia();
-            }
-        }
-
-        private static SeparatedSyntaxList<ArgumentSyntax> GetUpdatedSyntax(SeparatedSyntaxList<ArgumentSyntax> syntax)
-        {
-            var updatedItems = syntax.GetWithSeparators()
-                                     .Select(token =>
-                                                     {
-                                                         if (token.IsNode)
-                                                         {
-                                                             return GetUpdatedSyntax(token.AsNode());
-                                                         }
-
-                                                         if (token.IsToken)
-                                                         {
-                                                             return token.AsToken().WithLeadingSpace().WithoutTrailingTrivia();
-                                                         }
-
-                                                         return token;
-                                                     });
-
-            return SyntaxFactory.SeparatedList<ArgumentSyntax>(updatedItems);
-        }
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => PlacedOnSameLine(syntax);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -92,6 +92,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                        .WithWhenClause(PlacedOnSameLine(patternLabel.WhenClause))
                                        .WithColonToken(patternLabel.ColonToken.WithoutLeadingTrivia()) as T;
 
+                case SwitchExpressionArmSyntax arm:
+                    return arm.WithoutTrailingTrivia()
+                              .WithEqualsGreaterThanToken(arm.EqualsGreaterThanToken.WithLeadingSpace().WithoutTrailingTrivia())
+                              .WithExpression(PlacedOnSameLine(arm.Expression))
+                              .WithWhenClause(PlacedOnSameLine(arm.WhenClause))
+                              .WithPattern(PlacedOnSameLine(arm.Pattern)) as T;
+
                 case MemberAccessExpressionSyntax maes:
                     return maes.WithoutTrivia()
                                .WithName(PlacedOnSameLine(maes.Name))
@@ -119,6 +126,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     return clause?.WithoutTrivia()
                                   .WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
                                   .WithCondition(PlacedOnSameLine(clause.Condition)) as T;
+
+                case ConstantPatternSyntax constantPattern:
+                    return constantPattern.WithoutTrivia()
+                                          .WithExpression(PlacedOnSameLine(constantPattern.Expression)) as T;
 
                 case DeclarationPatternSyntax declaration:
                     return declaration.WithoutTrivia()
@@ -155,6 +166,18 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                            .WithArguments(PlacedOnSameLine(typeArgumentList.Arguments))
                                            .WithGreaterThanToken(typeArgumentList.GreaterThanToken.WithoutTrivia())
                                            .WithLessThanToken(typeArgumentList.LessThanToken.WithoutTrivia()) as T;
+
+                case ThrowExpressionSyntax throwExpression:
+                    return throwExpression.WithoutTrivia()
+                                          .WithThrowKeyword(throwExpression.ThrowKeyword.WithoutTrivia())
+                                          .WithExpression(PlacedOnSameLine(throwExpression.Expression)) as T;
+
+                case ObjectCreationExpressionSyntax creation:
+                    return creation.WithoutTrivia()
+                                   .WithNewKeyword(creation.NewKeyword.WithoutTrivia())
+                                   .WithType(PlacedOnSameLine(creation.Type).WithLeadingSpace())
+                                   .WithArgumentList(PlacedOnSameLine(creation.ArgumentList))
+                                   .WithInitializer(PlacedOnSameLine(creation.Initializer)) as T;
 
                 default:
                     return syntax.WithoutTrivia();

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
@@ -1,0 +1,219 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_switch_expression_arm_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_expression_arm_if_comma_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true
+                                                                        ,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_expression_arm_if_result_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal =>
+                                                                    true,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_expression_arm_if_arm_is_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal
+                                                                 => true,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_expression_arm_if_value_is_split_after_dot_and_placed_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.
+                                                    Ordinal => true,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_switch_expression_arm_if_value_is_split_before_dot_and_placed_on_different_line() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison
+                                                    .Ordinal => true,
+                                        _ => false,
+                                    };
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_switch_expression_arm_if_it_spans_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison
+                                                    .
+                                                      Ordinal
+                                                            =>
+                                                                true
+                                                                    ,
+                                        _ => false,
+                                    };
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ => false,
+                                    };
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_switch_expression_arm_throwing_an_exception_if_it_spans_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _
+                                            =>
+                                                throw
+                                                    new
+                                                      ArgumentOutOfRangeException(
+                                                            nameof(
+                                                                direction
+                                                                        )
+                                                                         ,
+                                                                            ""some value""
+                                                                                )
+                                                                                    ,
+                                    };
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ => throw new ArgumentOutOfRangeException(nameof(direction), ""some value""),
+                                    };
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6059_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
@@ -119,6 +119,24 @@ public class TestMe
 ");
 
         [Test]
+        public void An_issue_is_reported_for_last_switch_expression_arm_if_value_is_on_different_line_but_arm_does_not_end_with_separator() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ =>
+                                             false
+                                    };
+    }
+}
+");
+
+        [Test]
         public void Code_gets_fixed_for_switch_expression_arm_if_it_spans_multiple_lines()
         {
             const string OriginalCode = @"
@@ -202,6 +220,45 @@ public class TestMe
                                     {
                                         StringComparison.Ordinal => true,
                                         _ => throw new ArgumentOutOfRangeException(nameof(direction), ""some value""),
+                                    };
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_last_switch_expression_arm_if_value_is_on_different_line_but_arm_does_not_end_with_separator()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ =>
+                                             false
+                                    };
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => true,
+                                        _ => false
                                     };
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
@@ -29,6 +29,28 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_switch_expression_arm_with_initializer_spanning_multiple_lines() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison Comparison { get; }
+
+    public TestMe DoSomething(StringComparison comparison)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => new TestMe
+                                                                        {
+                                                                            Comparison = comparison,
+                                                                        },
+                                        _ => null,
+                                    };
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_switch_expression_arm_if_comma_is_on_different_line() => An_issue_is_reported_for(@"
 using System;
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 462 rules that are currently provided by the analyzer.
+The following tables lists all the 463 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -505,5 +505,6 @@ The following tables lists all the 462 rules that are currently provided by the 
 |MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
 |MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|
 |MiKo_6058|Type parameter constraint clauses should be indented below parameter list|&#x2713;|&#x2713;|
+|MiKo_6059|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
 


### PR DESCRIPTION
- Implemented a new rule, `MiKo_6059`, to ensure switch expression arms are placed on a single line.
- Added a code fix provider for `MiKo_6059` to automatically correct code style issues.
- Introduced a new analyzer for `MiKo_6059` to detect violations of the rule.
- Refactored existing code to use the new `PlacedOnSameLine` method for consistency.
- Added comprehensive unit tests for the new rule and code fix.
- Updated project files and resources to include the new rule and its components.
- Updated `README` to reflect the addition of the new rule.

(resolves #1060)