### PR TITLE
MiKo_2023 and MiKo_2060 key creation refactored, ToArray() used

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1099,7 +1099,7 @@ namespace MiKoSolutions.Analyzers
                                                                                               "candidateUnderTest",
                                                                                           };
 
-            internal static readonly ISet<string> TypeUnderTestFieldNames = Markers.FieldPrefixes.SelectMany(_ => TypeUnderTestRawFieldNames, (prefix, name) => prefix + name).ToHashSet();
+            internal static readonly ISet<string> TypeUnderTestFieldNames = Markers.FieldPrefixes.SelectMany(_ => TypeUnderTestRawFieldNames, string.Concat).ToHashSet();
 
             internal static readonly ISet<string> TypeUnderTestPropertyNames = new HashSet<string>
                                                                                    {
@@ -1120,7 +1120,7 @@ namespace MiKoSolutions.Analyzers
                                                                                        "Testee",
                                                                                    };
 
-            internal static readonly ISet<string> TypeUnderTestMethodNames = new[] { "Create", "Get" }.SelectMany(_ => TypeUnderTestPropertyNames, (prefix, name) => prefix + name).ToHashSet();
+            internal static readonly ISet<string> TypeUnderTestMethodNames = new[] { "Create", "Get" }.SelectMany(_ => TypeUnderTestPropertyNames, string.Concat).ToHashSet();
 
             internal static readonly ISet<string> TypeUnderTestVariableNames = new HashSet<string>
                                                                                    {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2675,7 +2675,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static T WithAdditionalLeadingTrivia<T>(this T value, SyntaxTriviaList trivia) where T : SyntaxNode
         {
-            return value.WithAdditionalLeadingTrivia(trivia.ToArray());
+            return value.WithLeadingTrivia(value.GetLeadingTrivia().AddRange(trivia));
         }
 
         internal static T WithAdditionalLeadingTrivia<T>(this T value, SyntaxTrivia trivia) where T : SyntaxNode
@@ -2690,7 +2690,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static T WithAdditionalTrailingTrivia<T>(this T value, SyntaxTriviaList trivia) where T : SyntaxNode
         {
-            return value.WithAdditionalTrailingTrivia(trivia.ToArray());
+            return value.WithTrailingTrivia(value.GetTrailingTrivia().AddRange(trivia));
         }
 
         internal static T WithAdditionalTrailingTrivia<T>(this T value, SyntaxTrivia trivia) where T : SyntaxNode

--- a/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                             "dictionary",
                                                         };
 
-        private static readonly string[] AllowedListNames = Constants.Markers.FieldPrefixes.SelectMany(_ => AllowedNames, (prefix, name) => prefix + name).ToArray();
+        private static readonly string[] AllowedListNames = Constants.Markers.FieldPrefixes.SelectMany(_ => AllowedNames, string.Concat).ToArray();
 
         private static readonly string[] PluralEndings = { "gers", "tchers", "pters", "stors", "ptors", "tures", "ties", "dges", "rges", "sages" };
         private static readonly string[] NonPluralEndings = { "ges", "nues", "curs", "opts", "nforms", "ses" };

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
@@ -51,8 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Pair[] ReplacementMap = ReplacementMapKeys.OrderByDescending(_ => _.Length)
                                                                           .ThenBy(_ => _)
-                                                                          .Select(_ => new Pair(_, Constants.Comments.EventHandlerSummaryStartingPhrase))
-                                                                          .ToArray();
+                                                                          .ToArray(_ => new Pair(_, Constants.Comments.EventHandlerSummaryStartingPhrase));
 
 //// ncrunch: rdi default
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("Determines to ", "value to "), // TODO RKN: new Pair("Determines to ", "value to "),
                                                         };
 
-        private static readonly string[] ReplacementMapKeys = ReplacementMap.Select(_ => _.Key).ToArray();
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
 
         public override string FixableDiagnosticId => "MiKo_2021";
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -148,14 +148,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     //    false: some other condition'
                     var replacement = text.Contains(':') ? ReplacementTo : Replacement;
 
