### PR TITLE
Added caching of StringBuilders to lower used memory and perform less garbage collections

### DIFF
--- a/BenchmarkConsole/Benchmarks.cs
+++ b/BenchmarkConsole/Benchmarks.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using BenchmarkDotNet.Attributes;
 
@@ -17,20 +13,8 @@ namespace BenchmarkConsole
         [Params(100, 125, 150, 175)]
         public int Times;
 
-        // [Benchmark(Baseline = true)]
-        public string HumanizedConcatenated_Before()
-        {
-            return data.HumanizedConcatenated();
-        }
-
-        // [Benchmark]
-        public string HumanizedConcatenated_After()
-        {
-            return HumanizedConcatenatedNew(data);
-        }
-
-        // [Benchmark(Baseline = true)]
-        // public void MiKo_2023_Original() => GC.KeepAlive(new MiKoSolutions.Analyzers.Rules.Documentation.MiKo_2023_CodeFixProvider.MapData());
+       // [Benchmark(Baseline = true)]
+       // public void MiKo_2023_Original() => GC.KeepAlive(new MiKoSolutions.Analyzers.Rules.Documentation.MiKo_2023_CodeFixProvider.MapData());
 
         // [Benchmark(Baseline = true)]
         // [Benchmark]
@@ -40,98 +24,8 @@ namespace BenchmarkConsole
         // [Benchmark]
         // public void MiKo_2060_Original() => GC.KeepAlive(new MiKoSolutions.Analyzers.Rules.Documentation.MiKo_2060_CodeFixProvider.MapData());
 
-        //[Benchmark(Baseline = true)]
+        // [Benchmark(Baseline = true)]
         // [Benchmark]
         // public void MiKo_2080_Original() => GC.KeepAlive(new MiKoSolutions.Analyzers.Rules.Documentation.MiKo_2080_CodeFixProvider.MapData());
-
-        [Benchmark]
-        public void ArrayViaNew()
-        {
-            GC.KeepAlive(new int[Times]);
-        }
-
-        [Benchmark]
-        public void SharedArrayPool()
-        {
-            var array = ArrayPool<int>.Shared.Rent(Times);
-            ArrayPool<int>.Shared.Return(array);
-        }
-
-        private string[] data;
-
-        [GlobalSetup]
-        public void Setup()
-        {
-            data = new string[Times];
-
-            Array.Fill(data, "a");
-        }
-
-        public static string HumanizedConcatenatedNew(IEnumerable<string> values, string lastSeparator = "or")
-        {
-            var items = values.Select(_ => _.SurroundedWithApostrophe()).ToArray();
-
-            var count = items.Length;
-
-            switch (count)
-            {
-                case 0: return string.Empty;
-                case 1: return items[0];
-            }
-
-            var items0 = items[0];
-            var items1 = items[1];
-
-            return HumanizedConcatenatedCore().ToString();
-
-            StringBuilder HumanizedConcatenatedCore()
-            {
-                const string Separator = ", ";
-
-                switch (count)
-                {
-                    case 2:
-                    {
-                        var builder = new StringBuilder(items0.Length + items1.Length + lastSeparator.Length + 2);
-
-                        return builder.Append(items0).Append(' ').Append(lastSeparator).Append(' ').Append(items1);
-                    }
-
-                    case 3:
-                    {
-                        var items2 = items[2];
-
-                        var builder = new StringBuilder(items0.Length + items1.Length + items2.Length + Separator.Length + lastSeparator.Length + 2);
-
-                        return builder.Append(items0).Append(Separator).Append(items1).Append(' ').Append(lastSeparator).Append(' ').Append(items2);
-                    }
-
-                    case 4:
-                    {
-                        var items2 = items[2];
-                        var items3 = items[3];
-
-                        var builder = new StringBuilder(items0.Length + items1.Length + items2.Length + items3.Length + Separator.Length + Separator.Length + lastSeparator.Length + 2);
-
-                        return builder.Append(items0).Append(Separator).Append(items1).Append(Separator).Append(items[2]).Append(' ').Append(lastSeparator).Append(' ').Append(items3);
-                    }
-
-                    default:
-                    {
-                        var builder = new StringBuilder(128);
-
-                        var last = count - 1;
-                        var beforeLast = last - 1;
-
-                        for (var index = 0; index < beforeLast; index++)
-                        {
-                            builder.Append(items[index]).Append(Separator);
-                        }
-
-                        return builder.Append(items[beforeLast]).Append(' ').Append(lastSeparator).Append(' ').Append(items[last]);
-                    }
-                }
-            }
-        }
     }
 }

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -301,6 +301,10 @@ namespace MiKoSolutions.Analyzers
             internal const string XmlElementEndingTag = "/>";
             internal const string XmlElementStartingTag = "<";
 
