### PR TITLE
MiKo_2082 is now aware of 'None', 'On', 'Off' and 'Undefined'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -65,6 +65,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                   .Append(article)
                                                   .Append(unsuffixed)
                                                   .Append('.')
+                                                  .ReplaceWithCheck(" is a None.", " is none.")
+                                                  .ReplaceWithCheck(" is an On.", " is on.")
+                                                  .ReplaceWithCheck(" is an Off.", " is off.")
+                                                  .ReplaceWithCheck(" is an Undefined.", " is undefined.")
                                                   .ToString();
 
                         return Comment(comment, replacement);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
@@ -229,6 +229,35 @@ public enum TestMe" + suffix + @"
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [TestCase("On", "on")]
+        [TestCase("Off", "off")]
+        [TestCase("Undefined", "undefined")]
+        [TestCase("None", "none")]
+        public void Code_gets_fixed_for_special_phrase_of_enum_member_(string phrase1, string phrase2)
+        {
+            const string OriginalCode = @"
+public enum MessageType
+{
+    /// <summary>
+    /// Enum #1#Enum for #2#
+    /// </summary>
+    #1#Enum = 0,
+
+";
+
+            const string FixedCode = @"
+public enum MessageType
+{
+    /// <summary>
+    /// The message is #2#.
+    /// </summary>
+    #1#Enum = 0,
+
+";
+
+            VerifyCSharpFix(OriginalCode.Replace("#1#", phrase1).Replace("#2#", phrase2), FixedCode.Replace("#1#", phrase1).Replace("#2#", phrase2));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2082_EnumMemberAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2082_EnumMemberAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_2082_CodeFixProvider` to handle specific enum member phrases: 'None', 'On', 'Off', and 'Undefined'.
- Implemented string replacements to ensure consistent phrasing in documentation comments.
- Added new test cases to verify the correct application of these replacements in `MiKo_2082_EnumMemberAnalyzerTests`.
