### PR TITLE
Constants resorted

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -289,10 +289,10 @@ namespace MiKoSolutions.Analyzers
             internal const string SealedClassPhrase = "This class cannot be inherited.";
             internal const string SpecialOrPhrase = "-or-";
             internal const string StringReturnTypeStartingPhraseTemplate = "A {0} {1} ";
-            internal const string ValueConverterSummaryStartingPhrase = "Represents a converter that converts ";
             internal const string ThatContainsTerm = "that contains";
             internal const string ToSeekTerm = "to seek";
             internal const string TryStartingPhrase = "Attempts to";
+            internal const string ValueConverterSummaryStartingPhrase = "Represents a converter that converts ";
             internal const string WasNotSuccessfulPhrase = "was not successful";
             internal const string WhenAllTaskReturnTypeStartingPhrase = "A task that represents the completion of all of the supplied tasks.";
             internal const string WhenAnyTaskReturnTypeStartingPhraseTemplate = "A {0} that represents the completion of one of the supplied tasks. Its {1} is the task that completed first.";


### PR DESCRIPTION
- Reordered the `ValueConverterSummaryStartingPhrase` constant in the `Constants.cs` file for better organization and readability.
