### PR TITLE
introduced extension method 'WhereNotNull' to speed up null check

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
@@ -102,14 +102,14 @@ namespace MiKoSolutions.Analyzers
             return FlattenComment(GetExceptionCommentElements(commentXml).Where(_ => _.Attribute(Constants.XmlTag.Attribute.Cref)?.Value == exceptionTypeFullName));
         }
 
-        internal static IEnumerable<string> GetExceptionComments(string commentXml) => Cleaned(GetExceptionCommentElements(commentXml)).Where(_ => _ != null);
+        internal static IEnumerable<string> GetExceptionComments(string commentXml) => Cleaned(GetExceptionCommentElements(commentXml)).WhereNotNull();
 
         internal static IEnumerable<string> GetExceptionsOfExceptionComments(string commentXml)
         {
-            return GetExceptionCommentElements(commentXml).Select(_ => _.Attribute(Constants.XmlTag.Attribute.Cref)?.Value).Where(_ => _ != null);
+            return GetExceptionCommentElements(commentXml).Select(_ => _.Attribute(Constants.XmlTag.Attribute.Cref)?.Value).WhereNotNull();
         }
 
-        internal static IReadOnlyCollection<string> Cleaned(IEnumerable<string> comments) => comments.Where(_ => _ != null).WithoutParaTags().ToHashSet(_ => _.Trim());
+        internal static IReadOnlyCollection<string> Cleaned(IEnumerable<string> comments) => comments.WhereNotNull().WithoutParaTags().ToHashSet(_ => _.Trim());
 
         internal static string Cleaned(XElement element)
         {

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -1360,7 +1360,38 @@ namespace System.Linq
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool TrueForAll<T>(this T[] source, Predicate<T> match) => Array.TrueForAll(source, match);
 
+        internal static IEnumerable<TSource> WhereNotNull<TSource>(this IEnumerable<TSource> source) where TSource : class
+        {
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var item in source)
+            {
+                if (item != null)
+                {
+                    yield return item;
+                }
+            }
+        }
+
         internal static IEnumerable<SyntaxToken> Where(this SyntaxTokenList source, Func<SyntaxToken, bool> predicate)
+        {
+            // keep in local variable to avoid multiple requests (see Roslyn implementation)
+            var sourceCount = source.Count;
+
+            if (sourceCount > 0)
+            {
+                for (var index = 0; index < sourceCount; index++)
+                {
+                    var value = source[index];
+
+                    if (predicate(value))
+                    {
+                        yield return value;
+                    }
+                }
+            }
+        }
+
+        internal static IEnumerable<SyntaxTrivia> Where(this SyntaxTriviaList source, Func<SyntaxTrivia, bool> predicate)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -209,7 +209,7 @@ namespace System
         public static InterpolatedStringTextSyntax AsInterpolatedString(this string value) => SyntaxFactory.InterpolatedStringText(value.AsToken(SyntaxKind.InterpolatedStringTextToken));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ConcatenatedWith(this IEnumerable<string> values) => string.Concat(values.Where(_ => _ != null));
