### PR TITLE
XML tags updated by MiKo_20xx code fixes are now on separate lines, MiKo_2013 code fix lower-cases starting word, MiKo_2035 code fix considers generic

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -174,6 +174,10 @@ namespace MiKoSolutions.Analyzers
         internal static class Comments
         {
             internal const string AlternativeStringReturnTypeStartingPhraseTemplate = "An interned copy of the {0} {1} ";
+            internal const string ArrayReturnTypeStartingPhraseA = "An array of ";
+            internal const string ArrayReturnTypeStartingPhraseALowerCase = "an array of ";
+            internal const string ByteArrayReturnTypeStartingPhraseA = "A byte array containing ";
+            internal const string ByteArrayReturnTypeStartingPhraseALowerCase = "a byte array containing ";
             internal const string Asynchronously = "Asynchronously";
             internal const string AsynchronouslyStartingPhrase = Asynchronously + " ";
             internal const string BooleanParameterEndingPhraseTemplate = "; otherwise, {0}.";
@@ -183,6 +187,8 @@ namespace MiKoSolutions.Analyzers
             internal const string BooleanTaskReturnTypeEndingPhraseTemplate = ", otherwise with a result of {0}.";
             internal const string BooleanTaskReturnTypeStartingPhraseTemplate = "A task that will complete with a result of {0} if ";
             internal const string CallbackTerm = "callback";
+            internal const string CollectionReturnTypeStartingPhrase = "A collection of ";
+            internal const string CollectionReturnTypeStartingPhraseLowerCase = "a collection of ";
             internal const string CommandPropertyGetterOnlySummaryStartingPhraseTemplate = "Gets the {0} that can ";
             internal const string CommandPropertyGetterSetterSummaryStartingPhraseTemplate = "Gets or sets the {0} that can ";
             internal const string CommandPropertySetterOnlySummaryStartingPhraseTemplate = "Sets the {0} that can ";
@@ -239,6 +245,7 @@ namespace MiKoSolutions.Analyzers
             internal const string SpecialOrPhrase = "-or-";
             internal const string StringReturnTypeStartingPhraseTemplate = "A {0} {1} ";
             internal const string ValueConverterSummaryStartingPhrase = "Represents a converter that converts ";
+            internal const string ThatContainsTerm = "that contains";
             internal const string ToSeekTerm = "to seek";
             internal const string TryStartingPhrase = "Attempts to";
             internal const string WasNotSuccessfulPhrase = "was not successful";
@@ -443,10 +450,10 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] StringReturnTypeStartingPhrase =
                                                                                {
-                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", "that contains"), // this is just to have a proposal how to optimize
-                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", "that contains"),
-                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", "that contains"),
-                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\" />", "that contains"),
+                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", ThatContainsTerm), // this is just to have a proposal how to optimize
+                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", ThatContainsTerm),
+                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", ThatContainsTerm),
+                                                                                   StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\" />", ThatContainsTerm),
                                                                                    StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", "containing"),
                                                                                    StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", "containing"),
                                                                                    StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", "containing"),
@@ -463,10 +470,10 @@ namespace MiKoSolutions.Analyzers
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", "where"),
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", "where"),
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\" />", "where"),
-                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", "that contains"),
-                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", "that contains"),
-                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", "that contains"),
-                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\" />", "that contains"),
+                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", ThatContainsTerm),
+                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", ThatContainsTerm),
+                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", ThatContainsTerm),
+                                                                                   AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\" />", ThatContainsTerm),
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", "containing"),
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\" />", "containing"),
                                                                                    AlternativeStringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.String\"/>", "containing"),
@@ -503,22 +510,22 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] EnumerableReturnTypeStartingPhrase =
                                                                                    {
-                                                                                       "A collection of ",
+                                                                                       CollectionReturnTypeStartingPhrase,
                                                                                        "A <see cref=\"{0}\"/> that contains ",
                                                                                        "A <see cref=\"{0}\" /> that contains ",
                                                                                        "An <see cref=\"{0}\"/> that contains ",
                                                                                        "An <see cref=\"{0}\" /> that contains ",
                                                                                    };
 
