### PR TITLE
MiKo_6040 is now aware of leading comments when moving nodes

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -520,14 +520,14 @@ namespace System.Text
 
                     var length = difference + 1; // increased by 1 to have the complete difference investigated
 
-                    if (difference < QuickCompareRentLengthThreshold)
+                    if (difference >= QuickCompareRentLengthThreshold)
                     {
-                        // could be part in the replacement only if characters match
-                        return QuickCompareAtIndices(ref current, ref otherFirst, ref otherLast, ref length, ref lastIndex);
+                        // use rented arrays here (if we have larger differences, the start and end may be in different chunks)
+                        return QuickCompareAtIndicesWithRent(ref current, ref otherFirst, ref otherLast, ref length, ref lastIndex);
                     }
 
-                    // use rented arrays here (if we have larger differences, the start and end may be in different chunks)
-                    return QuickCompareAtIndicesWithRent(ref current, ref otherFirst, ref otherLast, ref length, ref lastIndex);
+                    // could be part in the replacement only if characters match
+                    return QuickCompareAtIndices(ref current, ref otherFirst, ref otherLast, ref length, ref lastIndex);
                 }
 
                 // can be part in the replacement as other value is smaller and could fit current value

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -247,7 +247,7 @@ namespace MiKoSolutions.Analyzers
                 // we have to add the spaces after the comment, so we have to determine the additional spaces to add
                 var additionalSpaces = count - value.GetPositionWithinStartLine();
 
-                var leadingTrivia = value.LeadingTrivia;
+                var leadingTrivia = value.LeadingTrivia.ToList();
                 var triviaCount = leadingTrivia.Count;
 
                 // first collect all indices of the comments, for later reference
@@ -263,12 +263,15 @@ namespace MiKoSolutions.Analyzers
                     }
                 }
 
+                // ensure proper size to avoid multiple resizes
+                leadingTrivia.Capacity += additionalSpaces * indices.Count;
+
                 // now update the comments, but adjust the offset to remember the already added spaces (trivia indices change due to that)
                 var offset = 0;
 
                 foreach (var index in indices)
                 {
-                    leadingTrivia = leadingTrivia.InsertRange(index + offset, Spaces(additionalSpaces));
+                    leadingTrivia.InsertRange(index + offset, Spaces(additionalSpaces));
 
                     offset += additionalSpaces;
                 }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzerTests.cs
@@ -429,6 +429,132 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_and_adjusts_but_keeps_comment_with_empty_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public TestMe Start()
+    {
+        return new TestMe().DoSomethingMore()
+           .DoSomething(1, 2, 3)
+           .DoSomething(4, 5, 6)
+
+           // some comment here
+           .DoSomething(7, 8, 9);
+    }
+
+    public TestMe DoSomething(int x, int y, int z)
+    {
+        return this;
+    }
+
+    public TestMe DoSomethingMore()
+    {
+        return this;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public TestMe Start()
+    {
+        return new TestMe().DoSomethingMore()
+                           .DoSomething(1, 2, 3)
+                           .DoSomething(4, 5, 6)
+
+                           // some comment here
+                           .DoSomething(7, 8, 9);
+    }
+
+    public TestMe DoSomething(int x, int y, int z)
+    {
+        return this;
+    }
+
+    public TestMe DoSomethingMore()
+    {
+        return this;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_and_adjusts_but_keeps_multiple_comments_with_empty_lines()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public TestMe Start()
+    {
+        return new TestMe().DoSomethingMore()
+           .DoSomething(1, 2, 3)
+           .DoSomething(4, 5, 6)
+
+           // some comment
+           // some comment here
+           .DoSomething(7, 8, 9);
+    }
+
+    public TestMe DoSomething(int x, int y, int z)
+    {
+        return this;
+    }
+
+    public TestMe DoSomethingMore()
+    {
+        return this;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public TestMe Start()
+    {
+        return new TestMe().DoSomethingMore()
+                           .DoSomething(1, 2, 3)
+                           .DoSomething(4, 5, 6)
+
+                           // some comment
+                           // some comment here
+                           .DoSomething(7, 8, 9);
+    }
+
+    public TestMe DoSomething(int x, int y, int z)
+    {
+        return this;
+    }
+
+    public TestMe DoSomethingMore()
+    {
+        return this;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer();


### PR DESCRIPTION
- Fixed a bug where comments preceding multiline call chains were removed during formatting.
- Enhanced `SyntaxTokenExtensions` to correctly handle leading spaces when comments are present.
- Added new tests to ensure comments are preserved in multiline call chains.
- Updated `StringBuilderExtensions` to optimize string comparison logic.

(fixes #1163)