### PR TITLE
GetTextWithoutTrivia now directly returns a string so that we do not need to convert the return value back to a string

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1103,7 +1103,7 @@ namespace MiKoSolutions.Analyzers
             return result;
         }
 
-        internal static ReadOnlySpan<char> GetTextWithoutTrivia(this XmlTextSyntax value)
+        internal static string GetTextWithoutTrivia(this XmlTextSyntax value)
         {
             if (value is null)
             {
@@ -1119,7 +1119,7 @@ namespace MiKoSolutions.Analyzers
 
             var result = builder.Trim();
 
-            return result.AsSpan();
+            return result;
         }
 
         internal static StringBuilder GetTextWithoutTrivia(this XmlElementSyntax value) => value?.GetTextWithoutTrivia(new StringBuilder());

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -137,7 +137,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (content.FirstOrDefault() is XmlTextSyntax t)
             {
-                var text = t.GetTextWithoutTrivia();
+                var text = t.GetTextWithoutTrivia().AsSpan();
 
                 if (text.StartsWith("Interaction logic for", StringComparison.Ordinal))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             else
                             {
                                 // inspect first and last word
-                                var words = text.WordsAsSpan();
+                                var words = text.AsSpan().WordsAsSpan();
 
                                 if (words.First().Text.StartsWithAny(InheritMarkerTexts, StringComparison.OrdinalIgnoreCase)
                                  || words.Last().Text.ToString().ContainsAny(InheritMarkerTexts, StringComparison.OrdinalIgnoreCase))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 case 0:
                     return CommentStartingWith(preparedComment, phrase + Constants.TODO + ".");
 
-                case 1 when contents[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsEmpty:
+                case 1 when contents[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
                     return comment.ReplaceNode(text, XmlText(phrase + Constants.TODO + ".").WithLeadingXmlComment().WithTrailingXmlComment());
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -136,7 +136,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 case 1 when contents[0] is XmlTextSyntax t:
                 {
-                    var text = t.GetTextWithoutTrivia();
+                    var text = t.GetTextWithoutTrivia().AsSpan();
 
                     if (text.IsEmpty)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
@@ -88,7 +88,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         if (text.StartsWithAny(ContinueTextParts))
                         {
-                            var newText = text.ToString().Without(ContinueTextParts);
+                            var newText = text.Without(ContinueTextParts);
 
                             if (newText.EndsWith('.') is false)
                             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var text = txt.GetTextWithoutTrivia();
 
-                if (text.StartsWith("Enum"))
+                if (text.StartsWith("Enum", StringComparison.Ordinal))
                 {
                     var enumMember = txt.FirstAncestor<EnumMemberDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (syntax is XmlElementSyntax element && element.Content.FirstOrDefault() is XmlTextSyntax text)
             {
-                var code = text.GetTextWithoutTrivia().ToString();
+                var code = text.GetTextWithoutTrivia();
 
                 return element.WithContent(XmlText(code));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -93,7 +94,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             void RemoveEmptyText(int i)
             {
-                if (content.Count > i && content[i] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsEmpty)
+                if (content.Count > i && content[i] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty())
                 {
                     content.RemoveAt(i);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -27,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 switch (content.Count)
                 {
                     case 0:
-                    case 1 when content[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsEmpty:
+                    case 1 when content[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
                         return new[] { Issue(summary) };
                 }
             }


### PR DESCRIPTION
- Refactored `GetTextWithoutTrivia` methods to return `string` instead of `ReadOnlySpan<char>`.
- Updated all usages of `GetTextWithoutTrivia` to accommodate the change in return type.
- Replaced `IsEmpty` checks with `IsNullOrEmpty` for string handling.
- Added `StringComparison.Ordinal` to `StartsWith` method for explicit comparison.
- Added necessary `System` namespace imports where required.
