### PR TITLE
MiKo_2076 is now aware of structs like 'CancellationToken' for default values

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var summary in summaries)
             {
-                var trimmed = summary.GetTextTrimmed().ToString();
+                var trimmed = summary.GetTextTrimmed();
 
                 if (obviousComments.Contains(trimmed))
                 {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using System.Threading;
+
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -479,7 +481,8 @@ public namespace Bla
 
         [TestCase("bool", "<see langword=\"false\"/>")]
         [TestCase("byte", "<c>0</c>")]
-        [TestCase("CancellationToken", "<see cref=\"CancellationToken\"/>")]
+        [TestCase("CancellationToken", "<see cref=\"CancellationToken.None\"/>")]
+        [TestCase("GCCollectionMode", "<see cref=\"GCCollectionMode.Default\"/>")]
         [TestCase("char", "<c>'\\0' (U+0000)</c>")]
         [TestCase("DateTime", "<see cref=\"DateTime.MinValue\"/>")]
         [TestCase("double", "<c>0</c>")]
@@ -529,7 +532,8 @@ public namespace Bla
 
         [TestCase("bool", "<see langword=\"false\"/>")]
         [TestCase("byte", "<c>0</c>")]
-        [TestCase("CancellationToken", "<see cref=\"CancellationToken\"/>")]
+        [TestCase("CancellationToken", "<see cref=\"CancellationToken.None\"/>")]
+        [TestCase("GCCollectionMode", "<see cref=\"GCCollectionMode.Default\"/>")]
         [TestCase("char", "<c>'\\0' (U+0000)</c>")]
         [TestCase("DateTime", "<see cref=\"DateTime.MinValue\"/>")]
         [TestCase("double", "<c>0</c>")]


### PR DESCRIPTION
- Enhanced the `MiKo_2076_OptionalParameterDefaultPhraseAnalyzer` to better handle default values for structs and enums, including static properties and fields.
- Updated and added test cases to verify the new behavior for handling default values, including specific cases for `CancellationToken.None` and `GCCollectionMode.Default`.
- Simplified the logic for trimming text in the `MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer`.
