### PR TITLE
MiK_2013 codefix now detects if the type ends with 'Enum' but not in comment

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -128,7 +128,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var enumName = text.FirstAncestor<EnumDeclarationSyntax>()?.GetName();
 
                     // seems like the continuation is a single word and ends with the name of the enum, so it can be lower-case plural
-                    if (continuation == enumName)
+                    if (enumName == continuation || enumName == continuation + "Enum")
                     {
                         startingPhrase = KindPhrase;
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -396,6 +396,31 @@ public enum " + typeName + @"
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [TestCase("Message", "messages")]
+        [TestCase("MessageKind", "messages")]
+        [TestCase("MessageType", "messages")]
+        public void Code_gets_fixed_for_sentenced_with_special_documentation_suffixed_with_Enum_(string typeName, string fixedEnding)
+        {
+            var originalCode = @"
+/// <summary>
+/// Gets or Sets " + typeName + @".
+/// </summary>
+public enum " + typeName + @"Enum
+{
+}
+";
+
+            var fixedCode = @"
+/// <summary>
+/// Defines values that specify the different kinds of " + fixedEnding + @".
+/// </summary>
+public enum " + typeName + @"Enum
+{
+}
+";
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2013_EnumSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2013_EnumSummaryAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_2013_CodeFixProvider` to detect enum names that end with 'Enum' but are referenced without 'Enum' in comments.
- Added new test cases in `MiKo_2013_EnumSummaryAnalyzerTests` to verify the handling of enum names suffixed with 'Enum' in documentation.