-                    var data = FindMatchingReplacementMapKeysInUpperCase(text);
-                    var keysInUpperCase = data.KeysInUpperCase;
-                    var length = keysInUpperCase.Length;
+                    var data = FindMatchingReplacementMapKeys(text);
+                    var uniqueKeys = data.UniqueKeys;
+                    var length = uniqueKeys.Length;
 
 //// ncrunch: no coverage start
                     for (var index = 0; index < length; index++)
                     {
-                        var key = keysInUpperCase[index];
+                        var key = uniqueKeys[index];
 
                         if (text.StartsWith(key, StringComparison.OrdinalIgnoreCase))
                         {
@@ -177,7 +177,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                           .TrimStart(Constants.TrailingSentenceMarkers)
                                           .TrimEnd(Constants.TrailingSentenceMarkers);
 
-                        return FixTextOnlyComment(comment, t, subText, replacement, FindMatchingReplacementMapKeysInUpperCase(ReadOnlySpan<char>.Empty));
+                        return FixTextOnlyComment(comment, t, subText, replacement, FindMatchingReplacementMapKeys(ReadOnlySpan<char>.Empty));
                     }
 
                     break;
@@ -308,63 +308,66 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static ReadOnlySpan<char> ModifyOrNotPart(ReadOnlySpan<char> text) => text.WithoutSuffix(OrNotPhrase);
 
-        private static ConcreteMapInfo FindMatchingReplacementMapKeysInUpperCase(ReadOnlySpan<char> text)
+        private static ConcreteMapInfo FindMatchingReplacementMapKeys(ReadOnlySpan<char> text)
         {
             // now get all data
             var mappedDataValue = MappedData.Value;
 
-            if (text.StartsWith(StartWithArticleA, StringComparison.Ordinal))
+            if (text.Length > 0)
             {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForA, mappedDataValue.ReplacementMapKeysForA, mappedDataValue.ReplacementMapKeysInUpperCaseForA);
+                if (text.StartsWith(StartWithArticleA, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForA, mappedDataValue.ReplacementMapKeysForA, mappedDataValue.UniqueReplacementMapKeysForA);
+                }
+
+                if (text.StartsWith(StartWithArticleAn, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForAn, mappedDataValue.ReplacementMapKeysForAn, mappedDataValue.UniqueReplacementMapKeysForAn);
+                }
+
+                if (text.StartsWith(StartWithArticleThe, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForThe, mappedDataValue.ReplacementMapKeysForThe, mappedDataValue.UniqueReplacementMapKeysForThe);
+                }
+
+                if (text.StartsWith(StartWithParenthesis, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForParenthesis, mappedDataValue.ReplacementMapKeysForParenthesis, mappedDataValue.UniqueReplacementMapKeysForParenthesis);
+                }
+
+                if (text.StartsWith(StartWithArticleLowerCaseA, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseA, mappedDataValue.ReplacementMapKeysForLowerCaseA, mappedDataValue.UniqueReplacementMapKeysForA);
+                }
+
+                if (text.StartsWith(StartWithArticleLowerCaseAn, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseAn, mappedDataValue.ReplacementMapKeysForLowerCaseAn, mappedDataValue.UniqueReplacementMapKeysForAn);
+                }
+
+                if (text.StartsWith(StartWithArticleLowerCaseThe, StringComparison.Ordinal))
+                {
+                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseThe, mappedDataValue.ReplacementMapKeysForLowerCaseThe, mappedDataValue.UniqueReplacementMapKeysForThe);
+                }
             }
 
