### PR TITLE
MiKo_2082 can now handle special enum type 'TypeEnum'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (text.StartsWithAny(startPhrases, StringComparison.OrdinalIgnoreCase))
                     {
-                        var enumType = enumMember.FirstAncestor<EnumDeclarationSyntax>().GetName();
+                        var enumType = enumMember.FirstAncestor<EnumDeclarationSyntax>().GetName().Without("Type").Without("Enum");
                         var separated = WordSeparator.Separate(enumType, ' ', FirstWordHandling.MakeLowerCase);
                         var article = ArticleProvider.GetArticleFor(unsuffixed, FirstWordHandling.MakeLowerCase);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
@@ -197,6 +197,36 @@ public enum TestMeKind
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_special_phrase_of_enum_member_suffixed_with_enum_and_type_suffixed_with_type_enum()
+        {
+            const string OriginalCode = @"
+using System;
+
+public enum TestMeTypeEnum
+{
+    /// <summary>
+    /// Enum WhateverIdentifierEnum for WhateverIdentifier
+    /// </summary>
+    WhateverIdentifierEnum = 0,
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public enum TestMeTypeEnum
+{
+    /// <summary>
+    /// The test me is a WhateverIdentifier.
+    /// </summary>
+    WhateverIdentifierEnum = 0,
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2082_EnumMemberAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2082_EnumMemberAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_2082_CodeFixProvider` to handle special enum types by removing "Type" and "Enum" suffixes from the `enumType` variable.
- Added a new test case in `MiKo_2082_EnumMemberAnalyzerTests` to verify the code fix for enum members suffixed with "Enum" and "TypeEnum".
