### PR TITLE
MiKo_3065 is now better aware of string.Format calls and does not report for non-format calls

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2091,6 +2091,12 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        internal static bool IsStringFormat(this InvocationExpressionSyntax value) => value.Expression is MemberAccessExpressionSyntax maes
+                                                                                   && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression)
+                                                                                   && maes.Expression is TypeSyntax invokedType
+                                                                                   && invokedType.IsString()
+                                                                                   && maes.GetName() == nameof(string.Format);
+
         internal static bool IsStruct(this ExpressionSyntax value, SemanticModel semanticModel)
         {
             var type = value.GetTypeSymbol(semanticModel);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
@@ -33,13 +33,13 @@
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <!-- Required by NCrunch on remote machines as those machines do not have the package installed -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- Required by NCrunch on remote machines as those machines do not have the package installed -->
   <ItemGroup Condition="'$(NCrunch)' != '1'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is InvocationExpressionSyntax node && IsLoggingCall(node, context.SemanticModel))
+            if (context.Node is InvocationExpressionSyntax node && node.IsStringFormat() && IsLoggingCall(node, context.SemanticModel))
             {
                 ReportDiagnostics(context, Issue(node));
             }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzerTests.cs
@@ -96,7 +96,7 @@ namespace log4net
 ");
 
         [Test]
-        public void No_issue_is_reported_for_Microsoft_logging_call_without_interpolation_([ValueSource(nameof(Methods))] string method) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Microsoft_logging_call_without_interpolation_and_simple_text_([ValueSource(nameof(Methods))] string method) => No_issue_is_reported_for(@"
 using System;
 using Microsoft.Extensions.Logging;
 
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Logging
 ");
 
         [Test]
-        public void No_issue_is_reported_for_Microsoft_logging_call_with_interpolation_as_argument_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Microsoft_logging_call_without_interpolation_and_template_placeholder_([ValueSource(nameof(Methods))] string method) => No_issue_is_reported_for(@"
 using System;
 using Microsoft.Extensions.Logging;
 
@@ -135,9 +135,9 @@ namespace Microsoft.Extensions.Logging
     {
         private ILogger _logger;
 
-        public void DoSomething(int i)
+        public void DoSomething()
         {
-            _logger." + method + @"(""some text for {i}"", $""some text for {i}"");
+            _logger." + method + @"(""some {text} here"", 42.ToString());
         }
     }
 }
@@ -162,6 +162,30 @@ namespace Microsoft.Extensions.Logging
         public void DoSomething(int i)
         {
             _logger." + method + @"($""some text for {i}"");
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Microsoft_logging_call_with_interpolation_as_argument_([ValueSource(nameof(Methods))] string method) => An_issue_is_reported_for(@"
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Logging
+{
+    public interface ILogger
+    {
+        public void " + method + @"(string message, params object[] args);
+    }
+
+    public class TestMe
+    {
+        private ILogger _logger;
+
+        public void DoSomething(int i)
+        {
+            _logger." + method + @"(""some text for {i}"", $""some text for {i}"");
         }
     }
 }


### PR DESCRIPTION
- Added a new method `IsStringFormat` to identify `string.Format` calls in the code.
- Updated the `AnalyzeInvocation` method to utilize the new `IsStringFormat` method for better detection of logging calls.
- Enhanced test cases to improve clarity and coverage, particularly for logging calls with interpolation.
- Reordered comments in the project file for better organization.

(resolves #1093)