### PR TITLE
MiKo_1063 codefix is now aware of fields with prefixes

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -549,6 +549,24 @@ namespace Bla
             VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
+        [TestCase("config", "configuration")]
+        public void Code_gets_fixed_for_incorrectly_named_field_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        private int _###;
+    }
+}
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
         protected override string GetDiagnosticId() => MiKo_1063_AbbreviationsInNameAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1063_AbbreviationsInNameAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_1063_AbbreviationsInNameAnalyzer` to handle field prefixes when analyzing field names.
- Changed the return type of `AnalyzeName` methods to `Diagnostic[]` for consistency.
- Added a new test case to verify the code fix for incorrectly named fields with abbreviations.

