### PR TITLE
Updated NuGet packages

### DIFF
--- a/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
+++ b/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
+++ b/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
@@ -48,7 +48,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -4,10 +4,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MiKoSolutions.Analyzers.Tests</AssemblyName>
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
-    
+
     <!-- needed for ReSharper tests and others, see https://github.com/dotnet/sdk/issues/10506 -->
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <IsTestProject>true</IsTestProject>	
+    <IsTestProject>true</IsTestProject>
+    <!-- we do not want to get informed about security vulnerabilities here because this is a test project that is not published to customers -->
+    <NuGetAudit>false</NuGetAudit>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -45,7 +48,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="5.3.11" />
+    <PackageReference Include="ReportGenerator" Version="5.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Updated `Microsoft.VisualStudio.Threading.Analyzers` package version to 17.12.19 across multiple projects
- Updated `ReportGenerator` package version to 5.4.0 in the test project
- Added configuration to the test project to disable NuGet audit and specify warnings not treated as errors
