### PR TITLE
'GetAllLocations' changed to increase performance

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
-                    var switchedText = string.Join(" ", parts).AdjustFirstWord(FirstWordHandling.MakeLowerCase);
+                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordHandling.MakeLowerCase);
                     var startText = switchedText.AsBuilder().Insert(0, ' ').TrimEnd();
 
                     var updatedContents = contents.Remove(t);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -215,8 +215,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var text = textToken.ValueText;
 
-                if (text.IsNullOrWhiteSpace())
+                if (text.Length <= 2 && text.IsNullOrWhiteSpace())
                 {
+                    // nothing to inspect as the text is too short and consists of whitespaces only
                     continue;
                 }
 


### PR DESCRIPTION
- Enhanced performance of `GetAllLocations` methods by changing `IEnumerable<string>` to `IReadOnlyList<string>` and optimizing loop structures.
- Improved string concatenation in `MiKo_2034_CodeFixProvider.cs` by using `ConcatenatedWith`.
- Added additional checks for text length in `MiKo_2040_LangwordAnalyzer.cs` to avoid unnecessary processing.