+            internal const string SingleWhitespaceString = " ";
+
+            internal static readonly string[] MultiWhitespaceStrings = { "    ", "   ", "  " };
+
             internal static readonly char[] Delimiters = { ' ', '.', ',', ';', ':', '!', '?' };
             internal static readonly string[] UnusedPhrase = { "Unused.", "Unused", "This parameter is not used.", "This parameter is not used" };
             internal static readonly string[] FuturePhrase = { "Reserved for future usage.", "Reserved for future usage", "Reserved.", "Reserved", "future", };

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -998,7 +998,7 @@ namespace System.Linq
             return result;
         }
 
-        internal static IEnumerable<T> Skip<T>(this SeparatedSyntaxList<T> source, int count) where T : SyntaxNode
+        internal static T[] Skip<T>(this SeparatedSyntaxList<T> source, int count) where T : SyntaxNode
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
@@ -1007,7 +1007,7 @@ namespace System.Linq
 
             if (difference <= 0)
             {
-                return Enumerable.Empty<T>();
+                return Array.Empty<T>();
             }
 
             var result = new T[difference];
@@ -1020,7 +1020,7 @@ namespace System.Linq
             return result;
         }
 
-        internal static IEnumerable<SyntaxToken> Skip(this SyntaxTokenList source, int count)
+        internal static SyntaxToken[] Skip(this SyntaxTokenList source, int count)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
@@ -1029,7 +1029,7 @@ namespace System.Linq
 
             if (difference <= 0)
             {
-                return Enumerable.Empty<SyntaxToken>();
+                return Array.Empty<SyntaxToken>();
             }
 
             var result = new SyntaxToken[difference];
@@ -1055,6 +1055,8 @@ namespace System.Linq
                 {
                     target[index] = source[index];
                 }
+
+                return target;
             }
 
             return Array.Empty<SyntaxToken>();

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace System.Text
     internal static class StringBuilderExtensions
     {
         private const int QuickCompareLengthThreshold = 4;
-        private const int QuickCompareRentLengthThreshold = 24;
+        private const int QuickCompareRentLengthThreshold = 22;
 
         public static bool IsNullOrWhiteSpace(this StringBuilder value) => value is null || value.CountLeadingWhitespaces() == value.Length;
 
@@ -419,7 +419,17 @@ namespace System.Text
             var start = value.CountLeadingWhitespaces();
             var end = value.CountTrailingWhitespaces(start);
 
-            return value.Remove(0, start).Remove(length - start - end, end);
+            if (end > 0)
+            {
+                value.Remove(length - end, end);
+            }
+
+            if (start > 0)
+            {
+                value.Remove(0, start);
+            }
+
+            return value;
         }
 
         public static string Trim(this StringBuilder value)
@@ -435,6 +445,20 @@ namespace System.Text
             var end = value.CountTrailingWhitespaces(start);
 
             return value.ToString(start, length - start - end);
+        }
+
+        public static StringBuilder TrimmedStart(this StringBuilder value)
+        {
+            var length = value.Length;
+
+            if (length == 0)
+            {
+                return value;
+            }
+
+            var start = value.CountLeadingWhitespaces();
+
+            return value.Remove(0, start);
         }
 
         public static string TrimStart(this StringBuilder value)
@@ -485,6 +509,25 @@ namespace System.Text
             }
 
             return value.Remove(length - count, count);
+        }
+
+        public static StringBuilder TrimmedEnd(this StringBuilder value)
+        {
+            var length = value.Length;
+
+            if (length == 0)
+            {
+                return value;
+            }
+
+            var end = value.CountTrailingWhitespaces();
+
+            if (end == 0)
+            {
+                return value;
+            }
+
+            return value.Remove(length - end, end);
         }
 
         public static StringBuilder Without(this StringBuilder value, string phrase) => value.ReplaceWithCheck(phrase, string.Empty); // ncrunch: no coverage

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1038,23 +1038,11 @@ namespace MiKoSolutions.Analyzers
 
                 if (token.HasStructuredTrivia)
                 {
-                    var leadingTrivia = token.LeadingTrivia;
-                    var count = leadingTrivia.Count;
-
-                    for (var index = 0; index < count; index++)
-                    {
-                        var trivia = leadingTrivia[index];
-
-                        if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
-                        {
-                            if (trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
-                            {
-                                yield return syntax;
-                            }
-                        }
-                    }
+                    return GetDocumentationCommentTriviaSyntax(token);
                 }
             }
+
+            return Array.Empty<DocumentationCommentTriviaSyntax>();
         }
 
         internal static string GetTextTrimmed(this XmlElementSyntax value)
