### PR TITLE
MiKo_3065 is now aware of parameters and 'string.Format'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -488,6 +488,21 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
+        internal static ExpressionSyntax GetIdentifierExpression(this ExpressionSyntax value)
+        {
+            switch (value)
+            {
+                case InvocationExpressionSyntax invocation:
+                    return invocation.GetIdentifierExpression();
+
+                case IdentifierNameSyntax identifier:
+                    return identifier;
+
+                default:
+                    return null;
+            }
+        }
+
         internal static ExpressionSyntax GetIdentifierExpression(this InvocationExpressionSyntax value)
         {
             switch (value?.Expression)
@@ -502,6 +517,8 @@ namespace MiKoSolutions.Analyzers
                     return null;
             }
         }
+
+        internal static string GetIdentifierName(this ExpressionSyntax value) => value.GetIdentifierExpression().GetName();
 
         internal static string GetIdentifierName(this InvocationExpressionSyntax value) => value.GetIdentifierExpression().GetName();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
@@ -52,7 +52,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                         if (type.Name == Constants.MicrosoftLogging.TypeName && type.ContainingNamespace.FullyQualifiedName() == Constants.MicrosoftLogging.NamespaceName)
                         {
-                            return new[] { Issue(node.StringStartToken) };
+                            var argumentSymbol = a.GetTypeSymbol(semanticModel);
+
+                            if (argumentSymbol.IsString())
+                            {
+                                return new[] { Issue(node.StringStartToken) };
+                            }
                         }
 
                         break;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -19,19 +16,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName(Constants.MicrosoftLogging.FullTypeName) != null;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInterpolatedString, SyntaxKind.InterpolatedStringExpression);
-
-        private void AnalyzeInterpolatedString(SyntaxNodeAnalysisContext context)
+        protected override void InitializeCore(CompilationStartAnalysisContext context)
         {
-            if (context.Node is InterpolatedStringExpressionSyntax node)
-            {
-                var issues = AnalyzeInterpolatedString(node, context.SemanticModel);
-
-                ReportDiagnostics(context, issues);
-            }
+            context.RegisterSyntaxNodeAction(AnalyzeInterpolatedString, SyntaxKind.InterpolatedStringExpression);
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
         }
 
-        private IEnumerable<Diagnostic> AnalyzeInterpolatedString(InterpolatedStringExpressionSyntax node, SemanticModel semanticModel)
+        private static bool IsLoggingCall(SyntaxNode node, SemanticModel semanticModel)
         {
             if (node.Parent is ArgumentSyntax a && a.Parent is ArgumentListSyntax al && al.Parent is InvocationExpressionSyntax invocation && invocation.Expression is MemberAccessExpressionSyntax methodCall)
             {
@@ -54,18 +45,31 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         {
                             var argumentSymbol = a.GetTypeSymbol(semanticModel);
 
-                            if (argumentSymbol.IsString())
-                            {
-                                return new[] { Issue(node.StringStartToken) };
-                            }
+                            return argumentSymbol.IsString();
                         }
 
-                        break;
+                        return false;
                     }
                 }
             }
 
-            return Enumerable.Empty<Diagnostic>();
+            return false;
+        }
+
+        private void AnalyzeInterpolatedString(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InterpolatedStringExpressionSyntax node && IsLoggingCall(node, context.SemanticModel))
+            {
+                ReportDiagnostics(context, Issue(node.StringStartToken));
+            }
+        }
+
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax node && IsLoggingCall(node, context.SemanticModel))
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
@@ -50,6 +50,20 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_non_logging_calls_with_stringFormat() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public TestMe(int i) => SomeMethod($""some text for {i}"");
+
+    public void DoSomething(int i) => SomeMethod(string.Format(""some text for {0}"", i));
+
+    public void SomeMethod(string text) { }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_log4net_calls_with_interpolation_([ValueSource(nameof(LogForNetMethods))] string method) => No_issue_is_reported_for(@"
 using System;
 
@@ -178,6 +192,54 @@ namespace Microsoft.Extensions.Logging
 ");
 
         [Test]
+        public void An_issue_is_reported_for_Microsoft_logging_call_with_stringFormat_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"(string.Format(""some text for {0}"", i));
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Microsoft_logging_call_with_stringFormat_and_format_provider_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"(string.Format(""some text for {0}"", i.ToString(""D"")));
+        }
+    }
+}
+");
+
+        [Test]
         public void Code_gets_fixed_for_Microsoft_logging_call_with_interpolation_([ValueSource(nameof(Methods))] string method)
         {
             var originalCode = @"
@@ -198,6 +260,58 @@ namespace Microsoft.Extensions.Logging
         public void DoSomething(int x, int y, int z)
         {
             _logger." + method + @"($""some text for {x}, {y} and {z}"");
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(""some text for {x}, {y} and {z}"", x, y, z);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Microsoft_logging_call_with_stringFormat_([ValueSource(nameof(Methods))] string method)
+        {
+            var originalCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(string.Format(""some text for {0}, {1} and {2}"", x, y, z));
         }
     }
 }
@@ -281,7 +395,57 @@ namespace Microsoft.Extensions.Logging
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
-        //// TODO RKN: Add tests for 'string.Format'
+        [Test]
+        public void Code_gets_fixed_for_Microsoft_logging_call_with_stringFormat_and_format_provider_([ValueSource(nameof(Methods))] string method)
+        {
+            var originalCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(string.Format(""some text for {0}, {1} and {2}"", x.ToString(""D""), y.ToString(""G""), z.ToString(""C"")));
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object?[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int x, int y, int z)
+        {
+            _logger." + method + @"(""some text for {x}, {y} and {z}"", x.ToString(""D""), y.ToString(""G""), z.ToString(""C""));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
 
         protected override string GetDiagnosticId() => MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.Id;
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging
 {
     public interface ILogger
     {
-        public void " + method + @"();
+        public void " + method + @"(string message, params object[] args);
     }
 
     public class TestMe
@@ -106,6 +106,30 @@ namespace Microsoft.Extensions.Logging
 ");
 
         [Test]
+        public void No_issue_is_reported_for_Microsoft_logging_call_with_interpolation_as_argument_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"(""some text for {i}"", $""some text for {i}"");
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_Microsoft_logging_call_with_interpolation_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
 using System;
 using Microsoft.Extensions.Logging;
@@ -114,7 +138,7 @@ namespace Microsoft.Extensions.Logging
 {
     public interface ILogger
     {
-        public void " + method + @"(string message);
+        public void " + method + @"(string message, params object[] args);
     }
 
     public class TestMe
@@ -138,7 +162,7 @@ namespace Microsoft.Extensions.Logging
 {
     public interface ILogger
     {
-        public void " + method + @"(string message);
+        public void " + method + @"(string message, params object[] args);
     }
 
     public class TestMe
@@ -256,6 +280,8 @@ namespace Microsoft.Extensions.Logging
 
             VerifyCSharpFix(originalCode, fixedCode);
         }
+
+        //// TODO RKN: Add tests for 'string.Format'
 
         protected override string GetDiagnosticId() => MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.Id;
 


### PR DESCRIPTION
- Enhanced `MiKo_3065` to differentiate between message templates and other parameters, focusing on interpolated strings and `string.Format`.
- Updated `SyntaxNodeExtensions` to include methods for handling identifier expressions and names.
- Refactored `MiKo_3065_CodeFixProvider` to handle `InvocationExpressionSyntax` and separate logic for interpolated strings and string formats.
- Extended `MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer` to analyze invocation expressions.
- Added comprehensive tests for non-logging calls, Microsoft logging calls, and code fixes involving `string.Format`.

(resolves #1093)