### PR TITLE
Added new rule MiKo_6071 for local statements with using modifiers

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -380,6 +380,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -543,6 +543,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -16168,5 +16168,41 @@ namespace MiKoSolutions.Analyzers {
                 return ResourceManager.GetString("MiKo_6070_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Surround with blank lines.
+        /// </summary>
+        internal static string MiKo_6071_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6071_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Surround local &apos;using&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
+        /// </summary>
+        internal static string MiKo_6071_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6071_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Surround local &apos;using&apos; with a blank line.
+        /// </summary>
+        internal static string MiKo_6071_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6071_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local using statements should be surrounded by blank lines.
+        /// </summary>
+        internal static string MiKo_6071_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6071_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5612,4 +5612,16 @@ This organization ensures clarity and makes the code easier to find, understand 
   <data name="MiKo_6070_Title" xml:space="preserve">
     <value>Console statements should be surrounded by blank lines</value>
   </data>
+  <data name="MiKo_6071_CodeFixTitle" xml:space="preserve">
+    <value>Surround with blank lines</value>
+  </data>
+  <data name="MiKo_6071_Description" xml:space="preserve">
+    <value>Surround local 'using' statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow.</value>
+  </data>
+  <data name="MiKo_6071_MessageFormat" xml:space="preserve">
+    <value>Surround local 'using' with a blank line</value>
+  </data>
+  <data name="MiKo_6071_Title" xml:space="preserve">
+    <value>Local using statements should be surrounded by blank lines</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6071_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6071_CodeFixProvider.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6071_CodeFixProvider)), Shared]
+    public sealed class MiKo_6071_CodeFixProvider : SurroundedByBlankLinesCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6071";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<LocalDeclarationStatementSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer : StatementSurroundedByBlankLinesAnalyzer<LocalDeclarationStatementSyntax>
+    {
+        public const string Id = "MiKo_6071";
+
+        public MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer() : base(SyntaxKind.LocalDeclarationStatement, Id)
+        {
+        }
+
+        protected override SyntaxToken GetKeyword(LocalDeclarationStatementSyntax node) => node.UsingKeyword;
+
+        protected override bool ShallAnalyzeStatement(LocalDeclarationStatementSyntax node) => node.UsingKeyword.IsDefaultValue() is false;
+
+        protected override bool ShallAnalyzeOtherStatement(StatementSyntax node)
+        {
+            if (node is LocalDeclarationStatementSyntax local)
+            {
+                // ignore other using statements
+                return ShallAnalyzeStatement(local) is false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzerTests.cs
@@ -1,0 +1,267 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_method() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_non_using_statements_in_method() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            var something = new TestMe();
+            DoSomething();
+            var something = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_using_statement_as_only_statement_in_method() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_using_statements_in_method() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something1 = new TestMe();
+            using var something2 = new TestMe();
+            using var something3 = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_using_statement_with_blank_line_before() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+
+            using var something = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_using_statement_with_blank_line_after() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+
+            DoSomething();
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_using_statement_without_blank_line_before() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+            using var something = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_using_statement_without_blank_line_after() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+            DoSomething();
+        }
+    }
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_separate_using_statements_without_blank_line_before_or_after() => An_issue_is_reported_for(2, @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+            DoSomething();
+            using var something = new TestMe();
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_using_statement_without_blank_line_before()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+            using var something = new TestMe();
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+
+            using var something = new TestMe();
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_using_statement_without_blank_line_after()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+            DoSomething();
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            using var something = new TestMe();
+
+            DoSomething();
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_using_statement_without_blank_line_before_and_after()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+            using var something = new TestMe();
+            DoSomething();
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe : IDisposable
+    {
+        public void DoSomething()
+        {
+            DoSomething();
+
+            using var something = new TestMe();
+
+            DoSomething();
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer();
+
+        protected override string GetDiagnosticId() => MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.Id;
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6071_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 470 rules that are currently provided by the analyzer.
+The following tables lists all the 471 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -514,3 +514,4 @@ The following tables lists all the 470 rules that are currently provided by the 
 |MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6061|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6070|Console statements should be surrounded by blank lines|&#x2713;|&#x2713;|
+|MiKo_6071|Local using statements should be surrounded by blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Introduced a new rule, MiKo_6071, to ensure local `using` statements are surrounded by blank lines for improved readability.
- Implemented an analyzer and code fix provider for the MiKo_6071 rule.
- Added comprehensive tests to verify the correct behavior of the new rule.
- Updated project configuration files to include the new analyzer and code fix provider.
- Updated documentation to reflect the addition of the new rule.


Note: This rule is similar to rule MiKo_6016 for using statements.

(resolves #1158)