### PR TITLE
MiKo_2082 can now handle special enum text "Enum XYZEnum for XYZ"

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Buffers;
 
+using MiKoSolutions.Analyzers;
 using MiKoSolutions.Analyzers.Linguistics;
 
 // for performance reasons we switch of RDI and NCrunch instrumentation

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -1838,25 +1838,19 @@ namespace System
                 return null;
             }
 
-            var length = value.Length - suffix.Length;
-
-            return length <= 0
-                   ? string.Empty
-                   : value.Substring(0, length);
-        }
-
-        public static StringBuilder WithoutSuffix(this StringBuilder value, string suffix)
-        {
-            if (value is null)
+            if (value.EndsWith(suffix, StringComparison.Ordinal))
             {
-                return null;
+                var length = value.Length - suffix.Length;
+
+                if (length <= 0)
+                {
+                    return string.Empty;
+                }
+
+                return value.Substring(0, length);
             }
 
-            var length = value.Length - suffix.Length;
-
-            return length <= 0
-                   ? value.Remove(0, value.Length)
-                   : value.Remove(0, length);
+            return value;
         }
 
         public static ReadOnlySpan<char> WithoutSuffix(this ReadOnlySpan<char> value, char suffix)

--- a/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
@@ -4,11 +4,16 @@ namespace MiKoSolutions.Analyzers.Linguistics
 {
     internal static class ArticleProvider
     {
-        internal static string GetIndefiniteArticleFor(string text)
+        internal static string GetArticleFor(string text, FirstWordHandling firstWordHandling = FirstWordHandling.None)
         {
+            if (text is null)
+            {
+                return string.Empty;
+            }
+
             if (text.StartsWithAny("AaEeIiOo"))
             {
-                return "An ";
+                return An();
             }
 
             if (text.StartsWithAny("Uu"))
@@ -18,14 +23,14 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     if (text.Length > 3 && text[3].ToUpperCase() == 'N')
                     {
                         // something like 'uninformed', so is a vowel sound
-                        return "An ";
+                        return An();
                     }
 
                     // uni is pronounced like 'yuni' where 'y' is a consonant and no vowel sound, hence we have to use 'A'
-                    return "A ";
+                    return A();
                 }
 
-                return "An ";
+                return An();
             }
 
             if (text.StartsWithAny("Hh"))
@@ -33,11 +38,15 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 if (text.StartsWith("hon", StringComparison.OrdinalIgnoreCase))
                 {
                     // it is a vowel sound if 'h' is followed by 'on' (as in such case 'h' it is silent, like in 'honest')
-                    return "An ";
+                    return An();
                 }
             }
 
