### PR TITLE
Added tests for NamesFinder and Pair

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class CommentExtensions

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System.Linq
 {
     internal static class EnumerableExtensions

--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class LocationExtensions

--- a/MiKo.Analyzer.Shared/Extensions/ReadOnlySpanEnumeratorEntry.cs
+++ b/MiKo.Analyzer.Shared/Extensions/ReadOnlySpanEnumeratorEntry.cs
@@ -1,6 +1,7 @@
 ﻿// ncrunch: no coverage start
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     internal readonly ref struct ReadOnlySpanEnumeratorEntry

--- a/MiKo.Analyzer.Shared/Extensions/SplitReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SplitReadOnlySpanEnumerator.cs
@@ -1,6 +1,7 @@
 ﻿// ncrunch: no coverage start
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     // Must be a ref struct as it contains a ReadOnlySpan<char>

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using System.Buffers;
 
-using MiKoSolutions.Analyzers;
 using MiKoSolutions.Analyzers.Linguistics;
 
 // for performance reasons we switch of RDI and NCrunch instrumentation
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System.Text
 {
     internal static class StringBuilderExtensions

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -15,6 +15,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 
 //// ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     internal static class StringExtensions

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     internal static class StringSplitExtensions

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class SymbolExtensions

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -16,6 +16,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxNodeExtensions

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeOrTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeOrTokenExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Text;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxNodeOrTokenExtensions

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxTokenExtensions

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxTriviaExtensions

--- a/MiKo.Analyzer.Shared/Extensions/TimeSpanExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/TimeSpanExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// ncrunch: rdi off
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     internal static class TimeSpanExtensions

--- a/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
@@ -3,6 +3,7 @@
 // ncrunch: rdi off
 // ncrunch: no coverage start
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     // Must be a ref struct as it contains a ReadOnlySpan<char>

--- a/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumeratorSelectDelegate.cs
+++ b/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumeratorSelectDelegate.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     internal delegate string WordsReadOnlySpanEnumeratorSelectDelegate(ReadOnlySpanEnumeratorEntry entry);

--- a/MiKo.Analyzer.Shared/Pair.cs
+++ b/MiKo.Analyzer.Shared/Pair.cs
@@ -1,19 +1,14 @@
-﻿using System.Collections.Generic;
-
-// for performance reasons we switch of RDI and NCrunch instrumentation
+﻿// for performance reasons we switch of RDI and NCrunch instrumentation
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
 // ReSharper disable once CheckNamespace
+#pragma warning disable IDE0130
 namespace System
 {
     public readonly struct Pair : IEquatable<Pair>
     {
         public readonly string Key; // made as field instead of property for performance reasons
         public readonly string Value; // made as field instead of property for performance reasons
-
-        public Pair(KeyValuePair<string, string> pair) : this(pair.Key, pair.Value)
-        {
-        }
 
         public Pair(string key, string value)
         {
@@ -38,11 +33,5 @@ namespace System
         }
 
         public override string ToString() => string.Concat(Key, " -> ", Value);
-
-        public void Deconstruct(out string key, out string value)
-        {
-            key = Key;
-            value = Value;
-        }
     }
 }

--- a/MiKo.Analyzer.Tests/PairTests.cs
+++ b/MiKo.Analyzer.Tests/PairTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+
+using NUnit.Framework;
+
+namespace MiKoSolutions.Analyzers
+{
+    [TestFixture]
+    public sealed class PairTests
+    {
+        [TestCase("some", "value")]
+        public void Equality_operator_considers_similar_pairs_as_equal_(string key, string value)
+        {
+            var pair1 = new Pair(key, value);
+            var pair2 = new Pair(key, value);
+
+            Assert.Multiple(() =>
+                                 {
+                                     // ReSharper disable once EqualExpressionComparison
+                                     Assert.That(pair1 == pair1, "Equality operator for same instance");
+                                     Assert.That(pair1 == pair2, "Equality operator for similar instances");
+                                 });
+        }
+
+        [TestCase("some", "value", "some", "other")]
+        [TestCase("some", "value", "other", "value")]
+        public void Equality_operator_considers_different_pairs_as_not_equal_(string key1, string value1, string key2, string value2)
+        {
+            var pair1 = new Pair(key1, value1);
+            var pair2 = new Pair(key2, value2);
+
+            Assert.That(pair1 == pair2, Is.False);
+        }
+
+        [TestCase("some", "value")]
+        public void Inequality_operator_considers_similar_pairs_as_equal_(string key, string value)
+        {
+            var pair1 = new Pair(key, value);
+            var pair2 = new Pair(key, value);
+
+            Assert.Multiple(() =>
+                                 {
+                                     // ReSharper disable once EqualExpressionComparison
+                                     Assert.That(pair1 != pair1, Is.False, "Inequality operator for same instance");
+                                     Assert.That(pair1 != pair2, Is.False, "Inequality operator for similar instances");
+                                 });
+        }
+
+        [TestCase("some", "value", "some", "other")]
+        [TestCase("some", "value", "other", "value")]
+        public void Inequality_operator_considers_different_pairs_as_not_equal_(string key1, string value1, string key2, string value2)
+        {
+            var pair1 = new Pair(key1, value1);
+            var pair2 = new Pair(key2, value2);
+
+            Assert.That(pair1 != pair2);
+        }
+
+        [Test]
+        public void ToString_returns_value()
+        {
+            var pair = new Pair("some", "text");
+
+            Assert.That(pair.ToString(), Is.EqualTo("some -> text"));
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/NamesFinderTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/NamesFinderTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public static class NamesFinderTests
+    {
+        [TestCase(' ', ExpectedResult = "SPACE")]
+        [TestCase('!', ExpectedResult = "EXCLAMATION_MARK")]
+        [TestCase('"', ExpectedResult = "QUOTATION_MARK")]
+        [TestCase('#', ExpectedResult = "HASH")]
+        [TestCase('$', ExpectedResult = "DOLLAR")]
+        [TestCase('%', ExpectedResult = "PERCENT")]
+        [TestCase('&', ExpectedResult = "AMPERSAND")]
+        [TestCase('(', ExpectedResult = "OPENING_PARENTHESIS")]
+        [TestCase(')', ExpectedResult = "CLOSING_PARENTHESIS")]
+        [TestCase('*', ExpectedResult = "ASTERIX")]
+        [TestCase('-', ExpectedResult = "MINUS")]
+        [TestCase(',', ExpectedResult = "COMMA")]
+        [TestCase('.', ExpectedResult = "DOT")]
+        [TestCase('/', ExpectedResult = "SLASH")]
+        [TestCase(':', ExpectedResult = "COLON")]
+        [TestCase(';', ExpectedResult = "SEMICOLON")]
+        [TestCase('?', ExpectedResult = "QUESTION_MARK")]
+        [TestCase('@', ExpectedResult = "AT")]
+        [TestCase('[', ExpectedResult = "OPENING_BRACKET")]
+        [TestCase('\'', ExpectedResult = "APOSTROPHE")]
+        [TestCase('\\', ExpectedResult = "BACKSLASH")]
+        [TestCase(']', ExpectedResult = "CLOSING_BRACKET")]
+        [TestCase('_', ExpectedResult = "UNDERLINE")]
+        [TestCase('{', ExpectedResult = "CLOSING_BRACE")]
+        [TestCase('}', ExpectedResult = "OPENING_BRACE")]
+        [TestCase('~', ExpectedResult = "TILDE")]
+        [TestCase('€', ExpectedResult = "EURO")]
+        [TestCase('+', ExpectedResult = "PLUS")]
+        [TestCase('<', ExpectedResult = "OPENING_CHEVRON")]
+        [TestCase('=', ExpectedResult = "EQUALS")]
+        [TestCase('>', ExpectedResult = "CLOSING_CHEVRON")]
+        [TestCase('§', ExpectedResult = "PARAGRAPH")]
+        [TestCase('a', ExpectedResult = null)]
+        public static string FindDescribingWord_returns_describing_word_for_(char input) => NamesFinder.FindDescribingWord(input);
+    }
+}


### PR DESCRIPTION
- Added comprehensive unit tests for the `Pair` struct, covering equality, inequality, and `ToString` method.
- Removed unnecessary constructor and method from `Pair` struct for simplification.
- Implemented unit tests for `NamesFinder` to verify character description functionality.
- Suppressed IDE0130 warnings across multiple extension files to maintain consistent namespace usage.