-            internal static readonly string[] EnumerableTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + "a collection of ");
+            internal static readonly string[] EnumerableTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + CollectionReturnTypeStartingPhraseLowerCase);
 
-            internal static readonly string[] ArrayReturnTypeStartingPhrase = { "An array of ", "The array of " };
+            internal static readonly string[] ArrayReturnTypeStartingPhrase = { ArrayReturnTypeStartingPhraseA, "The array of " };
 
-            internal static readonly string[] ByteArrayReturnTypeStartingPhrase = { "A byte array containing ", "The byte array containing " };
+            internal static readonly string[] ByteArrayReturnTypeStartingPhrase = { ByteArrayReturnTypeStartingPhraseA, "The byte array containing " };
 
-            internal static readonly string[] ArrayTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + "an array of ");
+            internal static readonly string[] ArrayTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + ArrayReturnTypeStartingPhraseALowerCase);
 
-            internal static readonly string[] ByteArrayTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + "a byte array containing ");
+            internal static readonly string[] ByteArrayTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + ByteArrayReturnTypeStartingPhraseALowerCase);
 
             internal static readonly string[] DependencyPropertyFieldSummaryPhrase =
                                                                                      {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -668,12 +668,11 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case IdentifierNameSyntax i: return i.GetName();
                 case MemberAccessExpressionSyntax m: return m.GetName();
                 case MemberBindingExpressionSyntax b: return b.GetName();
                 case InvocationExpressionSyntax i: return i.GetName();
-                case SimpleNameSyntax s: return s.GetName();
                 case LiteralExpressionSyntax l: return l.GetName();
+                case TypeSyntax t: return t.GetName();
                 default: return string.Empty;
             }
         }
@@ -770,6 +769,18 @@ namespace MiKoSolutions.Analyzers
                 case StructDeclarationSyntax s: return s.GetName();
                 default:
                     return string.Empty;
+            }
+        }
+
+        internal static string GetName(this TypeSyntax value)
+        {
+            switch (value)
+            {
+                case null: return string.Empty;
+                case IdentifierNameSyntax i: return i.GetName();
+                case SimpleNameSyntax s: return s.GetName();
+                default:
+                    return value.ToString();
             }
         }
 

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -241,14 +241,14 @@ namespace MiKoSolutions.Analyzers.Linguistics
         private static readonly Pair[] MidTerms = Prefixes.Concat(OnlyMidTerms).ToArray();
 
         private static readonly Pair[] Postfixes = OnlyMidTerms.Concat(new[]
-                                                                            {
-                                                                                new Pair("BL", "BusinessLogic"),
-                                                                                new Pair("Bl", "BusinessLogic"),
-                                                                                new Pair("VM", "ViewModel"),
-                                                                                new Pair("VMs", "ViewModels"),
-                                                                                new Pair("Vm", "ViewModel"),
-                                                                                new Pair("Vms", "ViewModels"),
-                                                                            })
+                                                                           {
+                                                                               new Pair("BL", "BusinessLogic"),
+                                                                               new Pair("Bl", "BusinessLogic"),
+                                                                               new Pair("VM", "ViewModel"),
+                                                                               new Pair("VMs", "ViewModels"),
+                                                                               new Pair("Vm", "ViewModel"),
+                                                                               new Pair("Vms", "ViewModels"),
+                                                                           })
                                                                .ToArray();
 
         private static readonly string[] AllowedPostFixTerms =

--- a/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace MiKoSolutions.Analyzers.Linguistics

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -363,7 +363,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
 
                     return comment.ReplaceNode(t, XmlText(text))
-                                  .AddContent(seeCref, XmlText(commentContinue).WithTrailingXmlComment());
+                                  .AddContent(seeCref, XmlText(commentContinue))
+                                  .WithTagsOnSeparateLines();
                 }
 
                 default:
@@ -383,7 +384,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var content = CommentStartingWith(comment.Content, phrase, firstWordHandling);
 
-            return SyntaxFactory.XmlElement(comment.StartTag, content, comment.EndTag);
+            return CommentWithContent(comment, content);
         }
 
         protected static SyntaxList<XmlNodeSyntax> CommentStartingWith(SyntaxList<XmlNodeSyntax> content, string phrase, FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
@@ -428,7 +429,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return comment;
             }
 
