### PR TITLE
MiKo_3098 is now aware of some more keywords to report on

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return true; // justification is too short
             }
 
-            if (text.ToString().Without("emplate").ContainsAny(BadJustificationMarkers, StringComparison.OrdinalIgnoreCase))
+            if (text.ToString().Replace("emplate", "#").ContainsAny(BadJustificationMarkers, StringComparison.OrdinalIgnoreCase))
             {
                 return true; // no justification that explains
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer.cs
@@ -16,7 +16,25 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private const int MinimumJustificationLength = 10;
         private const string BadJustificationGapFillers = " .<>-*";
 
-        private static readonly string[] BadJustificationMarkers = { "as design", "by design", "suppress", "pending", "review", "temp", "temporarily", "intent", "intend", "todo", "to do", "fixme", "fix me" };
+        private static readonly string[] BadJustificationMarkers =
+                                                                   {
+                                                                       "as design",
+                                                                       "by design",
+                                                                       "fix me",
+                                                                       "fixme",
+                                                                       "for reason",
+                                                                       "future",
+                                                                       "intend",
+                                                                       "intent",
+                                                                       "just because",
+                                                                       "later",
+                                                                       "pending",
+                                                                       "review",
+                                                                       "suppress",
+                                                                       "temp", // includes "temporarily"
+                                                                       "to do",
+                                                                       "todo",
+                                                                   };
 
         public MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer() : base(Id, (SymbolKind)(-1))
         {
@@ -36,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return true; // justification is too short
             }
 
-            if (text.ToString().ContainsAny(BadJustificationMarkers, StringComparison.OrdinalIgnoreCase))
+            if (text.ToString().Without("emplate").ContainsAny(BadJustificationMarkers, StringComparison.OrdinalIgnoreCase))
             {
                 return true; // no justification that explains
             }
@@ -57,11 +75,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     case "SuppressMessage":
                     case nameof(SuppressMessageAttribute):
                     {
-                        if (argument.NameEquals.GetName() == nameof(SuppressMessageAttribute.Justification)
-                         && argument.Expression is LiteralExpressionSyntax literal
-                         && HasIssue(literal.Token.ValueText.AsSpan().Trim(BadJustificationGapFillers.AsSpan())))
+                        if (argument.NameEquals.GetName() == nameof(SuppressMessageAttribute.Justification) && argument.Expression is LiteralExpressionSyntax literal)
                         {
-                            ReportDiagnostics(context, Issue(literal));
+                            var justification = literal.Token.ValueText.AsSpan().Trim(BadJustificationGapFillers.AsSpan());
+
+                            if (HasIssue(justification))
+                            {
+                                ReportDiagnostics(context, Issue(literal));
+                            }
                         }
 
                         break;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzerTests.cs
@@ -59,7 +59,8 @@ namespace Bla
 }
 ");
 
-        [TestCase("There is a reason for the suppression.")]
+        [TestCase("We do not want to have that method.")]
+        [TestCase("This is a template.")]
         public void No_issue_is_reported_for_SuppressMessage_attribute_with_proper_justification_(string justification) => No_issue_is_reported_for(@"
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -68,7 +69,7 @@ namespace Bla
 {
     public class TestMe
     {
-        [SuppressMessage(""category"", ""checkId"", Justification = " + justification + @")]
+        [SuppressMessage(""category"", ""checkId"", Justification = """ + justification + @""")]
         public void DoSomething()
         {
         }
@@ -83,6 +84,8 @@ namespace Bla
         [TestCase("To do")]
         [TestCase("FIXME")]
         [TestCase("Fix me")]
+        [TestCase("Fix it later")]
+        [TestCase("Fix it in future")]
         [TestCase("Pending")]
         [TestCase("<Pending>")]
         [TestCase("Reviewed")]
@@ -114,6 +117,8 @@ namespace Bla
         [TestCase("<------------->")] // some placeholders to attempt to avoid match
         [TestCase("<- ->")] // some placeholders to attempt to avoid match
         [TestCase("<- whatever ->")] // no explanation that would explain
+        [TestCase("for reason")] // no explanation that would explain
+        [TestCase("just because")] // no explanation that would explain
         public void An_issue_is_reported_for_SuppressMessage_attribute_with_poor_justification_(string justification) => An_issue_is_reported_for(@"
 using System;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
- Enhanced the `MiKo_3098_SuppressMessageAttributeHasJustificationAnalyzer` by adding more keywords to the `BadJustificationMarkers` list to improve detection of poor justifications.
- Refined the logic to exclude "template" from being considered as a bad justification marker.
- Extended the test suite with additional cases to verify the new keywords and logic changes, ensuring robust validation of justifications.
