### PR TITLE
GetPositionWithinEndLine() added

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -22,6 +22,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static int GetPositionWithinStartLine(this Location value) => value.GetStartPosition().Character;
 
+        internal static int GetPositionWithinEndLine(this Location value) => value.GetEndPosition().Character;
+
         internal static int GetStartingLine(this Location value) => value.GetStartPosition().Line;
 
         internal static int GetEndingLine(this Location value) => value.GetEndPosition().Line;

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -23,6 +23,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static int GetPositionWithinStartLine(this SyntaxToken value) => value.GetLocation().GetPositionWithinStartLine();
 
+        internal static int GetPositionWithinEndLine(this SyntaxToken value) => value.GetLocation().GetPositionWithinEndLine();
+
         internal static LinePosition GetPositionAfterEnd(this SyntaxToken value)
         {
             var position = value.GetEndPosition();

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -62,22 +62,22 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 switch (item)
                 {
                     case IfStatementSyntax ifStatement:
-                        return ifStatement.IfKeyword.GetEndPosition().Character - 1;
+                        return ifStatement.IfKeyword.GetPositionWithinEndLine() - 1;
 
                     case ReturnStatementSyntax returnStatement:
-                        return returnStatement.ReturnKeyword.GetEndPosition().Character - 2;
+                        return returnStatement.ReturnKeyword.GetPositionWithinEndLine() - 2;
 
                     case WhenClauseSyntax whenClause:
-                        return whenClause.WhenKeyword.GetEndPosition().Character - 2;
+                        return whenClause.WhenKeyword.GetPositionWithinEndLine() - 2;
 
                     case ArgumentListSyntax argument:
-                        return argument.OpenParenToken.GetEndPosition().Character - 3;
+                        return argument.OpenParenToken.GetPositionWithinEndLine() - 3;
 
                     case EqualsValueClauseSyntax clause:
-                        return clause.EqualsToken.GetEndPosition().Character - 2;
+                        return clause.EqualsToken.GetPositionWithinEndLine() - 2;
 
                     case AssignmentExpressionSyntax assignment:
-                        return assignment.OperatorToken.GetEndPosition().Character - 2;
+                        return assignment.OperatorToken.GetPositionWithinEndLine() - 2;
                 }
             }
 


### PR DESCRIPTION
- Added `GetPositionWithinEndLine` method in `LocationExtensions` to retrieve the character position within the end line of a location.
- Added `GetPositionWithinEndLine` method in `SyntaxTokenExtensions` to retrieve the character position within the end line of a syntax token.
- Updated `MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer` to use `GetPositionWithinEndLine` for consistent and clearer code.