-            var startText = XmlText(commentStart).WithLeadingXmlComment();
+            var startText = XmlText(commentStart);
 
             XmlTextSyntax continueText;
             var syntax = content[index];
@@ -467,8 +468,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                     .Insert(index + 1, seeCref)
                                     .Insert(index + 2, continueText);
 
-            return SyntaxFactory.XmlElement(comment.StartTag, newContent, comment.EndTag);
+            return CommentWithContent(comment, newContent);
         }
+
+        protected static XmlElementSyntax CommentWithContent(XmlElementSyntax value, SyntaxList<XmlNodeSyntax> content) => SyntaxFactory.XmlElement(value.StartTag, content, value.EndTag).WithTagsOnSeparateLines();
 
         protected static XmlEmptyElementSyntax Cref(string tag, TypeSyntax type)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_CodeFixProvider.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -16,12 +15,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comment = (XmlElementSyntax)syntax;
 
-            const string SealedText = Constants.Comments.SealedClassPhrase;
+            const string Text = Constants.Comments.SealedClassPhrase;
 
-            return SyntaxFactory.XmlElement(
-                                        comment.StartTag,
-                                        comment.WithoutText(SealedText).Add(XmlText(SealedText)),
-                                        comment.EndTag.WithLeadingXmlComment()); // place on new line
+            return CommentWithContent(comment, comment.WithoutText(Text).Add(XmlText(Text)));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_CodeFixProvider.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -16,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comment = (XmlElementSyntax)syntax;
 
-            return SyntaxFactory.XmlElement(comment.StartTag, comment.WithoutText(Constants.Comments.SealedClassPhrase), comment.EndTag);
+            return CommentWithContent(comment, comment.WithoutText(Constants.Comments.SealedClassPhrase));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -75,17 +75,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     contents[lastIndex] = WithoutEmptyTextAtEnd(last, last.TextTokens.ToList());
                 }
 
-                return SyntaxFactory.XmlElement(
-                                            comment.StartTag,
-                                            contents.ToSyntaxList(),
-                                            comment.EndTag.WithLeadingXmlComment());
+                return CommentWithContent(comment, contents.ToSyntaxList());
             }
 
             // happens if we start e.g. with a <see link
-            return SyntaxFactory.XmlElement(
-                                        comment.StartTag,
-                                        originalContent.Insert(0, XmlText(startingPhrase).WithLeadingXmlComment()),
-                                        comment.EndTag.WithLeadingXmlComment());
+            return CommentWithContent(comment, originalContent.Insert(0, XmlText(startingPhrase).WithLeadingXmlComment()));
         }
 
         private static XmlNodeSyntax NewXmlComment(XmlTextSyntax text, string startingPhrase)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -96,8 +96,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var contents = firstComment.Content.WithoutTrailingXmlComment()
                                            .Add(TrailingNewLineXmlText())
-                                           .AddRange(partsAfterSentence)
-                                           .Add(TrailingNewLineXmlText());
+                                           .AddRange(partsAfterSentence);
 
                 return firstComment.WithContent(contents);
             }
@@ -200,7 +199,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var startFixed = CommentStartingWith(comment, StartPhraseParts0, SeeLangword_True(), Replacement + Constants.TODO);
             var bothFixed = CommentEndingWith(startFixed, EndPhraseParts0, SeeLangword_False(), EndPhraseParts1);
 
-            return bothFixed;
+            return bothFixed.WithTagsOnSeparateLines();
         }
 
         private static XmlElementSyntax FixTextOnlyComment(XmlElementSyntax comment, XmlTextSyntax originalText, ReadOnlySpan<char> subText, string replacement, ConcreteMapInfo info)
@@ -258,7 +257,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var fixedComment = Comment(bothFixed, replacementMapKeys, replacementMap);
 
-            return fixedComment;
+            return fixedComment.WithTagsOnSeparateLines();
         }
 
         private static XmlElementSyntax ModifyElseOtherwisePart(XmlElementSyntax comment)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -9,11 +9,45 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using MiKoSolutions.Analyzers.Linguistics;
