### PR TITLE
MiKo_6059 is now aware of lambdas

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -49,6 +49,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     case AssignmentExpressionSyntax assignment:
                         return assignment.OperatorToken;
+
+                    case LambdaExpressionSyntax lambda:
+                        return lambda.ArrowToken;
                 }
             }
 
@@ -78,6 +81,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     case AssignmentExpressionSyntax assignment:
                         return assignment.OperatorToken.GetPositionWithinEndLine() - 2;
+
+                    case LambdaExpressionSyntax lambda:
+                        return lambda.ArrowToken.GetPositionWithinEndLine() - 2;
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
@@ -1253,6 +1253,157 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void No_issue_is_reported_for_lambda_argument_in_same_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1 && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_lambda_argument_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                           && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_lambda_argument_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                                 && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_lambda_argument_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                    && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_lambda_argument_in_case_operator_is_indented_below_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                                 && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                           && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_lambda_argument_in_case_operator_is_outdented_to_left_operand()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                    && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition1, bool condition2)
+    {
+        DoSomethingElse(() => condition1
+                           && condition2);
+    }
+
+    public void DoSomethingElse(Func<bool> condition)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer();


### PR DESCRIPTION
- Enhanced the `MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer` to handle lambda expressions, ensuring correct indentation of boolean operators.
- Added comprehensive test cases to verify the correct handling of boolean operators in lambda expressions, including both correct and incorrect indentation scenarios.
- Fixed the indentation issue reported in the ticket by ensuring lambda expressions are correctly processed.

(fixes #1164)