### PR TITLE
Added new rule MiKo_6059 that reports if operators of binary expressions are not properly outdented

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -367,6 +367,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -367,8 +367,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_CodeFixProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -532,6 +532,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_TypeParameterConstraintClausesVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -532,8 +532,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6057_TypeParameterConstraintClausesVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15881,6 +15881,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Align condition outdented.
+        /// </summary>
+        internal static string MiKo_6059_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6059_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To easily read the multi-line conditions, those conditions should be positioned outdented below the corresponding call..
+        /// </summary>
+        internal static string MiKo_6059_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6059_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align condition outdented.
+        /// </summary>
+        internal static string MiKo_6059_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6059_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multi-line conditions are positioned outdented below associated calls.
+        /// </summary>
+        internal static string MiKo_6059_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6059_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Place switch case label on single line.
         /// </summary>
         internal static string MiKo_6060_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15881,42 +15881,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place switch expression arm on single line.
-        /// </summary>
-        internal static string MiKo_6059_CodeFixTitle {
-            get {
-                return ResourceManager.GetString("MiKo_6059_CodeFixTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To ease reading, switch expression arms should span a single line..
-        /// </summary>
-        internal static string MiKo_6059_Description {
-            get {
-                return ResourceManager.GetString("MiKo_6059_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Place switch expression arm on single line.
-        /// </summary>
-        internal static string MiKo_6059_MessageFormat {
-            get {
-                return ResourceManager.GetString("MiKo_6059_MessageFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Switch expression arms should be placed on same line.
-        /// </summary>
-        internal static string MiKo_6059_Title {
-            get {
-                return ResourceManager.GetString("MiKo_6059_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Place switch case label on single line.
         /// </summary>
         internal static string MiKo_6060_CodeFixTitle {
@@ -15949,6 +15913,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_6060_Title {
             get {
                 return ResourceManager.GetString("MiKo_6060_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place switch expression arm on single line.
+        /// </summary>
+        internal static string MiKo_6061_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6061_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To ease reading, switch expression arms should span a single line..
+        /// </summary>
+        internal static string MiKo_6061_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6061_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place switch expression arm on single line.
+        /// </summary>
+        internal static string MiKo_6061_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6061_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch expression arms should be placed on same line.
+        /// </summary>
+        internal static string MiKo_6061_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6061_Title", resourceCulture);
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5546,18 +5546,6 @@ Hence, their open brackets should be positioned at the same position where the c
   <data name="MiKo_6058_Title" xml:space="preserve">
     <value>Type parameter constraint clauses should be indented below parameter list</value>
   </data>
-  <data name="MiKo_6059_CodeFixTitle" xml:space="preserve">
-    <value>Place switch expression arm on single line</value>
-  </data>
-  <data name="MiKo_6059_Description" xml:space="preserve">
-    <value>To ease reading, switch expression arms should span a single line.</value>
-  </data>
-  <data name="MiKo_6059_MessageFormat" xml:space="preserve">
-    <value>Place switch expression arm on single line</value>
-  </data>
-  <data name="MiKo_6059_Title" xml:space="preserve">
-    <value>Switch expression arms should be placed on same line</value>
-  </data>
   <data name="MiKo_6060_CodeFixTitle" xml:space="preserve">
     <value>Place switch case label on single line</value>
   </data>
@@ -5569,5 +5557,17 @@ Hence, their open brackets should be positioned at the same position where the c
   </data>
   <data name="MiKo_6060_Title" xml:space="preserve">
     <value>Switch case labels should be placed on same line</value>
+  </data>
+  <data name="MiKo_6061_CodeFixTitle" xml:space="preserve">
+    <value>Place switch expression arm on single line</value>
+  </data>
+  <data name="MiKo_6061_Description" xml:space="preserve">
+    <value>To ease reading, switch expression arms should span a single line.</value>
+  </data>
+  <data name="MiKo_6061_MessageFormat" xml:space="preserve">
+    <value>Place switch expression arm on single line</value>
+  </data>
+  <data name="MiKo_6061_Title" xml:space="preserve">
+    <value>Switch expression arms should be placed on same line</value>
   </data>
 </root>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5546,6 +5546,18 @@ Hence, their open brackets should be positioned at the same position where the c
   <data name="MiKo_6058_Title" xml:space="preserve">
     <value>Type parameter constraint clauses should be indented below parameter list</value>
   </data>
+  <data name="MiKo_6059_CodeFixTitle" xml:space="preserve">
+    <value>Align condition outdented</value>
+  </data>
+  <data name="MiKo_6059_Description" xml:space="preserve">
+    <value>To easily read the multi-line conditions, those conditions should be positioned outdented below the corresponding call.</value>
+  </data>
+  <data name="MiKo_6059_MessageFormat" xml:space="preserve">
+    <value>Align condition outdented</value>
+  </data>
+  <data name="MiKo_6059_Title" xml:space="preserve">
+    <value>Multi-line conditions are positioned outdented below associated calls</value>
+  </data>
   <data name="MiKo_6060_CodeFixTitle" xml:space="preserve">
     <value>Place switch case label on single line</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6059";
+
+        private static readonly SyntaxKind[] Expressions =
+                                                           {
+                                                               // binary ones
+                                                               SyntaxKind.LogicalOrExpression,
+                                                               SyntaxKind.LogicalAndExpression,
+                                                               SyntaxKind.BitwiseOrExpression,
+                                                               SyntaxKind.BitwiseAndExpression,
+                                                               SyntaxKind.ExclusiveOrExpression,
+                                                           };
+
+        public MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, Expressions);
+
+        private static SyntaxToken GetOutdentedOrientationToken(BinaryExpressionSyntax binary)
+        {
+            foreach (var item in binary.Ancestors())
+            {
+                switch (item)
+                {
+                    case IfStatementSyntax ifStatement:
+                        return ifStatement.IfKeyword;
+
+                    case ReturnStatementSyntax returnStatement:
+                        return returnStatement.ReturnKeyword;
+
+                    case WhenClauseSyntax whenClause:
+                        return whenClause.WhenKeyword;
+                }
+            }
+
+            return binary.OperatorToken;
+        }
+
+        private static int GetOutdentedPosition(BinaryExpressionSyntax binary)
+        {
+            foreach (var item in binary.Ancestors())
+            {
+                switch (item)
+                {
+                    case IfStatementSyntax ifStatement:
+                        return ifStatement.IfKeyword.GetEndPosition().Character - 1;
+
+                    case ReturnStatementSyntax returnStatement:
+                        return returnStatement.ReturnKeyword.GetEndPosition().Character - 2;
+
+                    case WhenClauseSyntax whenClause:
+                        return whenClause.WhenKeyword.GetEndPosition().Character - 2;
+                }
+            }
+
+            return binary.OperatorToken.GetPositionWithinStartLine();
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var issue = AnalyzeNode(context.Node);
+
+            if (issue != null)
+            {
+                ReportDiagnostics(context, issue);
+            }
+        }
+
+        private Diagnostic AnalyzeNode(SyntaxNode node)
+        {
+            if (node is BinaryExpressionSyntax binary)
+            {
+                var orientationToken = GetOutdentedOrientationToken(binary);
+                var operatorToken = binary.OperatorToken;
+
+                var orientationStartingLine = orientationToken.GetStartingLine();
+                var operatorTokenStartingLine = operatorToken.GetStartingLine();
+
+                if (orientationStartingLine != operatorTokenStartingLine)
+                {
+                    var spaces = GetOutdentedPosition(binary);
+
+                    if (operatorToken.GetPositionWithinStartLine() != spaces)
+                    {
+                        return Issue(operatorToken, CreateProposalForSpaces(spaces));
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -80,19 +80,23 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (node is BinaryExpressionSyntax binary)
             {
-                var orientationToken = GetOutdentedOrientationToken(binary);
                 var operatorToken = binary.OperatorToken;
 
-                var orientationStartingLine = orientationToken.GetStartingLine();
-                var operatorTokenStartingLine = operatorToken.GetStartingLine();
-
-                if (orientationStartingLine != operatorTokenStartingLine)
+                if (binary.Left.GetEndingLine() < operatorToken.GetStartingLine())
                 {
-                    var spaces = GetOutdentedPosition(binary);
+                    var orientationToken = GetOutdentedOrientationToken(binary);
 
-                    if (operatorToken.GetPositionWithinStartLine() != spaces)
+                    var orientationStartingLine = orientationToken.GetStartingLine();
+                    var operatorTokenStartingLine = operatorToken.GetStartingLine();
+
+                    if (orientationStartingLine != operatorTokenStartingLine)
                     {
-                        return Issue(operatorToken, CreateProposalForSpaces(spaces));
+                        var spaces = GetOutdentedPosition(binary);
+
+                        if (operatorToken.GetPositionWithinStartLine() != spaces)
+                        {
+                            return Issue(operatorToken, CreateProposalForSpaces(spaces));
+                        }
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_CodeFixProvider.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6059_CodeFixProvider)), Shared]
+    public sealed class MiKo_6059_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6059";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            var token = syntax.FindToken(issue);
+
+            var spaces = GetProposedSpaces(issue);
+
+            return syntax.ReplaceToken(token, token.WithLeadingSpaces(spaces));
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_CodeFixProvider.cs
@@ -9,10 +9,10 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6059_CodeFixProvider)), Shared]
-    public sealed class MiKo_6059_CodeFixProvider : SpacingCodeFixProvider
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6061_CodeFixProvider)), Shared]
+    public sealed class MiKo_6061_CodeFixProvider : SpacingCodeFixProvider
     {
-        public override string FixableDiagnosticId => "MiKo_6059";
+        public override string FixableDiagnosticId => "MiKo_6061";
 
         protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<SwitchExpressionSyntax>().FirstOrDefault();
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
@@ -8,13 +8,13 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer : SpacingAnalyzer
+    public sealed class MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer : SpacingAnalyzer
     {
-        public const string Id = "MiKo_6059";
+        public const string Id = "MiKo_6061";
 
         private static readonly SyntaxKind[] SwitchArms = { SyntaxKind.SwitchExpressionArm };
 
-        public MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer() : base(Id)
+        public MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer() : base(Id)
         {
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
@@ -1,0 +1,614 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_if_statement_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1 && condition2)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_if_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+         && condition2)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_if_statement_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+                && condition2)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_if_statement_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+            && condition2)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_if_statement_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+           && condition2)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_if_statement_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+                && condition2)
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+         && condition2)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_if_statement_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+            && condition2)
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+         && condition2)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_if_statement_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+           && condition2)
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        if (condition1
+         && condition2)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void No_issue_is_reported_for_return_statement_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1 && condition2;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_return_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+            && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_return_statement_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+                && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_return_statement_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+               && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_return_statement_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+              && condition2;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_return_statement_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+                && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+            && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_return_statement_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+               && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+            && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_return_statement_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+              && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool condition1, bool condition2)
+    {
+        return condition1
+            && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void No_issue_is_reported_for_when_clause_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1 && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_when_clause_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                            && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_when_clause_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                                 && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_when_clause_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                               && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_when_clause_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                        && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_when_clause_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                                && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                            && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_when_clause_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                               && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                            && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_when_clause_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                        && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1
+                            && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6059_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
@@ -27,6 +27,24 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_if_statement_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2, bool condition3, bool condition4)
+    {
+        if (condition1 &&
+            condition2 ||
+            condition3 &&
+            condition4)
+        {
+        }
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_if_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
 using System;
 
@@ -212,6 +230,22 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_return_statement_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2, bool condition3, bool condition4)
+    {
+        return condition1 &&
+               condition2 ||
+               condition3 &&
+               condition4;
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_return_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
 using System;
 
@@ -374,6 +408,29 @@ public class TestMe
         switch (o)
         {
             case string s when s.Length > 1 && s.Length < 10:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_when_clause_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(object o)
+    {
+        switch (o)
+        {
+            case string s when s.Length > 1 &&
+                               s.Length < 10 ||
+                               s.Length > 11 &&
+                               s.Length <= 42:
                 return true;
 
             default:

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
@@ -9,7 +9,7 @@ using TestHelper;
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     [TestFixture]
-    public sealed class MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzerTests : CodeFixVerifier
+    public sealed class MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzerTests : CodeFixVerifier
     {
         [Test]
         public void No_issue_is_reported_for_switch_expression_arm_on_same_line() => No_issue_is_reported_for(@"
@@ -289,10 +289,10 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
-        protected override string GetDiagnosticId() => MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer.Id;
+        protected override string GetDiagnosticId() => MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.Id;
 
-        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6059_SwitchExpressionArmsAreOnSameLineAnalyzer();
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer();
 
-        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6059_CodeFixProvider();
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6061_CodeFixProvider();
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 463 rules that are currently provided by the analyzer.
+The following tables lists all the 464 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -505,6 +505,7 @@ The following tables lists all the 463 rules that are currently provided by the 
 |MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
 |MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|
 |MiKo_6058|Type parameter constraint clauses should be indented below parameter list|&#x2713;|&#x2713;|
+|MiKo_6059|Multi-line conditions are positioned outdented below associated calls|&#x2713;|&#x2713;|
 |MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6061|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,6 @@ The following tables lists all the 463 rules that are currently provided by the 
 |MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
 |MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|
 |MiKo_6058|Type parameter constraint clauses should be indented below parameter list|&#x2713;|&#x2713;|
-|MiKo_6059|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
+|MiKo_6061|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 


### PR DESCRIPTION
- Changed existing rule `MiKo_6059` to `MiKo_6061`.
- Implemented a new analyzer `MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer` to ensure boolean operators are correctly indented.

(resolves #1058)