+
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2035_CodeFixProvider)), Shared]
     public sealed class MiKo_2035_CodeFixProvider : ReturnTypeDocumentationCodeFixProvider
     {
+        private static readonly HashSet<string> WellKnownTypeNames = new HashSet<string>
+                                                                         {
+                                                                             "string",
+                                                                             nameof(String),
+                                                                             "short",
+                                                                             nameof(Int16),
+                                                                             "int",
+                                                                             nameof(Int32),
+                                                                             "long",
+                                                                             nameof(Int64),
+                                                                             "ushort",
+                                                                             nameof(UInt16),
+                                                                             "uint",
+                                                                             nameof(UInt32),
+                                                                             "ulong",
+                                                                             nameof(UInt64),
+                                                                             "bool",
+                                                                             nameof(Boolean),
+                                                                             "float",
+                                                                             nameof(Single),
+                                                                             "double",
+                                                                             nameof(Double),
+                                                                             "object",
+                                                                             nameof(Object),
+                                                                             "decimal",
+                                                                             nameof(Decimal),
+                                                                             "byte",
+                                                                             nameof(Byte),
+                                                                             "sbyte",
+                                                                             nameof(SByte),
+                                                                         };
+
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
         private static readonly string[] TaskParts = Constants.Comments.GenericTaskReturnTypeStartingPhraseTemplate.FormatWith("task", '|').Split('|');
@@ -31,7 +65,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var preparedComment = PrepareComment(comment);
 
             // it's either a task or a generic collection
-            if (returnType.Identifier.ValueText == nameof(Task))
+            var returnTypeValue = returnType.Identifier.ValueText;
+
+            if (returnTypeValue == nameof(Task))
             {
                 // it is a task, so inspect the typ argument to check if it is an array type
                 var middlePart = GetGenericCommentMiddlePart(returnType);
@@ -39,7 +75,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return CommentStartingWith(preparedComment, TaskParts[0], SeeCrefTaskResult(), TaskParts[1] + middlePart);
             }
 
-            return CommentStartingWith(preparedComment, Constants.Comments.EnumerableReturnTypeStartingPhrase);
+            var startingPhrase = Constants.Comments.CollectionReturnTypeStartingPhrase;
+
+            if (returnType.TypeArgumentList.Arguments.Count == 1)
+            {
+                var typeName = GetGenericTypeArgumentTypeName(returnType);
+
+                if (WellKnownTypeNames.Contains(typeName) is false)
+                {
+                    var text = typeName.AsBuilder().AdjustFirstWord(FirstWordHandling.MakePlural).SeparateWords(' ', FirstWordHandling.MakeLowerCase).ToString();
+
+                    if (text.Length > 0)
+                    {
+                        startingPhrase = startingPhrase + text + " " + Constants.Comments.ThatContainsTerm + " ";
+                    }
+                }
+            }
+
+            return CommentStartingWith(preparedComment, startingPhrase);
         }
 
         protected override XmlElementSyntax NonGenericComment(Document document, XmlElementSyntax comment, string memberName, TypeSyntax returnType)
@@ -54,7 +107,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return CommentStartingWith(PrepareComment(comment), Constants.Comments.ArrayReturnTypeStartingPhrase);
             }
 
-            return CommentStartingWith(PrepareComment(comment), Constants.Comments.EnumerableReturnTypeStartingPhrase);
+            return CommentStartingWith(PrepareComment(comment), Constants.Comments.CollectionReturnTypeStartingPhrase);
+        }
+
+        private static string GetGenericTypeArgumentTypeName(GenericNameSyntax returnType)
+        {
+            var argument = returnType.TypeArgumentList.Arguments[0];
+
+            return argument is ArrayTypeSyntax arrayType
+                   ? arrayType.ElementType.GetName()
+                   : argument.GetName();
         }
 
         private static string GetGenericCommentMiddlePart(GenericNameSyntax returnType)
@@ -64,11 +126,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (argument is ArrayTypeSyntax arrayType)
             {
                 return arrayType.ElementType.IsByte()
-                       ? "a byte array containing "
-                       : "an array of ";
+                       ? Constants.Comments.ByteArrayReturnTypeStartingPhraseALowerCase
+                       : Constants.Comments.ArrayReturnTypeStartingPhraseALowerCase;
             }
 