@@ -3936,6 +3924,25 @@ namespace MiKoSolutions.Analyzers
             }
 
             return finalTrivia;
+        }
+
+        private static IEnumerable<DocumentationCommentTriviaSyntax> GetDocumentationCommentTriviaSyntax(SyntaxToken value)
+        {
+            var leadingTrivia = value.LeadingTrivia;
+            var count = leadingTrivia.Count;
+
+            for (var index = 0; index < count; index++)
+            {
+                var trivia = leadingTrivia[index];
+
+                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+                {
+                    if (trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
+                    {
+                        yield return syntax;
+                    }
+                }
+            }
         }
 
         private static XmlTextSyntax XmlText(string text) => SyntaxFactory.XmlText(text);

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -407,8 +407,6 @@ namespace MiKoSolutions.Analyzers
 
         internal static SyntaxToken WithText(this SyntaxToken value, string text) => SyntaxFactory.Token(value.LeadingTrivia, value.Kind(), text, text, value.TrailingTrivia);
 
-        internal static SyntaxToken WithText(this SyntaxToken value, StringBuilder text) => WithText(value, text.ToString());
-
         internal static SyntaxToken WithText(this SyntaxToken value, ReadOnlySpan<char> text) => value.WithText(text.ToString());
 
         internal static SyntaxToken WithTrailingEmptyLine(this SyntaxToken value) => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -379,7 +379,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         {
             if (findings.Length > 0)
             {
-                return ReplaceAllAbbreviations(value.AsBuilder(), findings).ToString();
+                return ReplaceAllAbbreviations(value.AsCachedBuilder(), findings).ToStringAndRelease();
             }
 
             return value;

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -367,13 +367,13 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     return word + "ing";
                 }
 
-                var gerundVerb = word.AsBuilder()
+                var gerundVerb = word.AsCachedBuilder()
                                      .Append("ing")
                                      .ReplaceWithCheck("ping", "pping")
                                      .ReplaceWithCheck("eing", "ing")
                                      .ReplaceWithCheck("uring", "urring")
                                      .ReplaceWithCheck("uting", "utting")
-                                     .ToString();
+                                     .ToStringAndRelease();
 
                 return gerundVerb;
             }

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -383,6 +383,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)StringBuilderCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -547,6 +547,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)StringBuilderCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxNodeCollector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxNodeCollector{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -187,10 +187,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         if (originalText.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase))
                         {
-                            var replacedText = originalText.AsBuilder()
+                            var replacedText = originalText.AsCachedBuilder()
                                                            .ReplaceAllWithCheck(map)
                                                            .AdjustFirstWord(firstWordHandling)
-                                                           .ToString();
+                                                           .ToStringAndRelease();
 
                             if (originalText.Equals(replacedText, StringComparison.Ordinal))
                             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -117,7 +117,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     trimmedExistingText = trimmedExistingText.Slice(0, end);
                 }
 
-                var continuation = trimmedExistingText.AsBuilder().Without(EnumStartingPhrases).Trimmed();
+                var continuation = trimmedExistingText.ToString().AsCachedBuilder().Without(EnumStartingPhrases).Trimmed();
 
                 if (continuation.IsSingleWord())
                 {
@@ -152,7 +152,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                             .Append(trimmedExistingTextEnd)
                                             .ReplaceWithCheck(" kinds of state ", " states of ")
                                             .ReplaceWithCheck(" of of ", " of ")
-                                            .ToString();
+                                            .ToStringAndRelease();
 
                 textTokens.RemoveAt(0);
                 textTokens.Insert(0, XmlTextToken(finalText));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -52,11 +52,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             comparison = StringComparison.OrdinalIgnoreCase;
 
-            var trimmedSummary = valueText.AsBuilder()
+            var trimmedSummary = valueText.AsCachedBuilder()
                                           .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
                                           .Without(Constants.Comments.RecursivelyStartingPhrase) // skip over recursively starting phrase
                                           .Without(",") // skip over first comma
-                                          .TrimStart();
+                                          .TrimmedStart()
+                                          .ToStringAndRelease();
 
             foreach (var wrongPhrase in WrongPhrases)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
@@ -39,11 +39,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             comparison = StringComparison.Ordinal;
 
-            problematicText = valueText.AsBuilder()
-                                       .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
-                                       .Without(Constants.Comments.RecursivelyStartingPhrase) // skip over recursively starting phrase
-                                       .Without(",") // skip over first comma
-                                       .FirstWord(out _);
+            var builder = valueText.AsCachedBuilder()
+                                   .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
+                                   .Without(Constants.Comments.RecursivelyStartingPhrase) // skip over recursively starting phrase
+                                   .Without(","); // skip over first comma
+
+            problematicText = builder.FirstWord(out _);
+
+            StringBuilderCache.Release(builder);
 
             return Verbalizer.IsThirdPersonSingularVerb(problematicText) is false;
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
                     var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordHandling.MakeLowerCase);
