### PR TITLE
Added new rule MiKo_3223 to simplify reference comparisons

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -198,6 +198,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -303,6 +303,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3220_LogicalConditionsUsingTrueFalseCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_GetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13025,6 +13025,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Simplify comparison.
+        /// </summary>
+        internal static string MiKo_3223_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3223_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comparisons for equality on reference types can be simplified by using the specific methods provided by the .NET framework. This makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_3223_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3223_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comparison can be simplified.
+        /// </summary>
+        internal static string MiKo_3223_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3223_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reference comparisons can be simplified.
+        /// </summary>
+        internal static string MiKo_3223_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3223_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4586,6 +4586,18 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3222_Title" xml:space="preserve">
     <value>String comparisons can be simplified</value>
   </data>
+  <data name="MiKo_3223_CodeFixTitle" xml:space="preserve">
+    <value>Simplify comparison</value>
+  </data>
+  <data name="MiKo_3223_Description" xml:space="preserve">
+    <value>Comparisons for equality on reference types can be simplified by using the specific methods provided by the .NET framework. This makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_3223_MessageFormat" xml:space="preserve">
+    <value>Comparison can be simplified</value>
+  </data>
+  <data name="MiKo_3223_Title" xml:space="preserve">
+    <value>Reference comparisons can be simplified</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_CodeFixProvider.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3223_CodeFixProvider)), Shared]
+    public sealed class MiKo_3223_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3223";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            var node = syntaxNodes.OfType<BinaryExpressionSyntax>().FirstOrDefault();
+
+            if (node?.Parent is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression == node)
+            {
+                return parenthesized;
+            }
+
+            return node;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
+            {
+                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left)
+                {
+                    var arguments = binary.Right.FirstDescendant<ArgumentListSyntax>()?.Arguments;
+
+                    var argument1 = Argument(left.Left);
+                    var argument2 = Argument(left.Right);
+
+                    var access = SimpleMemberAccess(PredefinedType(SyntaxKind.ObjectKeyword), nameof(Equals));
+
+                    var updatedSyntax = arguments?.Count > 1
+                                            ? Invocation(access, argument1, argument2, arguments.Value[1])
+                                            : Invocation(access, argument1, argument2);
+
+                    return updatedSyntax.WithTriviaFrom(syntax);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
@@ -1,0 +1,145 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3223";
+
+        private static readonly SyntaxKind[] LogicalOr = { SyntaxKind.LogicalOrExpression };
+
+        public MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalOr);
+
+        private static bool TryGetBinaryExpression(ExpressionSyntax expression, out BinaryExpressionSyntax result)
+        {
+            if (expression.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+            {
+                result = left;
+
+                return true;
+            }
+
+            result = null;
+
+            return false;
+        }
+
+        private static bool TryGetInvocationExpression(ExpressionSyntax expression, out InvocationExpressionSyntax result)
+        {
+            result = null;
+
+            var syntax = expression.WithoutParenthesis();
+
+            switch (syntax)
+            {
+                // (a != null && a.Equals(b))
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
+                                                && b.Right.WithoutParenthesis() is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b) == true
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.EqualsExpression)
+                                                && b.Right.IsKind(SyntaxKind.TrueLiteralExpression)
+                                                && b.Left is ConditionalAccessExpressionSyntax c
+                                                && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b) is true
+                case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
+                                                   && p.Expression is ConditionalAccessExpressionSyntax c
+                                                   && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BinaryExpressionSyntax node)
+            {
+                var issues = AnalyzeLogicalExpressions(node, context);
+
+                ReportDiagnostics(context, issues);
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeLogicalExpressions(BinaryExpressionSyntax node, SyntaxNodeAnalysisContext context)
+        {
+            // "a == b || (a != null && a.Equals(b))"
+            // "a == b || a?.Equals(b) is true)"
+            // "left.A == right.A || (left.A != null && left.A.Equals(right.A))"
+            if (TryGetBinaryExpression(node.Left, out var left) && TryGetInvocationExpression(node.Right, out var invocation))
+            {
+                var arguments = invocation.ArgumentList.Arguments;
+
+                if (arguments.Count != 1)
+                {
+                    // different arguments, so nothing to report here as simplifiable
+                    yield break;
+                }
+
+                var name = invocation.GetName();
+
+                if (name != nameof(Equals))
+                {
+                    // no Equals method, so nothing to report here as simplifiable
+                    yield break;
+                }
+
+                var semanticModel = context.SemanticModel;
+
+                // we might have properties, so we investigate the complete expression
+                var typeSymbol = invocation.GetIdentifierExpression().GetTypeSymbol(semanticModel);
+
+                if (typeSymbol.IsString())
+                {
+                    // already reported by MiKo_3222
+                    yield break;
+                }
+
+                if (typeSymbol.IsReferenceType)
+                {
+                    var partA = left.Left;
+                    var partB = left.Right;
+
+                    var nameA = partA.ToString();
+                    var nameB = partB.ToString();
+
+                    var argument = arguments[0];
+                    var argumentName = argument.ToString();
+
+                    if (nameB == argumentName || nameA == argumentName)
+                    {
+                        if (partA.GetTypeSymbol(semanticModel).IsReferenceType && partB.GetTypeSymbol(semanticModel).IsReferenceType && argument.GetTypeSymbol(semanticModel).IsReferenceType)
+                        {
+                            yield return Issue(node);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -1,0 +1,277 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_logical_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null)
+        { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_logical_And_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null && o is string s)
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("a == b || (a?.Equals(b) is true)")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        public void No_issue_is_reported_for_non_reference_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int? a, int? b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("""a == b || a?.ToString("D") is null""")]
+        [TestCase("a == b || a?.GetHashCode() == 42")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
+        [TestCase("a == b || c?.Equals(d) == true")]
+        [TestCase("a == b || c?.Equals(d) is true")]
+        [TestCase("a == b || c?.Equals(d) == true")]
+        [TestCase("a == b || c?.Equals(d) is true")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        public void No_issue_is_reported_for_condition_with_unrelated_condition_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object a, object b, string c, string d)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b || (a?.Equals(b) == true))")]
+        [TestCase("(a == b || (a?.Equals(b) is true))")]
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object a, object b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_condition_with_property() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public object A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A)))
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void Code_gets_fixed_for_condition__(string condition)
+        {
+            var originalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object a, object b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object a, object b)
+    {
+        if (object.Equals(a, b))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A)))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (object.Equals(left.A, right.A))
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_multi_line_condition()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object A { get; }
+    public string B { get; }
+    public object C { get; }
+
+    public bool Equals(TestMe other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return
+            (
+                A == other.A ||
+                A != null &&
+                A.Equals(other.A)
+            ) &&
+            (
+                B == other.B ||
+                B != null &&
+                B.Equals(other.B)
+            ) &&
+            (
+                C == other.C ||
+                C != null &&
+                C.Equals(other.C)
+            ) && base.Equals(other);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object A { get; }
+    public string B { get; }
+    public object C { get; }
+
+    public bool Equals(TestMe other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return
+            object.Equals(A, other.A) &&
+            (
+                B == other.B ||
+                B != null &&
+                B.Equals(other.B)
+            ) &&
+            object.Equals(C, other.C) && base.Equals(other);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3223_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 464 rules that are currently provided by the analyzer.
+The following tables lists all the 465 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -413,6 +413,7 @@ The following tables lists all the 464 rules that are currently provided by the 
 |MiKo_3220|Logical '&amp;&amp;' or '&#124;&#124;' conditions using 'true' or 'false' should be simplified|&#x2713;|&#x2713;|
 |MiKo_3221|GetHashCode overrides should use 'HashCode.Combine'|&#x2713;|&#x2713;|
 |MiKo_3222|String comparisons can be simplified|&#x2713;|&#x2713;|
+|MiKo_3223|Reference comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduced a new rule, MiKo_3223, to simplify reference comparisons in C# code.
- Implemented a code fix provider for MiKo_3223 to automate the simplification process.
- Added an analyzer to detect logical conditions using reference comparisons that can be simplified.
- Developed comprehensive unit tests to ensure the correct functionality of the new rule and its code fix.
- Updated project configuration files to include the new analyzer and code fix provider.
- Enhanced the README documentation to reflect the addition of the new rule.


(resolves #1067)