-            return "A ";
+            return A();
+
+            string A() => firstWordHandling == FirstWordHandling.MakeLowerCase ? "a " : "A ";
+
+            string An() => firstWordHandling == FirstWordHandling.MakeLowerCase ? "an " : "An ";
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Linguistics/WordSeparator.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/WordSeparator.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MiKoSolutions.Analyzers.Linguistics
+{
+    internal static class WordSeparator
+    {
+        internal static string Separate(string text, char separator, FirstWordHandling firstWordHandling = FirstWordHandling.None)
+        {
+            if (text.IsNullOrEmpty())
+            {
+                return text;
+            }
+
+            var multipleUpperCases = false;
+
+            const int CharacterToStartWith = 1;
+
+            var characters = new List<char>(text);
+
+            for (var index = CharacterToStartWith; index < characters.Count; index++)
+            {
+                var c = characters[index];
+
+                if (c == separator)
+                {
+                    // keep the existing separator
+                    continue;
+                }
+
+                if (c.IsUpperCase())
+                {
+                    if (index == CharacterToStartWith)
+                    {
+                        // multiple upper cases in a line at beginning of the name, so do not flip
+                        multipleUpperCases = true;
+                    }
+
+                    if (multipleUpperCases)
+                    {
+                        // let's see if we start with an IXyz interface
+                        if (characters[index - 1] == 'I')
+                        {
+                            // seems we are in an IXyz interface
+                            multipleUpperCases = false;
+                        }
+
+                        continue;
+                    }
+
+                    // let's consider an upper-case 'A' as a special situation as that is a single word
+                    var isSpecialCharA = c == 'A';
+
+                    multipleUpperCases = isSpecialCharA is false;
+
+                    var nextC = c.ToLowerCase();
+
+                    var nextIndex = index + 1;
+
+                    if ((nextIndex >= characters.Count || (nextIndex < characters.Count && characters[nextIndex].IsUpperCase())) && isSpecialCharA is false)
+                    {
+                        // multiple upper cases in a line, so do not flip
+                        nextC = c;
+                    }
+
+                    if (characters[index - 1] == separator)
+                    {
+                        characters[index] = nextC;
+                    }
+                    else
+                    {
+                        // only add an underline if we not already have one
+                        characters[index] = separator;
+                        index++;
+                        characters.Insert(index, nextC);
+                    }
+                }
+                else
+                {
+                    if (multipleUpperCases && characters[index - 1].IsUpperCase())
+                    {
+                        // we are behind multiple upper cases in a line, so add an underline
+                        characters[index++] = separator;
+
+                        characters.Insert(index, c);
+                    }
+
+                    multipleUpperCases = false;
+                }
+            }
+
+            switch (firstWordHandling)
+            {
+                case FirstWordHandling.MakeLowerCase:
+                    characters[0] = characters[0].ToLowerCase();
+
+                    break;
+
+                case FirstWordHandling.MakeUpperCase:
+                    characters[0] = characters[0].ToLowerCase();
+
+                    break;
+            }
+
+            return new string(characters.ToArray());
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -27,10 +27,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TimeSpanExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WordsReadOnlySpanEnumerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WordsReadOnlySpanEnumeratorSelectDelegate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\ArticleProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\AscendingStringComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordHandling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\WordSeparator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.Designer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\CodeDetector.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordHandling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\WordSeparator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.Designer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Analyzer.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2004_EventHandlerParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2004_EventHandlerParametersAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return VerifyParameterComments(symbol, commentXml, comment);
         }
 
-        private static string GetDefaultStartingPhrase(string name) => ArticleProvider.GetIndefiniteArticleFor(name);
+        private static string GetDefaultStartingPhrase(string name) => ArticleProvider.GetArticleFor(name);
 
         private static IEnumerable<string> CreatePhrases(IMethodSymbol method)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
@@ -5,7 +5,6 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -323,7 +323,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        private static bool IndicatesNewWord(char c) => c == '_' || c.IsUpperCase();
+        private static bool IndicatesNewWord(char c) => c == Constants.Underscore || c.IsUpperCase();
 
         private static bool PrefixHasIssue(string key, string symbolName) => symbolName.Length > key.Length && IndicatesNewWord(symbolName[key.Length]) && symbolName.StartsWith(key, StringComparison.Ordinal);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 
+using MiKoSolutions.Analyzers.Linguistics;
+
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     public static class NamesFinder
@@ -90,113 +92,37 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                    .ReplaceWithCheck(nameof(Exception) + "Thrown", "Throws" + nameof(Exception))
                                                                    .ToString();
 
-            var multipleUpperCases = false;
-
-            const int CharacterToStartWith = 1;
-
-            var characters = new List<char>(correctedSymbolName);
-
-            for (var index = CharacterToStartWith; index < characters.Count; index++)
-            {
-                var c = characters[index];
-
-                if (c == Constants.Underscore)
-                {
-                    // keep the existing underline
-                    continue;
-                }
-
-                if (c.IsUpperCase())
-                {
-                    if (index == CharacterToStartWith)
-                    {
-                        // multiple upper cases in a line at beginning of the name, so do not flip
-                        multipleUpperCases = true;
-                    }
-
-                    if (multipleUpperCases)
-                    {
-                        // let's see if we start with an IXyz interface
-                        if (characters[index - 1] == 'I')
-                        {
-                            // seems we are in an IXyz interface
-                            multipleUpperCases = false;
-                        }
-
-                        continue;
-                    }
-
-                    // let's consider an upper-case 'A' as a special situation as that is a single word
-                    var isSpecialCharA = c == 'A';
-
-                    multipleUpperCases = isSpecialCharA is false;
-
-                    var nextC = c.ToLowerCase();
-
-                    var nextIndex = index + 1;
-
-                    if ((nextIndex >= characters.Count || (nextIndex < characters.Count && characters[nextIndex].IsUpperCase())) && isSpecialCharA is false)
-                    {
-                        // multiple upper cases in a line, so do not flip
-                        nextC = c;
-                    }
-
-                    if (characters[index - 1] == Constants.Underscore)
-                    {
-                        characters[index] = nextC;
-                    }
-                    else
-                    {
-                        // only add an underline if we not already have one
-                        characters[index] = Constants.Underscore;
-                        index++;
-                        characters.Insert(index, nextC);
-                    }
-                }
-                else
-                {
-                    if (multipleUpperCases && characters[index - 1].IsUpperCase())
-                    {
-                        // we are behind multiple upper cases in a line, so add an underline
-                        characters[index++] = Constants.Underscore;
-
-                        characters.Insert(index, c);
-                    }
-
-                    multipleUpperCases = false;
-                }
-            }
+            var newSymbolName = WordSeparator.Separate(correctedSymbolName, Constants.Underscore);
 
             // fix some corrections, such as for known exceptions
-            var result = new StringBuilder(characters.Count).Append(characters.ToArray())
-                                                            .ReplaceWithCheck("argument_null_exception", nameof(ArgumentNullException))
-                                                            .ReplaceWithCheck("argument_exception", nameof(ArgumentException))
-                                                            .ReplaceWithCheck("argument_out_of_range_exception", nameof(ArgumentOutOfRangeException))
-                                                            .ReplaceWithCheck("invalid_operation_exception", nameof(InvalidOperationException))
-                                                            .ReplaceWithCheck("object_disposed_exception", nameof(ObjectDisposedException))
-                                                            .ReplaceWithCheck("not_supported_exception", nameof(NotSupportedException))
-                                                            .ReplaceWithCheck("not_implemented_exception", nameof(NotImplementedException))
-                                                            .ReplaceWithCheck("task_canceled_exception", nameof(TaskCanceledException))
-                                                            .ReplaceWithCheck("operation_canceled_exception", nameof(OperationCanceledException))
-                                                            .ReplaceWithCheck("null_reference_exception", nameof(NullReferenceException))
-                                                            .ReplaceWithCheck("_guid_empty", "_empty_guid")
-                                                            .ReplaceWithCheck("_string_empty", "_empty_string")
-                                                            .ReplaceWithCheck("_in_return_", "<1>")
-                                                            .ReplaceWithCheck("_to_return_", "<2>")
-                                                            .ReplaceWithCheck("_not_throw_", "<3>")
-                                                            .ReplaceWithCheck("_return_", "_returns_")
-                                                            .ReplaceWithCheck("_throw_", "_throws_")
-                                                            .ReplaceWithCheck("<1>", "_in_return_")
-                                                            .ReplaceWithCheck("<2>", "_to_return_")
-                                                            .ReplaceWithCheck("<3>", "_not_throw_")
-                                                            .ReplaceWithCheck("_not_throws_", "_throws_no_")
-                                                            .ReplaceWithCheck("_no_throws_", "_throws_no_")
-                                                            .ReplaceWithCheck("_has_has_", "_has_")
-                                                            .ReplaceWithCheck("D_oes", "_does")
-                                                            .ReplaceWithCheck("O_bject", "_object")
-                                                            .ReplaceWithCheck("R_eference", "_reference")
-                                                            .ReplaceWithCheck("T_ype", "_type")
-                                                            .ToString();
+            var result = new StringBuilder(newSymbolName).ReplaceWithCheck("argument_null_exception", nameof(ArgumentNullException))
+                                                         .ReplaceWithCheck("argument_exception", nameof(ArgumentException))
+                                                         .ReplaceWithCheck("argument_out_of_range_exception", nameof(ArgumentOutOfRangeException))
+                                                         .ReplaceWithCheck("invalid_operation_exception", nameof(InvalidOperationException))
+                                                         .ReplaceWithCheck("object_disposed_exception", nameof(ObjectDisposedException))
+                                                         .ReplaceWithCheck("not_supported_exception", nameof(NotSupportedException))
+                                                         .ReplaceWithCheck("not_implemented_exception", nameof(NotImplementedException))
+                                                         .ReplaceWithCheck("task_canceled_exception", nameof(TaskCanceledException))
+                                                         .ReplaceWithCheck("operation_canceled_exception", nameof(OperationCanceledException))
+                                                         .ReplaceWithCheck("null_reference_exception", nameof(NullReferenceException))
+                                                         .ReplaceWithCheck("_guid_empty", "_empty_guid")
+                                                         .ReplaceWithCheck("_string_empty", "_empty_string")
+                                                         .ReplaceWithCheck("_in_return_", "<1>")
+                                                         .ReplaceWithCheck("_to_return_", "<2>")
+                                                         .ReplaceWithCheck("_not_throw_", "<3>")
+                                                         .ReplaceWithCheck("_return_", "_returns_")
+                                                         .ReplaceWithCheck("_throw_", "_throws_")
+                                                         .ReplaceWithCheck("<1>", "_in_return_")
+                                                         .ReplaceWithCheck("<2>", "_to_return_")
+                                                         .ReplaceWithCheck("<3>", "_not_throw_")
+                                                         .ReplaceWithCheck("_not_throws_", "_throws_no_")
+                                                         .ReplaceWithCheck("_no_throws_", "_throws_no_")
+                                                         .ReplaceWithCheck("_has_has_", "_has_")
+                                                         .ReplaceWithCheck("D_oes", "_does")
+                                                         .ReplaceWithCheck("O_bject", "_object")
+                                                         .ReplaceWithCheck("R_eference", "_reference")
+                                                         .ReplaceWithCheck("T_ype", "_type")
+                                                         .ToString();
 
             return result;
         }
@@ -222,7 +148,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 case ';': return "SEMICOLON";
                 case '/': return "SLASH";
                 case '\\': return "BACKSLASH";
-                case '_': return "UNDERLINE";
+                case Constants.Underscore: return "UNDERLINE";
                 case '+': return "PLUS";
                 case '-': return "MINUS";
                 case '*': return "ASTERIX";

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/MiKo.Analyzer.Tests/Linguistics/ArticleProviderTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/ArticleProviderTests.cs
@@ -32,6 +32,6 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("uninformed", ExpectedResult = "An ")]
         [TestCase("State", ExpectedResult = "A ")]
         [TestCase("state", ExpectedResult = "A ")]
