### PR TITLE
MiKo_2233 now also detects and fixes multi-line XML start and end tags

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_CodeFixProvider.cs
@@ -13,20 +13,33 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2233";
 
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<XmlEmptyElementSyntax>().FirstOrDefault();
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
         {
-            if (syntax is XmlEmptyElementSyntax element)
+            switch (syntax)
             {
-                return element.WithLessThanToken(element.LessThanToken.WithoutTrivia())
-                              .WithName(element.Name.WithoutTrivia())
-                              .WithAttributes(element.Attributes.Select(GetUpdatedSyntax).ToSyntaxList())
-                              .WithSlashGreaterThanToken(element.SlashGreaterThanToken.WithoutTrivia());
+                case XmlEmptyElementSyntax element: return GetUpdatedSyntax(element);
+                case XmlElementStartTagSyntax start: return GetUpdatedSyntax(start);
+                case XmlElementEndTagSyntax end: return GetUpdatedSyntax(end);
+                default:
+                    return base.GetUpdatedSyntax(document, syntax, issue);
             }
-
-            return base.GetUpdatedSyntax(document, syntax, issue);
         }
+
+        private static XmlElementStartTagSyntax GetUpdatedSyntax(XmlElementStartTagSyntax tag) => tag.WithLessThanToken(tag.LessThanToken.WithoutTrivia())
+                                                                                                     .WithName(tag.Name.WithoutTrivia())
+                                                                                                     .WithAttributes(tag.Attributes.Select(GetUpdatedSyntax).ToSyntaxList())
+                                                                                                     .WithGreaterThanToken(tag.GreaterThanToken.WithoutTrivia());
+
+        private static XmlElementEndTagSyntax GetUpdatedSyntax(XmlElementEndTagSyntax tag) => tag.WithLessThanSlashToken(tag.LessThanSlashToken.WithoutTrivia())
+                                                                                                 .WithName(tag.Name.WithoutTrivia())
+                                                                                                 .WithGreaterThanToken(tag.GreaterThanToken.WithoutTrivia());
+
+        private static XmlEmptyElementSyntax GetUpdatedSyntax(XmlEmptyElementSyntax element) => element.WithLessThanToken(element.LessThanToken.WithoutTrivia())
+                                                                                                       .WithName(element.Name.WithoutTrivia())
+                                                                                                       .WithAttributes(element.Attributes.Select(GetUpdatedSyntax).ToSyntaxList())
+                                                                                                       .WithSlashGreaterThanToken(element.SlashGreaterThanToken.WithoutTrivia());
 
         private static XmlAttributeSyntax GetUpdatedSyntax(XmlAttributeSyntax attribute) => attribute.WithoutTrivia()
                                                                                                      .WithName(attribute.Name.WithoutTrivia())

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
@@ -9,13 +9,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2233";
 
+        private static readonly SyntaxKind[] XmlTags = { SyntaxKind.XmlEmptyElement, SyntaxKind.XmlElementStartTag, SyntaxKind.XmlElementEndTag };
+
         public MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer() : base(Id, (SymbolKind)(-1))
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeXmlEmptyElement, SyntaxKind.XmlEmptyElement);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeXmlTags, XmlTags);
 
-        private void AnalyzeXmlEmptyElement(SyntaxNodeAnalysisContext context)
+        private void AnalyzeXmlTags(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_on_documentation_with_no_empty_XML_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_on_documentation_with_XML_start_and_end_tags_on_single_lines() => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something.
 /// </summary>
@@ -115,6 +115,106 @@ public sealed class TestMe
     /// </summary>
     public void DoSomething(object o)
     { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_LessThan_token_of_start_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <
+/// summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_GreaterThan_token_of_start_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <summary
+/// >
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_LessThanSlash_token_of_end_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// Does something.
+/// </
+/// summary>
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_documentation_with_GreaterThan_token_of_end_XML_tag_on_different_line()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// Does something.
+/// </summary
+/// >
+public sealed class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Does something.
+/// </summary>
+public sealed class TestMe
+{
 }
 ";
 


### PR DESCRIPTION
- Enhanced the `MiKo_2233_CodeFixProvider` to handle and fix multi-line XML start and end tags in documentation.
- Updated the analyzer to detect XML tags that span multiple lines, ensuring they are reported and fixed.
- Added comprehensive tests to verify the correct handling and fixing of multi-line XML tags in documentation.

(resolves #1137)