### PR TITLE
Linq calls replaced by code

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -274,16 +274,19 @@ namespace System.Linq
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceLength = source.Length;
+
+            if (sourceLength <= 0)
+            {
+                return 0;
+            }
+
             var count = 0;
 
-            if (sourceLength > 0)
+            for (var index = 0; index < sourceLength; index++)
             {
-                for (var index = 0; index < sourceLength; index++)
+                if (filter(source[index]))
                 {
-                    if (filter(source[index]))
-                    {
-                        count++;
-                    }
+                    count++;
                 }
             }
 
@@ -294,16 +297,19 @@ namespace System.Linq
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var valueCount = value.Count;
+
+            if (valueCount <= 0)
+            {
+                return 0;
+            }
+
             var count = 0;
 
-            if (valueCount > 0)
+            for (var index = 0; index < valueCount; index++)
             {
-                for (var index = 0; index < valueCount; index++)
+                if (filter(value[index]))
                 {
-                    if (filter(value[index]))
-                    {
-                        count++;
-                    }
+                    count++;
                 }
             }
 
@@ -314,16 +320,19 @@ namespace System.Linq
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var valueCount = value.Count;
+
+            if (valueCount <= 0)
+            {
+                return 0;
+            }
+
             var count = 0;
 
-            if (valueCount > 0)
+            for (var index = 0; index < valueCount; index++)
             {
-                for (var index = 0; index < valueCount; index++)
+                if (filter(value[index]))
                 {
-                    if (filter(value[index]))
-                    {
-                        count++;
-                    }
+                    count++;
                 }
             }
 
@@ -426,12 +435,19 @@ namespace System.Linq
 
         internal static bool Exists<T>(this IReadOnlyList<T> value, Predicate<T> match)
         {
-            if (value is List<T> list)
+            if (value.Count <= 0)
             {
-                return list.Exists(match);
+                return false;
             }
 
-            return value.Any(new Func<T, bool>(match));
+            switch (value)
+            {
+                case List<T> list: return list.Exists(match);
+                case T[] array: return array.Exists(match);
+
+                default:
+                    return value.Any(new Func<T, bool>(match));
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -442,13 +458,16 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            for (var index = 0; index < sourceCount; index++)
+            if (sourceCount > 0)
             {
-                var value = source[index];
-
-                if (predicate(value))
+                for (var index = 0; index < sourceCount; index++)
                 {
-                    return value;
+                    var value = source[index];
+
+                    if (predicate(value))
+                    {
+                        return value;
+                    }
                 }
             }
 
@@ -460,13 +479,16 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            for (var index = 0; index < sourceCount; index++)
+            if (sourceCount > 0)
             {
-                var value = source[index];
-
-                if (predicate(value))
+                for (var index = 0; index < sourceCount; index++)
                 {
-                    return value;
+                    var value = source[index];
+
+                    if (predicate(value))
+                    {
+                        return value;
+                    }
                 }
             }
 
@@ -478,13 +500,16 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            for (var index = 0; index < sourceCount; index++)
+            if (sourceCount > 0)
             {
-                var value = source[index];
-
-                if (predicate(value))
+                for (var index = 0; index < sourceCount; index++)
                 {
-                    return value;
+                    var value = source[index];
+
+                    if (predicate(value))
+                    {
+                        return value;
+                    }
                 }
             }
 
@@ -568,10 +593,20 @@ namespace System.Linq
             return default;
         }
 
-        internal static int IndexOf<T>(this T[] source, T value) => source.Length != 0 ? Array.IndexOf(source, value) : -1;
+        internal static int IndexOf<T>(this T[] source, T value) => source.Length == 0 ? -1 : Array.IndexOf(source, value);
+
+        internal static int IndexOf<T>(this T[] source, Func<T, bool> predicate) => source.Length == 0 ? -1 : source.IndexOf(new Predicate<T>(predicate));
+
+        internal static int IndexOf<T>(this T[] source, Predicate<T> predicate) => source.Length == 0 ? -1 : Array.FindIndex(source, predicate);
 
         internal static int IndexOf<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
+            switch (source)
+            {
+                case T[] array: return array.IndexOf(predicate);
+                case List<T> list: return list.FindIndex(new Predicate<T>(predicate));
+            }
+
             var index = 0;
 
             foreach (var value in source)
@@ -587,19 +622,19 @@ namespace System.Linq
             return -1;
         }
 
-        internal static bool None(this SyntaxTriviaList source) => source.Any() is false;
+        internal static bool None(this SyntaxTriviaList source) => source.Count == 0;
 
