### PR TITLE
MiKo_6059 is now aware of arguments, assignments and variable declarations

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -40,6 +40,15 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     case WhenClauseSyntax whenClause:
                         return whenClause.WhenKeyword;
+
+                    case ArgumentListSyntax argument:
+                        return argument.OpenParenToken;
+
+                    case EqualsValueClauseSyntax clause:
+                        return clause.EqualsToken;
+
+                    case AssignmentExpressionSyntax assignment:
+                        return assignment.OperatorToken;
                 }
             }
 
@@ -60,6 +69,15 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     case WhenClauseSyntax whenClause:
                         return whenClause.WhenKeyword.GetEndPosition().Character - 2;
+
+                    case ArgumentListSyntax argument:
+                        return argument.OpenParenToken.GetEndPosition().Character - 3;
+
+                    case EqualsValueClauseSyntax clause:
+                        return clause.EqualsToken.GetEndPosition().Character - 2;
+
+                    case AssignmentExpressionSyntax assignment:
+                        return assignment.OperatorToken.GetEndPosition().Character - 2;
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
@@ -662,6 +662,597 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void No_issue_is_reported_for_variable_declaration_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1 && condition2;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_variable_declaration_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2, bool condition3, bool condition4)
+    {
+        var x = condition1 &&
+                condition2 ||
+                condition3 &&
+                condition4;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_variable_declaration_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+             && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+                    && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+                && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+            && condition2;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+                    && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+             && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+                && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+             && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+            && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        var x = condition1
+             && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void No_issue_is_reported_for_assignment_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1 && condition2;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_assignment_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2, bool condition3, bool condition4)
+    {
+        condition1 = condition1 &&
+                     condition2 ||
+                     condition3 &&
+                     condition4;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_assignment_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                  && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assignment_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                          && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assignment_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                     && condition2;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assignment_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+            && condition2;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_assignment_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                        && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                  && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assignment_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                     && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                  && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assignment_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+            && condition2;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        condition1 = condition1
+                  && condition2;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void No_issue_is_reported_for_argument_if_complete_operation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1 && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_argument_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2, bool condition3, bool condition4)
+    {
+        DoSomethingElse(condition1 &&
+                        condition2 ||
+                        condition3 &&
+                        condition4;
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_argument_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                     && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_argument_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                            && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_argument_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                        && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_argument_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                    && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_argument_in_case_operator_is_indented_to_right_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                           && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                     && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_argument_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                        && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                     && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_argument_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                  && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(condition1
+                     && condition2);
+    }
+
+    public void DoSomethingElse(bool condition)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer` to handle additional syntax types such as `ArgumentListSyntax`, `EqualsValueClauseSyntax`, and `AssignmentExpressionSyntax`.
- Improved the logic to determine the outdented position for these new syntax types.
- Added comprehensive tests to verify the correct indentation of boolean operators in variable declarations, assignments, and method arguments.
- Implemented fixes for test cases where operators were incorrectly indented.