-                    var startText = switchedText.AsBuilder().Insert(0, ' ').TrimEnd();
+                    var startText = switchedText.AsCachedBuilder().Insert(0, ' ').TrimmedEnd().ToStringAndRelease();
 
                     var updatedContents = contents.Remove(t);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -83,7 +83,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (WellKnownTypeNames.Contains(typeName) is false)
                 {
-                    var text = typeName.AsBuilder().AdjustFirstWord(FirstWordHandling.MakePlural).SeparateWords(' ', FirstWordHandling.MakeLowerCase).ToString();
+                    var text = typeName.AsCachedBuilder()
+                                       .AdjustFirstWord(FirstWordHandling.MakePlural)
+                                       .SeparateWords(' ', FirstWordHandling.MakeLowerCase)
+                                       .ToStringAndRelease();
 
                     if (text.Length > 0)
                     {
@@ -157,7 +160,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (text.StartsWithAny(MappedData.Value.ByteArrayContinueTexts))
                     {
-                        var newContinueText = continueText.ReplaceToken(token, token.WithText(text.AsBuilder().Without(MappedData.Value.ByteArrayContinueTexts)));
+                        var fixedText = text.AsCachedBuilder().Without(MappedData.Value.ByteArrayContinueTexts).ToStringAndRelease();
+                        var newContinueText = continueText.ReplaceToken(token, token.WithText(fixedText));
 
                         preparedComment = preparedComment.ReplaceNode(continueText, newContinueText);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -209,13 +209,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         continue;
                     }
 
-                    var newText = valueText.AsBuilder().Without("otherwise").Without("false").ReplaceWithCheck("; , .", ".");
+                    var newText = valueText.AsCachedBuilder().Without("otherwise").Without("false").ReplaceWithCheck("; , .", ".");
 
                     if (valueText.Length > newText.Length)
                     {
                         newText = newText.ReplaceAllWithCheck(TrailingSentenceMarkers, ".");
 
-                        summary = summary.ReplaceToken(token, token.WithText(newText));
+                        summary = summary.ReplaceToken(token, token.WithText(newText.ToStringAndRelease()));
+                    }
+                    else
+                    {
+                        StringBuilderCache.Release(newText);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
@@ -38,10 +38,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             comparison = StringComparison.Ordinal;
 
-            var firstWord = valueText.AsBuilder()
-                                     .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
-                                     .ToString()
-                                     .FirstWord();
+            var builder = valueText.AsCachedBuilder()
+                                   .Without(Constants.Comments.AsynchronouslyStartingPhrase); // skip over async starting phrase
+
+            var firstWord = builder.FirstWord(out _);
+
+            StringBuilderCache.Release(builder);
 
             if (firstWord.EqualsAny(Constants.Comments.TryWords))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -90,7 +90,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             firstWordHandling |= FirstWordHandling.MakePlural;
                         }
 
-                        var replacement = enumType.AsBuilder()
+                        var replacement = enumType.AsCachedBuilder()
                                                   .Without(TypesSuffixes)
                                                   .SeparateWords(' ', firstWordHandling)
                                                   .Without(KindEndings)
@@ -99,7 +99,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                   .Append(article)
                                                   .Append(unsuffixed)
                                                   .Append('.')
-                                                  .ToString();
+                                                  .ToStringAndRelease();
 
                         return Comment(comment, replacement);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
@@ -37,27 +37,30 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             foreach (var xml in comment.GetSummaryXmls())
             {
-                var summary = xml.GetTextWithoutTrivia();
-
-                if (HasIssue(summary))
+                if (HasIssue(xml))
                 {
                     yield return Issue(xml.StartTag);
                 }
             }
         }
 
-        private static bool HasIssue(StringBuilder builder)
+        private static bool HasIssue(XmlElementSyntax xml)
         {
-            var summary = builder.ReplaceWithCheck(" - ", " ")
-                                 .ReplaceWithCheck(" />", "/>")
-                                 .ReplaceWithCheck(" </", "</")
-                                 .ReplaceWithCheck("> <", "><")
-                                 .ReplaceWithCheck(" cref=", "cref=")
-                                 .ReplaceWithCheck(" href=", "href=")
-                                 .ReplaceWithCheck(" type=", "type=")
-                                 .ReplaceWithCheck(" langref=", "langref=")
-                                 .ReplaceWithCheck(" langword=", "langword=")
-                                 .Trim();
+            var builder = StringBuilderCache.Acquire();
+
+            var summary = xml.GetTextWithoutTrivia(builder)
+                             .ReplaceWithCheck(" - ", " ")
+                             .ReplaceWithCheck(" />", "/>")
+                             .ReplaceWithCheck(" </", "</")
+                             .ReplaceWithCheck("> <", "><")
+                             .ReplaceWithCheck(" cref=", "cref=")
+                             .ReplaceWithCheck(" href=", "href=")
+                             .ReplaceWithCheck(" type=", "type=")
+                             .ReplaceWithCheck(" langref=", "langref=")
+                             .ReplaceWithCheck(" langword=", "langword=")
+                             .Trim();
+
+            StringBuilderCache.Release(builder);
 
             return HasIssue(summary.AsSpan());
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
@@ -27,16 +27,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return syntax.ReplaceToken(token, token.WithText(ReplaceText(token.Text)));
         }
 
-        private static StringBuilder ReplaceText(string originalText)
+        private static string ReplaceText(string originalText)
         {
-            var result = originalText.AsBuilder();
+            var result = originalText.AsCachedBuilder();
 
             foreach (var pair in ReplacementMap)
             {
                 result.ReplaceWithCheck(pair.Key, pair.Value);
             }
 
-            return result;
+            return result.ToStringAndRelease();
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
         {
             var token = syntax.FindToken(diagnostic);
-            var text = token.ValueText.AsBuilder().ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan());
+            var text = token.ValueText.AsCachedBuilder().ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToStringAndRelease();
 
             return syntax.ReplaceToken(token, token.WithText(text));
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
@@ -53,16 +53,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             foreach (var node in comment.DescendantNodes<XmlElementSyntax>().Where(_ => XmlTags.Contains(_.GetName())))
             {
-                var commentBuilder = new StringBuilder();
+                var builder = StringBuilderCache.Acquire();
 
                 foreach (var syntax in node.DescendantNodes(_ => _.IsCode() is false, true).OfType<XmlTextSyntax>())
                 {
-                    commentBuilder.Append(' ').WithoutXmlCommentExterior(syntax).Append(' ');
+                    builder.Append(' ').WithoutXmlCommentExterior(syntax).Append(' ');
                 }
 
-                var specificComment = commentBuilder.ToString();
+                var specificComment = builder.Trim();
 
-                if (HasIssue(specificComment.AsSpan().Trim()))
+                StringBuilderCache.Release(builder);
+
+                if (HasIssue(specificComment.AsSpan()))
                 {
                     return true;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2309_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2309_CodeFixProvider.cs
@@ -19,9 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (DocumentationComment.ContainsPhrases(Constants.Comments.NotContractionPhrase, comment.AsSpan().TrimEnd()))
             {
-                var text = comment.AsBuilder()
-                                  .ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan())
-                                  .ToString();
+                var text = comment.AsCachedBuilder().ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToStringAndRelease();
 
                 return SyntaxFactory.Comment(text);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -27,13 +26,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private IEnumerable<Diagnostic> AnalyzeComment(SyntaxNode node)
         {
-            foreach (var trivia in node.DescendantTrivia().Where(_ => _.IsSingleLineComment()))
+            foreach (var trivia in node.DescendantTrivia())
             {
-                var comment = trivia.ToString();
-
-                if (CommentContainsSeparator(comment.AsSpan()))
+                if (trivia.IsSingleLineComment())
                 {
-                    yield return Issue(string.Empty, trivia);
+                    var comment = trivia.ToString();
+
+                    if (CommentContainsSeparator(comment.AsSpan()))
+                    {
+                        yield return Issue(string.Empty, trivia);
+                    }
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
@@ -45,10 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return CommentHasIssue(comment, semanticModel);
         }
 
-        protected virtual IEnumerable<Diagnostic> CollectIssues(string name, SyntaxTrivia trivia)
-        {
-            yield return Issue(name, trivia);
-        }
+        protected virtual IEnumerable<Diagnostic> CollectIssues(string name, SyntaxTrivia trivia) => new[] { Issue(name, trivia) };
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => true;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
@@ -145,8 +145,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var used = methodBody.GetAllUsedVariables(semanticModel);
 
-            foreach (var parameter in parameters)
+            var count = parameters.Count;
+
+            for (var index = 0; index < count; index++)
             {
+                var parameter = parameters[index];
                 var parameterName = parameter.GetName();
 
                 if (used.Contains(parameterName))
@@ -188,7 +191,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var root = methodBody.SyntaxTree.GetCompilationUnitRoot();
 
                 var identifiers = root.DescendantNodes<IdentifierNameSyntax>(_ => _.Parent is ArgumentSyntax
-                                                                          || (_.Parent is BinaryExpressionSyntax b && b.IsKind(SyntaxKind.CoalesceExpression) && b.Parent is ArgumentSyntax));
+                                                                              || (_.Parent is BinaryExpressionSyntax b && b.IsKind(SyntaxKind.CoalesceExpression) && b.Parent is ArgumentSyntax));
 
                 return identifiers.ToHashSet(_ => _.Identifier.ValueText);
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
         {
-            return GetUpdatedSyntaxWithFixedText(syntax, _ => _.AsBuilder().ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToString());
+            return GetUpdatedSyntaxWithFixedText(syntax, _ => _.AsCachedBuilder().ReplaceAllWithCheck(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToStringAndRelease());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
@@ -91,9 +91,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 pairs[i] = new Pair("{" + indexString + "}", "{" + identifier + "}");
             }
 
-            var updatedText = token.ValueText.AsBuilder().ReplaceAllWithCheck(pairs);
+            var updatedText = token.ValueText.AsCachedBuilder().ReplaceAllWithCheck(pairs).ToStringAndRelease();
 
-            return StringLiteral(updatedText.ToString());
+            return StringLiteral(updatedText);
         }
 
         private static ExpressionSyntax ConvertToExpression(InterpolationSyntax syntax)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1011_DoMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1011_DoMethodsAnalyzer.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static string FindBetterName(IMethodSymbol symbol)
         {
             var methodName = symbol.Name;
-            var escapedMethod = methodName.AsBuilder();
+            var escapedMethod = methodName.AsCachedBuilder();
 
             var found = ContainsPhrase(methodName);
 
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 UnescapeValidPhrases(escapedMethod.Without(DoPhrase));
 
-                var proposal = escapedMethod.ToString();
+                var proposal = escapedMethod.ToStringAndRelease();
 
                 switch (proposal)
                 {
@@ -78,6 +78,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     default:
                         return proposal;
                 }
+            }
+            else
+            {
+                StringBuilderCache.Release(escapedMethod);
             }
 
             return null;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1012_FireMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1012_FireMethodsAnalyzer.cs
@@ -39,11 +39,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         private static string FindBetterName(IMethodSymbol method) => method.Name
-                                                                            .AsBuilder()
+                                                                            .AsCachedBuilder()
                                                                             .ReplaceWithCheck("Fire", "Raise")
                                                                             .ReplaceWithCheck("_fire", "_raise")
                                                                             .ReplaceWithCheck("Firing", "Raising")
                                                                             .ReplaceWithCheck("_firing", "_raising")
-                                                                            .ToString();
+                                                                            .ToStringAndRelease();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
@@ -35,10 +35,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 // avoid situation that method has no name
                 if (symbolName.Without(StartingPhrase).Length != 0)
                 {
-                    var proposal = symbolName.AsBuilder()
+                    var proposal = symbolName.AsCachedBuilder()
                                              .ReplaceWithCheck(StartingPhrase, CorrectStartingPhrase)
-                                             .ReplaceWithCheck(CorrectStartingPhrase + CorrectStartingPhrase, CorrectStartingPhrase) // may happen for "OnNotifyXyz"
-                                             .ToString();
+                                             .ReplaceWithCheck(CorrectStartingPhrase + CorrectStartingPhrase, CorrectStartingPhrase)
+                                             .ToStringAndRelease(); // may happen for "OnNotifyXyz"
 
                     return new[] { Issue(symbol, CreateBetterNameProposal(proposal)) };
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_TypeSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_TypeSuffixAnalyzer.cs
@@ -60,10 +60,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var symbolName = symbol.Name;
 
-            var betterName = symbolName.AsBuilder()
+            var betterName = symbolName.AsCachedBuilder()
                                        .ReplaceWithCheck("TypeEnum", "Kind")
                                        .Without(WrongSuffixes)
-                                       .ToString();
+                                       .ToStringAndRelease();
 
             if (betterName.IsNullOrWhiteSpace())
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
@@ -81,26 +81,26 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static string FindBetterName(string symbolName)
         {
-            var result = symbolName.AsBuilder();
+            var result = symbolName.AsCachedBuilder();
 
             foreach (var pair in ReplacementMap)
             {
                 result.ReplaceWithCheck(pair.Key, pair.Value);
             }
 
-            return result.ToString();
+            return result.ToStringAndRelease();
         }
 
         private IEnumerable<Diagnostic> AnalyzeName(ISymbol symbol)
         {
             var symbolName = symbol.Name
-                                   .AsBuilder()
+                                   .AsCachedBuilder()
                                    .ReplaceWithCheck("efresh", "#") // filter 'refresh' and 'Refresh'
                                    .ReplaceWithCheck("hallow", "#") // filter 'shallow' and 'Shallow'
                                    .ReplaceWithCheck("icenseNeed", "#") // filter 'licenseNeed' and 'LicenseNeed'
                                    .ReplaceWithCheck("eeded", "#") // filter 'needed' and 'Needed'
                                    .ReplaceWithCheck("eeds", "#") // filter 'needs' and 'Needs'
-                                   .ToString();
+                                   .ToStringAndRelease();
 
             return Constants.Markers.Requirements
                             .Where(_ => symbolName.Contains(_, StringComparison.OrdinalIgnoreCase))

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1067_PerformMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1067_PerformMethodsAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var methodName = symbol.Name;
 
-            if (ContainsPhrase(methodName) && ContainsPhrase(methodName.AsBuilder().Without("Performance").Without("Performed").ToString()))
+            if (ContainsPhrase(methodName) && ContainsPhrase(methodName.AsCachedBuilder().Without("Performance").Without("Performed").ToStringAndRelease()))
             {
                 var proposal = FindBetterName(methodName);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
@@ -185,7 +185,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static string HandleKnownParts(string name)
         {
-            var finalName = name.AsBuilder();
+            var finalName = name.AsCachedBuilder();
 
             foreach (var part in KnownParts)
             {
@@ -200,7 +200,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 }
             }
 
-            return finalName.ToString();
+            return finalName.ToStringAndRelease();
         }
 
         private IEnumerable<Diagnostic> AnalyzeName(ISymbol symbol) => HasIssue(symbol.Name)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -180,7 +180,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 capacity += ifToAdd.Length;
             }
 
-            var builder = new StringBuilder(capacity);
+            var builder = StringBuilderCache.Acquire(capacity);
             FixPart(builder, part1);
 
             if (addIf)
@@ -192,7 +192,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             builder.ReplaceWithCheck(When, If).ReplaceWithCheck(If + If, If);
 
-            result = builder.ToString();
+            result = StringBuilderCache.GetStringAndRelease(builder);
 
             return true;
         }
@@ -217,7 +217,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 capacity += ifToAdd.Length;
             }
 
-            var builder = new StringBuilder(capacity);
+            var builder = StringBuilderCache.Acquire(capacity);
             FixPart(builder, part0);
             FixPart(builder, part2);
 
@@ -235,7 +235,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             builder.ReplaceWithCheck(When, If).ReplaceWithCheck(If + If, If);
 
-            result = builder.ToString();
+            result = StringBuilderCache.GetStringAndRelease(builder);
 
             return true;
         }
@@ -270,7 +270,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 capacity += ifToAdd.Length;
             }
 
-            var builder = new StringBuilder(capacity);
+            var builder = StringBuilderCache.Acquire(capacity);
             FixPart(builder, part0);
             FixPart(builder, part3);
 
@@ -293,7 +293,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             builder.ReplaceWithCheck(When, If).ReplaceWithCheck(If + If, If);
 
-            result = builder.ToString();
+            result = StringBuilderCache.GetStringAndRelease(builder);
 
             return true;
         }

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -30,10 +30,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                     if (betterName.StartsWith(betterNamePrefix, StringComparison.Ordinal))
                     {
-                        var fixedBetterName = betterName.AsBuilder()
+                        var fixedBetterName = betterName.AsCachedBuilder()
                                                         .Remove(0, betterNamePrefix.Length)
                                                         .Insert(0, methodName)
-                                                        .ToString();
+                                                        .ToStringAndRelease();
                         return fixedBetterName;
                     }
                 }
@@ -128,7 +128,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return symbolName;
             }
 