-            if (text.StartsWith(StartWithArticleAn, StringComparison.Ordinal))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForAn, mappedDataValue.ReplacementMapKeysForAn, mappedDataValue.ReplacementMapKeysInUpperCaseForAn);
-            }
-
-            if (text.StartsWith(StartWithArticleThe, StringComparison.Ordinal))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForThe, mappedDataValue.ReplacementMapKeysForThe, mappedDataValue.ReplacementMapKeysInUpperCaseForThe);
-            }
-
-            if (text.StartsWith(StartWithParenthesis, StringComparison.OrdinalIgnoreCase))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForParenthesis, mappedDataValue.ReplacementMapKeysForParenthesis, mappedDataValue.ReplacementMapKeysInUpperCaseForParenthesis);
-            }
-
-            if (text.StartsWith(StartWithArticleLowerCaseA, StringComparison.Ordinal))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseA, mappedDataValue.ReplacementMapKeysForLowerCaseA, mappedDataValue.ReplacementMapKeysInUpperCaseForA);
-            }
-
-            if (text.StartsWith(StartWithArticleLowerCaseAn, StringComparison.Ordinal))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseAn, mappedDataValue.ReplacementMapKeysForLowerCaseAn, mappedDataValue.ReplacementMapKeysInUpperCaseForAn);
-            }
-
-            if (text.StartsWith(StartWithArticleLowerCaseThe, StringComparison.Ordinal))
-            {
-                return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseThe, mappedDataValue.ReplacementMapKeysForLowerCaseThe, mappedDataValue.ReplacementMapKeysInUpperCaseForThe);
-            }
-
-            return new ConcreteMapInfo(mappedDataValue.ReplacementMapForOthers, mappedDataValue.ReplacementMapKeysForOthers, mappedDataValue.ReplacementMapKeysInUpperCaseForOthers);
+            return new ConcreteMapInfo(mappedDataValue.ReplacementMapForOthers, mappedDataValue.ReplacementMapKeysForOthers, mappedDataValue.UniqueReplacementMapKeysForOthers);
         }
 
         private readonly ref struct ConcreteMapInfo
         {
-            public ConcreteMapInfo(ReadOnlySpan<Pair> map, string[] keys, string[] keysInUpperCase)
+            public ConcreteMapInfo(ReadOnlySpan<Pair> map, string[] keys, string[] uniqueKeys)
             {
                 Map = map;
                 Keys = keys;
-                KeysInUpperCase = keysInUpperCase;
+                UniqueKeys = uniqueKeys;
             }
 
             public ReadOnlySpan<Pair> Map { get; }
 
             public string[] Keys { get; }
 
-            public string[] KeysInUpperCase { get; }
+            public string[] UniqueKeys { get; }
         }
 
         private sealed class MapData
@@ -488,28 +491,48 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 ReplacementMapForParenthesis = ToMapArray(replacementMap, replacementMapKeysForParenthesisHashSet, replacementMapCommon);
                 ReplacementMapForOthers = ToMapArray(replacementMap, replacementMapKeysForOthersHashSet, replacementMapCommon);
 
-                ReplacementMapKeysInUpperCaseForA = ToIgnoreCase(replacementMapKeysForA);
-                ReplacementMapKeysInUpperCaseForAn = ToIgnoreCase(replacementMapKeysForAn);
-                ReplacementMapKeysInUpperCaseForThe = ToIgnoreCase(replacementMapKeysForThe);
-                ReplacementMapKeysInUpperCaseForParenthesis = ToIgnoreCase(replacementMapKeysForParenthesis);
-                ReplacementMapKeysInUpperCaseForOthers = ToIgnoreCase(replacementMapKeysForOthersHashSet);
+                UniqueReplacementMapKeysForA = ToUnique(replacementMapKeysForA);
+                UniqueReplacementMapKeysForAn = ToUnique(replacementMapKeysForAn);
+                UniqueReplacementMapKeysForThe = ToUnique(replacementMapKeysForThe);
+                UniqueReplacementMapKeysForParenthesis = ToUnique(replacementMapKeysForParenthesis);
+                UniqueReplacementMapKeysForOthers = ToUnique(replacementMapKeysForOthersHashSet);
 
                 // now set keys here at the end as we want these keys sorted based on string contents (and only contain the smallest sub-sequences)