-        internal static bool None<T>(this SyntaxList<T> source) where T : SyntaxNode => source.Any() is false;
+        internal static bool None<T>(this SyntaxList<T> source) where T : SyntaxNode => source.Count == 0;
 
-        internal static bool None<T>(this SeparatedSyntaxList<T> source) where T : SyntaxNode => source.Any() is false;
+        internal static bool None<T>(this SeparatedSyntaxList<T> source) where T : SyntaxNode => source.Count == 0;
 
-        internal static bool None(this SyntaxTokenList source) => source.Any() is false;
+        internal static bool None(this SyntaxTokenList source) => source.Count == 0;
 
         internal static bool None<T>(this IEnumerable<T> source) => source.Any() is false;
 
         internal static bool None<T>(this IReadOnlyCollection<T> source) => source.Count == 0;
 
-        internal static bool None<T>(this ImmutableArray<T> source) => source.Any() is false;
+        internal static bool None<T>(this ImmutableArray<T> source) => source.Length == 0;
 
         internal static bool None<T>(this SyntaxList<T> source, SyntaxKind kind) where T : SyntaxNode => source.IndexOf(kind) == -1;
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -61,11 +61,14 @@ namespace MiKoSolutions.Analyzers
             // for performance reasons we use indexing instead of an enumerator
             var length = kinds.Length;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                if (kinds[index] == valueKind)
