### PR TITLE
Suppressed/fixed analysis errors reported by VS IDE

### DIFF
--- a/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/Assert.cs
+++ b/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/Assert.cs
@@ -1,4 +1,5 @@
-﻿#pragma warning disable IDE0130 // Namespace does not match folder structure
+﻿#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 // ReSharper disable once CheckNamespace : Fake for Xunit Assert
 namespace Xunit
@@ -16,3 +17,4 @@ namespace Xunit
 }
 
 #pragma warning restore IDE0130 // Namespace does not match folder structure
+#pragma warning restore IDE0060 // Remove unused parameter

--- a/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/Mock.cs
+++ b/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/Mock.cs
@@ -1,4 +1,5 @@
-﻿#pragma warning disable IDE0130 // Namespace does not match folder structure
+﻿#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable CA1805 // Do not initialize unnecessarily
 
@@ -39,3 +40,4 @@ namespace Moq
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 #pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore IDE0130 // Namespace does not match folder structure
+#pragma warning restore IDE0060 // Remove unused parameter

--- a/MiKo.Analyzer.Tests/PairTests.cs
+++ b/MiKo.Analyzer.Tests/PairTests.cs
@@ -15,9 +15,13 @@ namespace MiKoSolutions.Analyzers
 
             Assert.Multiple(() =>
                                  {
+#pragma warning disable CS1718 // Comparison made to same variable
+
                                      // ReSharper disable once EqualExpressionComparison
                                      Assert.That(pair1 == pair1, "Equality operator for same instance");
                                      Assert.That(pair1 == pair2, "Equality operator for similar instances");
+
+#pragma warning restore CS1718 // Comparison made to same variable
                                  });
         }
 
@@ -39,9 +43,13 @@ namespace MiKoSolutions.Analyzers
 
             Assert.Multiple(() =>
                                  {
+#pragma warning disable CS1718 // Comparison made to same variable
+
                                      // ReSharper disable once EqualExpressionComparison
                                      Assert.That(pair1 != pair1, Is.False, "Inequality operator for same instance");
                                      Assert.That(pair1 != pair2, Is.False, "Inequality operator for similar instances");
+
+#pragma warning restore CS1718 // Comparison made to same variable
                                  });
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1077_EnumMemberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1077_EnumMemberSuffixAnalyzerTests.cs
@@ -25,7 +25,7 @@ public " + type + @" TestMe
         public void No_issue_is_reported_for_enum_member_without_suffix_([ValueSource(nameof(Suffixes))] string suffix) => No_issue_is_reported_for(@"
 public enum TestMe
 {
-    None,
+    " + suffix + @"_None,
 }
 ");
 


### PR DESCRIPTION
- Suppressed IDE warnings for unused parameters and namespace mismatches in helper classes.
- Enhanced test cases in `PairTests` by adding warning suppression for self-comparison.
- Updated a test case in `MiKo_1077_EnumMemberSuffixAnalyzerTests` to include suffix in enum member.
