### PR TITLE
Added rule MiKo_2233 to report (and fix) empty XML tags spanning multiple lines

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -130,6 +130,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2231_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -149,6 +149,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_XmlFragmentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2231_InheritdocGetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_EmptySummaryAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8347,6 +8347,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place on same line.
+        /// </summary>
+        internal static string MiKo_2233_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2233_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code readability improves when XML tags span a single line. This makes the code clearer and easier to follow..
+        /// </summary>
+        internal static string MiKo_2233_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2233_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place XML tag on single line.
+        /// </summary>
+        internal static string MiKo_2233_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2233_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XML tags should be placed on single line.
+        /// </summary>
+        internal static string MiKo_2233_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2233_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2947,6 +2947,18 @@ However, these suppressions should remain inline comments and must not be part o
   <data name="MiKo_2232_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation should not be empty</value>
   </data>
+  <data name="MiKo_2233_CodeFixTitle" xml:space="preserve">
+    <value>Place on same line</value>
+  </data>
+  <data name="MiKo_2233_Description" xml:space="preserve">
+    <value>Code readability improves when XML tags span a single line. This makes the code clearer and easier to follow.</value>
+  </data>
+  <data name="MiKo_2233_MessageFormat" xml:space="preserve">
+    <value>Place XML tag on single line</value>
+  </data>
+  <data name="MiKo_2233_Title" xml:space="preserve">
+    <value>XML tags should be placed on single line</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_CodeFixProvider.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2233_CodeFixProvider)), Shared]
+    public sealed class MiKo_2233_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2233";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<XmlEmptyElementSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is XmlEmptyElementSyntax element)
+            {
+                return element.WithLessThanToken(element.LessThanToken.WithoutTrivia())
+                              .WithName(element.Name.WithoutTrivia())
+                              .WithAttributes(element.Attributes.Select(GetUpdatedSyntax).ToSyntaxList())
+                              .WithSlashGreaterThanToken(element.SlashGreaterThanToken.WithoutTrivia());
+            }
+
+            return base.GetUpdatedSyntax(document, syntax, issue);
+        }
+
+        private static XmlAttributeSyntax GetUpdatedSyntax(XmlAttributeSyntax attribute) => attribute.WithoutTrivia()
+                                                                                                     .WithName(attribute.Name.WithoutTrivia())
+                                                                                                     .WithEqualsToken(attribute.EqualsToken.WithoutTrivia())
+                                                                                                     .WithStartQuoteToken(attribute.StartQuoteToken.WithoutTrivia())
+                                                                                                     .WithEndQuoteToken(attribute.EndQuoteToken.WithoutTrivia())
+                                                                                                     .WithLeadingSpace();
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer : DocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2233";
+
+        public MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeXmlEmptyElement, SyntaxKind.XmlEmptyElement);
+
+        private void AnalyzeXmlEmptyElement(SyntaxNodeAnalysisContext context)
+        {
+            var node = context.Node;
+
+            if (node.IsSpanningMultipleLines())
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_on_documentation_with_no_empty_XML_tag() => No_issue_is_reported_for(@"
+/// <summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_on_documentation_with_empty_XML_tag_on_single_line() => No_issue_is_reported_for(@"
+/// <inheritdoc />
+public sealed class TestMe
+{
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_LessThan_token_of_empty_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <
+/// inheritdoc />
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <inheritdoc/>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_SlashGreaterThan_token_of_empty_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <inheritdoc
+/// />
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <inheritdoc/>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_parameter_token_of_empty_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <inheritdoc
+/// cref=""TestMe"" />
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <inheritdoc cref=""TestMe""/>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_attribute_of_empty_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+public sealed class TestMe
+{
+    /// <summary>
+    /// Does something with <paramref
+    /// name=""o""/>.
+    /// </summary>
+    public void DoSomething(object o)
+    { }
+}
+";
+
+            const string FixedCode = @"
+public sealed class TestMe
+{
+    /// <summary>
+    /// Does something with <paramref name=""o""/>.
+    /// </summary>
+    public void DoSomething(object o)
+    { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2233_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 469 rules that are currently provided by the analyzer.
+The following tables lists all the 470 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -267,6 +267,7 @@ The following tables lists all the 469 rules that are currently provided by the 
 |MiKo_2229|Documentation should not contain left-over XML fragments|&#x2713;|&#x2713;|
 |MiKo_2231|Documentation of overridden 'GetHashCode()' methods shall use '&lt;inheritdoc /&gt;' marker|&#x2713;|&#x2713;|
 |MiKo_2232|&lt;summary&gt; documentation should not be empty|&#x2713;|&#x2713;|
+|MiKo_2233|XML tags should be placed on single line|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Implemented a new rule, MiKo_2233, to ensure empty XML tags do not span multiple lines.
- Added a code fix provider for automatically placing XML tags on a single line.
- Created unit tests to verify the functionality of the new analyzer and code fix.
- Updated project configuration to include the new analyzer and code fix provider.
- Updated resources and documentation to reflect the addition of the new rule.

(resolves #1137)