### PR TITLE
File extensions of generated C# files updated and moved to Constants

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -39,6 +39,8 @@ namespace MiKoSolutions.Analyzers
 
         internal const char Underscore = '_';
 
+        internal const string CSharpFileExtension = ".cs";
+
         internal static readonly char[] SentenceMarkers = ".?!;:".ToCharArray();
         internal static readonly char[] SentenceClauseMarkers = ",;".ToCharArray();
         internal static readonly char[] TrailingSentenceMarkers = " \t.?!;:,".ToCharArray();
@@ -49,6 +51,15 @@ namespace MiKoSolutions.Analyzers
         internal static readonly string[] ParaTags = { "<para>", "<para />", "<para/>", "</para>" };
 
         internal static readonly char[] Underscores = { Underscore };
+
+        internal static readonly string[] GeneratedCSharpFileExtensions =
+                                                                          {
+                                                                              ".g.cs",
+                                                                              ".g.i.cs",
+                                                                              ".generated.cs",
+                                                                              ".Designer.cs",
+                                                                              ".feature.cs", // SpecFlow generated code
+                                                                          };
 
         internal static class ILog
         {
@@ -153,7 +164,7 @@ namespace MiKoSolutions.Analyzers
             internal static readonly string[] Models = { "Model", "Models", "model", "models" };
             internal static readonly string[] ViewModels = { "ViewModel", "ViewModels", "viewModel", "viewModels" };
             internal static readonly string[] SpecialModels = { "Modeless", "modeless", "ModeLess", "modeLess", "semanticModel", "SemanticModel" };
-            internal static readonly string[] Collections = { "List", "Dictionary", "ObservableCollection", "Collection", "Array", "HashSet", "Stack", "list", "dictionary", "observableCollection", "collection", "array", "hashSet", "stack" };
+            internal static readonly string[] Collections = { "List", "Dictionary", "ObservableCollection", "Collection", "Array", "HashSet", "Stack", "Queue", "list", "dictionary", "observableCollection", "collection", "array", "hashSet", "stack", "queue" };
             internal static readonly string[] Symbols = { "T:", "P:", "M:", "F:", "E:", "!:" };
             internal static readonly string[] SymbolsAndLineBreaks = Symbols.Append(EnvironmentNewLine).ToArray();
             internal static readonly string[] Requirements = { "Must", "Need", "Shall", "Should", "Will", "Would" };

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -33,13 +33,6 @@ namespace MiKoSolutions.Analyzers
                                                                                                                   SymbolDisplayGenericsOptions.IncludeTypeParameters,
                                                                                                                   miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
 
-        private static readonly string[] GeneratedCSharpFileExtensions =
-                                                                         {
-                                                                             ".g.cs",
-                                                                             ".generated.cs",
-                                                                             ".Designer.cs",
-                                                                         };
-
         private static readonly SyntaxKind[] LocalFunctionContainerSyntaxKinds =
                                                                                  {
                                                                                      SyntaxKind.MethodDeclaration,
@@ -506,9 +499,9 @@ namespace MiKoSolutions.Analyzers
                     var filePath = sourceTree.FilePath;
 
                     // ignore non C# code (might be part of partial classes, e.g. for XAML)
-                    if (filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                    if (filePath.EndsWith(Constants.CSharpFileExtension, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (filePath.EndsWithAny(GeneratedCSharpFileExtensions, StringComparison.OrdinalIgnoreCase))
+                        if (filePath.EndsWithAny(Constants.GeneratedCSharpFileExtensions, StringComparison.OrdinalIgnoreCase))
                         {
                             // ignore generated code (might be part of partial classes)
                             continue;

--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -29,31 +29,15 @@ namespace MiKoSolutions.Analyzers.Rules
         [TestCase("TODO"), Timeout(4 * 60 * 60 * 1000)] // 4h
         public static void Performance_(string path)
         {
-            // ncrunch: no coverage start
-            var files = GetDocuments(path).ToList();
-            var sources = files.Select(File.ReadAllText).ToArray();
+//// ncrunch: no coverage start
+            var files = Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)
+                                 .Where(_ => _.EndsWithAny(Constants.GeneratedCSharpFileExtensions, StringComparison.OrdinalIgnoreCase) is false);
+            var sources = files.ToHashSet(File.ReadAllText).ToArray();
 
             var results = DiagnosticVerifier.GetDiagnostics(sources, LanguageVersion.LatestMajor, AllAnalyzers.Cast<DiagnosticAnalyzer>().ToArray(), true);
 
             Assert.That(results.Length, Is.Zero);
-
-            static IEnumerable<string> GetDocuments(string path)
-            {
-                foreach (var directory in Directory.EnumerateDirectories(path))
-                {
-                    foreach (var document in GetDocuments(directory))
-                    {
-                        yield return document;
-                    }
-                }
-
-                foreach (var file in Directory.EnumerateFiles(path, "*.cs"))
-                {
-                    yield return file;
-                }
-            }
-
-            // ncrunch: no coverage end
+//// ncrunch: no coverage end
         }
 
         [Test]


### PR DESCRIPTION
- Introduced `CSharpFileExtension` and `GeneratedCSharpFileExtensions` constants in `Constants.cs` for better maintainability.
- Updated `SymbolExtensions.cs` to use the new constants, removing redundant local definitions.
- Enhanced `AnalyzerTests.cs` by simplifying the file enumeration logic and using the new constants for filtering.
- Updated `Collections` in `Constants.cs` to include "Queue" and "queue".
