### PR TITLE
MiKo_1046 no longer reports on global statements

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -92,12 +92,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                  .SelectMany(_ => AnalyzeName(_, compilation));
         }
 
-        protected virtual bool ShallAnalyze(INamespaceSymbol symbol) => symbol.IsGlobalNamespace is false;
+        protected virtual bool ShallAnalyze(INamespaceSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsGlobalNamespace is false;
 
-        protected virtual bool ShallAnalyze(ITypeSymbol symbol) => true;
+        protected virtual bool ShallAnalyze(ITypeSymbol symbol) => symbol.CanBeReferencedByName;
 
         protected virtual bool ShallAnalyze(IMethodSymbol symbol)
         {
+            if (symbol.CanBeReferencedByName is false)
+            {
+                return false;
+            }
+
             if (symbol.IsOverride)
             {
                 return false;
@@ -116,14 +121,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
 
-        protected virtual bool ShallAnalyze(IEventSymbol symbol) => symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        protected virtual bool ShallAnalyze(IEventSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
 
-        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => symbol.IsOverride is false;
+        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false;
 
         protected virtual bool ShallAnalyze(IParameterSymbol symbol)
         {
+            if (symbol.CanBeReferencedByName is false)
+            {
+                return false;
+            }
+
             if (symbol.IsOverride)
             {
                 return false;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
@@ -37,16 +37,6 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_non_static_async_Main_method() => An_issue_is_reported_for(@"
-using System;
-
-public class TestMe
-{
-    public async Task Main() { }
-}
-");
-
-        [Test]
         public void No_issue_is_reported_for_correctly_named_async_void_method() => No_issue_is_reported_for(@"
 using System;
 
@@ -67,16 +57,6 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_async_void_method() => An_issue_is_reported_for(@"
-using System;
-
-public class TestMe
-{
-    public async void DoSomething() { }
-}
-");
-
-        [Test]
         public void No_issue_is_reported_for_correctly_named_Task_method() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
@@ -93,16 +73,6 @@ using System.Threading.Tasks;
 public class TestMe
 {
     protected Task DoSomethingAsyncCore() { }
-}
-");
-
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_named_Task_method() => An_issue_is_reported_for(@"
-using System.Threading.Tasks;
-
-public class TestMe
-{
-    public Task DoSomething() { }
 }
 ");
 
@@ -155,19 +125,6 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_async_void_local_function() => An_issue_is_reported_for(@"
-using System;
-
-public class TestMe
-{
-    public async void DoSomethingAsync()
-    {
-        async void DoSomethingCore() { }
-    }
-}
-");
-
-        [Test]
         public void No_issue_is_reported_for_correctly_named_Task_local_function() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
@@ -176,19 +133,6 @@ public class TestMe
     public Task DoSomethingAsync()
     {
         async Task DoSomethingCoreAsync() { }
-    }
-}
-");
-
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_named_Task_local_function() => An_issue_is_reported_for(@"
-using System.Threading.Tasks;
-
-public class TestMe
-{
-    public Task DoSomethingAsync()
-    {
-        async Task DoSomethingCore() { }
     }
 }
 ");
@@ -206,6 +150,69 @@ public class TestMe
     public Task DoSomething()
     {
         Task DoSomethingCoreAsync() => Task.CompletedTask;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_global_statement() => No_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+await Task.CompletedTask;
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_static_async_Main_method() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public async Task Main() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_named_async_void_method() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public async void DoSomething() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_named_Task_method() => An_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public Task DoSomething() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_named_async_void_local_function() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public async void DoSomethingAsync()
+    {
+        async void DoSomethingCore() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_named_Task_local_function() => An_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public Task DoSomethingAsync()
+    {
+        async Task DoSomethingCore() { }
     }
 }
 ");


### PR DESCRIPTION
- Updated the `ShallAnalyze` methods in `NamingAnalyzer.cs` to ensure that only symbols that can be referenced by name are analyzed, preventing unnecessary analysis of global statements.
- Reorganized and added test cases in `MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs` to improve coverage and clarity, including a new test for global statement handling.