-        public static string Provides_correct_indefinite_article_for_(string text) => ArticleProvider.GetIndefiniteArticleFor(text);
+        public static string Provides_correct_indefinite_article_for_(string text) => ArticleProvider.GetArticleFor(text);
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
@@ -137,6 +137,66 @@ public enum TestMe
             VerifyCSharpFix(OriginalCode, OriginalCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_special_phrase_of_enum_member()
+        {
+            const string OriginalCode = @"
+using System;
+
+public enum TestMeKind
+{
+    /// <summary>
+    /// Enum WhateverIdentifierEnum for WhateverIdentifier
+    /// </summary>
+    WhateverIdentifier = 0,
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public enum TestMeKind
+{
+    /// <summary>
+    /// The test me kind is a WhateverIdentifier.
+    /// </summary>
+    WhateverIdentifier = 0,
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_special_phrase_of_enum_member_suffixed_with_enum()
+        {
+            const string OriginalCode = @"
+using System;
+
+public enum TestMeKind
+{
+    /// <summary>
+    /// Enum WhateverIdentifierEnum for WhateverIdentifier
+    /// </summary>
+    WhateverIdentifierEnum = 0,
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public enum TestMeKind
+{
+    /// <summary>
+    /// The test me kind is a WhateverIdentifier.
+    /// </summary>
+    WhateverIdentifierEnum = 0,
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2082_EnumMemberAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2082_EnumMemberAnalyzer();


### PR DESCRIPTION
- Enhanced the `ArticleProvider` to handle null inputs and added a `FirstWordHandling` parameter.
- Introduced the `WordSeparator` class to facilitate word separation with a specified separator.
- Improved the logic in `MiKo_2082_CodeFixProvider` to handle special enum text phrases using the new utilities.
- Updated various components to use `GetArticleFor` and `WordSeparator`.
- Added new tests to verify the handling of special enum member phrases.
