### PR TITLE
Added new rule MiKo_3065 that reports and fixes string interpolations for Microsoft.Logging calls

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -90,6 +90,15 @@ namespace MiKoSolutions.Analyzers
             internal const string NamespaceName = "Microsoft.Extensions.Logging";
             internal const string TypeName = "ILogger";
             internal const string FullTypeName = NamespaceName + "." + TypeName;
+
+            internal const string BeginScope = nameof(BeginScope);
+            internal const string Log = nameof(Log);
+            internal const string LogCritical = nameof(LogCritical);
+            internal const string LogDebug = nameof(LogDebug);
+            internal const string LogError = nameof(LogError);
+            internal const string LogInformation = nameof(LogInformation);
+            internal const string LogTrace = nameof(LogTrace);
+            internal const string LogWarning = nameof(LogWarning);
         }
 
         internal static class Moq

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -167,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3062_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3063_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3064_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3065_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3075_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3077_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3078_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -234,6 +234,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3062_ExceptionLogMessageEndsWithColonAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3063_NonExceptionLogMessageEndsWithDotAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3064_LogMessagesContainsNtContradictionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3070_EnumerableMethodReturnsNullAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3071_TaskMethodReturnsNullAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3072_MethodReturnsListAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -10786,6 +10786,46 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change interpolated string into normal string.
+        /// </summary>
+        internal static string MiKo_3065_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3065_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Microsoft Logging API supports Semantic or Structured Logging via message templates. These message template can contain placeholders for which arguments are provided.
+        ///
+        ///Although these placeholders are names (not numbers) and require arguments, the message template looks almost identical to an interpolated string (except of the &apos;$&apos; and the additional arguments) which can be confusing.
+        ///
+        ///The arguments themselves are passed to the logging system, not just the formatted message template. This enables logg [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MiKo_3065_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3065_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use interpolated string.
+        /// </summary>
+        internal static string MiKo_3065_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3065_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Microsoft Logging calls should not use interpolated strings.
+        /// </summary>
+        internal static string MiKo_3065_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3065_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Methods that return IEnumerable are expected to be used in foreach loops or Linq queries.
         ///It is unexpected that such places throw a NullReferenceException or ArgumentNullException, so these methods should never return null..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3808,6 +3808,24 @@ It would therefore be better to clearly highlight the contradiction.</value>
   <data name="MiKo_3064_Title" xml:space="preserve">
     <value>Log messages should not use the contradiction "n't"</value>
   </data>
+  <data name="MiKo_3065_CodeFixTitle" xml:space="preserve">
+    <value>Change interpolated string into normal string</value>
+  </data>
+  <data name="MiKo_3065_Description" xml:space="preserve">
+    <value>The Microsoft Logging API supports Semantic or Structured Logging via message templates. These message template can contain placeholders for which arguments are provided.
+
+Although these placeholders are names (not numbers) and require arguments, the message template looks almost identical to an interpolated string (except of the '$' and the additional arguments) which can be confusing.
+
+The arguments themselves are passed to the logging system, not just the formatted message template. This enables logging providers to store the parameter values as fields which can be filtered on.
+
+Providing interpolated strings instead of message templates would prevent that filtering and contradict the intended Semantic or Structured Logging approach.</value>
+  </data>
+  <data name="MiKo_3065_MessageFormat" xml:space="preserve">
+    <value>Do not use interpolated string</value>
+  </data>
+  <data name="MiKo_3065_Title" xml:space="preserve">
+    <value>Microsoft Logging calls should not use interpolated strings</value>
+  </data>
   <data name="MiKo_3070_Description" xml:space="preserve">
     <value>Methods that return IEnumerable are expected to be used in foreach loops or Linq queries.
 It is unexpected that such places throw a NullReferenceException or ArgumentNullException, so these methods should never return null.</value>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3065_CodeFixProvider)), Shared]
