### PR TITLE
MiKo_1063 is now aware of abbreviation 'alt'

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -9,6 +9,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
     {
         private static readonly Pair[] Prefixes =
                                                   {
+                                                      new Pair("alt", "alternative"),
                                                       new Pair("app", "application"),
                                                       new Pair("apps", "applications"),
                                                       new Pair("assoc", "association"),
@@ -121,6 +122,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly Pair[] OnlyMidTerms =
                                                       {
+                                                          new Pair("Alt", "Alternative"),
                                                           new Pair("App", "Application"),
                                                           new Pair("Apps", "Applications"),
                                                           new Pair("Assoc", "Association"),
@@ -291,6 +293,8 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                             "Next",
                                                             "oAuth",
                                                             "OAuth",
+                                                            "salt",
+                                                            "Salt",
                                                             "text",
                                                             "Text",
                                                             "MEF",

--- a/MiKo.Analyzer.Tests/Linguistics/AbbreviationDetectorTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/AbbreviationDetectorTests.cs
@@ -5,6 +5,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
     [TestFixture]
     public static class AbbreviationDetectorTests
     {
+        [TestCase("alt", ExpectedResult = "alternative")]
         [TestCase("app", ExpectedResult = "application")]
         [TestCase("apps", ExpectedResult = "applications")]
         [TestCase("assoc", ExpectedResult = "association")]
@@ -121,6 +122,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
             return findings[0].Value;
         }
 
+        [TestCase("Alt", ExpectedResult = "Alternative")]
         [TestCase("App", ExpectedResult = "Application")]
         [TestCase("Apps", ExpectedResult = "Applications")]
         [TestCase("Assoc", ExpectedResult = "Association")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -16,6 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         private static readonly string[] BadPrefixes =
                                                        [
+                                                           "alt",
                                                            "app",
                                                            "apps",
                                                            "assoc",
@@ -114,6 +115,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static readonly string[] BadMidTerms =
                                                        [
+                                                           "Alt",
                                                            "App",
                                                            "Apps",
                                                            "Assoc",
@@ -288,6 +290,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "prompt",
                                                             "requestTime",
                                                             "responseTime",
+                                                            "saltIsUsed",
+                                                            "SomeSaltIsUsed",
                                                             "script",
                                                             "scripts",
                                                             "signCertificate",
@@ -328,7 +332,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_well_known_abbreviation_([Values("MEF")] string abbreviation) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_prefix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -336,6 +340,42 @@ namespace Bla
     public class TestMe
     {
         public static int " + abbreviation + @"DoSomething();
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_postfix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public static int DoSomething" + abbreviation + @"();
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_underscore_separated_prefix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public static int " + abbreviation + @"_DoSomething();
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_underscore_separated_postfix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public static int DoSomething_" + abbreviation + @"();
     }
 }");
 


### PR DESCRIPTION
- Added the abbreviation 'alt' as 'alternative' and 'Alt' as 'Alternative' to the `AbbreviationDetector`.
- Included 'salt' and 'Salt' in the list of midterms in `AbbreviationDetector`.
- Updated tests in `AbbreviationDetectorTests` to cover new abbreviations 'alt' and 'Alt'.
- Enhanced `MiKo_1063_AbbreviationsInNameAnalyzerTests` to include 'alt' and 'Alt' in bad prefixes and midterms.
- Added tests for handling well-known abbreviations including 'ALT'.
