### PR TITLE
MiKo_2041 codefix now replaces empty summaries with the nested XMLs

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1033,8 +1033,13 @@ namespace MiKoSolutions.Analyzers
 
                 if (token.HasStructuredTrivia)
                 {
-                    foreach (var trivia in token.LeadingTrivia)
+                    var leadingTrivia = token.LeadingTrivia;
+                    var count = leadingTrivia.Count;
+
+                    for (var index = 0; index < count; index++)
                     {
+                        var trivia = leadingTrivia[index];
+
                         if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
                         {
                             if (trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
@@ -1047,14 +1052,14 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
-        internal static ReadOnlySpan<char> GetTextTrimmed(this XmlElementSyntax value)
+        internal static string GetTextTrimmed(this XmlElementSyntax value)
         {
             if (value is null)
             {
-                return ReadOnlySpan<char>.Empty;
+                return string.Empty;
             }
 
-            return value.GetTextWithoutTrivia().Without(Constants.EnvironmentNewLine).WithoutParaTags().Trim().AsSpan();
+            return value.GetTextWithoutTrivia().Without(Constants.EnvironmentNewLine).WithoutParaTags().Trim();
         }
 
         internal static string GetTextWithoutTrivia(this XmlTextAttributeSyntax value)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzer.cs
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var trimmed = syntax.GetTextTrimmed();
 
-            return trimmed.SequenceEqual(text.AsSpan());
+            return trimmed.Equals(text);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var summaryXml in summaryXmls)
             {
-                if (symbol is ITypeSymbol && summaryXml.GetTextTrimmed().IsEmpty)
+                if (symbol is ITypeSymbol && summaryXml.GetTextTrimmed().IsNullOrEmpty())
                 {
                     // do not report for empty types
                     continue;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var text = xml.GetTextTrimmed();
 
-            foreach (var sentence in text.SplitBy(Constants.SentenceMarkers))
+            foreach (var sentence in text.AsSpan().SplitBy(Constants.SentenceMarkers))
             {
                 var indices = new HashSet<int>();
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2041_InvalidXmlInSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2041_InvalidXmlInSummaryAnalyzerTests.cs
@@ -177,6 +177,30 @@ public class TestMe
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_empty_summary_with_([ValueSource(nameof(AmbiguousPhrases))] string phrase)
+        {
+            var originalCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// " + phrase + @"
+    /// </summary>
+    public void DoSomething() { }
+}
+";
+
+            var fixedCode = @"
+public class TestMe
+{
+    /// " + phrase + @"
+    public void DoSomething() { }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2041_InvalidXmlInSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2041_InvalidXmlInSummaryAnalyzer();


### PR DESCRIPTION
- Enhanced code fix logic in `MiKo_2041_CodeFixProvider` to handle and remove empty summaries before adding content.
- Added a new test case for fixing empty summaries with ambiguous phrases in `MiKo_2041_InvalidXmlInSummaryAnalyzerTests`.
- Refactored `GetTextTrimmed` method to return a `string` instead of `ReadOnlySpan<char>`, improving text handling and comparison.
- Simplified text comparison in `MiKo_2014_DisposeDefaultPhraseAnalyzer` by using `Equals`.
- Improved empty summary checks in `MiKo_2018_ChecksSummaryAnalyzer` using `IsNullOrEmpty`.
- Optimized sentence splitting in `MiKo_2228_DocumentationIsNotNegativeAnalyzer` using `AsSpan`.
