### PR TITLE
MiKo_1107 and MiKo_1115 are now aware if test method names start with tested method names

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzer.cs
@@ -24,9 +24,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
         {
-            if (HasIssue(symbol.Name))
+            var symbolName = symbol.Name;
+
+            if (HasIssue(symbolName))
             {
-                var betterName = NamesFinder.FindBetterTestName(symbol.Name);
+                var betterName = NamesFinder.FindBetterTestName(symbolName, symbol);
 
                 return new[] { Issue(symbol, CreateBetterNameProposal(betterName)) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using MiKoSolutions.Analyzers.Linguistics;
@@ -135,31 +134,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var name = symbolName.Replace("_Expect_", "_");
 
-            var betterName = NamesFinder.FindBetterTestName(TryGetInOrder(name, out var nameInOrder) ? nameInOrder : name);
+            var nameToImprove = TryGetInOrder(name, out var nameInOrder)
+                                ? nameInOrder
+                                : name;
 
-            // let's see if the test name starts with any method/property/event/field name that shall be kept
-            var index = symbolName.IndexOf(Constants.Underscore);
-
-            if (index > 0)
-            {
-                var methodName = symbolName.Substring(0, index);
-
-                if (symbol.GetSyntax().DescendantNodes<IdentifierNameSyntax>().Any(_ => _.GetName() == methodName))
-                {
-                    var betterNamePrefix = NamesFinder.FindBetterTestName(methodName);
-
-                    if (betterName.StartsWith(betterNamePrefix, StringComparison.Ordinal))
-                    {
-                        var fixedBetterName = betterName.AsBuilder()
-                                                        .Remove(0, betterNamePrefix.Length)
-                                                        .Insert(0, methodName)
-                                                        .ToString();
-                        return fixedBetterName;
-                    }
-                }
-            }
-
-            return betterName;
+            return NamesFinder.FindBetterTestName(nameToImprove, symbol);
         }
 
         private static bool TryGetInOrder(string name, out string result)

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -5,11 +5,85 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     public static class NamesFinder
     {
+        internal static string FindBetterTestName(string name, ISymbol symbol)
+        {
+            var betterName = FindBetterTestName(name);
+
+            // let's see if the test name starts with any method/property/event/field name that shall be kept
+            var symbolName = symbol.Name;
+
+            var index = symbolName.IndexOf(Constants.Underscore);
+
+            if (index > 0)
+            {
+                var methodName = symbolName.Substring(0, index);
+
+                if (symbol.GetSyntax().DescendantNodes<IdentifierNameSyntax>().Any(_ => _.GetName() == methodName))
+                {
+                    var betterNamePrefix = FindBetterTestName(methodName);
+
+                    if (betterName.StartsWith(betterNamePrefix, StringComparison.Ordinal))
+                    {
+                        var fixedBetterName = betterName.AsBuilder()
+                                                        .Remove(0, betterNamePrefix.Length)
+                                                        .Insert(0, methodName)
+                                                        .ToString();
+                        return fixedBetterName;
+                    }
+                }
+            }
+
+            return betterName;
+        }
+
+        internal static string FindDescribingWord(char c, string defaultValue = null)
+        {
+            switch (c)
+            {
+                case '[': return "OPENING_BRACKET";
+                case ']': return "CLOSING_BRACKET";
+                case '(': return "OPENING_PARENTHESIS";
+                case ')': return "CLOSING_PARENTHESIS";
+                case '}': return "OPENING_BRACE";
+                case '{': return "CLOSING_BRACE";
+                case '<': return "OPENING_CHEVRON";
+                case '>': return "CLOSING_CHEVRON";
+                case ' ': return "SPACE";
+                case '.': return "DOT";
+                case '?': return "QUESTION_MARK";
+                case '!': return "EXCLAMATION_MARK";
+                case ',': return "COMMA";
+                case ':': return "COLON";
+                case ';': return "SEMICOLON";
+                case '/': return "SLASH";
+                case '\\': return "BACKSLASH";
+                case Constants.Underscore: return "UNDERLINE";
+                case '+': return "PLUS";
+                case '-': return "MINUS";
+                case '*': return "ASTERIX";
+                case '=': return "EQUALS";
+                case '&': return "AMPERSAND";
+                case '%': return "PERCENT";
+                case '$': return "DOLLAR";
+                case '€': return "EURO";
+                case '§': return "PARAGRAPH";
+                case '~': return "TILDE";
+                case '#': return "HASH";
+                case '@': return "AT";
+                case '"': return "QUOTATION_MARK";
+                case '\'': return "APOSTROPHE";
+
+                default:
+                    return defaultValue;
+            }
+        }
+
         internal static IReadOnlyCollection<string> FindPropertyNames(IFieldSymbol symbol, string unwantedSuffix, string invocation)
         {
             // find properties
@@ -47,7 +121,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return propertyNames;
         }
 
-        internal static string FindBetterTestName(string symbolName)
+        private static string FindBetterTestName(string symbolName)
         {
             if (symbolName.Length < 3)
             {
@@ -120,48 +194,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ToString();
 
             return result;
-        }
-
-        internal static string FindDescribingWord(char c, string defaultValue = null)
-        {
-            switch (c)
-            {
-                case '[': return "OPENING_BRACKET";
-                case ']': return "CLOSING_BRACKET";
-                case '(': return "OPENING_PARENTHESIS";
-                case ')': return "CLOSING_PARENTHESIS";
-                case '}': return "OPENING_BRACE";
-                case '{': return "CLOSING_BRACE";
-                case '<': return "OPENING_CHEVRON";
-                case '>': return "CLOSING_CHEVRON";
-                case ' ': return "SPACE";
-                case '.': return "DOT";
-                case '?': return "QUESTION_MARK";
-                case '!': return "EXCLAMATION_MARK";
-                case ',': return "COMMA";
-                case ':': return "COLON";
-                case ';': return "SEMICOLON";
-                case '/': return "SLASH";
-                case '\\': return "BACKSLASH";
-                case Constants.Underscore: return "UNDERLINE";
-                case '+': return "PLUS";
-                case '-': return "MINUS";
-                case '*': return "ASTERIX";
-                case '=': return "EQUALS";
-                case '&': return "AMPERSAND";
-                case '%': return "PERCENT";
-                case '$': return "DOLLAR";
-                case '€': return "EURO";
-                case '§': return "PARAGRAPH";
-                case '~': return "TILDE";
-                case '#': return "HASH";
-                case '@': return "AT";
-                case '"': return "QUOTATION_MARK";
-                case '\'': return "APOSTROPHE";
-
-                default:
-                    return defaultValue;
-            }
         }
 
         private static string GetRegisteredName(IFieldSymbol symbol, string invocation)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
@@ -123,6 +123,52 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", original), Template.Replace("###", fix));
         }
 
+        [Test]
+        public void Code_gets_fixed_for_test_method_if_method_name_starts_with_called_method()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public bool DoSomething() => false;
+}
+
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething_ThrowException_InsteadToReturnSomething()
+    {
+        var objectUnderTest = new TestMe();
+
+        var result = objectUnderTest.DoSomething();
+
+        Assert.That(result, Is.True);
+    }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public bool DoSomething() => false;
+}
+
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething_throws_exception_instead_to_return_something()
+    {
+        var objectUnderTest = new TestMe();
+
+        var result = objectUnderTest.DoSomething();
+
+        Assert.That(result, Is.True);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_1107_TestMethodsPascalCasingAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1107_TestMethodsPascalCasingAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -172,6 +172,52 @@ public class TestMe
                                                                                                             "class TestMe { [Test] public void " + originalName + "() { } }",
                                                                                                             "class TestMe { [Test] public void " + fixedName + "() { } }");
 
+        [Test]
+        public void Code_gets_fixed_for_2_slashes_if_method_name_starts_with_called_method()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public bool DoSomething() => false;
+}
+
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething_SomeSituation_ReturnsTrue()
+    {
+        var objectUnderTest = new TestMe();
+
+        var result = objectUnderTest.DoSomething();
+
+        Assert.That(result, Is.True);
+    }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public bool DoSomething() => false;
+}
+
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething_returns_true_if_some_situation()
+    {
+        var objectUnderTest = new TestMe();
+
+        var result = objectUnderTest.DoSomething();
+
+        Assert.That(result, Is.True);
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer();


### PR DESCRIPTION
- Enhanced the logic in `MiKo_1107` and `MiKo_1115` analyzers to better handle test method names that start with method, event, or property names.
- Updated `NamesFinder` to include symbol context when finding better test names, ensuring method names are preserved.
- Added new test cases to verify the improved behavior of test method name handling.

(resolves #1148)