-                ReplacementMapKeysForA = GetTermsForQuickLookup(ReplacementMapKeysInUpperCaseForA);
-                ReplacementMapKeysForAn = GetTermsForQuickLookup(ReplacementMapKeysInUpperCaseForAn);
-                ReplacementMapKeysForThe = GetTermsForQuickLookup(ReplacementMapKeysInUpperCaseForThe);
+                ReplacementMapKeysForA = GetTermsForQuickLookup(UniqueReplacementMapKeysForA);
+                ReplacementMapKeysForAn = GetTermsForQuickLookup(UniqueReplacementMapKeysForAn);
+                ReplacementMapKeysForThe = GetTermsForQuickLookup(UniqueReplacementMapKeysForThe);
                 ReplacementMapKeysForLowerCaseA = ReplacementMapKeysForA;
                 ReplacementMapKeysForLowerCaseAn = ReplacementMapKeysForAn;
                 ReplacementMapKeysForLowerCaseThe = ReplacementMapKeysForThe;
-                ReplacementMapKeysForParenthesis = GetTermsForQuickLookup(ReplacementMapKeysInUpperCaseForParenthesis);
-                ReplacementMapKeysForOthers = GetTermsForQuickLookup(ReplacementMapKeysInUpperCaseForOthers);
+                ReplacementMapKeysForParenthesis = GetTermsForQuickLookup(UniqueReplacementMapKeysForParenthesis);
+                ReplacementMapKeysForOthers = GetTermsForQuickLookup(UniqueReplacementMapKeysForOthers);
 
-                string[] ToKeyArray(IEnumerable<string> keys, string text) => keys.Where(_ => _.StartsWith(text, StringComparison.Ordinal)).ToArray();
+                string[] ToKeyArray(string[] keys, string text)
+                {
+                    var length = keys.Length;
+
+                    var indexInResult = 0;
+                    var results = new string[length];
+
+                    for (var index = 0; index < length; index++)
+                    {
+                        var key = keys[index];
+
+                        if (key.StartsWith(text, StringComparison.Ordinal))
+                        {
+                            results[indexInResult++] = key;
+                        }
+                    }
+
+                    Array.Resize(ref results, indexInResult);
+
+                    return results;
+                }
 
                 Pair[] ToMapArray(ReadOnlySpan<Pair> map, HashSet<string> keys, Pair[] others)
                 {
-                    var results = new Pair[keys.Count + others.Length];
                     var resultIndex = 0;
+                    var results = new Pair[keys.Count + others.Length];
 
                     var count = map.Length;
 
@@ -530,7 +553,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return results;
                 }
 
-                string[] ToIgnoreCase(IEnumerable<string> strings) => new HashSet<string>(strings, StringComparer.OrdinalIgnoreCase).ToArray();
+                string[] ToUnique(IEnumerable<string> strings) => new HashSet<string>(strings, StringComparer.OrdinalIgnoreCase).ToArray();
             }
 
             public Pair[] ReplacementMapForA { get; }
@@ -565,15 +588,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             public string[] ReplacementMapKeysForLowerCaseThe { get; }
 
-            public string[] ReplacementMapKeysInUpperCaseForA { get; }
+            public string[] UniqueReplacementMapKeysForA { get; }
 
-            public string[] ReplacementMapKeysInUpperCaseForAn { get; }
+            public string[] UniqueReplacementMapKeysForAn { get; }
 
-            public string[] ReplacementMapKeysInUpperCaseForThe { get; }
+            public string[] UniqueReplacementMapKeysForThe { get; }
 
-            public string[] ReplacementMapKeysInUpperCaseForParenthesis { get; }
+            public string[] UniqueReplacementMapKeysForParenthesis { get; }
 