+    public sealed class MiKo_3065_CodeFixProvider : StringMaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3065";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ArgumentListSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ArgumentListSyntax argumentList)
+            {
+                var arguments = argumentList.Arguments;
+
+                if (arguments.Count > 0)
+                {
+                    var argument = arguments[0];
+
+                    if (argument.Expression is InterpolatedStringExpressionSyntax interpolated)
+                    {
+                        var interpolations = interpolated.Contents.OfType<InterpolationSyntax>().ToList();
+
+                        // filter for format clauses as they are not needed inside the resulting text
+                        var formatClauses = interpolations.Select(_ => _.FormatClause).Where(_ => _ != null);
+
+                        var text = interpolated.Without(formatClauses).Contents.ToString();
+
+                        // find interpolated arguments and convert them
+                        var argumentsFromInterpolation = interpolations.ToArray(_ => Argument(ConvertToExpression(_)));
+
+                        return argumentList.ReplaceNode(argument, Argument(StringLiteral(text)))
+                                           .AddArguments(argumentsFromInterpolation);
+                    }
+                }
+            }
+
+            return syntax;
+        }
+
+        private static ExpressionSyntax ConvertToExpression(InterpolationSyntax syntax)
+        {
+            var clause = syntax.FormatClause;
+
+            return clause is null
+                   ? syntax.Expression
+                   : Invocation(SimpleMemberAccess(syntax.Expression, nameof(ToString)), Argument(StringLiteral(clause.FormatStringToken.ValueText)));
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3065";
+
+        public MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName(Constants.MicrosoftLogging.FullTypeName) != null;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInterpolatedString, SyntaxKind.InterpolatedStringExpression);
+
+        private void AnalyzeInterpolatedString(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InterpolatedStringExpressionSyntax node)
+            {
+                var issues = AnalyzeInterpolatedString(node, context.SemanticModel);
+
+                ReportDiagnostics(context, issues);
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeInterpolatedString(InterpolatedStringExpressionSyntax node, SemanticModel semanticModel)
+        {
+            if (node.Parent is ArgumentSyntax a && a.Parent is ArgumentListSyntax al && al.Parent is InvocationExpressionSyntax invocation && invocation.Expression is MemberAccessExpressionSyntax methodCall)
+            {
+                var methodName = methodCall.GetName();
+
+                switch (methodName)
+                {
+                    case Constants.MicrosoftLogging.BeginScope:
+                    case Constants.MicrosoftLogging.Log:
+                    case Constants.MicrosoftLogging.LogCritical:
+                    case Constants.MicrosoftLogging.LogDebug:
+                    case Constants.MicrosoftLogging.LogError:
+                    case Constants.MicrosoftLogging.LogInformation:
+                    case Constants.MicrosoftLogging.LogTrace:
+                    case Constants.MicrosoftLogging.LogWarning:
+                    {
+                        var type = methodCall.GetTypeSymbol(semanticModel);
+
+                        if (type.Name == Constants.MicrosoftLogging.TypeName && type.ContainingNamespace.FullyQualifiedName() == Constants.MicrosoftLogging.NamespaceName)
+                        {
+                            return new[] { Issue(node.StringStartToken) };
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return Enumerable.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
@@ -1,0 +1,266 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] LogForNetMethods = ["Debug", "Info", "Error", "Warn", "Fatal", "DebugFormat", "InfoFormat", "ErrorFormat", "WarnFormat", "FatalFormat"];
+        private static readonly string[] Methods = ["BeginScope", "Log", "LogCritical", "LogDebug", "LogError", "LogInformation", "LogTrace", "LogWarning"];
+
+        [Test]
+        public void No_issue_is_reported_for_empty_class() => No_issue_is_reported_for(@"
+namespace log4net
+{
+    public class TestMe
+    { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_method() => No_issue_is_reported_for(@"
+namespace log4net
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_logging_calls_with_interpolation() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public TestMe(int i) => SomeMethod($""some text for {i}"");
+
+    public void DoSomething(int i) => SomeMethod($""some text for {i}"");
+
+    public void SomeMethod(string text) { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_log4net_calls_with_interpolation_([ValueSource(nameof(LogForNetMethods))] string method) => No_issue_is_reported_for(@"
+using System;
+
+namespace log4net
+{
+    public interface ILog
+    {
+        void " + method + @"();
+    }
+
+    public class TestMe
+    {
+        private static ILog Log = null;
+
+        public TestMe()
+        {
+            Log." + method + @"(""some text"");
+        }
+
+        public TestMe(Exception ex)
+        {
+            Log." + method + @"(""some text"", ex);
+        }
+
+        public void DoSomething(int i) => Log." + method + @"($""some text for {i}"");
+
+        public void DoSomething(int i, Exception ex) => Log." + method + @"($""some text for {i}"", ex);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Microsoft_logging_call_without_interpolation_([ValueSource(nameof(Methods))] string method) => No_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"();
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething()
+        {
+            _logger." + method + @"(""some text"");
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Microsoft_logging_call_with_interpolation_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"($""some text for {i}"");
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Microsoft_logging_call_with_interpolation_and_format_provider_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"($""some text for {i:D}"");
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_Microsoft_logging_call_with_interpolation_([ValueSource(nameof(Methods))] string method)
+        {
+            var originalCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"($""some text for {x}, {y} and {z}"");
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(""some text for {x}, {y} and {z}"", x, y, z);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Microsoft_logging_call_with_interpolation_and_format_provider_([ValueSource(nameof(Methods))] string method)
+        {
+            var originalCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"($""some text for {x:D}, {y:G} and {z:C}"");
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(""some text for {x}, {y} and {z}"", x.ToString(""D""), y.ToString(""G""), z.ToString(""C""));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3065_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -56,17 +56,12 @@ public class TestMe
 ");
 
         [TestCase("""a == b || a?.ToString("D") is null""")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
         [TestCase("a == b || a?.GetHashCode() == 42")]
-        [TestCase("a == b || a?.Equals(b) == false")]
-        [TestCase("a == b || a?.Equals(b) is false")]
-        [TestCase("a == b || a?.Equals(b) == false")]
-        [TestCase("a == b || a?.Equals(b) is false")]
         [TestCase("a == b || c?.Equals(d) == true")]
         [TestCase("a == b || c?.Equals(d) is true")]
-        [TestCase("a == b || c?.Equals(d) == true")]
-        [TestCase("a == b || c?.Equals(d) is true")]
-        [TestCase("a == b || (c != null && c.Equals(d))")]
-        [TestCase("a == b || (c != null && c.Equals(d))")]
         public void No_issue_is_reported_for_condition_with_unrelated_condition_(string condition) => No_issue_is_reported_for(@"
 using System;
 
@@ -80,24 +75,16 @@ public class TestMe
 }
 ");
 
-        [TestCase("a == b || a?.Equals(b) == true")]
-        [TestCase("a == b || a?.Equals(b) is true")]
-        [TestCase("a == b || (a != null && a.Equals(b))")]
-        [TestCase("(a == b) || (a != null && a.Equals(b))")]
-        [TestCase("(a == b || a?.Equals(b) == true)")]
-        [TestCase("(a == b || a?.Equals(b) is true)")]
-        [TestCase("(a == b || (a != null && a.Equals(b)))")]
         [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
         [TestCase("(a == b || (a?.Equals(b) == true))")]
         [TestCase("(a == b || (a?.Equals(b) is true))")]
-        [TestCase("a == b || a?.Equals(b) == true")]
-        [TestCase("a == b || a?.Equals(b) is true")]
-        [TestCase("a == b || (a != null && a.Equals(b))")]
-        [TestCase("(a == b) || (a != null && a.Equals(b))")]
         [TestCase("(a == b || a?.Equals(b) == true)")]
         [TestCase("(a == b || a?.Equals(b) is true)")]
-        [TestCase("(a == b || (a != null && a.Equals(b)))")]
-        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
         public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzerTests.cs
@@ -56,17 +56,12 @@ public class TestMe
 ");
 
         [TestCase("""a == b || a?.ToString("D") is null""")]
+        [TestCase("a == b || (c != null && c.Equals(d))")]
+        [TestCase("a == b || a?.Equals(b) == false")]
+        [TestCase("a == b || a?.Equals(b) is false")]
         [TestCase("a == b || a?.GetHashCode() == 42")]
-        [TestCase("a == b || a?.Equals(b) == false")]
-        [TestCase("a == b || a?.Equals(b) is false")]
-        [TestCase("a == b || a?.Equals(b) == false")]
-        [TestCase("a == b || a?.Equals(b) is false")]
         [TestCase("a == b || c?.Equals(d) == true")]
         [TestCase("a == b || c?.Equals(d) is true")]
-        [TestCase("a == b || c?.Equals(d) == true")]
-        [TestCase("a == b || c?.Equals(d) is true")]
-        [TestCase("a == b || (c != null && c.Equals(d))")]
-        [TestCase("a == b || (c != null && c.Equals(d))")]
         public void No_issue_is_reported_for_condition_with_unrelated_condition_(string condition) => No_issue_is_reported_for(@"
 using System;
 
@@ -80,24 +75,16 @@ public class TestMe
 }
 ");
 
-        [TestCase("a == b || a?.Equals(b) == true")]
-        [TestCase("a == b || a?.Equals(b) is true")]
-        [TestCase("a == b || (a != null && a.Equals(b))")]
-        [TestCase("(a == b) || (a != null && a.Equals(b))")]
-        [TestCase("(a == b || a?.Equals(b) == true)")]
-        [TestCase("(a == b || a?.Equals(b) is true)")]
-        [TestCase("(a == b || (a != null && a.Equals(b)))")]
         [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b || (a != null && a.Equals(b)))")]
         [TestCase("(a == b || (a?.Equals(b) == true))")]
         [TestCase("(a == b || (a?.Equals(b) is true))")]
-        [TestCase("a == b || a?.Equals(b) == true")]
-        [TestCase("a == b || a?.Equals(b) is true")]
-        [TestCase("a == b || (a != null && a.Equals(b))")]
-        [TestCase("(a == b) || (a != null && a.Equals(b))")]
         [TestCase("(a == b || a?.Equals(b) == true)")]
         [TestCase("(a == b || a?.Equals(b) is true)")]
-        [TestCase("(a == b || (a != null && a.Equals(b)))")]
-        [TestCase("((a == b) || (a != null && a.Equals(b)))")]
+        [TestCase("(a == b) || (a != null && a.Equals(b))")]
+        [TestCase("a == b || (a != null && a.Equals(b))")]
+        [TestCase("a == b || a?.Equals(b) == true")]
+        [TestCase("a == b || a?.Equals(b) is true")]
         public void An_issue_is_reported_for_condition_(string condition) => An_issue_is_reported_for(@"
 using System;
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 467 rules that are currently provided by the analyzer.
+The following tables lists all the 468 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -343,6 +343,7 @@ The following tables lists all the 467 rules that are currently provided by the 
 |MiKo_3062|End log messages for exceptions with a colon|&#x2713;|&#x2713;|
 |MiKo_3063|End non-exceptional log messages with a dot|&#x2713;|&#x2713;|
 |MiKo_3064|Log messages should not use the contradiction "n't"|&#x2713;|&#x2713;|
+|MiKo_3065|Microsoft Logging calls should not use interpolated strings|&#x2713;|&#x2713;|
 |MiKo_3070|Do not return null for an IEnumerable|&#x2713;|\-|
 |MiKo_3071|Do not return null for a Task|&#x2713;|\-|
 |MiKo_3072|Non-private methods should not return 'List&lt;&gt;' or 'Dictionary&lt;&gt;'|&#x2713;|\-|


### PR DESCRIPTION
- Introduced a new rule, MiKo_3065, to detect and fix the use of interpolated strings in Microsoft Logging calls.
- Implemented `MiKo_3065_CodeFixProvider` to convert interpolated strings to normal strings with arguments.
- Added constants for Microsoft Logging methods in `Constants.cs`.
- Updated resources and project files to include the new rule and its components.
- Added comprehensive tests for the new rule and its code fix provider.
- Updated README to reflect the addition of the new rule.


(resolves #931)
