### PR TITLE
MiKo_6060 is now aware of "is" pattern expressions in switch case arms

### DIFF
--- a/BenchmarkConsole/Program.cs
+++ b/BenchmarkConsole/Program.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Running;
 
 namespace BenchmarkConsole
 {
-    internal class Program
+    internal static class Program
     {
         static void Main()
         {

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -1951,6 +1951,7 @@ namespace System
                 var bufferSpan = new Span<char>(buffer, length);
 
                 source.CopyTo(bufferSpan);
+
                 buffer[index] = buffer[index].ToUpperCase();
 
                 return new string(buffer, 0, length);
@@ -1967,6 +1968,7 @@ namespace System
                 var bufferSpan = new Span<char>(buffer, length);
 
                 source.CopyTo(bufferSpan);
+
                 buffer[index] = buffer[index].ToLowerCase();
 
                 return new string(buffer, 0, length);

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1879,8 +1879,10 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSpanningMultipleLines(this SyntaxNode value)
         {
-            var startingLine = value.GetStartingLine();
-            var endingLine = value.GetEndingLine();
+            var lineSpan = value.GetLocation().GetLineSpan();
+
+            var startingLine = lineSpan.StartLinePosition.Line;
+            var endingLine = lineSpan.EndLinePosition.Line;
 
             return startingLine != endingLine;
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
@@ -65,8 +65,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 // a?.Equals(b) is true
                 case IsPatternExpressionSyntax p when p.IsPatternCheckFor(SyntaxKind.TrueLiteralExpression)
-                                                      && p.Expression is ConditionalAccessExpressionSyntax c
-                                                      && c.WhenNotNull is InvocationExpressionSyntax invocation:
+                                                   && p.Expression is ConditionalAccessExpressionSyntax c
+                                                   && c.WhenNotNull is InvocationExpressionSyntax invocation:
                 {
                     result = invocation;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
@@ -188,7 +188,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var root = methodBody.SyntaxTree.GetCompilationUnitRoot();
 
                 var identifiers = root.DescendantNodes<IdentifierNameSyntax>(_ => _.Parent is ArgumentSyntax
-                                                                              || (_.Parent is BinaryExpressionSyntax b && b.IsKind(SyntaxKind.CoalesceExpression) && b.Parent is ArgumentSyntax));
+                                                                          || (_.Parent is BinaryExpressionSyntax b && b.IsKind(SyntaxKind.CoalesceExpression) && b.Parent is ArgumentSyntax));
 
                 return identifiers.ToHashSet(_ => _.Identifier.ValueText);
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
@@ -41,6 +41,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return syntax;
         }
 
+        private static PrefixUnaryExpressionSyntax GetUpdatedSyntax(PrefixUnaryExpressionSyntax unary) => unary.WithOperatorToken(unary.OperatorToken.WithoutTrailingTrivia())
+                                                                                                               .WithOperand(unary.Operand.WithoutLeadingTrivia());
+
+        private static PostfixUnaryExpressionSyntax GetUpdatedSyntax(PostfixUnaryExpressionSyntax unary) => unary.WithOperand(unary.Operand.WithoutTrailingTrivia())
+                                                                                                                 .WithOperatorToken(unary.OperatorToken.WithoutLeadingTrivia());
+
         private static BinaryExpressionSyntax GetUpdatedSyntax(BinaryExpressionSyntax binary, Diagnostic issue)
         {
             var spaces = GetProposedSpaces(issue);
@@ -50,8 +56,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             var right = binary.Right;
 
             var updatedLeft = left.GetStartingLine() != operatorToken.GetStartingLine() && left.HasTrailingComment()
-                                  ? left // there is already a comment, so nothing to do here
-                                  : left.WithTrailingTriviaFrom(operatorToken); // copy comment or line break
+                              ? left // there is already a comment, so nothing to do here
+                              : left.WithTrailingTriviaFrom(operatorToken); // copy comment or line break
 
             var updatedToken = operatorToken.WithLeadingSpaces(spaces).WithTrailingSpace();
             var updatedRight = right.WithoutLeadingTrivia();
@@ -60,11 +66,5 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                          .WithOperatorToken(updatedToken)
                          .WithRight(updatedRight);
         }
-
-        private static PrefixUnaryExpressionSyntax GetUpdatedSyntax(PrefixUnaryExpressionSyntax unary) => unary.WithOperatorToken(unary.OperatorToken.WithoutTrailingTrivia())
-                                                                                                               .WithOperand(unary.Operand.WithoutLeadingTrivia());
-
-        private static PostfixUnaryExpressionSyntax GetUpdatedSyntax(PostfixUnaryExpressionSyntax unary) => unary.WithOperand(unary.Operand.WithoutTrailingTrivia())
-                                                                                                                 .WithOperatorToken(unary.OperatorToken.WithoutLeadingTrivia());
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs
@@ -33,6 +33,11 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                         {
                             return false;
                         }
+
+                        if (condition.Left is IsPatternExpressionSyntax || condition.Right is IsPatternExpressionSyntax)
+                        {
+                            return false;
+                        }
                     }
 
                     return pattern.IsSpanningMultipleLines();

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6060_SwitchCasesAreOnSameLineAnalyzerTests.cs
@@ -361,6 +361,32 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_switch_case_pattern_with_complex_when_clause_including_pattern_spanning_multiple_lines() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o, out int result)
+    {
+        result = 0;
+
+        switch (o)
+        {
+            case string s when string.IsNullOrEmpty(s)
+                            && s.Length is int i:
+            {
+                result = i;
+                return true;
+            }
+
+            default:
+                return false;
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_switch_case_pattern_if_type_of_expression_is_on_different_line() => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Enhanced switch case analysis with pattern expression handling in `MiKo_6060_SwitchCasesAreOnSameLineAnalyzer`.
- Added a test for complex when clause in switch case pattern for `MiKo_6060`.
- Made the `Program` class static in `BenchmarkConsole`.
- Improved readability in `StringExtensions` by adding spacing in methods.
- Refactored line span calculation in `SyntaxNodeExtensions`.
- Updated pattern matching syntax in `LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer`.
- Re-arranged methods for updating syntax of unary expressions in `MiKo_6044_CodeFixProvider`.