-            public string[] ReplacementMapKeysInUpperCaseForOthers { get; }
+            public string[] UniqueReplacementMapKeysForOthers { get; }
 
             private static Pair[] CreateReplacementMap()
             {
@@ -581,8 +604,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var textsCount = startTerms.Count;
 
-                var replacements = new Pair[textsCount];
                 var index = 0;
+                var replacements = new Pair[textsCount];
 
                 foreach (var text in startTerms.OrderBy(_ => _, ArticleStartComparer).ThenByDescending(_ => _.Length).ThenBy(_ => _))
                 {
@@ -594,45 +617,38 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             private static HashSet<string> CreateStartTerms()
             {
-                var startTerms = new[] { "A", "An", "The", string.Empty };
-                var optionals = new[] { "Optional", "(optional)", "(Optional)", "optional", string.Empty };
+                var optionalStarts = CreateStartTermsWithOptionals();
+
+                var optionalStartsLength = optionalStarts.Length;
+
                 var booleans = new[] { "bool", "Bool", "boolean", "Boolean", string.Empty };
                 var parameters = new[] { "flag", "Flag", "value", "Value", "parameter", "Parameter", "paramter", "Paramter", string.Empty };
+                var booleansLength = booleans.Length;
+                var parametersLength = parameters.Length;
 
-                var starts = new List<string>((startTerms.Length * optionals.Length * booleans.Length * parameters.Length) + 1) { string.Empty };
+                var starts = new List<string>((optionalStartsLength * booleansLength * parametersLength) + 1) { string.Empty };
 
-                // ReSharper disable once LoopCanBeConvertedToQuery
-                foreach (var startTerm in startTerms)
+                for (var optionalIndex = 0; optionalIndex < optionalStartsLength; optionalIndex++)
                 {
-                    // we have lots of loops, so cache data to avoid unnecessary calculations
-                    var s = startTerm + " ";
+                    var optionalStart = optionalStarts[optionalIndex];
 
-                    // ReSharper disable once LoopCanBeConvertedToQuery
-                    foreach (var optional in optionals)
+                    for (var booleanIndex = 0; booleanIndex < booleansLength; booleanIndex++)
                     {
                         // we have lots of loops, so cache data to avoid unnecessary calculations
-                        var optionalStart = s + optional + " ";
+                        var optionalBooleanStart = optionalStart.AsBuilder()
+                                                                .Append(booleans[booleanIndex])
+                                                                .Append(' ')
+                                                                .ReplaceWithCheck("   ", " ")
+                                                                .ReplaceWithCheck("  ", " ")
+                                                                .TrimStart();
 
-                        // ReSharper disable once LoopCanBeConvertedToQuery
-                        foreach (var boolean in booleans)
+                        for (var parameterIndex = 0; parameterIndex < parametersLength; parameterIndex++)
                         {
-                            // we have lots of loops, so cache data to avoid unnecessary calculations
-                            var optionalBooleanStart = optionalStart.AsBuilder()
-                                                                    .Append(boolean)
-                                                                    .Append(' ')
-                                                                    .ReplaceWithCheck("   ", " ")
-                                                                    .ReplaceWithCheck("  ", " ")
-                                                                    .TrimStart();
+                            var fixedStart = optionalBooleanStart.AsBuilder().Append(parameters[parameterIndex]).TrimEnd();
 
-                            // ReSharper disable once LoopCanBeConvertedToQuery
-                            foreach (var parameter in parameters)
+                            if (fixedStart.IsNullOrWhiteSpace() is false)
                             {
-                                var fixedStart = optionalBooleanStart.AsBuilder().Append(parameter).TrimEnd();
-
-                                if (fixedStart.IsNullOrWhiteSpace() is false)
-                                {
-                                    starts.Add(fixedStart);
-                                }
+                                starts.Add(fixedStart);
                             }
                         }
                     }
@@ -727,6 +743,33 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
 
                 return results;
+
+                string[] CreateStartTermsWithOptionals()
+                {
+                    var startTerms = new[] { "A ", "An ", "The ", " " };
+                    var optionals = new[] { "Optional ", "(optional) ", "(Optional) ", "optional ", " " };
+
+                    var startTermsLength = startTerms.Length;
+                    var optionalsLength = optionals.Length;
+
+                    var index = 0;
+                    var strings = new string[startTermsLength * optionalsLength];
+
+                    // we have lots of loops, so cache data to avoid unnecessary calculations
+                    for (var startTermIndex = 0; startTermIndex < startTermsLength; startTermIndex++)
+                    {
+                        var startTerm = startTerms[startTermIndex];
+
+                        for (var optionalIndex = 0; optionalIndex < optionalsLength; optionalIndex++)
+                        {
+                            var optional = optionals[optionalIndex];
+
+                            strings[index++] = startTerm + optional;
+                        }
+                    }
+
+                    return strings;
+                }
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                            "Parameter is not used",
                                                            "Parameter is ignored",
                                                        }
-                                                   .SelectMany(_ => SentenceEndings, (phrase, end) => phrase + end)
+                                                   .SelectMany(_ => SentenceEndings, string.Concat)
                                                    .ToArray();
 
         public MiKo_2026_StillUsedParamPhraseAnalyzer() : base(Id, (SymbolKind)(-1))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                          "with",
                                                      };
 
-        private static readonly string[] ReplacementMapKeys = CreateReplacementMapKeys().Distinct().ToArray();
+        private static readonly string[] ReplacementMapKeys = CreateReplacementMapKeys().ToHashSet().ToArray();
 
         private static readonly Pair[] ReplacementMap = ReplacementMapKeys.Select(_ => new Pair(_))
                                                                           .ToArray(_ => _.Key, AscendingStringComparer.Default);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -343,17 +343,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var strangeTexts = new[]
                                        {
-                                           "methods a", "methods instance", "methods new", "methods the", "factory class method", "method that are", "method which are",
+                                           "ethods a", "ethods instance", "ethods new", "ethods the", "actory class method", "ethod that are", "ethod which are",
                                            "es that is capable", "es which is capable", "es that is able", "es which is able",
                                            "ss that are capable", "ss which are capable", "ss that are able", "ss which are able",
                                            "y that are capable", "y which are capable", "y that are able", "y which are able",
                                            "rn that are capable", "rn which are capable", "rn that are able", "rn which are able",
                                            "ace that are capable", "ace which are capable", "ace that are able", "ace which are able",
                                            "ies that provides", "ies which provides",
-                                           "providing provid", "provides provid", "provide provid",
+                                           "roviding provid", "rovides provid", "rovide provid",
                                        };
 
-                results.RemoveWhere(_ => _.ContainsAny(strangeTexts));
+                results.RemoveWhere(_ => _.ContainsAny(strangeTexts, StringComparison.Ordinal));
 
                 return results.ToArray();
             }
@@ -485,10 +485,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
                 }
 
