### PR TITLE
MiKo_1042 now ignores overridden methods

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Parameters.Length > 0;
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Parameters.Length > 0 && base.ShallAnalyze(symbol);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => from parameter in symbol.Parameters
                                                                                                                  where parameter.Type.IsCancellationToken() && parameter.Name != ExpectedName

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_overridden_method_with_CancellationToken_parameter_having_wrong_name() => An_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overridden_method_with_CancellationToken_parameter_having_wrong_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 


### PR DESCRIPTION
- Fixed a bug in the `MiKo_1042_CancellationTokenParameterNameAnalyzer` to ensure that overridden methods are ignored during the analysis.
- Updated the `ShallAnalyze` method to include a call to the base method, enhancing the logic for method analysis.
- Adjusted the test case to verify that no issue is reported for overridden methods with a `CancellationToken` parameter having the wrong name.