-            return "a collection of ";
+            return Constants.Comments.CollectionReturnTypeStartingPhraseLowerCase;
         }
 
         private static XmlElementSyntax PrepareComment(XmlElementSyntax comment)
@@ -83,11 +145,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var preparedComment = Comment(comment, MappedData.Value.ByteArrayReplacementMapKeys, MappedData.Value.ByteArrayReplacementMap);
 
             var contents = preparedComment.Content;
+            var count = contents.Count;
 
-            if (contents.Count > 1 && IsSeeCref(contents[1], "byte") && contents[0].IsWhiteSpaceOnlyText())
+            if (count > 1 && IsSeeCref(contents[1], "byte") && contents[0].IsWhiteSpaceOnlyText())
             {
                 // inspect the continue text and - if necessary - clean it up
-                if (contents.Count > 2 && contents[2] is XmlTextSyntax continueText)
+                if (count > 2 && contents[2] is XmlTextSyntax continueText)
                 {
                     var token = continueText.TextTokens.First();
                     var text = token.ValueText;
@@ -125,48 +188,48 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var phrases = CreatePhrases().ToHashSet(_ => _ + " "); // TODO RKN: Order by 'A', 'An ' and 'The '
 
-                var keyInput = AlmostCorrectTaskReturnTypeStartingPhrases.Concat(taskPhrases)
-                                                                         .Concat(phrases)
-                                                                         .OrderByDescending(_ => _.Length)
-                                                                         .ThenBy(_ => _)
-                                                                         .ToArray();
-                ReplacementMap = keyInput.ToArray(_ => new Pair(_, string.Empty));
-                ReplacementMapKeys = GetTermsForQuickLookup(keyInput);
+                ReplacementMap = AlmostCorrectTaskReturnTypeStartingPhrases.Concat(taskPhrases)
+                                                                           .Concat(phrases)
+                                                                           .OrderByDescending(_ => _.Length)
+                                                                           .ThenBy(_ => _)
+                                                                           .ToArray(_ => new Pair(_, string.Empty));
 
-                var byteKeyInput = AlmostCorrectTaskReturnTypeStartingPhrases.Concat(new[]
-                                                                                         {
-                                                                                             "A array of byte containing ",
-                                                                                             "A array of byte that contains ",
-                                                                                             "A array of byte which contains ",
-                                                                                             "A array of bytes containing ",
-                                                                                             "A array of bytes that contains ",
-                                                                                             "A array of bytes which contains ",
-                                                                                             "A array of ",
-                                                                                             "A array with ",
-                                                                                             "An array of byte containing ",
-                                                                                             "An array of byte that contains ",
-                                                                                             "An array of byte which contains ",
-                                                                                             "An array of bytes containing ",
-                                                                                             "An array of bytes that contains ",
-                                                                                             "An array of bytes which contains ",
-                                                                                             "An array of ",
-                                                                                             "An array with ",
-                                                                                             "Array of ",
-                                                                                             "Array with ",
-                                                                                             "The array of byte containing ",
-                                                                                             "The array of byte that contains ",
-                                                                                             "The array of byte which contains ",
-                                                                                             "The array of bytes containing ",
-                                                                                             "The array of bytes that contains ",
-                                                                                             "The array of bytes which contains ",
-                                                                                             "The array of ",
-                                                                                             "The array with ",
-                                                                                         })
-                                                                             .OrderByDescending(_ => _.Length)
-                                                                             .ThenBy(_ => _)
-                                                                             .ToArray();
-                ByteArrayReplacementMap = byteKeyInput.ToArray(_ => new Pair(_, string.Empty));
-                ByteArrayReplacementMapKeys = GetTermsForQuickLookup(byteKeyInput);
+                ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap.ToArray(_ => _.Key));
+
+                ByteArrayReplacementMap = AlmostCorrectTaskReturnTypeStartingPhrases.Concat(new[]
+                                                                                                {
+                                                                                                    "A array of byte containing ",
+                                                                                                    "A array of byte that contains ",
+                                                                                                    "A array of byte which contains ",
+                                                                                                    "A array of bytes containing ",
+                                                                                                    "A array of bytes that contains ",
+                                                                                                    "A array of bytes which contains ",
+                                                                                                    "A array of ",
+                                                                                                    "A array with ",
+                                                                                                    "An array of byte containing ",
+                                                                                                    "An array of byte that contains ",
+                                                                                                    "An array of byte which contains ",
+                                                                                                    "An array of bytes containing ",
+                                                                                                    "An array of bytes that contains ",
+                                                                                                    "An array of bytes which contains ",
+                                                                                                    "An array of ",
+                                                                                                    "An array with ",
+                                                                                                    "Array of ",
+                                                                                                    "Array with ",
+                                                                                                    "The array of byte containing ",
+                                                                                                    "The array of byte that contains ",
+                                                                                                    "The array of byte which contains ",
+                                                                                                    "The array of bytes containing ",
+                                                                                                    "The array of bytes that contains ",
+                                                                                                    "The array of bytes which contains ",
+                                                                                                    "The array of ",
+                                                                                                    "The array with ",
+                                                                                                })
+                                                                                    .OrderByDescending(_ => _.Length)
+                                                                                    .ThenBy(_ => _)
+                                                                                    .ToArray(_ => new Pair(_, string.Empty));
+
+                ByteArrayReplacementMapKeys = GetTermsForQuickLookup(ByteArrayReplacementMap.ToArray(_ => _.Key));
 
                 ByteArrayContinueTexts = new[]
                                              {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -73,9 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax PrepareComment(XmlElementSyntax comment)
         {
-            // ensure that end tag is on different line
-            var adjustedComment = comment.WithContent(comment.Content.WithoutTrailingXmlComment())
-                                         .WithEndTag(comment.EndTag.WithLeadingXmlComment());
+            var adjustedComment = CommentWithContent(comment, comment.Content);
 
             return Comment(adjustedComment, MappedData.Value.ReplacementMapKeys, MappedData.Value.ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -18,10 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             const string Text = Constants.Comments.FieldIsReadOnly;
 
-            return SyntaxFactory.XmlElement(
-                                        comment.StartTag,
-                                        comment.WithoutText(Text).Add(XmlText(Text)),
-                                        comment.EndTag.WithLeadingXmlComment()); // place on new line
+            return CommentWithContent(comment, comment.WithoutText(Text).Add(XmlText(Text))); // place on new line
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
@@ -101,8 +101,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var clause = syntax.FormatClause;
 
             return clause is null
-                       ? syntax.Expression
-                       : Invocation(SimpleMemberAccess(syntax.Expression, nameof(ToString)), Argument(StringLiteral(clause.FormatStringToken.ValueText)));
+                   ? syntax.Expression
+                   : Invocation(SimpleMemberAccess(syntax.Expression, nameof(ToString)), Argument(StringLiteral(clause.FormatStringToken.ValueText)));
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -103,7 +103,7 @@ public enum TestMe
 
             const string FixedCode = @"
 /// <summary>
-/// Defines values that specify Something.
+/// Defines values that specify something.
 /// </summary>
 public enum TestMe
 {
@@ -124,7 +124,7 @@ public enum TestMe
 
             const string FixedCode = @"
 /// <summary>
-/// Defines values that specify Something to do.
+/// Defines values that specify something to do.
 /// </summary>
 public enum TestMe
 {
@@ -148,7 +148,7 @@ public enum TestMe
 
             const string FixedCode = @"
 /// <summary>
-/// Defines values that specify Something
+/// Defines values that specify something
 /// to do.
 /// </summary>
 public enum TestMe
@@ -172,7 +172,7 @@ public enum TestMe
 
             const string FixedCode = @"
 ///<summary>
-/// Defines values that specify Something to do.
+/// Defines values that specify something to do.
 /// </summary>
 public enum TestMe
 {
@@ -193,7 +193,7 @@ public enum TestMe
 
             const string FixedCode = @"
 ///<summary>
-/// Defines values that specify Something to do.
+/// Defines values that specify something to do.
 /// </summary>
 public enum TestMe
 {
@@ -217,7 +217,7 @@ public enum TestMe
 
             const string FixedCode = @"
 ///<summary>
-/// Defines values that specify Something
+/// Defines values that specify something
 ///to do.
 /// </summary>
 public enum TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -159,6 +159,75 @@ public enum TestMe
         }
 
         [Test]
+        public void Code_gets_fixed_with_no_spaces_after_slashes()
+        {
+            const string OriginalCode = @"
+///<summary>
+///Something to do.
+///</summary>
+public enum TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+///<summary>
+/// Defines values that specify Something to do.
+/// </summary>
+public enum TestMe
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed__when_on_same_line_with_no_spaces_after_slashes()
+        {
+            const string OriginalCode = @"
+///<summary>Something to do.</summary>
+public enum TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+///<summary>
+/// Defines values that specify Something to do.
+/// </summary>
+public enum TestMe
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_with_multiline_but_no_spaces_after_slashes()
+        {
+            const string OriginalCode = @"
+///<summary>
+///Something
+///to do.
+///</summary>
+public enum TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+///<summary>
+/// Defines values that specify Something
+///to do.
+/// </summary>
+public enum TestMe
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_with_seecref_multiline()
         {
             const string OriginalCode = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
@@ -91,7 +91,9 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    /// <summary>Asynchronously does something.</summary>
+    /// <summary>
+    /// Asynchronously does something.
+    /// </summary>
     public async void DoSomething() { }
 }";
 
@@ -111,7 +113,9 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    /// <summary>Asynchronously does something.</summary>
+    /// <summary>
+    /// Asynchronously does something.
+    /// </summary>
     public async void DoSomething() { }
 }";
 
@@ -131,7 +135,9 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    /// <summary>Asynchronously does something.</summary>
+    /// <summary>
+    /// Asynchronously does something.
+    /// </summary>
     public async void DoSomething() { }
 }";
 
@@ -151,7 +157,9 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    /// <summary>Asynchronously <see cref=""string""/></summary>
+    /// <summary>
+    /// Asynchronously <see cref=""string""/>
+    /// </summary>
     public async void DoSomething() { }
 }";
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzerTests.cs
@@ -260,7 +260,9 @@ using System.Windows;
 public class TestMe
 {
     /// <summary />
-    /// <param name='o'>On successful return, indicates the something.</param>
+    /// <param name='o'>
+    /// On successful return, indicates the something.
+    /// </param>
     public void DoSomething(out bool o) { }
 }";
 
@@ -401,7 +403,9 @@ using System.Windows;
 public class TestMe
 {
     /// <summary />
-    /// <param name='o'>On successful return, contains the object.</param>
+    /// <param name='o'>
+    /// On successful return, contains the object.
+    /// </param>
     public void DoSomething(out object o) { }
 }";
 
@@ -427,7 +431,9 @@ using System.Windows;
 public class TestMe
 {
     /// <summary />
-    /// <param name='o'>On successful return, contains TODO.</param>
+    /// <param name='o'>
+    /// On successful return, contains TODO.
+    /// </param>
     public void DoSomething(out object o) { }
 }";
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
@@ -191,7 +191,9 @@ using System.Threading;
 public class TestMe
 {
     /// <summary />
-    /// <param name='o'>One of the enumeration members that specifies whatever it is.</param>
+    /// <param name='o'>
+    /// One of the enumeration members that specifies whatever it is.
+    /// </param>
     public void DoSomething(StringComparison o) { }
 }
 ";
@@ -220,7 +222,9 @@ using System.Threading;
 public class TestMe
 {
     /// <summary />
-    /// <param name='o'>One of the enumeration members that specifies whatever it is.</param>
+    /// <param name='o'>
+    /// One of the enumeration members that specifies whatever it is.
+    /// </param>
     public TestMe(StringComparison o) { }
 }
 ";

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -402,6 +402,45 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalPhrase), Template.Replace("###", fixedPhrase));
         }
 
+        [TestCase("Some integers.", "A collection of some integers.")]
+        [TestCase("The mapping information.", "A collection of the mapping information.")]
+        public void Code_gets_fixed_for_generic_collection_on_same_line_(string originalPhrase, string fixedPhrase)
+        {
+            var originalCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <returns>" + originalPhrase + @"</returns>
+    public IEnumerable<int> DoSomething { get; set; }
+}
+";
+
+            var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <returns>
+    /// " + fixedPhrase + @"
+    /// </returns>
+    public IEnumerable<int> DoSomething { get; set; }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
         [TestCase("Some integers.", "some integers.")]
         [TestCase("A task that can be used to await.", "")]
         [TestCase("A task that can be used to await", "")]
@@ -411,6 +450,55 @@ public class TestMe
         [TestCase("An awaitable task", "")]
         [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
         public void Code_gets_fixed_for_Task_with_generic_collection_(string originalText, string fixedText)
+        {
+            var originalCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <returns>
+    /// " + originalText + @"
+    /// </returns>
+    public Task<IList<int>> DoSomething { get; set; }
+}
+";
+
+            var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter contains a collection of " + fixedText + @"
+    /// </returns>
+    public Task<IList<int>> DoSomething { get; set; }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [TestCase("Some integers.", "some integers.")]
+        [TestCase("A task that can be used to await.", "")]
+        [TestCase("A task that can be used to await", "")]
+        [TestCase("A task to await.", "")]
+        [TestCase("A task to await", "")]
+        [TestCase("An awaitable task.", "")]
+        [TestCase("An awaitable task", "")]
+        [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
+        public void Code_gets_fixed_for_Task_with_generic_collection_on_same_line_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -441,6 +441,32 @@ public class TestMe
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_generic_collection_with_non_primitive_type()
+        {
+            const string Template = @"
+using System;
+using System.Collections.Generic;
+
+public record GroupedRow
+{
+}
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <returns>
+    /// ###.
+    /// </returns>
+    public IEnumerable<GroupedRow> DoSomething { get; set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", "Some data"), Template.Replace("###", "A collection of grouped rows that contains some data"));
+        }
+
         [TestCase("Some integers.", "some integers.")]
         [TestCase("A task that can be used to await.", "")]
         [TestCase("A task that can be used to await", "")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [TestFixture]
     public sealed class MiKo_2050_ExceptionSummaryAnalyzerTests : CodeFixVerifier
     {
-        private static readonly string[] StartingPhrases = [.. CreatePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase)];
+        private static readonly string[] StartingPhrases = [.. CreatePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase.Trim())];
 
         [Test]
         public void No_issue_is_reported_for_non_exception_class() => No_issue_is_reported_for(@"
@@ -627,7 +627,9 @@ public sealed class BlaBlaException : Exception
 using System;
 using System.Runtime.Serialization;
 
-/// <summary>The exception that is thrown when </summary>
+/// <summary>
+/// The exception that is thrown when 
+/// </summary>
 [Serializable]
 public sealed class BlaBlaException : Exception
 {
@@ -654,7 +656,9 @@ public sealed class BlaBlaException : Exception
 using System;
 using System.Runtime.Serialization;
 
-/// <summary>The exception that is thrown when </summary>
+/// <summary>
+/// The exception that is thrown when 
+/// </summary>
 [Serializable]
 public sealed class BlaBlaException : Exception
 {
@@ -740,7 +744,9 @@ public sealed class BlaBlaException : Exception
 using System;
 using System.Runtime.Serialization;
 
-/// <summary>The exception that is thrown when something is done.</summary>
+/// <summary>
+/// The exception that is thrown when something is done.
+/// </summary>
 [Serializable]
 public sealed class BlaBlaException : Exception
 {
@@ -766,7 +772,9 @@ public sealed class BlaBlaException : Exception
 using System;
 using System.Runtime.Serialization;
 
-/// <summary>The exception that is thrown when something is done.</summary>
+/// <summary>
+/// The exception that is thrown when something is done.
+/// </summary>
 [Serializable]
 public sealed class BlaBlaException : Exception
 {


### PR DESCRIPTION
- Enhanced handling of XML comments by ensuring tags are placed on separate lines.
- Extracted constants for handling array and collection return type phrases.
- Refactored several MiKo_20xx code fix providers to use a common method for XML element handling.
- Improved performance and readability by optimizing string handling and reformatting code.
- Added and updated test cases to verify the new enhancements and refactorings.
- Updated MiKo_2013 code fix provider to lower case of starting word.
- Updated MiKo_2035 code fix provider to place generic names in the updated comment.
