### PR TITLE
Added new rule MiKo_3224 to simplify value comparisons

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -200,6 +200,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -140,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ReturnTypeDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\SummaryDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DoNotUseSuppressNullableWarningAnalyzerCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\LogicalConditionsSimplifierCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MaintainabilityCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3011_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3012_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -305,6 +305,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3221_GetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -171,6 +171,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DependencyPropertyRegisterMaintainabilityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DoNotUseSuppressNullableWarningAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\InvertNegativeIfAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MaintainabilityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MethodReturnsNullAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3000_EmptyRegionAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13061,6 +13061,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Simplify comparison.
+        /// </summary>
+        internal static string MiKo_3224_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3224_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comparisons for equality on value types can be simplified by using the specific equality operators. This makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_3224_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3224_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comparison can be simplified.
+        /// </summary>
+        internal static string MiKo_3224_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3224_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value comparisons can be simplified.
+        /// </summary>
+        internal static string MiKo_3224_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3224_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4598,6 +4598,18 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3223_Title" xml:space="preserve">
     <value>Reference comparisons can be simplified</value>
   </data>
+  <data name="MiKo_3224_CodeFixTitle" xml:space="preserve">
+    <value>Simplify comparison</value>
+  </data>
+  <data name="MiKo_3224_Description" xml:space="preserve">
+    <value>Comparisons for equality on value types can be simplified by using the specific equality operators. This makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_3224_MessageFormat" xml:space="preserve">
+    <value>Comparison can be simplified</value>
+  </data>
+  <data name="MiKo_3224_Title" xml:space="preserve">
+    <value>Value comparisons can be simplified</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    public abstract class LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer : MaintainabilityAnalyzer
+    {
+        private static readonly SyntaxKind[] LogicalOr = { SyntaxKind.LogicalOrExpression };
+
+        protected LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer(string id) : base(id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalOr);
+
+        protected abstract bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments);
+
+        protected abstract bool IsApplicable(ITypeSymbol typeSymbol);
+
+        private static bool TryGetBinaryExpression(ExpressionSyntax expression, out BinaryExpressionSyntax result)
+        {
+            if (expression.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+            {
+                result = left;
+
+                return true;
+            }
+
+            result = null;
+
+            return false;
+        }
+
+        private static bool TryGetInvocationExpression(ExpressionSyntax expression, out InvocationExpressionSyntax result)
+        {
+            result = null;
+
+            var syntax = expression.WithoutParenthesis();
+
+            switch (syntax)
+            {
+                // (a != null && a.Equals(b))
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
+                                                && b.Right.WithoutParenthesis() is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b) == true
+                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.EqualsExpression)
+                                                && b.Right.IsKind(SyntaxKind.TrueLiteralExpression)
+                                                && b.Left is ConditionalAccessExpressionSyntax c
+                                                && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+
+                // a?.Equals(b) is true
+                case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
+                                                      && p.Expression is ConditionalAccessExpressionSyntax c
+                                                      && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                {
+                    result = invocation;
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool HasIssue(BinaryExpressionSyntax node, SyntaxNodeAnalysisContext context)
+        {
+            // "a == b || (a != null && a.Equals(b))"
+            // "a == b || a?.Equals(b) is true)"
+            // "left.A == right.A || (left.A != null && left.A.Equals(right.A))"
+            if (TryGetBinaryExpression(node.Left, out var left) && TryGetInvocationExpression(node.Right, out var invocation))
+            {
+                // "a == b || (a != null && a.Equals(b, StringComparison.Ordinal))"
+                // "a == b || a?.Equals(b, StringComparison.Ordinal) is true)"
+                // "left.A == right.A || (left.A != null && left.A.Equals(right.A, StringComparison.Ordinal))"
+                var arguments = invocation.ArgumentList.Arguments;
+
+                if (IsApplicable(arguments))
+                {
+                    var name = invocation.GetName();
+
+                    if (name != nameof(Equals))
+                    {
+                        // no Equals method, so nothing to report here as simplifiable
+                        return false;
+                    }
+
+                    var semanticModel = context.SemanticModel;
+
+                    // we might have properties, so we investigate the complete expression
+                    var typeSymbol = invocation.GetIdentifierExpression().GetTypeSymbol(semanticModel);
+
+                    if (IsApplicable(typeSymbol))
+                    {
+                        var partA = left.Left;
+                        var partB = left.Right;
+
+                        var nameA = partA.ToString();
+                        var nameB = partB.ToString();
+
+                        var argument = arguments[0];
+                        var argumentName = argument.ToString();
+
+                        if (nameB == argumentName || nameA == argumentName)
+                        {
+                            return IsApplicable(partA.GetTypeSymbol(semanticModel)) && IsApplicable(partB.GetTypeSymbol(semanticModel)) && IsApplicable(argument.GetTypeSymbol(semanticModel));
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BinaryExpressionSyntax node)
+            {
+                if (HasIssue(node, context))
+                {
+                    ReportDiagnostics(context, Issue(node));
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsSimplifierCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsSimplifierCodeFixProvider.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    public abstract class LogicalConditionsSimplifierCodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        protected abstract SyntaxKind PredefinedTypeKind { get; }
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            var node = syntaxNodes.OfType<BinaryExpressionSyntax>().FirstOrDefault();
+
+            if (node?.Parent is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression == node)
+            {
+                return parenthesized;
+            }
+
+            return node;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
+            {
+                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left)
+                {
+                    var arguments = binary.Right.FirstDescendant<ArgumentListSyntax>()?.Arguments;
+
+                    var argument1 = Argument(left.Left);
+                    var argument2 = Argument(left.Right);
+
+                    var access = SimpleMemberAccess(PredefinedType(PredefinedTypeKind), nameof(Equals));
+
+                    var updatedSyntax = arguments?.Count > 1
+                                        ? Invocation(access, argument1, argument2, arguments.Value[1])
+                                        : Invocation(access, argument1, argument2);
+
+                    return updatedSyntax.WithTriviaFrom(syntax);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_CodeFixProvider.cs
@@ -1,53 +1,16 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3222_CodeFixProvider)), Shared]
-    public sealed class MiKo_3222_CodeFixProvider : MaintainabilityCodeFixProvider
+    public sealed class MiKo_3222_CodeFixProvider : LogicalConditionsSimplifierCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_3222";
 
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
-        {
-            var node = syntaxNodes.OfType<BinaryExpressionSyntax>().FirstOrDefault();
-
-            if (node?.Parent is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression == node)
-            {
-                return parenthesized;
-            }
-
-            return node;
-        }
-
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
-        {
-            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
-            {
-                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left)
-                {
-                    var arguments = binary.Right.FirstDescendant<ArgumentListSyntax>()?.Arguments;
-
-                    var argument1 = Argument(left.Left);
-                    var argument2 = Argument(left.Right);
-
-                    var access = SimpleMemberAccess(PredefinedType(SyntaxKind.StringKeyword), nameof(string.Equals));
-
-                    var updatedSyntax = arguments?.Count > 1
-                                        ? Invocation(access, argument1, argument2, arguments.Value[1])
-                                        : Invocation(access, argument1, argument2);
-
-                    return updatedSyntax.WithTriviaFrom(syntax);
-                }
-            }
-
-            return syntax;
-        }
+        protected override SyntaxKind PredefinedTypeKind => SyntaxKind.StringKeyword;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs
@@ -1,138 +1,22 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer : MaintainabilityAnalyzer
+    public sealed class MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer : LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer
     {
         public const string Id = "MiKo_3222";
 
-        private static readonly SyntaxKind[] LogicalOr = { SyntaxKind.LogicalOrExpression };
-
-        public MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalOr);
+        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count > 0;
 
-        private static bool TryGetBinaryExpression(ExpressionSyntax expression, out BinaryExpressionSyntax result)
-        {
-            if (expression.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
-            {
-                result = left;
-
-                return true;
-            }
-
-            result = null;
-
-            return false;
-        }
-
-        private static bool TryGetInvocationExpression(ExpressionSyntax expression, out InvocationExpressionSyntax result)
-        {
-            result = null;
-
-            var syntax = expression.WithoutParenthesis();
-
-            switch (syntax)
-            {
-                // (a != null && a.Equals(b, StringComparison.Ordinal))
-                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
-                                                && b.Right.WithoutParenthesis() is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
-
-                // a?.Equals(b, StringComparison.Ordinal) == true
-                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.EqualsExpression)
-                                                && b.Right.IsKind(SyntaxKind.TrueLiteralExpression)
-                                                && b.Left is ConditionalAccessExpressionSyntax c
-                                                && c.WhenNotNull is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
-
-                // a?.Equals(b, StringComparison.Ordinal) is true
-                case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
-                                                   && p.Expression is ConditionalAccessExpressionSyntax c
-                                                   && c.WhenNotNull is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool HasIssue(BinaryExpressionSyntax node, SyntaxNodeAnalysisContext context)
-        {
-            // "a == b || (a != null && a.Equals(b, StringComparison.Ordinal))"
-            // "a == b || a?.Equals(b, StringComparison.Ordinal) is true)"
-            // "left.A == right.A || (left.A != null && left.A.Equals(right.A, StringComparison.Ordinal))"
-            if (TryGetBinaryExpression(node.Left, out var left) && TryGetInvocationExpression(node.Right, out var invocation))
-            {
-                var arguments = invocation.ArgumentList.Arguments;
-
-                if (arguments.Count <= 0)
-                {
-                    // no arguments, so nothing to report here as simplifiable
-                    return false;
-                }
-
-                var name = invocation.GetName();
-
-                if (name != nameof(Equals))
-                {
-                    // no Equals method, so nothing to report here as simplifiable
-                    return false;
-                }
-
-                var semanticModel = context.SemanticModel;
-
-                // we might have properties, so we investigate the complete expression
-                if (invocation.GetIdentifierExpression().GetTypeSymbol(semanticModel).IsString())
-                {
-                    var partA = left.Left;
-                    var partB = left.Right;
-
-                    var nameA = partA.ToString();
-                    var nameB = partB.ToString();
-
-                    var argument = arguments[0];
-                    var argumentName = argument.ToString();
-
-                    if (nameB == argumentName || nameA == argumentName)
-                    {
-                        if (partA.GetTypeSymbol(semanticModel).IsString() && partB.GetTypeSymbol(semanticModel).IsString() && argument.GetTypeSymbol(semanticModel).IsString())
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is BinaryExpressionSyntax node)
-            {
-                if (HasIssue(node, context))
-                {
-                    ReportDiagnostics(context, Issue(node));
-                }
-            }
-        }
+        protected override bool IsApplicable(ITypeSymbol typeSymbol) => typeSymbol.IsString();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
@@ -1,146 +1,31 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer : MaintainabilityAnalyzer
+    public sealed class MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer : LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer
     {
         public const string Id = "MiKo_3223";
 
-        private static readonly SyntaxKind[] LogicalOr = { SyntaxKind.LogicalOrExpression };
-
-        public MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalOr);
+        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count == 1;
 
-        private static bool TryGetBinaryExpression(ExpressionSyntax expression, out BinaryExpressionSyntax result)
+        protected override bool IsApplicable(ITypeSymbol typeSymbol)
         {
-            if (expression.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+            if (typeSymbol.IsReferenceType)
             {
-                result = left;
-
-                return true;
-            }
-
-            result = null;
-
-            return false;
-        }
-
-        private static bool TryGetInvocationExpression(ExpressionSyntax expression, out InvocationExpressionSyntax result)
-        {
-            result = null;
-
-            var syntax = expression.WithoutParenthesis();
-
-            switch (syntax)
-            {
-                // (a != null && a.Equals(b))
-                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
-                                                && b.Right.WithoutParenthesis() is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
-
-                // a?.Equals(b) == true
-                case BinaryExpressionSyntax b when b.IsKind(SyntaxKind.EqualsExpression)
-                                                && b.Right.IsKind(SyntaxKind.TrueLiteralExpression)
-                                                && b.Left is ConditionalAccessExpressionSyntax c
-                                                && c.WhenNotNull is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
-
-                // a?.Equals(b) is true
-                case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
-                                                   && p.Expression is ConditionalAccessExpressionSyntax c
-                                                   && c.WhenNotNull is InvocationExpressionSyntax invocation:
-                {
-                    result = invocation;
-
-                    return true;
-                }
+                // ignore strings as they are fixed by MiKo_3222
+                return typeSymbol.IsString() is false;
             }
 
             return false;
-        }
-
-        private static bool HasIssue(BinaryExpressionSyntax node, SyntaxNodeAnalysisContext context)
-        {
-            // "a == b || (a != null && a.Equals(b))"
-            // "a == b || a?.Equals(b) is true)"
-            // "left.A == right.A || (left.A != null && left.A.Equals(right.A))"
-            if (TryGetBinaryExpression(node.Left, out var left) && TryGetInvocationExpression(node.Right, out var invocation))
-            {
-                var arguments = invocation.ArgumentList.Arguments;
-
-                if (arguments.Count != 1)
-                {
-                    // different arguments, so nothing to report here as simplifiable
-                    return false;
-                }
-
-                var name = invocation.GetName();
-
-                if (name != nameof(Equals))
-                {
-                    // no Equals method, so nothing to report here as simplifiable
-                    return false;
-                }
-
-                var semanticModel = context.SemanticModel;
-
-                // we might have properties, so we investigate the complete expression
-                var typeSymbol = invocation.GetIdentifierExpression().GetTypeSymbol(semanticModel);
-
-                if (typeSymbol.IsString())
-                {
-                    // already reported by MiKo_3222
-                    return false;
-                }
-
-                if (typeSymbol.IsReferenceType)
-                {
-                    var partA = left.Left;
-                    var partB = left.Right;
-
-                    var nameA = partA.ToString();
-                    var nameB = partB.ToString();
-
-                    var argument = arguments[0];
-                    var argumentName = argument.ToString();
-
-                    if (nameB == argumentName || nameA == argumentName)
-                    {
-                        if (partA.GetTypeSymbol(semanticModel).IsReferenceType && partB.GetTypeSymbol(semanticModel).IsReferenceType && argument.GetTypeSymbol(semanticModel).IsReferenceType)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is BinaryExpressionSyntax node)
-            {
-                if (HasIssue(node, context))
-                {
-                    ReportDiagnostics(context, Issue(node));
-                }
-            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_CodeFixProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3224_CodeFixProvider)), Shared]
+    public sealed class MiKo_3224_CodeFixProvider : LogicalConditionsSimplifierCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3224";
+
+        protected override SyntaxKind PredefinedTypeKind => SyntaxKind.None;
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
+            {
+                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+                {
+                    return left.WithoutTrivia()
+                               .WithTriviaFrom(syntax);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer : LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3224";
+
+        public MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count == 1;
+
+        protected override bool IsApplicable(ITypeSymbol typeSymbol) => typeSymbol.IsValueType;
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -1,0 +1,207 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_logical_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null)
+        { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_logical_And_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null && o is string s)
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("a == b || (a?.Equals(b) is true)")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        public void No_issue_is_reported_for_reference_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object a, object b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("""a == b || a?.ToString("D") is null""")]
+        [TestCase("a == b || a?.GetHashCode() == 42")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
+        [TestCase("a == b || c?.Equals(d) == true")]
+        [TestCase("a == b || c?.Equals(d) is true")]
+        [TestCase("a == b || c?.Equals(d) == true")]
+        [TestCase("a == b || c?.Equals(d) is true")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        public void No_issue_is_reported_for_condition_with_unrelated_condition_(string condition) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int a, int b, object c, object d)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b || (a?.Equals(b) == true))")]
+        [TestCase("(a == b || (a?.Equals(b) is true))")]
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int a, int b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_condition_with_property() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A)))
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("(a == b || a?.Equals(b) == true)")]
+        [TestCase("(a == b || a?.Equals(b) is true)")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
+        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        public void Code_gets_fixed_for_condition__(string condition)
+        {
+            var originalCode = @"
+public class TestMe
+{
+    public void DoSomething(int a, int b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public void DoSomething(int a, int b)
+    {
+        if (a == b)
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || (left.A != null && left.A.Equals(right.A)))
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A)
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3224_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 465 rules that are currently provided by the analyzer.
+The following tables lists all the 466 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -414,6 +414,7 @@ The following tables lists all the 465 rules that are currently provided by the 
 |MiKo_3221|GetHashCode overrides should use 'HashCode.Combine'|&#x2713;|&#x2713;|
 |MiKo_3222|String comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3223|Reference comparisons can be simplified|&#x2713;|&#x2713;|
+|MiKo_3224|Value comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduced a new rule, MiKo_3224, to simplify value comparisons by using specific equality operators.
- Added new abstract classes to streamline the implementation of logical condition simplifications and code fixes.
- Refactored existing code fix providers and analyzers (MiKo_3222 and MiKo_3223) to inherit from new base classes, reducing redundancy.
- Implemented unit tests for the new MiKo_3224 rule to ensure correct detection and code fix application.
- Updated project configuration files to include new analyzers and code fix providers.
- Updated resources and documentation to reflect the addition of the MiKo_3224 rule.

