### PR TITLE
MiKo_1070 is now aware of 'document' types

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -1153,7 +1153,9 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsEnumerable(this ITypeSymbol value)
         {
-            switch (value.SpecialType)
+            var specialType = value.SpecialType;
+
+            switch (specialType)
             {
                 case SpecialType.System_Void:
                 case SpecialType.System_Boolean:
@@ -1176,7 +1178,8 @@ namespace MiKoSolutions.Analyzers
                     return false;
 
                 default:
-                    if (IsEnumerable(value.SpecialType))
+                {
+                    if (IsEnumerable(specialType))
                     {
                         return true;
                     }
@@ -1198,6 +1201,7 @@ namespace MiKoSolutions.Analyzers
                     }
 
                     return value.Implements<IEnumerable>();
+                }
             }
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -275,9 +275,65 @@ public class TestMe
 {
     public void DoSomething()
     {
-		XmlDocument document = null;
+        XmlDocument document = null;
         XmlNode xmlNode = document.SelectSingleNode("""");
         XmlNode node = xmlNode.SelectSingleNode("""");
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_XML_Linq_node() => No_issue_is_reported_for(@"
+using System;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        XDocument document = null;
+        XElement element = document.XPathSelectElement("""");
+        XNode node = element.FirstNode;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_document_node() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class Document : IEnumerable<int>
+{
+}
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        Document document = new Document();
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_document_variable_in_foreach() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class Document : IEnumerable<int>
+{
+}
+
+public class TestMe
+{
+    public void DoSomething(IEnumerable<Document> documents)
+    {
+        foreach (var document in documents)
+        {
+        }
     }
 }
 ");


### PR DESCRIPTION
- Enhanced `MiKo_1070_CollectionLocalVariableAnalyzer` with new methods `IsDocument` and `IsMefAggregateCatalog` for better type checking.
- Updated `ShallAnalyze` method to exclude certain document types from analysis.
- Added comprehensive test cases to ensure no issues are reported for XML Linq nodes and custom document types.
- Refactored `IsEnumerable` method in `SymbolExtensions` to improve clarity and efficiency by using a local variable and additional braces.
