### PR TITLE
Enhanced MiKo_2223 to recognize file extensions

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -61,6 +61,39 @@ namespace MiKoSolutions.Analyzers
                                                                               ".feature.cs", // SpecFlow generated code
                                                                           };
 
+        internal static readonly string[] WellknownFileExtensions =
+                                                                    {
+                                                                        ".bmp",
+                                                                        ".cert",
+                                                                        ".config",
+                                                                        ".cs",
+                                                                        ".dll",
+                                                                        ".doc",
+                                                                        ".docx",
+                                                                        ".eds",
+                                                                        ".exe",
+                                                                        ".gif",
+                                                                        ".htm",
+                                                                        ".html",
+                                                                        ".jpeg",
+                                                                        ".jpg",
+                                                                        ".js",
+                                                                        ".nupkg",
+                                                                        ".pdf",
+                                                                        ".png",
+                                                                        ".ps1",
+                                                                        ".resx",
+                                                                        ".rtf",
+                                                                        ".txt",
+                                                                        ".vb",
+                                                                        ".vbs",
+                                                                        ".yaml",
+                                                                        ".yml",
+                                                                        ".xaml",
+                                                                        ".xml",
+                                                                        ".zip",
+                                                                    };
+
         internal static class ILog
         {
             internal const string NamespaceName = "log4net";

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -78,6 +78,7 @@ namespace MiKoSolutions.Analyzers
                                                                         ".jpeg",
                                                                         ".jpg",
                                                                         ".js",
+                                                                        ".mp3",
                                                                         ".nupkg",
                                                                         ".pdf",
                                                                         ".png",

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
@@ -30,24 +30,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                        Constants.XmlTag.Permission,
                                                    };
 
-        private static readonly string[] WellknownFileExtensions =
-                                                                   {
-                                                                       ".bmp",
-                                                                       ".config",
-                                                                       ".cs",
-                                                                       ".dll",
-                                                                       ".eds",
-                                                                       ".gif",
-                                                                       ".htm",
-                                                                       ".jpeg",
-                                                                       ".jpg",
-                                                                       ".png",
-                                                                       ".resx",
-                                                                       ".txt",
-                                                                       ".xaml",
-                                                                       ".xml",
-                                                                   };
-
         public MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer() : base(Id)
         {
         }
@@ -156,6 +138,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static bool IsWellknownFileExtension(ReadOnlySpan<char> comment, int startIndex) => comment.Slice(startIndex).StartsWithAny(WellknownFileExtensions);
+        private static bool IsWellknownFileExtension(ReadOnlySpan<char> comment, int startIndex) => comment.Slice(startIndex).StartsWithAny(Constants.WellknownFileExtensions);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -44,11 +44,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly HashSet<string> WellKnownWords = new HashSet<string>
                                                                      {
+                                                                         "ASP.NET",
                                                                          "CSharp",
                                                                          "FxCop",
                                                                          "IntelliSense",
+                                                                         "Microsoft",
                                                                          "NCover",
                                                                          "NCrunch",
+                                                                         "Outlook",
                                                                          "PostSharp",
                                                                          "ReSharper",
                                                                          "SonarCube",
@@ -56,7 +59,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                          "SonarQube",
                                                                          "StyleCop",
                                                                          "VisualBasic",
-                                                                         "ASP.NET",
                                                                      };
 
         public MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer() : base(Id)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -27,6 +27,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                '#',
                                                            };
 
+        private static readonly string[] LangwordCandidates = { "true", "false", "null" };
+
         private static readonly string[] HyperlinkIndicators = { "http:", "https:", "ftp:", "ftps:" };
 
         private static readonly string[] CompilerWarningIndicators = { "CS", "CA", "SA" };
