### PR TITLE
Code refactored

### DIFF
--- a/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/CodeFixVerifier.Helper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -69,7 +70,7 @@ namespace TestHelper
         /// <returns>
         /// A list of Diagnostics that only surfaced in the code after the CodeFix was applied.
         /// </returns>
-        private static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
+        private static IEnumerable<Diagnostic> GetNewDiagnostics(ImmutableArray<Diagnostic> diagnostics, ImmutableArray<Diagnostic> newDiagnostics)
         {
             var oldArray = diagnostics.OrderBy(_ => _.Location.SourceSpan.Start).ToArray();
             var newArray = newDiagnostics.OrderBy(_ => _.Location.SourceSpan.Start).ToArray();
@@ -100,7 +101,7 @@ namespace TestHelper
         /// <returns>
         /// The compiler diagnostics that were found in the code.
         /// </returns>
-        private static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
+        private static ImmutableArray<Diagnostic> GetCompilerDiagnostics(Document document)
         {
             return document.GetSemanticModelAsync().Result.GetDiagnostics();
         }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading;
-
-using Microsoft.CodeAnalysis.CodeFixes;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;


### PR DESCRIPTION
- Enhanced the `CodeFixVerifier.Helper` by changing method signatures to use `ImmutableArray<Diagnostic>` for better performance and immutability.
- Removed unused namespace import in `MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests` to clean up the code.
