### PR TITLE
MiKo_1080 now ignores endings with '_one', '_first', '_second', '_third'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -159,6 +159,26 @@ namespace System.Text
             }
         }
 
+        public static bool EndsWith(this StringBuilder value, string ending, StringComparison comparison = StringComparison.Ordinal)
+        {
+            if (ending is null)
+            {
+                return false;
+            }
+
+            var valueLength = value.Length;
+            var endingLength = ending.Length;
+
+            if (valueLength >= endingLength)
+            {
+                var end = value.ToString(valueLength - endingLength, endingLength);
+
+                return end.Equals(ending, comparison);
+            }
+
+            return false;
+        }
+
         public static string FirstWord(this StringBuilder value, out int whitespacesBefore)
         {
             if (value is null)
@@ -426,6 +446,28 @@ namespace System.Text
             var end = value.CountTrailingWhitespaces();
 
             return value.ToString(0, length - end);
+        }
+
+        public static StringBuilder TrimEndBy(this StringBuilder value, int count)
+        {
+            if (count == 0)
+            {
+                return value;
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            var length = value.Length;
+
+            if (count > length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            return value.Remove(length - count, count);
         }
 
         public static StringBuilder Without(this StringBuilder value, string phrase) => value.ReplaceWithCheck(phrase, string.Empty); // ncrunch: no coverage

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
@@ -53,6 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                          "Bone",
                                                                          "omponent", // 'component'
                                                                          "OMPONENT",
+                                                                         "ondition", // prevent stuff like 'UseCondition' which contains the term 'seCond'
                                                                          "cone",
                                                                          "Cone",
                                                                          "done",
@@ -85,6 +86,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                          "NoOne",
                                                                          "onE", // 'SetupNonExistentDevice'
                                                                          "OnE",
+                                                                         "oneTime",
                                                                          "OneTime",
                                                                          "Ones",
                                                                          "oNeeded",
@@ -115,6 +117,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                          "ZONE",
                                                                          "xponent",
                                                                      };
+
+        private static readonly IEnumerable<string> KnownEndings = new[]
+                                                                       {
+                                                                           "_one",
+                                                                           "_first",
+                                                                           "_second",
+                                                                           "_third",
+                                                                       };
 
         public MiKo_1080_UseNumbersInsteadOfWordingAnalyzer() : base(Id)
         {
@@ -166,6 +176,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             foreach (var part in KnownParts)
             {
                 finalName.ReplaceWithCheck(part, "#");
+            }
+
+            foreach (var ending in KnownEndings)
+            {
+                if (finalName.EndsWith(ending))
+                {
+                    finalName.TrimEndBy(ending.Length);
+                }
             }
 
             return finalName.ToString();

--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -11,6 +11,27 @@ namespace MiKoSolutions.Analyzers.Extensions
     [TestFixture]
     public static class StringBuilderExtensionsTests
     {
+        [TestCase("", null, StringComparison.Ordinal, ExpectedResult = false)]
+        [TestCase("", "test", StringComparison.Ordinal, ExpectedResult = false)]
+        [TestCase("Something", "test", StringComparison.Ordinal, ExpectedResult = false)]
+        [TestCase("test", " test", StringComparison.Ordinal, ExpectedResult = false)]
+        [TestCase("test", "test", StringComparison.Ordinal, ExpectedResult = true)]
+        [TestCase(" test", "test", StringComparison.Ordinal, ExpectedResult = true)]
+        [TestCase("Some_test", "test", StringComparison.Ordinal, ExpectedResult = true)]
+        public static bool EndsWith_detects_ending_(string builderValue, string ending, StringComparison comparison) => new StringBuilder(builderValue).EndsWith(ending, comparison);
+
+        [TestCase("", -1)]
+        [TestCase("", 1)]
+        public static void TrimEndBy_throws_ArgumentOutOfRangeException_for_(string s, int count) => Assert.That(() => new StringBuilder(s).TrimEndBy(count), Throws.Exception.TypeOf<ArgumentOutOfRangeException>());
+
+        [TestCase("", 0, ExpectedResult = "")]
+        [TestCase("test", 0, ExpectedResult = "test")]
+        [TestCase("test", 1, ExpectedResult = "tes")]
+        [TestCase("test", 2, ExpectedResult = "te")]
+        [TestCase("test", 3, ExpectedResult = "t")]
+        [TestCase("test", 4, ExpectedResult = "")]
+        public static string TrimEndBy_trims_string_(string s, int count) => new StringBuilder(s).TrimEndBy(count).ToString();
+
         [TestCase("", ExpectedResult = "")]
         [TestCase(" ", ExpectedResult = "")]
         [TestCase("  ", ExpectedResult = "")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzerTests.cs
@@ -48,7 +48,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "noOne",
                                                             "NoOne",
                                                             "OnEntry",
-                                                            "OneTime",
+                                                            "oneTimeSetUp",
+                                                            "OneTimeSetUp",
+                                                            "oneTimeTearDown",
+                                                            "OneTimeTearDown",
                                                             "OnExit",
                                                             "oxone",
                                                             "phone",
@@ -72,6 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "exponential",
                                                             "GetDissimilarityForType",
                                                             "GetDissimilaritiesForType",
+                                                            "UseConditions",
                                                         ];
 
         private static readonly string[] WrongNames =
@@ -134,6 +138,22 @@ using System;
 public class TestMe
 {
     public void Do" + name + @"Something()
+    {
+    }
+}
+");
+
+        [TestCase("one")]
+        [TestCase("first")]
+        [TestCase("second")]
+        [TestCase("seconds")]
+        [TestCase("third")]
+        public void No_issue_is_reported_for_method_ending_with_(string name) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void Some_value_was_" + name + @"()
     {
     }
 }


### PR DESCRIPTION
- Added `EndsWith` and `TrimEndBy` methods to `StringBuilderExtensions` to enhance string manipulation capabilities.
- Updated tests for `StringBuilderExtensions` to cover new methods.
- Enhanced `MiKo_1080_UseNumbersInsteadOfWordingAnalyzer` to ignore specific endings like `_one`, `_first`, `_second`, and `_third`.
- Added and updated tests for `MiKo_1080_UseNumbersInsteadOfWordingAnalyzer` to ensure correct handling of new endings.
- Fixed `MiKo_1080_UseNumbersInsteadOfWordingAnalyzer` to no longer report `UseCondition` as a violation