-                var resultsArray = new string[results.Count];
-                results.CopyTo(resultsArray);
-
-                return resultsArray;
+                return results.ToArray();
             }
 
             private static HashSet<string> CreateAllPhrases()
@@ -638,31 +635,35 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             private static IEnumerable<string> CreateAllContinuations()
             {
                 var continuations = new[]
-                                        {
-                                            string.Empty,
-                                            "a ",
-                                            "a instance of a ",
-                                            //// "a instances of a ", // currently ignored as this contains typos which we did not see in the wild
-                                            "a new instance of a ",
-                                            //// "a new instances of a ", // currently ignored as this contains typos which we did not see in the wild
-                                            "an ",
-                                            "an instance of an ",
-                                            //// "an instances of an ", // currently ignored as this contains typos which we did not see in the wild
-                                            //// "an new instance of an ", // currently ignored as this contains typos which we did not see in the wild
-                                            //// "an new instances of an ", // currently ignored as this contains typos which we did not see in the wild
-                                            "instance of ",
-                                            "instances of ",
-                                            "new instance of ",
-                                            "new instances of ",
-                                            "the ",
-                                            "the instance of the ",
-                                            "the instances of the ",
-                                            "the new instance of the ",
-                                            "the new instances of the ",
-                                        };
+                                    {
+                                        string.Empty,
+                                        "a ",
+                                        "a instance of a ",
+                                        //// "a instances of a ", // currently ignored as this contains typos which we did not see in the wild
+                                        "a new instance of a ",
+                                        //// "a new instances of a ", // currently ignored as this contains typos which we did not see in the wild
+                                        "an ",
+                                        "an instance of an ",
+                                        //// "an instances of an ", // currently ignored as this contains typos which we did not see in the wild
+                                        //// "an new instance of an ", // currently ignored as this contains typos which we did not see in the wild
+                                        //// "an new instances of an ", // currently ignored as this contains typos which we did not see in the wild
+                                        "instance of ",
+                                        "instances of ",
+                                        "new instance of ",
+                                        "new instances of ",
+                                        "the ",
+                                        "the instance of the ",
+                                        "the instances of the ",
+                                        "the new instance of the ",
+                                        "the new instances of the ",
+                                    };
 
-                foreach (var continuation in continuations)
+                var continuationsLength = continuations.Length;
+
+                for (var index = 0; index < continuationsLength; index++)
                 {
+                    var continuation = continuations[index];
+
                     yield return " that can build " + continuation;
                     yield return " that build " + continuation;
                     yield return " that builds " + continuation;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] ContinuationPhrases = { "whether ", "if " };
 
-        private static readonly string[] BooleanPhrases = new[] { " indicating ", " indicates ", " indicate " }.SelectMany(term1 => ContinuationPhrases, string.Concat)
+        private static readonly string[] BooleanPhrases = new[] { " indicating ", " indicates ", " indicate " }.SelectMany(_ => ContinuationPhrases, string.Concat)
                                                                                                                .ToArray();
 
         public MiKo_2071_EnumMethodSummaryAnalyzer() : base(Id, (SymbolKind)(-1))

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                            "are",
                                                        };
 
