### PR TITLE
Enhanced MiKo_2034 to be aware of specific phrase 'if …, the result is/will be <see…/>' and fix it properly

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -249,7 +249,9 @@ namespace MiKoSolutions.Analyzers
             internal const string DisposeParameterPhrase = "Indicates whether unmanaged resources shall be freed.";
             internal const string DisposeSummaryPhrase = "Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.";
             internal const string EnumStartingPhrase = "Defines values that specify ";
-            internal const string EnumTaskReturnTypeStartingPhraseTemplate = GenericTaskReturnTypeStartingPhraseTemplate + "the enumerated constant that is the ";
+            internal const string EnumReturnTypeStartingPhraseTemplate = "The enumerated constant that is the ";
+            internal const string EnumTaskReturnTypeContinuePhraseTemplate = "the enumerated constant that is the ";
+            internal const string EnumTaskReturnTypeStartingPhraseTemplate = GenericTaskReturnTypeStartingPhraseTemplate + EnumTaskReturnTypeContinuePhraseTemplate;
             internal const string EventArgsSummaryStartingPhrase = "Provides data for the ";
             internal const string EventHandlerSummaryStartingPhrase = "Handles the ";
             internal const string EventSummaryStartingPhrase = "Occurs ";
@@ -549,9 +551,9 @@ namespace MiKoSolutions.Analyzers
                                                                                        StringTaskReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"System.Threading.Tasks.Task`1.Result\"/>", "<see cref=\"System.String\" />", "consists of"),
                                                                                    };
 
-            internal static readonly string[] EnumReturnTypeStartingPhrase = { "The enumerated constant that is the ", };
+            internal static readonly string[] EnumReturnTypeStartingPhrase = { EnumReturnTypeStartingPhraseTemplate, };
 
