### PR TITLE
Updated Nuget packages

### DIFF
--- a/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
+++ b/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41">
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
+++ b/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41">
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41">
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -37,7 +37,6 @@
 
   <!-- Required by NCrunch on remote machines as those machines do not have the package installed -->
   <ItemGroup Condition="'$(NCrunch)' != '1'">
-    <PackageReference Include="Codecov" Version="1.10.0" PrivateAssets="all" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,8 +45,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenCover" Version="4.7.1221" PrivateAssets="all" />
-    <PackageReference Include="ReportGenerator" Version="5.3.10" />
+    <PackageReference Include="ReportGenerator" Version="5.3.11" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MiKo.Analyzer.Vsix2019/MiKo.Analyzer.Vsix2019.csproj
+++ b/MiKo.Analyzer.Vsix2019/MiKo.Analyzer.Vsix2019.csproj
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41">
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MiKo.Analyzer.Vsix2022/MiKo.Analyzer.Vsix2022.csproj
+++ b/MiKo.Analyzer.Vsix2022/MiKo.Analyzer.Vsix2022.csproj
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.41">
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Updated `Microsoft.VisualStudio.SDK.Analyzers` package version across multiple projects from 17.7.41 to 17.7.47.
- Updated `Microsoft.VSSDK.BuildTools` package version in VSIX projects from 17.11.435 to 17.12.2069.
- Updated `ReportGenerator` package version in the test project from 5.3.10 to 5.3.11.
- Removed `OpenCover` package reference from the test project.
- Removed `Codecov` package reference from the test project.

