### PR TITLE
Added new rule MiKo_3225 to simplify redundant conditions

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -201,6 +201,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -306,6 +306,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3222_LogicalConditionsUsingStringComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_LogicalConditionsAreTheSameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13097,6 +13097,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Simplify redundant comparison.
+        /// </summary>
+        internal static string MiKo_3225_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3225_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Boolean comparisons comparing the same values on both sides are redundant and can be simplified by using only one of those sides. This makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_3225_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3225_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Redundant comparison can be simplified.
+        /// </summary>
+        internal static string MiKo_3225_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3225_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Redundant comparisons can be simplified.
+        /// </summary>
+        internal static string MiKo_3225_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3225_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4610,6 +4610,18 @@ Instead, it would be much easier to see what is meant if non-generic types would
   <data name="MiKo_3224_Title" xml:space="preserve">
     <value>Value comparisons can be simplified</value>
   </data>
+  <data name="MiKo_3225_CodeFixTitle" xml:space="preserve">
+    <value>Simplify redundant comparison</value>
+  </data>
+  <data name="MiKo_3225_Description" xml:space="preserve">
+    <value>Boolean comparisons comparing the same values on both sides are redundant and can be simplified by using only one of those sides. This makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_3225_MessageFormat" xml:space="preserve">
+    <value>Redundant comparison can be simplified</value>
+  </data>
+  <data name="MiKo_3225_Title" xml:space="preserve">
+    <value>Redundant comparisons can be simplified</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3225_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3225_CodeFixProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3225_CodeFixProvider)), Shared]
+    public sealed class MiKo_3225_CodeFixProvider : LogicalConditionsSimplifierCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3225";
+
+        protected override SyntaxKind PredefinedTypeKind => SyntaxKind.None;
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionSyntax expression && expression.WithoutParenthesis() is BinaryExpressionSyntax binary)
+            {
+                if (binary.Left.WithoutParenthesis() is BinaryExpressionSyntax left && left.IsKind(SyntaxKind.EqualsExpression))
+                {
+                    return left.WithoutTrivia()
+                               .WithTriviaFrom(syntax);
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3225_LogicalConditionsAreTheSameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3225_LogicalConditionsAreTheSameAnalyzer.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3225_LogicalConditionsAreTheSameAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3225";
+
+        private static readonly SyntaxKind[] LogicalConditions = { SyntaxKind.LogicalOrExpression, SyntaxKind.LogicalAndExpression };
+
+        public MiKo_3225_LogicalConditionsAreTheSameAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeLogicalExpressions, LogicalConditions);
+
+        private static bool HasIssue(BinaryExpressionSyntax expression) => expression.Left.WithoutParenthesis().ToString() == expression.Right.WithoutParenthesis().ToString();
+
+        private void AnalyzeLogicalExpressions(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BinaryExpressionSyntax node)
+            {
+                if (HasIssue(node))
+                {
+                    ReportDiagnostics(context, Issue(node));
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3225_LogicalConditionsAreTheSameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3225_LogicalConditionsAreTheSameAnalyzerTests.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3225_LogicalConditionsAreTheSameAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_logical_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null)
+        { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_logical_condition_doing_different_things() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        if (o != null && o is string s)
+        { }
+    }
+}
+");
+
+        [TestCase("a == b || a == b")]
+        [TestCase("(a == b) || a == b")]
+        [TestCase("(a == b) || (a == b)")]
+        [TestCase("a == b || (a == b)")]
+        [TestCase("a == b && a == b")]
+        [TestCase("(a == b) && a == b")]
+        [TestCase("(a == b) && (a == b)")]
+        [TestCase("a == b && (a == b)")]
+        public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int a, int b)
+    {
+        if (" + condition + @")
+        { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_condition_with_property() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || left.A == right.A)
+        { }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_condition_with_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A || left.A == right.A)
+        { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int A { get; }
+
+    public void DoSomething(TestMe left, TestMe right)
+    {
+        if (left.A == right.A)
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [TestCase("a == b || a == b", "a == b")]
+        [TestCase("(a == b) || a == b", "a == b")]
+        [TestCase("(a == b) || (a == b)", "a == b")]
+        [TestCase("a == b || (a == b)", "a == b")]
+        [TestCase("a == b && a == b", "a == b")]
+        [TestCase("(a == b) && a == b", "a == b")]
+        [TestCase("(a == b) && (a == b)", "a == b")]
+        [TestCase("a == b && (a == b)", "a == b")]
+        public void Code_gets_fixed_for_condition_(string originalCondition, string fixedCondition)
+        {
+            const string Template = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int a, int b)
+    {
+        if (###)
+        { }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalCondition), Template.Replace("###", fixedCondition));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3225_LogicalConditionsAreTheSameAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3225_LogicalConditionsAreTheSameAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3225_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 466 rules that are currently provided by the analyzer.
+The following tables lists all the 467 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -415,6 +415,7 @@ The following tables lists all the 466 rules that are currently provided by the 
 |MiKo_3222|String comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3223|Reference comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3224|Value comparisons can be simplified|&#x2713;|&#x2713;|
+|MiKo_3225|Redundant comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Implemented a new rule, MiKo_3225, to simplify redundant logical conditions by removing duplicate comparisons.
- Added a code fix provider for the MiKo_3225 rule to automatically simplify redundant conditions.
- Created unit tests to verify the functionality of the MiKo_3225 analyzer and its code fix.
- Updated project files to include the new analyzer and code fix provider.
- Enhanced documentation by updating the README to reflect the addition of the new rule.


(resolves #1000)