-            internal static readonly string[] EnumTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + "the enumerated constant that is the ");
+            internal static readonly string[] EnumTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + EnumTaskReturnTypeContinuePhraseTemplate + "the ");
 
             internal static readonly string[] EnumerableReturnTypeStartingPhrase =
                                                                                    {

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -10,7 +10,7 @@ namespace System
     {
         public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, ReadOnlySpan<char> separatorChars) => SplitBy(value, separatorChars, StringSplitOptions.None);
 
-        public static IReadOnlyList<string> SplitBy(this ReadOnlySpan<char> value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        public static IReadOnlyList<string> SplitBy(this ReadOnlySpan<char> value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
         {
             if (value.IsNullOrWhiteSpace())
             {
@@ -49,7 +49,11 @@ namespace System
                 var lastPart = remainingString.Slice(index + finding.Length).ToString();
 
                 results.Add(lastPart);
-                results.Add(finding);
+
+                if (options != StringSplitOptions.RemoveEmptyEntries)
+                {
+                    results.Add(finding);
+                }
 
                 remainingString = remainingString.Slice(0, index);
             }
@@ -67,14 +71,14 @@ namespace System
 
         public static SplitReadOnlySpanEnumerator SplitBy(this ReadOnlySpan<char> value, char[] separatorChars, StringSplitOptions options) => SplitBy(value, separatorChars.AsSpan(), options);
 
-        public static IReadOnlyList<string> SplitBy(this string value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        public static IReadOnlyList<string> SplitBy(this string value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
         {
             if (value is null)
             {
                 return Array.Empty<string>();
             }
 
-            return SplitBy(value.AsSpan(), findings, comparison);
+            return SplitBy(value.AsSpan(), findings, comparison, options);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Composition;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using MiKoSolutions.Analyzers.Linguistics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
@@ -12,16 +15,78 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly string[] Parts = Constants.Comments.EnumTaskReturnTypeStartingPhraseTemplate.FormatWith("task", "|").Split('|');
 
+        private static readonly string[] UnwantedResultTexts = { ", the result will be", ", the result is" };
+
         public override string FixableDiagnosticId => "MiKo_2034";
 
         protected override XmlElementSyntax GenericComment(Document document, XmlElementSyntax comment, string memberName, GenericNameSyntax returnType)
         {
-            return Comment(comment, Parts[0], SeeCrefTaskResult(), Parts[1], RemoveStartingWord(comment));
+            var commentStart = Parts[0];
+            var commentEnd = Parts[1];
+
+            if (TryUpdateSpecialPhrase(comment, out var updatedComment))
+            {
+                return Comment(updatedComment, commentStart, SeeCrefTaskResult(), commentEnd.WithoutSuffix("the "), RemoveStartingWord(updatedComment));
+            }
+
+            return Comment(comment, commentStart, SeeCrefTaskResult(), commentEnd, RemoveStartingWord(comment));
         }
 
         protected override XmlElementSyntax NonGenericComment(Document document, XmlElementSyntax comment, string memberName, TypeSyntax returnType)
         {
-            return Comment(comment, Constants.Comments.EnumReturnTypeStartingPhrase, RemoveStartingWord(comment));
+            var text = Constants.Comments.EnumReturnTypeStartingPhrase[0];
+
+            if (TryUpdateSpecialPhrase(comment, out var updatedComment))
+            {
+                return Comment(updatedComment, text.WithoutSuffix("the "), RemoveStartingWord(updatedComment));
+            }
+
+            return Comment(comment, text, RemoveStartingWord(comment));
+        }
+
+        private static bool TryUpdateSpecialPhrase(XmlElementSyntax comment, out XmlElementSyntax updatedSyntax)
+        {
+            updatedSyntax = null;
+
+            var contents = comment.Content;
+
+            if (contents.First() is XmlTextSyntax t)
+            {
+                var text = t.GetTextWithoutTrivia();
+
+                if (text.StartsWith("If ", StringComparison.OrdinalIgnoreCase) && text.ContainsAny(UnwantedResultTexts))
+                {
+                    // get rid of the unwanted phrases and switch text parts
+                    var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
+                    var switchedText = string.Join(" ", parts).AdjustFirstWord(FirstWordHandling.MakeLowerCase);
+                    var startText = switchedText.AsBuilder().Insert(0, ' ').TrimEnd();
+
+                    var updatedContents = contents.Remove(t);
+
+                    if (updatedContents.Count <= 1)
+                    {
+                        updatedContents = updatedContents.Add(XmlText(startText));
+                    }
+                    else
+                    {
+                        if (updatedContents[1] is XmlTextSyntax t1)
+                        {
+                            updatedContents = updatedContents.Replace(t1, t1.WithStartText(startText));
+                        }
+                        else
+                        {
+                            // insert at position 1, so that it is positioned after the <see> that's probably there
+                            updatedContents = updatedContents.Insert(1, XmlText(startText));
+                        }
+                    }
+
+                    updatedSyntax = comment.WithContent(updatedContents);
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static SyntaxList<XmlNodeSyntax> RemoveStartingWord(XmlElementSyntax comment) => RemoveStartingWord(comment.WithoutFirstXmlNewLine(), Constants.Comments.ParameterStartingCodefixPhrase);

--- a/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
@@ -15,23 +15,19 @@ namespace MiKoSolutions.Analyzers.Extensions
         private const string Text = $"{Line1}\r\n{Line2}";
 
         [Test]
-        public static void SplitBy_splits_text_by_lines_and_removes_empty_lines()
+        public static void SplitBy_splits_text_by_words()
         {
-            var lines = Text.AsSpan().SplitBy(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            var count = lines.Count();
+            var words = new List<string>();
 
-            Assert.That(count, Is.EqualTo(2));
-
-            var foundLines = new List<string>();
-
-            foreach (var line in lines)
+            foreach (ReadOnlySpan<char> line in Text.AsSpan().SplitBy(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
             {
-                foundLines.Add(line.ToString());
+                foreach (var item in line.SplitBy(" "))
+                {
+                    words.Add(item.ToString());
+                }
             }
 
-            Assert.That(foundLines.Count, Is.EqualTo(2));
-            Assert.That(foundLines[0], Is.EqualTo(Line1));
-            Assert.That(foundLines[1], Is.EqualTo(Line2));
+            Assert.That(words, Is.EqualTo(new[] { "This", "is", "a", "test", "to", "see", "if", "everything", "is", "working", "Another", "line.", "Some", "more", "text." }));
         }
 
         [Test]
@@ -56,19 +52,33 @@ namespace MiKoSolutions.Analyzers.Extensions
         }
 
         [Test]
-        public static void SplitBy_splits_text_by_words()
+        public static void SplitBy_splits_text_by_lines_and_removes_empty_lines()
         {
-            var words = new List<string>();
+            var lines = Text.AsSpan().SplitBy(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            var count = lines.Count();
 
-            foreach (ReadOnlySpan<char> line in Text.AsSpan().SplitBy(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+            Assert.That(count, Is.EqualTo(2));
+
+            var foundLines = new List<string>();
+
+            foreach (var line in lines)
             {
-                foreach (var item in line.SplitBy(" "))
-                {
-                    words.Add(item.ToString());
-                }
+                foundLines.Add(line.ToString());
             }
 
-            Assert.That(words, Is.EqualTo(new[] { "This", "is", "a", "test", "to", "see", "if", "everything", "is", "working", "Another", "line.", "Some", "more", "text." }));
+            Assert.That(foundLines.Count, Is.EqualTo(2));
+            Assert.That(foundLines[0], Is.EqualTo(Line1));
+            Assert.That(foundLines[1], Is.EqualTo(Line2));
+        }
+
+        [Test]
+        public static void SplitBy_splits_text_by_lines_and_removes_empty_lines_MultiFindings()
+        {
+            var lines = "something text to split".AsSpan().SplitBy([" text "], options: StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.That(lines.Count, Is.EqualTo(2));
+            Assert.That(lines[0], Is.EqualTo("something"));
+            Assert.That(lines[1], Is.EqualTo("to split"));
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2034_EnumReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2034_EnumReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -125,14 +125,16 @@ public class TestMe
 }
 ");
 
-        [TestCase("Something.", "something.")]
-        [TestCase(@"Something, such as <see cref=""string.Empty""/>.", @"something, such as <see cref=""string.Empty""/>.")]
-        [TestCase("The something.", "something.")]
-        [TestCase("the something.", "something.")]
-        [TestCase("A something.", "something.")]
-        [TestCase("a something.", "something.")]
-        [TestCase("An something.", "something.")]
-        [TestCase("an something.", "something.")]
+        [TestCase("Something.", "the something.")]
+        [TestCase("A something.", "the something.")]
+        [TestCase("a something.", "the something.")]
+        [TestCase("An something.", "the something.")]
+        [TestCase("an something.", "the something.")]
+        [TestCase("The something.", "the something.")]
+        [TestCase("the something.", "the something.")]
+        [TestCase("""Something, such as <see cref="string.Empty"/>.""", """the something, such as <see cref="string.Empty"/>.""")]
+        [TestCase("""If something, the result is <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
+        [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
         public void Code_gets_fixed_for_non_generic_method_(string originalText, string fixedText)
         {
             var originalCode = @"
@@ -157,7 +159,7 @@ public class TestMe
     /// Does something.
     /// </summary>
     /// <returns>
-    /// The enumerated constant that is the " + fixedText + @"
+    /// The enumerated constant that is " + fixedText + @"
     /// </returns>
     public StringComparison DoSomething(object o) => null;
 }
@@ -166,10 +168,18 @@ public class TestMe
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
-        [TestCase("Something.", "something.")]
-        [TestCase(@"Something, such as <see cref=""string.Empty""/>.", @"something, such as <see cref=""string.Empty""/>.")]
-        [TestCase("The something.", "something.")]
-        [TestCase("the something.", "something.")]
+        [TestCase("Something.", "the something.")]
+        [TestCase("A something.", "the something.")]
+        [TestCase("a something.", "the something.")]
+        [TestCase("An something.", "the something.")]
+        [TestCase("an something.", "the something.")]
+        [TestCase("The something.", "the something.")]
+        [TestCase("the something.", "the something.")]
+        [TestCase("""Something, such as <see cref="string.Empty"/>.""", """the something, such as <see cref="string.Empty"/>.""")]
+        [TestCase("""If something, the result is <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
+        [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
+        [TestCase("""If something, the result is <see cref="StringComparison.Ordinal"/>""", """<see cref="StringComparison.Ordinal"/> if something""")]
+        [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>""", """<see cref="StringComparison.Ordinal"/> if something""")]
         public void Code_gets_fixed_for_generic_method_(string originalText, string fixedText)
         {
             var originalCode = @"
@@ -196,7 +206,7 @@ public class TestMe
     /// Does something.
     /// </summary>
     /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter contains the enumerated constant that is the " + fixedText + @"
+    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter contains the enumerated constant that is " + fixedText + @"
     /// </returns>
     public Task<StringComparison> DoSomething(object o) => null;
 }


### PR DESCRIPTION
- Enhanced the MiKo_2034 codefix provider to correctly handle specific phrases in return type comments.
- Introduced new constants and refactored existing ones for better phrase management.
- Updated `SplitBy` method in `StringSplitExtensions` to include `StringSplitOptions` for more flexible splitting.
- Modified and added tests to ensure the new logic and enhancements work as expected.

(resolves #1150)