### PR TITLE
MiKo_3301 is now aware of 'async' modifier

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_CodeFixProvider.cs
@@ -33,10 +33,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (parameters.Count == 1)
             {
-                return SyntaxFactory.SimpleLambdaExpression(parameters.First(), body);
+                return SyntaxFactory.SimpleLambdaExpression(parameters.First(), body).WithModifiers(parenthesized.Modifiers);
             }
 
-            return SyntaxFactory.ParenthesizedLambdaExpression(parameterList, body);
+            return SyntaxFactory.ParenthesizedLambdaExpression(parameterList, body).WithModifiers(parenthesized.Modifiers);
         }
 
         private static CSharpSyntaxNode GetBody(ParenthesizedLambdaExpressionSyntax node)

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzerTests.cs
@@ -455,6 +455,49 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_async_parenthesized_lambda_expression()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async void DoSomething()
+        {
+            var result = async () =>
+                            {
+                                await Task.CompletedTask;
+                            };
+        }
+    }
+}}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async void DoSomething()
+        {
+            var result = async () => await Task.CompletedTask;
+        }
+    }
+}}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer();


### PR DESCRIPTION
- Fixed a bug in `MiKo_3301_CodeFixProvider` to ensure that lambda expressions retain their modifiers when transformed.
- Added a new test case in `MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzerTests` to verify the code fix for async parenthesized lambda expressions.

(resolves #1108)