### PR TITLE
Refactored detection of arguments in question in MiKo_3109

### DIFF
--- a/BenchmarkConsole/BenchmarkConsole.csproj
+++ b/BenchmarkConsole/BenchmarkConsole.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     <StartupObject>BenchmarkConsole.Program</StartupObject>
     <BaseOutputPath></BaseOutputPath>
+	<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -393,7 +393,7 @@ namespace System.Linq
             }
         }
 
-        internal static IEnumerable<T> Except<T>(this SeparatedSyntaxList<T> first, List<T> second) where T : SyntaxNode
+        internal static IEnumerable<T> Except<T>(this SeparatedSyntaxList<T> first, IReadOnlyCollection<T> second) where T : SyntaxNode
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var firstCount = first.Count;

--- a/MiKo.Analyzer.Tests/PairTests.cs
+++ b/MiKo.Analyzer.Tests/PairTests.cs
@@ -56,6 +56,45 @@ namespace MiKoSolutions.Analyzers
         }
 
         [Test]
+        public void Object_Equals_considers_similar_pairs_as_equal()
+        {
+            var pair1 = new Pair("key", "value");
+            var pair2 = new Pair("key", "value");
+
+            Assert.That(pair1.Equals((object)pair1), Is.True);
+            Assert.That(pair1.Equals((object)pair2), Is.True);
+        }
+
+        [TestCase("some", "value", "some", "other")]
+        [TestCase("some", "value", "other", "value")]
+        public void Object_Equals_considers_different_pairs_as_not_equal_(string key1, string value1, string key2, string value2)
+        {
+            var pair1 = new Pair(key1, value1);
+            var pair2 = new Pair(key2, value2);
+
+            Assert.That(pair1.Equals((object)pair2), Is.False);
+        }
+
+        [Test]
+        public void GetHashCode_of_similar_pairs_is_equal()
+        {
+            var hash1 = new Pair("key", "value").GetHashCode();
+            var hash2 = new Pair("key", "value").GetHashCode();
+
+            Assert.That(hash1, Is.EqualTo(hash2));
+        }
+
+        [TestCase("some", "value", "some", "other")]
+        [TestCase("some", "value", "other", "value")]
+        public void GetHashCode_of_different_pairs_is_not_equal_(string key1, string value1, string key2, string value2)
+        {
+            var hash1 = new Pair(key1, value1).GetHashCode();
+            var hash2 = new Pair(key2, value2).GetHashCode();
+
+            Assert.That(hash1, Is.Not.EqualTo(hash2));
+        }
+
+        [Test]
         public void ToString_returns_value()
         {
             var pair = new Pair("some", "text");


### PR DESCRIPTION
- Refactored the `MiKo_3109_TestAssertsHaveMessageAnalyzer` to use a `ConcurrentDictionary` for mapping method names to expected argument indices, improving maintainability and performance.
- Removed the `GetExpectedMessageParameterIndices` method, simplifying the codebase.
- Added comprehensive tests for the `Pair` class, covering `Object.Equals` and `GetHashCode` methods to ensure correct behavior.
- Enhanced `Except` method in `EnumerableExtensions` to accept any `IReadOnlyCollection`.
- Suppressed TFM support build warnings in the `BenchmarkConsole` project file to clean up build output.