@@ -135,6 +137,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
+            if (trimmed.EqualsAny(LangwordCandidates, StringComparison.OrdinalIgnoreCase))
+            {
+                // do not report stuff like 'true' as that is a langword which gets reported by MiKo_2040
+                return false;
+            }
+
             if (trimmed.StartsWithAny(HyperlinkIndicators, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -233,6 +241,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     start += span.Length - trimmedStart.Length;
                     end -= span.Length - trimmedEnd.Length;
+
+                    if (start > end)
+                    {
+                        // we are at the end, so nothing more to report
+                        break;
+                    }
 
                     var trimmed = text.AsSpan(start, end - start);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -153,6 +153,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
+            if (trimmed.EndsWithAny(Constants.WellknownFileExtensions, StringComparison.OrdinalIgnoreCase))
+            {
+                // do not report files
+                return false;
+            }
+
             if (trimmed.Length > 31 && Guid.TryParse(trimmed.ToString(), out _))
             {
                 return false;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -588,6 +588,22 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_para_phrase() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// <para>
+    ///   This option affects the way the generated SFX runs. By default it is
+    ///   false.  When you set it to true,...
+    /// </para>
+    /// </summary>
+    void DoSomething();
+}
+");
+
         protected override string GetDiagnosticId() => MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -301,13 +301,28 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_file_extension() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_correctly_documented_method_with_file_extension_in_quotes() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
 {
     /// <summary>
     /// Does something regarding '*.ZipFile' that is very important.
+    /// </summary>
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_documented_method_with_file_extension_not_in_quotes() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something regarding *.txt that is very important.
     /// </summary>
     public void DoSomething()
     {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -10,6 +10,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [TestFixture]
     public sealed class MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests : CodeFixVerifier
     {
+        private static readonly string[] WellknownWords =
+                                                          [
+                                                              "IntelliSense",
+                                                              "FxCop",
+                                                              "StyleCop",
+                                                              "SonarCube",
+                                                              "SonarQube",
+                                                              "CSharp",
+                                                              "VisualBasic",
+                                                              "NCrunch",
+                                                              "NCrunch's",
+                                                              "NCover",
+                                                              "PostSharp",
+                                                              "SonarLint",
+                                                              "ReSharper",
+                                                              "ASP.NET",
+                                                              "Microsoft",
+                                                              "Outlook",
+                                                          ];
+
         [Test]
         public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 using System;
@@ -236,8 +256,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_known_text_([Values("IntelliSense", "FxCop", "StyleCop", "SonarCube", "SonarQube", "CSharp", "VisualBasic", "NCrunch", "NCrunch's", "NCover", "PostSharp", "SonarLint", "ReSharper", "ASP.NET")] string text)
-            => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_correctly_documented_method_with_known_text_([ValueSource(nameof(WellknownWords))] string text) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -342,6 +342,35 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_para_phrase() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// <para>
+    ///   This option affects the way the generated SFX runs. By default it is
+    ///   false.  When you set it to true,...
+    /// </para>
+    /// </summary>
+    void DoSomething();
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_file_with_extension_([Values("zip", "exe", "pdf", "docx")] string extension) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// Can be SomeFile." + extension + @"
+    /// </summary>
+    void DoSomething();
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
 using System;
 
@@ -585,22 +614,6 @@ public class TestMe
     /// You may want to call stream.Seek() before.
     /// </summary>
     void DoSomething(Stream stream);
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_para_phrase() => No_issue_is_reported_for(@"
-using System;
-
-public class TestMe
-{
-    /// <summary>
-    /// <para>
-    ///   This option affects the way the generated SFX runs. By default it is
-    ///   false.  When you set it to true,...
-    /// </para>
-    /// </summary>
-    void DoSomething();
 }
 ");
 


### PR DESCRIPTION
- Enhanced `MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer` to recognize and handle language-specific words and file extensions, preventing incorrect reports.
- Introduced a centralized list of well-known file extensions in `Constants.cs` to avoid duplication.
- Added "Microsoft" and "Outlook" to the list of well-known words to improve documentation analysis.
- Updated tests to cover new scenarios, including handling of language-specific words and file extensions.