-            var result = symbolName.AsBuilder()
+            var result = symbolName.AsCachedBuilder()
                                    .ReplaceWithCheck("MustBe", "Is")
                                    .ReplaceWithCheck("MustNotBe", "IsNot")
                                    .ReplaceWithCheck("ShallBe", "Is")
@@ -191,7 +191,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ReplaceWithCheck("O_bject", "_object")
                                    .ReplaceWithCheck("R_eference", "_reference")
                                    .ReplaceWithCheck("T_ype", "_type")
-                                   .ToString();
+                                   .ToStringAndRelease();
 
             return result;
         }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs
@@ -49,14 +49,14 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
                         continue;
                     }
 
-                    var builder = new StringBuilder();
+                    var builder = StringBuilderCache.Acquire();
 
                     foreach (var similarMethod in similarMethods)
                     {
                         similarMethod.GetMethodSignature(builder.Append("   ")).AppendLine();
                     }
 
-                    var order = builder.ToString();
+                    var order = StringBuilderCache.GetStringAndRelease(builder);
 
                     // check for locations
                     var lastLine = similarMethods.First().GetStartingLine();

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
                     {
                         var method = allMethods[index];
 
-                        var builder = new StringBuilder();
+                        var builder = StringBuilderCache.Acquire();
 
                         foreach (var other in methodsWithSameName)
                         {
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
                             }
                         }
 