+                for (var index = 0; index < length; index++)
                 {
-                    return true;
+                    if (kinds[index] == valueKind)
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -101,13 +104,16 @@ namespace MiKoSolutions.Analyzers
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
                 var tokensCount = textTokens.Count;
 
-                for (var index = 0; index < tokensCount; index++)
+                if (tokensCount > 0)
                 {
-                    var token = textTokens[index];
-
-                    if (token.IsKind(SyntaxKind.XmlTextLiteralToken))
+                    for (var index = 0; index < tokensCount; index++)
                     {
-                        yield return token;
+                        var token = textTokens[index];
+
+                        if (token.IsKind(SyntaxKind.XmlTextLiteralToken))
+                        {
+                            yield return token;
+                        }
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
@@ -13,10 +13,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2071";
 
-        private static readonly string[] BooleanPhrases = (from term1 in new[] { " indicating ", " indicates ", " indicate " }
-                                                           from term2 in new[] { "whether ", "if " }
-                                                           select string.Concat(term1, term2))
-                                                          .ToArray();
+        private static readonly string[] ContinuationPhrases = { "whether ", "if " };
+
+        private static readonly string[] BooleanPhrases = new[] { " indicating ", " indicates ", " indicate " }.SelectMany(term1 => ContinuationPhrases, string.Concat)
+                                                                                                               .ToArray();
 
         public MiKo_2071_EnumMethodSummaryAnalyzer() : base(Id, (SymbolKind)(-1))
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -16,8 +15,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => from token in comment.GetXmlTextTokens()
-                                                                                                                                                                           from location in GetAllLocations(token, Constants.Markers.ReSharper)
-                                                                                                                                                                           select Issue(location);
+        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        {
+            foreach (var token in comment.GetXmlTextTokens())
+            {
+                foreach (var location in GetAllLocations(token, Constants.Markers.ReSharper))
+                {
+                    yield return Issue(location);
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3023_CancellationTokenSourceParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3023_CancellationTokenSourceParameterAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 using Microsoft.CodeAnalysis;
@@ -16,9 +15,24 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation) => from parameter in symbol.Parameters
-                                                                                                             let parameterType = parameter.Type
-                                                                                                             where parameterType.TypeKind == TypeKind.Class && parameterType.ToString() == TypeNames.CancellationTokenSource
-                                                                                                             select Issue(parameter, nameof(CancellationToken));
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        {
+            var parameters = symbol.Parameters;
+            var length = parameters.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var parameter = parameters[index];
+                    var parameterType = parameter.Type;
+
+                    if (parameterType.TypeKind == TypeKind.Class && parameterType.ToString() == TypeNames.CancellationTokenSource)
+                    {
+                        yield return Issue(parameter, nameof(CancellationToken));
+                    }
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1026_LocalVariableNameLengthAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1026_LocalVariableNameLengthAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -24,12 +23,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             context.RegisterSyntaxNodeAction(AnalyzeDeclarationPattern, SyntaxKind.DeclarationPattern);
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => AnalyzeIdentifiers(semanticModel, identifiers);
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
 
-        private IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, IEnumerable<SyntaxToken> identifiers) => from identifier in identifiers
-                                                                                                                                 let exceeding = GetExceedingCharacters(identifier.ValueText)
-                                                                                                                                 where exceeding > 0
-                                                                                                                                 let symbol = identifier.GetSymbol(semanticModel)
-                                                                                                                                 select Issue(symbol, exceeding);
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var exceeding = GetExceedingCharacters(identifier.ValueText);
+
+                    if (exceeding > 0)
+                    {
+                        var symbol = identifier.GetSymbol(semanticModel);
+
+                        yield return Issue(symbol, exceeding);
+                    }
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1027_LocalVariableNameInForLoopsLengthAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1027_LocalVariableNameInForLoopsLengthAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -24,12 +23,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             context.RegisterSyntaxNodeAction(AnalyzeForStatement, SyntaxKind.ForStatement);
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => AnalyzeIdentifiers(semanticModel, identifiers);
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
 
-        private IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, IEnumerable<SyntaxToken> identifiers) => from identifier in identifiers
-                                                                                                                                 let exceeding = GetExceedingCharacters(identifier.ValueText)
-                                                                                                                                 where exceeding > 0
-                                                                                                                                 let symbol = identifier.GetSymbol(semanticModel)
-                                                                                                                                 select Issue(symbol, exceeding);
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var exceeding = GetExceedingCharacters(identifier.ValueText);
+
+                    if (exceeding > 0)
+                    {
+                        var symbol = identifier.GetSymbol(semanticModel);
+
+                        yield return Issue(symbol, exceeding);
+                    }
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -19,8 +18,23 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Parameters.Length > 0 && base.ShallAnalyze(symbol);
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => from parameter in symbol.Parameters
-                                                                                                                 where parameter.Type.IsCancellationToken() && parameter.Name != ExpectedName
-                                                                                                                 select Issue(parameter, ExpectedName, CreateBetterNameProposal(ExpectedName));
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            var parameters = symbol.Parameters;
+            var length = parameters.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var parameter = parameters[index];
+
+                    if (parameter.Type.IsCancellationToken() && parameter.Name != ExpectedName)
+                    {
+                        yield return Issue(parameter, ExpectedName, CreateBetterNameProposal(ExpectedName));
+                    }
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -19,9 +18,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol?.IsCancellationToken() is true;
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => from identifier in identifiers
-                                                                                                                                                          where identifier.ValueText != ExpectedName
-                                                                                                                                                          select identifier.GetSymbol(semanticModel) into symbol
-                                                                                                                                                          select Issue(symbol, ExpectedName, CreateBetterNameProposal(ExpectedName));
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+
+                    if (identifier.ValueText != ExpectedName)
+                    {
+                        var symbol = identifier.GetSymbol(semanticModel);
+
+                        yield return Issue(symbol, ExpectedName, CreateBetterNameProposal(ExpectedName));
+                    }
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
@@ -151,10 +151,21 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => from identifier in identifiers
-                                                                                                                                                          let name = identifier.Text
-                                                                                                                                                          where HasIssue(name)
-                                                                                                                                                          select Issue(name, identifier);
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            for (var index = 0; index < length; index++)
+            {
+                var identifier = identifiers[index];
+                var name = identifier.Text;
+
+                if (HasIssue(name))
+                {
+                    yield return Issue(name, identifier);
+                }
+            }
+        }
 
         private static bool HasIssue(string name)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
@@ -155,14 +155,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var length = identifiers.Length;
 
-            for (var index = 0; index < length; index++)
+            if (length > 0)
             {
-                var identifier = identifiers[index];
-                var name = identifier.Text;
-
-                if (HasIssue(name))
+                for (var index = 0; index < length; index++)
                 {
-                    yield return Issue(name, identifier);
+                    var identifier = identifiers[index];
+                    var name = identifier.Text;
+
+                    if (HasIssue(name))
+                    {
+                        yield return Issue(name, identifier);
+                    }
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -18,9 +17,23 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.Name.EndsWithNumber();
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => from identifier in identifiers
-                                                                                                                                                          let name = identifier.ValueText
-                                                                                                                                                          where name.EndsWithCommonNumber()
-                                                                                                                                                          select Issue(name, identifier, CreateBetterNameProposal(name.WithoutNumberSuffix()));
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+
+                    if (name.EndsWithCommonNumber())
+                    {
+                        yield return Issue(name, identifier, CreateBetterNameProposal(name.WithoutNumberSuffix()));
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Replaced LINQ calls with explicit loops across multiple files to improve performance and readability.
- Added length checks before loops to prevent unnecessary iterations.
- Improved `None` method by using `Count` instead of `Any` for better performance.
- Enhanced `IndexOf` method to handle different collection types.