+        public static string ConcatenatedWith(this IEnumerable<string> values) => string.Concat(values.WhereNotNull());
 
         public static StringBuilder ConcatenatedWith<T>(this IEnumerable<T> values) where T : class
         {

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -580,7 +580,7 @@ namespace MiKoSolutions.Analyzers
             var propertyTypes = members.OfType<IPropertySymbol>().Where(_ => Constants.Names.TypeUnderTestPropertyNames.Contains(_.Name));
             var fieldTypes = members.OfType<IFieldSymbol>().Where(_ => Constants.Names.TypeUnderTestFieldNames.Contains(_.Name));
 
-            return Enumerable.Empty<ISymbol>().Concat(propertyTypes).Concat(fieldTypes).Concat(methodTypes).Where(_ => _ != null).ToHashSet(SymbolEqualityComparer.Default);
+            return Enumerable.Empty<ISymbol>().Concat(propertyTypes).Concat(fieldTypes).Concat(methodTypes).WhereNotNull().ToHashSet(SymbolEqualityComparer.Default);
 
             IEnumerable<IMethodSymbol> GetTestCreationMethods()
             {
@@ -597,7 +597,7 @@ namespace MiKoSolutions.Analyzers
         internal static IReadOnlyCollection<ITypeSymbol> GetTypeUnderTestTypes(this ITypeSymbol value)
         {
             // TODO: RKN what about base types?
-            return value.GetTypeUnderTestMembers().Select(_ => _.GetReturnTypeSymbol()).Where(_ => _ != null).ToHashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+            return value.GetTypeUnderTestMembers().Select(_ => _.GetReturnTypeSymbol()).WhereNotNull().ToHashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
         }
 
         internal static bool HasAttribute(this ISymbol value, ISet<string> attributeNames)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var foundIssues = false;
 
-                foreach (var returnComment in CommentExtensions.GetComments(commentXml, XmlTag.Returns).Where(_ => _ != null))
+                foreach (var returnComment in CommentExtensions.GetComments(commentXml, XmlTag.Returns).WhereNotNull())
                 {
                     foreach (var finding in AnalyzeReturnType(owningSymbol, returnType, comment, returnComment, XmlTag.Returns))
                     {
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (foundIssues is false)
                 {
-                    foreach (var valueComment in CommentExtensions.GetComments(commentXml, XmlTag.Value).Where(_ => _ != null))
+                    foreach (var valueComment in CommentExtensions.GetComments(commentXml, XmlTag.Value).WhereNotNull())
                     {
                         foreach (var finding in AnalyzeReturnType(owningSymbol, returnType, comment, valueComment, XmlTag.Value))
                         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => symbol.GetNamedMethods()
                                                                                                                       .Where(ShallAnalyze)
                                                                                                                       .Select(AnalyzeTryMethod)
-                                                                                                                      .Where(_ => _ != null);
+                                                                                                                      .WhereNotNull();
 
         private Diagnostic AnalyzeTryMethod(IMethodSymbol method)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Interface;
 
-        protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => symbol.GetMethods(MethodKind.Ordinary).Select(AnalyzeOrdinaryMethod).Where(_ => _ != null);
+        protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => symbol.GetMethods(MethodKind.Ordinary).Select(AnalyzeOrdinaryMethod).WhereNotNull();
 
         private Diagnostic AnalyzeOrdinaryMethod(IMethodSymbol method)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var interpolations = interpolated.Contents.OfType<InterpolationSyntax>().ToList();
 
             // filter for format clauses as they are not needed inside the resulting text
-            var formatClauses = interpolations.Select(_ => _.FormatClause).Where(_ => _ != null);
+            var formatClauses = interpolations.Select(_ => _.FormatClause).WhereNotNull();
 
             var text = interpolated.Without(formatClauses).Contents.ToString();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var candidates = node.DescendantNodes<AssignmentExpressionSyntax>(_ => _.IsKind(SyntaxKind.SimpleAssignmentExpression))
                                  .Select(_ => _.FirstChild<IdentifierNameSyntax>())
-                                 .Where(_ => _ != null)
+                                 .WhereNotNull()
                                  .Select(_ => _.GetName());
 
             return candidates;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => symbol.IsTestClass()
                                                                                                                     ? Enumerable.Empty<Diagnostic>() // ignore tests
-                                                                                                                    : symbol.GetNamedMethods().Select(AnalyzeTryMethod).Where(_ => _ != null);
+                                                                                                                    : symbol.GetNamedMethods().Select(AnalyzeTryMethod).WhereNotNull();
 
         private static string GetPreferredParameterName(string methodName)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1065_OperatorParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1065_OperatorParameterNameAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeParameters(symbol.Parameters).Where(_ => _ != null);
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeParameters(symbol.Parameters).WhereNotNull();
 
         private IEnumerable<Diagnostic> AnalyzeParameters(ImmutableArray<IParameterSymbol> parameters)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             if (typesUnderTest.Any())
             {
                 var typeUnderTestNames = typesUnderTest.Select(_ => GetTypeUnderTestName(symbol, _))
-                                                       .Where(_ => _ != null) // ignore generic class or struct constraint
+                                                       .WhereNotNull() // ignore generic class or struct constraint
                                                        .Distinct()
                                                        .ToList();
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             // get namespace (qualified) of class and of extension method parameter (first one) and compare those
             var diagnostic = symbol.GetExtensionMethods()
                                    .Select(_ => _.Parameters[0].Type.ContainingNamespace)
-                                   .Where(_ => _ != null) // generic types do not have a namespace to detect
+                                   .WhereNotNull() // generic types do not have a namespace to detect
                                    .Select(_ => _.ToString())
                                    .Where(_ => _ != qualifiedNamespaceOfExtensionMethod)
                                    .Select(_ => Issue(symbol, _))

--- a/MiKo.Analyzer.Shared/Rules/Ordering/DisposeOrderingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/DisposeOrderingCodeFixProvider.cs
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
                         }
 
                         return modifiedTypeSyntax.ReplaceNodes(
-                                                           new[] { parent, disposeMethod }.Where(_ => _ != null),
+                                                           new[] { parent, disposeMethod }.WhereNotNull(),
                                                            (original, rewritten) =>
                                                                                    {
                                                                                        if (rewritten.IsEquivalentTo(parent))

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             // handle each accessibility separately, to avoid situations such as that private methods suddenly get sorted before other public methods
             foreach (var nodes in methodsOrderedByParameters.GroupBy(_ => _.DeclaredAccessibility))
             {
-                var methodNodes = nodes.Select(_ => _.GetSyntax()).Where(_ => _ != null).ToList();
+                var methodNodes = nodes.Select(_ => _.GetSyntax()).WhereNotNull().ToList();
 
                 if (methodNodes.Count <= 1)
                 {


### PR DESCRIPTION
- Introduced a new extension method `WhereNotNull` to streamline null checks across the codebase.
- Replaced existing null checks with `WhereNotNull` in various files to improve code readability and performance.
- Added `Where` method for `SyntaxTriviaList` in `EnumerableExtensions`.