-        private static readonly string[] Prefixes = Constants.Markers.FieldPrefixes.SelectMany(_ => RawPrefixes, (prefix, name) => prefix + name).ToArray();
+        private static readonly string[] Prefixes = Constants.Markers.FieldPrefixes.SelectMany(_ => RawPrefixes, string.Concat).ToArray();
 
         private static readonly string[] AllowedPrefixes = Constants.Markers.FieldPrefixes.ToArray(_ => _ + "IsInDesign");
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -1007,9 +1007,9 @@ public class TestMe
 
             results.AddRange(types);
             results.AddRange(phrases);
-            results.AddRange(from type in types from phrase in phrases select type + " " + phrase);
-            results.AddRange(phrases.Select(_ => _.ToLower(CultureInfo.CurrentCulture)));
-            results.AddRange(phrases.Select(_ => _.ToUpper(CultureInfo.CurrentCulture)));
+            results.AddRange(from type in types from phrase in phrases select string.Concat(type, " ", phrase));
+            results.AddRange(phrases.Select(_ => _.ToLowerInvariant()));
+            results.AddRange(phrases.Select(_ => _.ToUpperInvariant()));
 
             results.Add("<see cref=\"ITestMe\"/>");
             results.Add("<see cref=\"ITestMe\" />");


### PR DESCRIPTION
- Refactored multiple files to replace lambda expressions with `string.Concat` for string concatenation, improving performance and readability.
- Optimized trivia handling in syntax node extensions by replacing `ToArray()` with `AddRange`.
- Enhanced replacement map key handling by ensuring uniqueness and improving logic.
- Fixed typos in string literals and improved filtering logic in replacement map key creation.
- Updated test cases to use consistent string concatenation methods.
