### PR TITLE
MiKo_6006 (and other surrounding lines codefixes) are now aware of trailing comments

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3568,6 +3568,8 @@ namespace MiKoSolutions.Analyzers
             return value;
         }
 
+        internal static T WithAdditionalTrailingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithAdditionalTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
         internal static T WithTrailingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
 
         internal static T WithTrailingNewLine<T>(this T value) where T : SyntaxNode => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed); // do not use an elastic one to enforce the line break

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesCodeFixProvider.cs
@@ -33,7 +33,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             if (issue.Properties.ContainsKey(Constants.AnalyzerCodeFixSharedData.NoLineAfter))
             {
-                result = result.WithTrailingEmptyLine();
+                result = result.HasTrailingComment()
+                         ? result.WithAdditionalTrailingEmptyLine()
+                         : result.WithTrailingEmptyLine();
             }
 
             return result;

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzerTests.cs
@@ -746,6 +746,194 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_awaited_call_not_preceded_by_blank_line_with_single_line_comment()
+        {
+            const string OriginalCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            DoSomethingElse();
+            await Task.CompletedTask; // some comment
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            DoSomethingElse();
+
+            await Task.CompletedTask; // some comment
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_awaited_call_not_followed_by_blank_line_with_single_line_comment()
+        {
+            const string OriginalCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            await Task.CompletedTask; // some comment
+            DoSomethingElse();
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            await Task.CompletedTask; // some comment
+
+            DoSomethingElse();
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_awaited_call_not_preceded_by_blank_line_with_multi_line_comment()
+        {
+            const string OriginalCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            DoSomethingElse();
+            await Task.CompletedTask; /* some comment */
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            DoSomethingElse();
+
+            await Task.CompletedTask; /* some comment */
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_awaited_call_not_followed_by_blank_line_with_multi_line_comment()
+        {
+            const string OriginalCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            await Task.CompletedTask; /* some comment */
+            DoSomethingElse();
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Threading.Tasks;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public async Task DoSomething()
+        {
+            await Task.CompletedTask; /* some comment */
+
+            DoSomethingElse();
+        }
+
+        private void DoSomethingElse()
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzer();


### PR DESCRIPTION
- Added a new method `WithAdditionalTrailingEmptyLine` to handle syntax nodes with trailing comments, ensuring proper spacing.
- Enhanced the `SurroundedByBlankLinesCodeFixProvider` to apply additional trailing empty lines when trailing comments are present.
- Introduced new test cases in `MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzerTests` to verify the behavior of awaited calls with single and multi-line comments.