-                        var signatures = builder.ToString();
+                        var signatures = StringBuilderCache.GetStringAndRelease(builder);
 
                         yield return Issue(method, signatures);
                     }

--- a/MiKo.Analyzer.Shared/StringBuilderCache.cs
+++ b/MiKo.Analyzer.Shared/StringBuilderCache.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Text;
+
+//// ncrunch: rdi off
+//// ncrunch: no coverage start
+namespace MiKoSolutions.Analyzers
+{
+    internal static class StringBuilderCache
+    {
+        private const int MaxBuilderSize = 1000;
+        private const int DefaultCapacity = 16;
+
+        [ThreadStatic]
+        private static StringBuilder s_cachedInstance;
+
+        public static StringBuilder Acquire(int capacity = DefaultCapacity)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                var cachedInstance = s_cachedInstance;
+
+                // only return the cached instance if the requested capacity is less than the currently cached capacity (avoids fragmentation of chunks in case the requested capacity is larger)
+                if (cachedInstance != null && capacity <= cachedInstance.Capacity)
+                {
+                    s_cachedInstance = null;
+
+                    cachedInstance.Clear();
+
+                    return cachedInstance;
+                }
+            }
+
+            return new StringBuilder(capacity);
+        }
+
+        public static void Release(StringBuilder builder)
+        {
+            if (builder.Capacity <= MaxBuilderSize)
+            {
+                s_cachedInstance = builder;
+            }
+        }
+
+        public static string GetStringAndRelease(StringBuilder builder)
+        {
+            var result = builder.ToString();
+
+            Release(builder);
+
+            return result;
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -1055,7 +1055,7 @@ public class TestMe
                                    from boolean in booleans
                                    select " " + boolean + vc into end // we have lots of loops, so cache data to avoid unnecessary calculations
                                    from start in starts
-                                   select new StringBuilder(start + end).Replace("   ", " ").Replace("  ", " ").Trim())
+                                   select StringBuilderCache.GetStringAndRelease(StringBuilderCache.Acquire(start.Length + end.Length).Append(start).Append(end).Replace("   ", " ").Replace("  ", " ").Trimmed()))
             {
                 results.Add(phrase.ToUpperCaseAt(0));
                 results.Add(phrase.ToLowerCaseAt(0));

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -750,9 +749,17 @@ internal interface IFactory
             var s = verbs.SelectMany(_ => phrases, (verb, phrase) => phrase + " " + verb).ToList();
 
             var startingPhrases = s.Concat(s.Select(_ => _.Replace("actory", "actory class"))).ToList();
-            var constructionPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "construction").Replace("creating", "constructing").Replace("create", "construct").ToString()).ToList();
-            var buildingPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "building").Replace("creating", "building").Replace("create", "build").ToString()).ToList();
-            var providingPhrases = startingPhrases.Select(_ => new StringBuilder(_).Replace("creation", "providing").Replace("creating", "providing").Replace("create", "provide").ToString()).ToList();
+
+            var constructionPhrases = new List<string>(startingPhrases.Count);
+            var buildingPhrases = new List<string>(startingPhrases.Count);
+            var providingPhrases = new List<string>(startingPhrases.Count);
+
+            foreach (var phrase in startingPhrases)
+            {
+                constructionPhrases.Add(phrase.AsCachedBuilder().Replace("creation", "construction").Replace("creating", "constructing").Replace("create", "construct").ToStringAndRelease());
+                buildingPhrases.Add(phrase.AsCachedBuilder().Replace("creation", "building").Replace("creating", "building").Replace("create", "build").ToStringAndRelease());
+                providingPhrases.Add(phrase.AsCachedBuilder().Replace("creation", "providing").Replace("creating", "providing").Replace("create", "provide").ToStringAndRelease());
+            }
 
             var results = new HashSet<string>();
 


### PR DESCRIPTION
- Introduced a new `StringBuilderCache` utility to optimize string handling and reduce memory allocations.
- Refactored multiple extensions and methods across the project to utilize `StringBuilderCache`.
- Added new trimming methods to `StringBuilderExtensions` for better string manipulation capabilities.
- Updated test cases to align with the new `StringBuilderCache` implementation.
- Updated project files to include the new `StringBuilderCache` utility.
- Fixed a bug in the `Skip` method of `EnumerableExtensions` to ensure correct return types and improved performance.
- Removed unused benchmark methods and cleaned up related code.

