### PR TITLE
Added new rule MiKo_1079 for DDD repositories

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
@@ -316,7 +316,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     return proposedName.WithoutSuffix("on").ConcatenatedWith('a');
                 }
 
-                if (proposedName.EndsWith("child", comparison))
+                if (proposedName.EndsWith("hild", comparison))
                 {
                     return proposedName.ConcatenatedWith("ren");
                 }

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -270,6 +270,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1076_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1077_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1078_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1079_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1081_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1082_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1083_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -405,6 +405,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1076_PrismEventTypeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1077_EnumMemberSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1078_BuilderMethodsAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1079_RepositorySuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1081_MethodsWithNumberSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1082_PropertiesWithNumberSuffixAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MiKoSolutions.Analyzers.Resources", typeof(Resources).Assembly);
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should be short to ease reading and maintenance (SRP, SLoA)..
         /// </summary>
-        internal static string MiKo_0001_Description {
+        public static string MiKo_0001_Description {
             get {
                 return ResourceManager.GetString("MiKo_0001_Description", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many LoC: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0001_MessageFormat {
+        public static string MiKo_0001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0001_MessageFormat", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method is too big.
         /// </summary>
-        internal static string MiKo_0001_Title {
+        public static string MiKo_0001_Title {
             get {
                 return ResourceManager.GetString("MiKo_0001_Title", resourceCulture);
             }
@@ -92,7 +92,7 @@ namespace MiKoSolutions.Analyzers {
         ///Following code constructs increase the Cyclomatic Complexity (CC) by +1:
         ///    if | while | for | foreach | case | continue | goto | &amp;&amp; | || | catch | catch when | ternary operator ?: | ?? | ?..
         /// </summary>
-        internal static string MiKo_0002_Description {
+        public static string MiKo_0002_Description {
             get {
                 return ResourceManager.GetString("MiKo_0002_Description", resourceCulture);
             }
@@ -101,7 +101,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too high CC: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0002_MessageFormat {
+        public static string MiKo_0002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0002_MessageFormat", resourceCulture);
             }
@@ -110,7 +110,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method is too complex.
         /// </summary>
-        internal static string MiKo_0002_Title {
+        public static string MiKo_0002_Title {
             get {
                 return ResourceManager.GetString("MiKo_0002_Title", resourceCulture);
             }
@@ -119,7 +119,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make code easier to read and maintain, types should be kept small. This follows the Single Responsibility Principle (SRP)..
         /// </summary>
-        internal static string MiKo_0003_Description {
+        public static string MiKo_0003_Description {
             get {
                 return ResourceManager.GetString("MiKo_0003_Description", resourceCulture);
             }
@@ -128,7 +128,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many LoC: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0003_MessageFormat {
+        public static string MiKo_0003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0003_MessageFormat", resourceCulture);
             }
@@ -137,7 +137,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type is too big.
         /// </summary>
-        internal static string MiKo_0003_Title {
+        public static string MiKo_0003_Title {
             get {
                 return ResourceManager.GetString("MiKo_0003_Title", resourceCulture);
             }
@@ -146,7 +146,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To follow the Single Responsibility Principle (SRP), methods should use as few parameters as possible..
         /// </summary>
-        internal static string MiKo_0004_Description {
+        public static string MiKo_0004_Description {
             get {
                 return ResourceManager.GetString("MiKo_0004_Description", resourceCulture);
             }
@@ -155,7 +155,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many parameters: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0004_MessageFormat {
+        public static string MiKo_0004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0004_MessageFormat", resourceCulture);
             }
@@ -164,7 +164,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method has too many parameters.
         /// </summary>
-        internal static string MiKo_0004_Title {
+        public static string MiKo_0004_Title {
             get {
                 return ResourceManager.GetString("MiKo_0004_Title", resourceCulture);
             }
@@ -173,7 +173,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make code easier to read and maintain, local functions should be kept short. This follows the Single Responsibility Principle (SRP) and the Single Level of Abstraction (SLoA) principle..
         /// </summary>
-        internal static string MiKo_0005_Description {
+        public static string MiKo_0005_Description {
             get {
                 return ResourceManager.GetString("MiKo_0005_Description", resourceCulture);
             }
@@ -182,7 +182,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many LoC: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0005_MessageFormat {
+        public static string MiKo_0005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0005_MessageFormat", resourceCulture);
             }
@@ -191,7 +191,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local function is too big.
         /// </summary>
-        internal static string MiKo_0005_Title {
+        public static string MiKo_0005_Title {
             get {
                 return ResourceManager.GetString("MiKo_0005_Title", resourceCulture);
             }
@@ -202,7 +202,7 @@ namespace MiKoSolutions.Analyzers {
         ///Following code constructs increase the Cyclomatic Complexity (CC) by +1:
         ///    if | while | for | foreach | case | continue | goto | &amp;&amp; | || | catch | catch when | ternary operator ?: | ?? | ?..
         /// </summary>
-        internal static string MiKo_0006_Description {
+        public static string MiKo_0006_Description {
             get {
                 return ResourceManager.GetString("MiKo_0006_Description", resourceCulture);
             }
@@ -211,7 +211,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too high CC: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0006_MessageFormat {
+        public static string MiKo_0006_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0006_MessageFormat", resourceCulture);
             }
@@ -220,7 +220,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local function is too complex.
         /// </summary>
-        internal static string MiKo_0006_Title {
+        public static string MiKo_0006_Title {
             get {
                 return ResourceManager.GetString("MiKo_0006_Title", resourceCulture);
             }
@@ -229,7 +229,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To follow the Single Responsibility Principle (SRP), local functions should use as few parameters as possible..
         /// </summary>
-        internal static string MiKo_0007_Description {
+        public static string MiKo_0007_Description {
             get {
                 return ResourceManager.GetString("MiKo_0007_Description", resourceCulture);
             }
@@ -238,7 +238,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many parameters: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_0007_MessageFormat {
+        public static string MiKo_0007_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_0007_MessageFormat", resourceCulture);
             }
@@ -247,7 +247,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local function has too many parameters.
         /// </summary>
-        internal static string MiKo_0007_Title {
+        public static string MiKo_0007_Title {
             get {
                 return ResourceManager.GetString("MiKo_0007_Title", resourceCulture);
             }
@@ -256,7 +256,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append suffix &apos;EventArgs&apos;.
         /// </summary>
-        internal static string MiKo_1000_CodeFixTitle {
+        public static string MiKo_1000_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1000_CodeFixTitle", resourceCulture);
             }
@@ -265,7 +265,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To maintain consistency and clarity in code, event argument types should inherit from &apos;System.EventArgs&apos; and their names should end with &apos;EventArgs&apos;..
         /// </summary>
-        internal static string MiKo_1000_Description {
+        public static string MiKo_1000_Description {
             get {
                 return ResourceManager.GetString("MiKo_1000_Description", resourceCulture);
             }
@@ -274,7 +274,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1000_MessageFormat {
+        public static string MiKo_1000_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1000_MessageFormat", resourceCulture);
             }
@@ -283,7 +283,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;System.EventArgs&apos; types should be suffixed with &apos;EventArgs&apos;.
         /// </summary>
-        internal static string MiKo_1000_Title {
+        public static string MiKo_1000_Title {
             get {
                 return ResourceManager.GetString("MiKo_1000_Title", resourceCulture);
             }
@@ -292,7 +292,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename event argument.
         /// </summary>
-        internal static string MiKo_1001_CodeFixTitle {
+        public static string MiKo_1001_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1001_CodeFixTitle", resourceCulture);
             }
@@ -301,7 +301,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To maintain consistency and clarity in code, parameters that inherit from &apos;System.EventArgs&apos; should be named &apos;e&apos;..
         /// </summary>
-        internal static string MiKo_1001_Description {
+        public static string MiKo_1001_Description {
             get {
                 return ResourceManager.GetString("MiKo_1001_Description", resourceCulture);
             }
@@ -310,7 +310,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
         /// </summary>
-        internal static string MiKo_1001_HelpLinkUri {
+        public static string MiKo_1001_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1001_HelpLinkUri", resourceCulture);
             }
@@ -319,7 +319,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1001_MessageFormat {
+        public static string MiKo_1001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1001_MessageFormat", resourceCulture);
             }
@@ -328,7 +328,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;System.EventArgs&apos; parameters should be named &apos;e&apos;.
         /// </summary>
-        internal static string MiKo_1001_Title {
+        public static string MiKo_1001_Title {
             get {
                 return ResourceManager.GetString("MiKo_1001_Title", resourceCulture);
             }
@@ -337,7 +337,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename event argument.
         /// </summary>
-        internal static string MiKo_1002_CodeFixTitle {
+        public static string MiKo_1002_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1002_CodeFixTitle", resourceCulture);
             }
@@ -346,7 +346,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To follow the .NET Framework Design Guidelines, parameters of event handlers should be named &apos;sender&apos; and &apos;e&apos;..
         /// </summary>
-        internal static string MiKo_1002_Description {
+        public static string MiKo_1002_Description {
             get {
                 return ResourceManager.GetString("MiKo_1002_Description", resourceCulture);
             }
@@ -355,7 +355,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
         /// </summary>
-        internal static string MiKo_1002_HelpLinkUri {
+        public static string MiKo_1002_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1002_HelpLinkUri", resourceCulture);
             }
@@ -364,7 +364,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1002_MessageFormat {
+        public static string MiKo_1002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1002_MessageFormat", resourceCulture);
             }
@@ -373,7 +373,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should be named according the .NET Framework Design Guidelines for event handlers.
         /// </summary>
-        internal static string MiKo_1002_Title {
+        public static string MiKo_1002_Title {
             get {
                 return ResourceManager.GetString("MiKo_1002_Title", resourceCulture);
             }
@@ -382,7 +382,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename method according to event pattern.
         /// </summary>
-        internal static string MiKo_1003_CodeFixTitle {
+        public static string MiKo_1003_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1003_CodeFixTitle", resourceCulture);
             }
@@ -391,7 +391,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event handlers should be named starting with &apos;On&apos; followed by the event name to show they handle events..
         /// </summary>
-        internal static string MiKo_1003_Description {
+        public static string MiKo_1003_Description {
             get {
                 return ResourceManager.GetString("MiKo_1003_Description", resourceCulture);
             }
@@ -400,7 +400,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/event-pattern.
         /// </summary>
-        internal static string MiKo_1003_HelpLinkUri {
+        public static string MiKo_1003_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1003_HelpLinkUri", resourceCulture);
             }
@@ -409,7 +409,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1003_MessageFormat {
+        public static string MiKo_1003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1003_MessageFormat", resourceCulture);
             }
@@ -418,7 +418,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event handling method names should follow the .NET Framework Design Guidelines.
         /// </summary>
-        internal static string MiKo_1003_Title {
+        public static string MiKo_1003_Title {
             get {
                 return ResourceManager.GetString("MiKo_1003_Title", resourceCulture);
             }
@@ -427,7 +427,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Event&apos; suffix.
         /// </summary>
-        internal static string MiKo_1004_CodeFixTitle {
+        public static string MiKo_1004_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1004_CodeFixTitle", resourceCulture);
             }
@@ -436,7 +436,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using &apos;Event&apos; as a suffix in event names because it&apos;s unnecessary and adds clutter..
         /// </summary>
-        internal static string MiKo_1004_Description {
+        public static string MiKo_1004_Description {
             get {
                 return ResourceManager.GetString("MiKo_1004_Description", resourceCulture);
             }
@@ -445,7 +445,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1004_MessageFormat {
+        public static string MiKo_1004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1004_MessageFormat", resourceCulture);
             }
@@ -454,7 +454,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events should not contain term &apos;Event&apos; in their names.
         /// </summary>
-        internal static string MiKo_1004_Title {
+        public static string MiKo_1004_Title {
             get {
                 return ResourceManager.GetString("MiKo_1004_Title", resourceCulture);
             }
@@ -463,7 +463,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename EventArgs variable.
         /// </summary>
-        internal static string MiKo_1005_CodeFixTitle {
+        public static string MiKo_1005_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1005_CodeFixTitle", resourceCulture);
             }
@@ -472,7 +472,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To maintain consistency and clarity in code, variables of type &apos;System.EventArgs&apos; (or its inheritors) should be named &apos;e&apos;..
         /// </summary>
-        internal static string MiKo_1005_Description {
+        public static string MiKo_1005_Description {
             get {
                 return ResourceManager.GetString("MiKo_1005_Description", resourceCulture);
             }
@@ -481,7 +481,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1005_MessageFormat {
+        public static string MiKo_1005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1005_MessageFormat", resourceCulture);
             }
@@ -490,7 +490,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;System.EventArgs&apos; variables should be named properly.
         /// </summary>
-        internal static string MiKo_1005_Title {
+        public static string MiKo_1005_Title {
             get {
                 return ResourceManager.GetString("MiKo_1005_Title", resourceCulture);
             }
@@ -500,7 +500,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Events should use &apos;EventHandler&lt;T&gt;&apos;, where &apos;T&apos; is a class that inherits from &apos;System.EventArgs&apos; and is named after the event.
         ///Example: A &apos;Loaded&apos; event should use an &apos;EventHandler&lt;LoadedEventArgs&gt;&apos;..
         /// </summary>
-        internal static string MiKo_1006_Description {
+        public static string MiKo_1006_Description {
             get {
                 return ResourceManager.GetString("MiKo_1006_Description", resourceCulture);
             }
@@ -509,7 +509,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;EventHandler&lt;{1}&gt;&apos; instead.
         /// </summary>
-        internal static string MiKo_1006_MessageFormat {
+        public static string MiKo_1006_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1006_MessageFormat", resourceCulture);
             }
@@ -518,7 +518,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events should use &apos;EventHandler&lt;T&gt;&apos; with &apos;EventArgs&apos; which are named after the event.
         /// </summary>
-        internal static string MiKo_1006_Title {
+        public static string MiKo_1006_Title {
             get {
                 return ResourceManager.GetString("MiKo_1006_Title", resourceCulture);
             }
@@ -527,7 +527,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events and their event arguments are logically related, so they should be placed in the same namespace for better organization..
         /// </summary>
-        internal static string MiKo_1007_Description {
+        public static string MiKo_1007_Description {
             get {
                 return ResourceManager.GetString("MiKo_1007_Description", resourceCulture);
             }
@@ -536,7 +536,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Used &apos;{1}&apos; should be in namespace &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_1007_MessageFormat {
+        public static string MiKo_1007_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1007_MessageFormat", resourceCulture);
             }
@@ -545,7 +545,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events and their corresponding &apos;EventArgs&apos; types should be located in the same namespace.
         /// </summary>
-        internal static string MiKo_1007_Title {
+        public static string MiKo_1007_Title {
             get {
                 return ResourceManager.GetString("MiKo_1007_Title", resourceCulture);
             }
@@ -554,7 +554,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename DependencyProperty event handler argument.
         /// </summary>
-        internal static string MiKo_1008_CodeFixTitle {
+        public static string MiKo_1008_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1008_CodeFixTitle", resourceCulture);
             }
@@ -563,7 +563,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To follow the .NET Framework Design Guidelines, parameters of DependencyProperty event handlers should be named &apos;d&apos; and &apos;e&apos;..
         /// </summary>
-        internal static string MiKo_1008_Description {
+        public static string MiKo_1008_Description {
             get {
                 return ResourceManager.GetString("MiKo_1008_Description", resourceCulture);
             }
@@ -572,7 +572,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1008_MessageFormat {
+        public static string MiKo_1008_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1008_MessageFormat", resourceCulture);
             }
@@ -581,7 +581,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should be named according the .NET Framework Design Guidelines for DependencyProperty event handlers.
         /// </summary>
-        internal static string MiKo_1008_Title {
+        public static string MiKo_1008_Title {
             get {
                 return ResourceManager.GetString("MiKo_1008_Title", resourceCulture);
             }
@@ -590,7 +590,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name event handler variable &apos;handler&apos;.
         /// </summary>
-        internal static string MiKo_1009_CodeFixTitle {
+        public static string MiKo_1009_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1009_CodeFixTitle", resourceCulture);
             }
@@ -599,7 +599,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to EventHandler variables should be named &apos;handler&apos;, to show they handle events..
         /// </summary>
-        internal static string MiKo_1009_Description {
+        public static string MiKo_1009_Description {
             get {
                 return ResourceManager.GetString("MiKo_1009_Description", resourceCulture);
             }
@@ -608,7 +608,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;handler&apos;.
         /// </summary>
-        internal static string MiKo_1009_MessageFormat {
+        public static string MiKo_1009_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1009_MessageFormat", resourceCulture);
             }
@@ -617,7 +617,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;System.EventHandler&apos; variables should be named properly.
         /// </summary>
-        internal static string MiKo_1009_Title {
+        public static string MiKo_1009_Title {
             get {
                 return ResourceManager.GetString("MiKo_1009_Title", resourceCulture);
             }
@@ -626,7 +626,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Execute&apos; from name.
         /// </summary>
-        internal static string MiKo_1010_CodeFixTitle {
+        public static string MiKo_1010_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1010_CodeFixTitle", resourceCulture);
             }
@@ -635,7 +635,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods are meant to run code, so adding words like &apos;CanExecute&apos; or &apos;Execute&apos; to their names is unnecessary and repetitive. It&apos;s like saying &apos;executeExecute&apos; - it does not add any useful information..
         /// </summary>
-        internal static string MiKo_1010_Description {
+        public static string MiKo_1010_Description {
             get {
                 return ResourceManager.GetString("MiKo_1010_Description", resourceCulture);
             }
@@ -644,7 +644,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1010_MessageFormat {
+        public static string MiKo_1010_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1010_MessageFormat", resourceCulture);
             }
@@ -653,7 +653,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not contain &apos;CanExecute&apos; or &apos;Execute&apos; in their names.
         /// </summary>
-        internal static string MiKo_1010_Title {
+        public static string MiKo_1010_Title {
             get {
                 return ResourceManager.GetString("MiKo_1010_Title", resourceCulture);
             }
@@ -662,7 +662,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Do&apos; from name.
         /// </summary>
-        internal static string MiKo_1011_CodeFixTitle {
+        public static string MiKo_1011_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1011_CodeFixTitle", resourceCulture);
             }
@@ -671,7 +671,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods are meant to run code, so adding words like &apos;Do&apos; to their names is unnecessary and repetitive. It&apos;s like saying &apos;doDo&apos; - it doesn&apos;t add any useful information..
         /// </summary>
-        internal static string MiKo_1011_Description {
+        public static string MiKo_1011_Description {
             get {
                 return ResourceManager.GetString("MiKo_1011_Description", resourceCulture);
             }
@@ -680,7 +680,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1011_MessageFormat {
+        public static string MiKo_1011_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1011_MessageFormat", resourceCulture);
             }
@@ -689,7 +689,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not contain &apos;Do&apos; in their names.
         /// </summary>
-        internal static string MiKo_1011_Title {
+        public static string MiKo_1011_Title {
             get {
                 return ResourceManager.GetString("MiKo_1011_Title", resourceCulture);
             }
@@ -698,7 +698,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;fire&apos; to &apos;raise&apos;.
         /// </summary>
-        internal static string MiKo_1012_CodeFixTitle {
+        public static string MiKo_1012_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1012_CodeFixTitle", resourceCulture);
             }
@@ -707,7 +707,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The word &apos;Fire&apos; has negative connotations, like firing employees or guns. It&apos;s not appropriate for events. Instead, use &apos;Raise&apos; for events, as it conveys a more neutral and accurate action..
         /// </summary>
-        internal static string MiKo_1012_Description {
+        public static string MiKo_1012_Description {
             get {
                 return ResourceManager.GetString("MiKo_1012_Description", resourceCulture);
             }
@@ -716,7 +716,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1012_MessageFormat {
+        public static string MiKo_1012_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1012_MessageFormat", resourceCulture);
             }
@@ -725,7 +725,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should be named &apos;Raise&apos; instead of &apos;Fire&apos;.
         /// </summary>
-        internal static string MiKo_1012_Title {
+        public static string MiKo_1012_Title {
             get {
                 return ResourceManager.GetString("MiKo_1012_Title", resourceCulture);
             }
@@ -734,7 +734,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;Notify&apos; to &apos;On&apos;.
         /// </summary>
-        internal static string MiKo_1013_CodeFixTitle {
+        public static string MiKo_1013_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1013_CodeFixTitle", resourceCulture);
             }
@@ -743,7 +743,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Seeing &apos;Notify&apos; in a method name often means an event is being raised. In these cases, it&apos;s better to use the prefix &apos;On&apos; instead. For example, instead of &apos;NotifyPropertyChanged&apos;, use &apos;OnPropertyChanged&apos;. This makes it clearer that an event is being triggered..
         /// </summary>
-        internal static string MiKo_1013_Description {
+        public static string MiKo_1013_Description {
             get {
                 return ResourceManager.GetString("MiKo_1013_Description", resourceCulture);
             }
@@ -752,7 +752,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use term &apos;Notify&apos;.
         /// </summary>
-        internal static string MiKo_1013_MessageFormat {
+        public static string MiKo_1013_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1013_MessageFormat", resourceCulture);
             }
@@ -761,7 +761,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be named &apos;Notify&apos; or &apos;OnNotify&apos;.
         /// </summary>
-        internal static string MiKo_1013_Title {
+        public static string MiKo_1013_Title {
             get {
                 return ResourceManager.GetString("MiKo_1013_Title", resourceCulture);
             }
@@ -770,7 +770,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;Check&apos;.
         /// </summary>
-        internal static string MiKo_1014_CodeFixTitle {
+        public static string MiKo_1014_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1014_CodeFixTitle", resourceCulture);
             }
@@ -779,7 +779,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The term &apos;Check&apos; is ambiguous. If you mean to validate parameters, use words like &apos;Validate&apos; or &apos;Verify&apos;. If you&apos;re checking for a specific state, use &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos; instead. This makes your code more precise and easier to understand..
         /// </summary>
-        internal static string MiKo_1014_Description {
+        public static string MiKo_1014_Description {
             get {
                 return ResourceManager.GetString("MiKo_1014_Description", resourceCulture);
             }
@@ -788,7 +788,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use ambiguous term &apos;Check&apos;.
         /// </summary>
-        internal static string MiKo_1014_MessageFormat {
+        public static string MiKo_1014_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1014_MessageFormat", resourceCulture);
             }
@@ -797,7 +797,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be named with ambiguous &apos;Check&apos;.
         /// </summary>
-        internal static string MiKo_1014_Title {
+        public static string MiKo_1014_Title {
             get {
                 return ResourceManager.GetString("MiKo_1014_Title", resourceCulture);
             }
@@ -806,7 +806,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;Init&apos; to &apos;Initialize&apos;.
         /// </summary>
-        internal static string MiKo_1015_CodeFixTitle {
+        public static string MiKo_1015_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1015_CodeFixTitle", resourceCulture);
             }
@@ -815,7 +815,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Instead of using the short form &apos;Init&apos;, you should use the full word &apos;Initialize&apos;. Using &apos;Init&apos; is considered lazy and less clear..
         /// </summary>
-        internal static string MiKo_1015_Description {
+        public static string MiKo_1015_Description {
             get {
                 return ResourceManager.GetString("MiKo_1015_Description", resourceCulture);
             }
@@ -824,7 +824,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1015_MessageFormat {
+        public static string MiKo_1015_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1015_MessageFormat", resourceCulture);
             }
@@ -833,7 +833,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should be named &apos;Initialize&apos; instead of &apos;Init&apos;.
         /// </summary>
-        internal static string MiKo_1015_Title {
+        public static string MiKo_1015_Title {
             get {
                 return ResourceManager.GetString("MiKo_1015_Title", resourceCulture);
             }
@@ -842,7 +842,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename factory method.
         /// </summary>
-        internal static string MiKo_1016_CodeFixTitle {
+        public static string MiKo_1016_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1016_CodeFixTitle", resourceCulture);
             }
@@ -851,7 +851,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Since the method is part of a factory, its name should begin with &apos;Create&apos;. This helps indicate its purpose more clearly..
         /// </summary>
-        internal static string MiKo_1016_Description {
+        public static string MiKo_1016_Description {
             get {
                 return ResourceManager.GetString("MiKo_1016_Description", resourceCulture);
             }
@@ -860,7 +860,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start name with &apos;Create&apos;.
         /// </summary>
-        internal static string MiKo_1016_MessageFormat {
+        public static string MiKo_1016_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1016_MessageFormat", resourceCulture);
             }
@@ -869,7 +869,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Factory methods should be named &apos;Create&apos;.
         /// </summary>
-        internal static string MiKo_1016_Title {
+        public static string MiKo_1016_Title {
             get {
                 return ResourceManager.GetString("MiKo_1016_Title", resourceCulture);
             }
@@ -878,7 +878,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove prefix from method.
         /// </summary>
-        internal static string MiKo_1017_CodeFixTitle {
+        public static string MiKo_1017_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1017_CodeFixTitle", resourceCulture);
             }
@@ -887,7 +887,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using &apos;Get&apos; or &apos;Set&apos; at the beginning of method names if the method already starts with &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos;. The &apos;Get&apos; or &apos;Set&apos; is unnecessary and makes the name longer without adding value..
         /// </summary>
-        internal static string MiKo_1017_Description {
+        public static string MiKo_1017_Description {
             get {
                 return ResourceManager.GetString("MiKo_1017_Description", resourceCulture);
             }
@@ -896,7 +896,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1017_MessageFormat {
+        public static string MiKo_1017_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1017_MessageFormat", resourceCulture);
             }
@@ -905,7 +905,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be prefixed with &apos;Get&apos; or &apos;Set&apos; if followed by &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos;.
         /// </summary>
-        internal static string MiKo_1017_Title {
+        public static string MiKo_1017_Title {
             get {
                 return ResourceManager.GetString("MiKo_1017_Title", resourceCulture);
             }
@@ -914,7 +914,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change noun to verb.
         /// </summary>
-        internal static string MiKo_1018_CodeFixTitle {
+        public static string MiKo_1018_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1018_CodeFixTitle", resourceCulture);
             }
@@ -923,7 +923,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When naming methods, avoid adding a noun form of a verb at the end if the verb itself is appropriate as the method name. This practice ensures method names are concise and clear..
         /// </summary>
-        internal static string MiKo_1018_Description {
+        public static string MiKo_1018_Description {
             get {
                 return ResourceManager.GetString("MiKo_1018_Description", resourceCulture);
             }
@@ -932,7 +932,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1018_MessageFormat {
+        public static string MiKo_1018_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1018_MessageFormat", resourceCulture);
             }
@@ -941,7 +941,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be suffixed with noun of a verb.
         /// </summary>
-        internal static string MiKo_1018_Title {
+        public static string MiKo_1018_Title {
             get {
                 return ResourceManager.GetString("MiKo_1018_Title", resourceCulture);
             }
@@ -950,7 +950,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;Clear&apos; and &apos;Remove&apos;.
         /// </summary>
-        internal static string MiKo_1019_CodeFixTitle {
+        public static string MiKo_1019_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1019_CodeFixTitle", resourceCulture);
             }
@@ -961,7 +961,7 @@ namespace MiKoSolutions.Analyzers {
         ///Conversely, methods named &apos;Clear&apos; that have parameters should be renamed to &apos;Remove&apos; to accurately describe their action.
         ///This naming convention helps ensure clarity and consistency in method functionality..
         /// </summary>
-        internal static string MiKo_1019_Description {
+        public static string MiKo_1019_Description {
             get {
                 return ResourceManager.GetString("MiKo_1019_Description", resourceCulture);
             }
@@ -970,7 +970,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1019_MessageFormat {
+        public static string MiKo_1019_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1019_MessageFormat", resourceCulture);
             }
@@ -979,7 +979,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Clear&apos; and &apos;Remove&apos; methods should be named based on their number of parameters.
         /// </summary>
-        internal static string MiKo_1019_Title {
+        public static string MiKo_1019_Title {
             get {
                 return ResourceManager.GetString("MiKo_1019_Title", resourceCulture);
             }
@@ -988,7 +988,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1020_Description {
+        public static string MiKo_1020_Description {
             get {
                 return ResourceManager.GetString("MiKo_1020_Description", resourceCulture);
             }
@@ -997,7 +997,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1020_MessageFormat {
+        public static string MiKo_1020_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1020_MessageFormat", resourceCulture);
             }
@@ -1006,7 +1006,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type names should be limited in length.
         /// </summary>
-        internal static string MiKo_1020_Title {
+        public static string MiKo_1020_Title {
             get {
                 return ResourceManager.GetString("MiKo_1020_Title", resourceCulture);
             }
@@ -1015,7 +1015,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1021_Description {
+        public static string MiKo_1021_Description {
             get {
                 return ResourceManager.GetString("MiKo_1021_Description", resourceCulture);
             }
@@ -1024,7 +1024,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1021_MessageFormat {
+        public static string MiKo_1021_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1021_MessageFormat", resourceCulture);
             }
@@ -1033,7 +1033,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method names should be limited in length.
         /// </summary>
-        internal static string MiKo_1021_Title {
+        public static string MiKo_1021_Title {
             get {
                 return ResourceManager.GetString("MiKo_1021_Title", resourceCulture);
             }
@@ -1042,7 +1042,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1022_Description {
+        public static string MiKo_1022_Description {
             get {
                 return ResourceManager.GetString("MiKo_1022_Description", resourceCulture);
             }
@@ -1051,7 +1051,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameter name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1022_MessageFormat {
+        public static string MiKo_1022_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1022_MessageFormat", resourceCulture);
             }
@@ -1060,7 +1060,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameter names should be limited in length.
         /// </summary>
-        internal static string MiKo_1022_Title {
+        public static string MiKo_1022_Title {
             get {
                 return ResourceManager.GetString("MiKo_1022_Title", resourceCulture);
             }
@@ -1069,7 +1069,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1023_Description {
+        public static string MiKo_1023_Description {
             get {
                 return ResourceManager.GetString("MiKo_1023_Description", resourceCulture);
             }
@@ -1078,7 +1078,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Field name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1023_MessageFormat {
+        public static string MiKo_1023_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1023_MessageFormat", resourceCulture);
             }
@@ -1087,7 +1087,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Field names should be limited in length.
         /// </summary>
-        internal static string MiKo_1023_Title {
+        public static string MiKo_1023_Title {
             get {
                 return ResourceManager.GetString("MiKo_1023_Title", resourceCulture);
             }
@@ -1096,7 +1096,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1024_Description {
+        public static string MiKo_1024_Description {
             get {
                 return ResourceManager.GetString("MiKo_1024_Description", resourceCulture);
             }
@@ -1105,7 +1105,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Property name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1024_MessageFormat {
+        public static string MiKo_1024_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1024_MessageFormat", resourceCulture);
             }
@@ -1114,7 +1114,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Property names should be limited in length.
         /// </summary>
-        internal static string MiKo_1024_Title {
+        public static string MiKo_1024_Title {
             get {
                 return ResourceManager.GetString("MiKo_1024_Title", resourceCulture);
             }
@@ -1123,7 +1123,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1025_Description {
+        public static string MiKo_1025_Description {
             get {
                 return ResourceManager.GetString("MiKo_1025_Description", resourceCulture);
             }
@@ -1132,7 +1132,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1025_MessageFormat {
+        public static string MiKo_1025_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1025_MessageFormat", resourceCulture);
             }
@@ -1141,7 +1141,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event names should be limited in length.
         /// </summary>
-        internal static string MiKo_1025_Title {
+        public static string MiKo_1025_Title {
             get {
                 return ResourceManager.GetString("MiKo_1025_Title", resourceCulture);
             }
@@ -1150,7 +1150,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1026_Description {
+        public static string MiKo_1026_Description {
             get {
                 return ResourceManager.GetString("MiKo_1026_Description", resourceCulture);
             }
@@ -1159,7 +1159,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variable name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1026_MessageFormat {
+        public static string MiKo_1026_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1026_MessageFormat", resourceCulture);
             }
@@ -1168,7 +1168,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variable names should be limited in length.
         /// </summary>
-        internal static string MiKo_1026_Title {
+        public static string MiKo_1026_Title {
             get {
                 return ResourceManager.GetString("MiKo_1026_Title", resourceCulture);
             }
@@ -1177,7 +1177,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1027_Description {
+        public static string MiKo_1027_Description {
             get {
                 return ResourceManager.GetString("MiKo_1027_Description", resourceCulture);
             }
@@ -1186,7 +1186,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variable name in loop exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1027_MessageFormat {
+        public static string MiKo_1027_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1027_MessageFormat", resourceCulture);
             }
@@ -1195,7 +1195,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variable names in loops should be limited in length.
         /// </summary>
-        internal static string MiKo_1027_Title {
+        public static string MiKo_1027_Title {
             get {
                 return ResourceManager.GetString("MiKo_1027_Title", resourceCulture);
             }
@@ -1204,7 +1204,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency..
         /// </summary>
-        internal static string MiKo_1028_Description {
+        public static string MiKo_1028_Description {
             get {
                 return ResourceManager.GetString("MiKo_1028_Description", resourceCulture);
             }
@@ -1213,7 +1213,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local function name exceeds limit of {2} chars by {1}.
         /// </summary>
-        internal static string MiKo_1028_MessageFormat {
+        public static string MiKo_1028_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1028_MessageFormat", resourceCulture);
             }
@@ -1222,7 +1222,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local function names should be limited in length.
         /// </summary>
-        internal static string MiKo_1028_Title {
+        public static string MiKo_1028_Title {
             get {
                 return ResourceManager.GetString("MiKo_1028_Title", resourceCulture);
             }
@@ -1231,7 +1231,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove base type indicator.
         /// </summary>
-        internal static string MiKo_1030_CodeFixTitle {
+        public static string MiKo_1030_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1030_CodeFixTitle", resourceCulture);
             }
@@ -1240,7 +1240,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Abstract&apos; or &apos;Base&apos; in the name of a type to indicate it is a base type is unnecessary. Any interface or type that is not sealed can serve as a base type, so adding these terms only creates clutter and distracts users..
         /// </summary>
-        internal static string MiKo_1030_Description {
+        public static string MiKo_1030_Description {
             get {
                 return ResourceManager.GetString("MiKo_1030_Description", resourceCulture);
             }
@@ -1249,7 +1249,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{1}&apos; from name.
         /// </summary>
-        internal static string MiKo_1030_MessageFormat {
+        public static string MiKo_1030_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1030_MessageFormat", resourceCulture);
             }
@@ -1258,7 +1258,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Types should not have an &apos;Abstract&apos; or &apos;Base&apos; marker to indicate that they are base types.
         /// </summary>
-        internal static string MiKo_1030_Title {
+        public static string MiKo_1030_Title {
             get {
                 return ResourceManager.GetString("MiKo_1030_Title", resourceCulture);
             }
@@ -1267,7 +1267,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1031_CodeFixTitle {
+        public static string MiKo_1031_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1031_CodeFixTitle", resourceCulture);
             }
@@ -1276,7 +1276,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Model&apos; as a suffix for entity types is unnecessary. Entities should just be named plainly without any suffixes. For example, use &apos;User&apos; instead of &apos;UserModel&apos;..
         /// </summary>
-        internal static string MiKo_1031_Description {
+        public static string MiKo_1031_Description {
             get {
                 return ResourceManager.GetString("MiKo_1031_Description", resourceCulture);
             }
@@ -1285,7 +1285,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1031_MessageFormat {
+        public static string MiKo_1031_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1031_MessageFormat", resourceCulture);
             }
@@ -1294,7 +1294,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Entity types should not use a &apos;Model&apos; suffix.
         /// </summary>
-        internal static string MiKo_1031_Title {
+        public static string MiKo_1031_Title {
             get {
                 return ResourceManager.GetString("MiKo_1031_Title", resourceCulture);
             }
@@ -1303,7 +1303,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1032_CodeFixTitle {
+        public static string MiKo_1032_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1032_CodeFixTitle", resourceCulture);
             }
@@ -1312,7 +1312,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Model&apos; in a method name to indicate it deals with an entity is unnecessary. Just name the method clearly without using &apos;Model&apos;..
         /// </summary>
-        internal static string MiKo_1032_Description {
+        public static string MiKo_1032_Description {
             get {
                 return ResourceManager.GetString("MiKo_1032_Description", resourceCulture);
             }
@@ -1321,7 +1321,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1032_MessageFormat {
+        public static string MiKo_1032_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1032_MessageFormat", resourceCulture);
             }
@@ -1330,7 +1330,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods dealing with entities should not use a &apos;Model&apos; as marker.
         /// </summary>
-        internal static string MiKo_1032_Title {
+        public static string MiKo_1032_Title {
             get {
                 return ResourceManager.GetString("MiKo_1032_Title", resourceCulture);
             }
@@ -1339,7 +1339,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1033_CodeFixTitle {
+        public static string MiKo_1033_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1033_CodeFixTitle", resourceCulture);
             }
@@ -1348,7 +1348,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding &apos;Model&apos; as a suffix to a parameter name is unnecessary. Just name the parameter plainly, like using &apos;user&apos; instead of &apos;userModel&apos;. This keeps it simple and clear..
         /// </summary>
-        internal static string MiKo_1033_Description {
+        public static string MiKo_1033_Description {
             get {
                 return ResourceManager.GetString("MiKo_1033_Description", resourceCulture);
             }
@@ -1357,7 +1357,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1033_MessageFormat {
+        public static string MiKo_1033_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1033_MessageFormat", resourceCulture);
             }
@@ -1366,7 +1366,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters representing entities should not use a &apos;Model&apos; suffix.
         /// </summary>
-        internal static string MiKo_1033_Title {
+        public static string MiKo_1033_Title {
             get {
                 return ResourceManager.GetString("MiKo_1033_Title", resourceCulture);
             }
@@ -1375,7 +1375,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1034_CodeFixTitle {
+        public static string MiKo_1034_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1034_CodeFixTitle", resourceCulture);
             }
@@ -1384,7 +1384,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Model&apos; as a suffix for field names is unnecessary. Just name the field plainly, like &apos;user&apos; instead of &apos;userModel&apos;. This keeps it simple and clear..
         /// </summary>
-        internal static string MiKo_1034_Description {
+        public static string MiKo_1034_Description {
             get {
                 return ResourceManager.GetString("MiKo_1034_Description", resourceCulture);
             }
@@ -1393,7 +1393,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1034_MessageFormat {
+        public static string MiKo_1034_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1034_MessageFormat", resourceCulture);
             }
@@ -1402,7 +1402,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fields representing entities should not use a &apos;Model&apos; suffix.
         /// </summary>
-        internal static string MiKo_1034_Title {
+        public static string MiKo_1034_Title {
             get {
                 return ResourceManager.GetString("MiKo_1034_Title", resourceCulture);
             }
@@ -1411,7 +1411,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1035_CodeFixTitle {
+        public static string MiKo_1035_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1035_CodeFixTitle", resourceCulture);
             }
@@ -1420,7 +1420,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Model&apos; in a property name to show it deals with an entity is unnecessary. Just name the property clearly without &apos;Model&apos;..
         /// </summary>
-        internal static string MiKo_1035_Description {
+        public static string MiKo_1035_Description {
             get {
                 return ResourceManager.GetString("MiKo_1035_Description", resourceCulture);
             }
@@ -1429,7 +1429,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1035_MessageFormat {
+        public static string MiKo_1035_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1035_MessageFormat", resourceCulture);
             }
@@ -1438,7 +1438,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Properties dealing with entities should not use a &apos;Model&apos; marker.
         /// </summary>
-        internal static string MiKo_1035_Title {
+        public static string MiKo_1035_Title {
             get {
                 return ResourceManager.GetString("MiKo_1035_Title", resourceCulture);
             }
@@ -1447,7 +1447,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Model&apos; indicator.
         /// </summary>
-        internal static string MiKo_1036_CodeFixTitle {
+        public static string MiKo_1036_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1036_CodeFixTitle", resourceCulture);
             }
@@ -1456,7 +1456,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Model&apos; in an event name to show it deals with an entity is unnecessary. Just name the event clearly without &apos;Model&apos;..
         /// </summary>
-        internal static string MiKo_1036_Description {
+        public static string MiKo_1036_Description {
             get {
                 return ResourceManager.GetString("MiKo_1036_Description", resourceCulture);
             }
@@ -1465,7 +1465,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1036_MessageFormat {
+        public static string MiKo_1036_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1036_MessageFormat", resourceCulture);
             }
@@ -1474,7 +1474,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events dealing with entities should not use a &apos;Model&apos; marker.
         /// </summary>
-        internal static string MiKo_1036_Title {
+        public static string MiKo_1036_Title {
             get {
                 return ResourceManager.GetString("MiKo_1036_Title", resourceCulture);
             }
@@ -1483,7 +1483,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove type suffix.
         /// </summary>
-        internal static string MiKo_1037_CodeFixTitle {
+        public static string MiKo_1037_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1037_CodeFixTitle", resourceCulture);
             }
@@ -1492,7 +1492,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Enum&apos; as a suffix to indicate a type an Enum is unnecessary. This also goes for suffixes in general, whether for interfaces, classes, records, or structs. Keeping names clear and straightforward without these suffixes makes the code cleaner and easier to understand..
         /// </summary>
-        internal static string MiKo_1037_Description {
+        public static string MiKo_1037_Description {
             get {
                 return ResourceManager.GetString("MiKo_1037_Description", resourceCulture);
             }
@@ -1501,7 +1501,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1037_MessageFormat {
+        public static string MiKo_1037_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1037_MessageFormat", resourceCulture);
             }
@@ -1510,7 +1510,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Types should not be suffixed with &apos;Type&apos;, &apos;Interface&apos;, &apos;Class&apos;, &apos;Struct&apos;, &apos;Record&apos; or &apos;Enum&apos;.
         /// </summary>
-        internal static string MiKo_1037_Title {
+        public static string MiKo_1037_Title {
             get {
                 return ResourceManager.GetString("MiKo_1037_Title", resourceCulture);
             }
@@ -1519,7 +1519,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suffix type with &apos;Extensions&apos;.
         /// </summary>
-        internal static string MiKo_1038_CodeFixTitle {
+        public static string MiKo_1038_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1038_CodeFixTitle", resourceCulture);
             }
@@ -1528,7 +1528,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, classes with extension methods should all end with the same suffix. This helps quickly identify their purpose and makes the code easier to work with..
         /// </summary>
-        internal static string MiKo_1038_Description {
+        public static string MiKo_1038_Description {
             get {
                 return ResourceManager.GetString("MiKo_1038_Description", resourceCulture);
             }
@@ -1537,7 +1537,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End name with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1038_MessageFormat {
+        public static string MiKo_1038_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1038_MessageFormat", resourceCulture);
             }
@@ -1546,7 +1546,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Classes that contain extension methods should end with same suffix.
         /// </summary>
-        internal static string MiKo_1038_Title {
+        public static string MiKo_1038_Title {
             get {
                 return ResourceManager.GetString("MiKo_1038_Title", resourceCulture);
             }
@@ -1555,7 +1555,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename &apos;this&apos; argument.
         /// </summary>
-        internal static string MiKo_1039_CodeFixTitle {
+        public static string MiKo_1039_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1039_CodeFixTitle", resourceCulture);
             }
@@ -1564,7 +1564,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance, the &apos;this&apos; parameter in extension methods should always have a standard name. This makes the code consistent and easier to understand..
         /// </summary>
-        internal static string MiKo_1039_Description {
+        public static string MiKo_1039_Description {
             get {
                 return ResourceManager.GetString("MiKo_1039_Description", resourceCulture);
             }
@@ -1573,7 +1573,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it {1}.
         /// </summary>
-        internal static string MiKo_1039_MessageFormat {
+        public static string MiKo_1039_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1039_MessageFormat", resourceCulture);
             }
@@ -1582,7 +1582,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;this&apos; parameter of extension methods should have a default name.
         /// </summary>
-        internal static string MiKo_1039_Title {
+        public static string MiKo_1039_Title {
             get {
                 return ResourceManager.GetString("MiKo_1039_Title", resourceCulture);
             }
@@ -1591,7 +1591,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding suffixes like &apos;List&apos; to parameter names adds unnecessary clutter. It&apos;s best to avoid them for cleaner, more readable code..
         /// </summary>
-        internal static string MiKo_1040_Description {
+        public static string MiKo_1040_Description {
             get {
                 return ResourceManager.GetString("MiKo_1040_Description", resourceCulture);
             }
@@ -1600,7 +1600,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1040_MessageFormat {
+        public static string MiKo_1040_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1040_MessageFormat", resourceCulture);
             }
@@ -1609,7 +1609,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should not be suffixed with implementation details.
         /// </summary>
-        internal static string MiKo_1040_Title {
+        public static string MiKo_1040_Title {
             get {
                 return ResourceManager.GetString("MiKo_1040_Title", resourceCulture);
             }
@@ -1618,7 +1618,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding suffixes like &apos;List&apos; to field names adds unnecessary clutter. It&apos;s best to avoid them for cleaner, more readable code..
         /// </summary>
-        internal static string MiKo_1041_Description {
+        public static string MiKo_1041_Description {
             get {
                 return ResourceManager.GetString("MiKo_1041_Description", resourceCulture);
             }
@@ -1627,7 +1627,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1041_MessageFormat {
+        public static string MiKo_1041_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1041_MessageFormat", resourceCulture);
             }
@@ -1636,7 +1636,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fields should not be suffixed with implementation details.
         /// </summary>
-        internal static string MiKo_1041_Title {
+        public static string MiKo_1041_Title {
             get {
                 return ResourceManager.GetString("MiKo_1041_Title", resourceCulture);
             }
@@ -1645,7 +1645,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;cancellationToken&apos;.
         /// </summary>
-        internal static string MiKo_1042_CodeFixTitle {
+        public static string MiKo_1042_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1042_CodeFixTitle", resourceCulture);
             }
@@ -1654,7 +1654,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance and align with .NET Framework standards, &apos;CancellationToken&apos; parameters should be consistently named. This helps keep the code clear and consistent..
         /// </summary>
-        internal static string MiKo_1042_Description {
+        public static string MiKo_1042_Description {
             get {
                 return ResourceManager.GetString("MiKo_1042_Description", resourceCulture);
             }
@@ -1663,7 +1663,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1042_MessageFormat {
+        public static string MiKo_1042_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1042_MessageFormat", resourceCulture);
             }
@@ -1672,7 +1672,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;CancellationToken&apos; parameters should have specific name.
         /// </summary>
-        internal static string MiKo_1042_Title {
+        public static string MiKo_1042_Title {
             get {
                 return ResourceManager.GetString("MiKo_1042_Title", resourceCulture);
             }
@@ -1681,7 +1681,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;token&apos;.
         /// </summary>
-        internal static string MiKo_1043_CodeFixTitle {
+        public static string MiKo_1043_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1043_CodeFixTitle", resourceCulture);
             }
@@ -1690,7 +1690,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance and align with .NET Framework standards, &apos;CancellationToken&apos; variables should be consistently named. This helps keep the code clear and consistent..
         /// </summary>
-        internal static string MiKo_1043_Description {
+        public static string MiKo_1043_Description {
             get {
                 return ResourceManager.GetString("MiKo_1043_Description", resourceCulture);
             }
@@ -1699,7 +1699,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1043_MessageFormat {
+        public static string MiKo_1043_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1043_MessageFormat", resourceCulture);
             }
@@ -1708,7 +1708,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;CancellationToken&apos; variables should have specific name.
         /// </summary>
-        internal static string MiKo_1043_Title {
+        public static string MiKo_1043_Title {
             get {
                 return ResourceManager.GetString("MiKo_1043_Title", resourceCulture);
             }
@@ -1717,7 +1717,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append &apos;Command&apos; suffix.
         /// </summary>
-        internal static string MiKo_1044_CodeFixTitle {
+        public static string MiKo_1044_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1044_CodeFixTitle", resourceCulture);
             }
@@ -1726,7 +1726,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance, always add the suffix &apos;Command&apos; to commands. This makes it clear they are commands and keeps the code consistent..
         /// </summary>
-        internal static string MiKo_1044_Description {
+        public static string MiKo_1044_Description {
             get {
                 return ResourceManager.GetString("MiKo_1044_Description", resourceCulture);
             }
@@ -1735,7 +1735,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add &apos;{1}&apos; as suffix.
         /// </summary>
-        internal static string MiKo_1044_MessageFormat {
+        public static string MiKo_1044_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1044_MessageFormat", resourceCulture);
             }
@@ -1744,7 +1744,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Commands should be suffixed with &apos;Command&apos;.
         /// </summary>
-        internal static string MiKo_1044_Title {
+        public static string MiKo_1044_Title {
             get {
                 return ResourceManager.GetString("MiKo_1044_Title", resourceCulture);
             }
@@ -1753,7 +1753,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Command&apos; suffix.
         /// </summary>
-        internal static string MiKo_1045_CodeFixTitle {
+        public static string MiKo_1045_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1045_CodeFixTitle", resourceCulture);
             }
@@ -1762,7 +1762,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance, drop the &apos;Command&apos; suffix since the method is already invoked as a command. Keeps things clean and clear..
         /// </summary>
-        internal static string MiKo_1045_Description {
+        public static string MiKo_1045_Description {
             get {
                 return ResourceManager.GetString("MiKo_1045_Description", resourceCulture);
             }
@@ -1771,7 +1771,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1045_MessageFormat {
+        public static string MiKo_1045_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1045_MessageFormat", resourceCulture);
             }
@@ -1780,7 +1780,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods that are invoked by commands should not be suffixed with &apos;Command&apos;.
         /// </summary>
-        internal static string MiKo_1045_Title {
+        public static string MiKo_1045_Title {
             get {
                 return ResourceManager.GetString("MiKo_1045_Title", resourceCulture);
             }
@@ -1789,7 +1789,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MiKo_1046_CodeFixTitle {
+        public static string MiKo_1046_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1046_CodeFixTitle", resourceCulture);
             }
@@ -1798,7 +1798,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, methods using the Task-based Asynchronous Pattern (TAP) should end with the suffix &apos;Async.&apos; This helps clearly identify them as asynchronous methods..
         /// </summary>
-        internal static string MiKo_1046_Description {
+        public static string MiKo_1046_Description {
             get {
                 return ResourceManager.GetString("MiKo_1046_Description", resourceCulture);
             }
@@ -1807,7 +1807,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.
         /// </summary>
-        internal static string MiKo_1046_HelpLinkUri {
+        public static string MiKo_1046_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1046_HelpLinkUri", resourceCulture);
             }
@@ -1816,7 +1816,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1046_MessageFormat {
+        public static string MiKo_1046_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1046_MessageFormat", resourceCulture);
             }
@@ -1825,7 +1825,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous methods should follow the Task-based Asynchronous Pattern (TAP).
         /// </summary>
-        internal static string MiKo_1046_Title {
+        public static string MiKo_1046_Title {
             get {
                 return ResourceManager.GetString("MiKo_1046_Title", resourceCulture);
             }
@@ -1834,7 +1834,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MiKo_1047_CodeFixTitle {
+        public static string MiKo_1047_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1047_CodeFixTitle", resourceCulture);
             }
@@ -1843,7 +1843,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance, do not add the &apos;Async&apos; suffix to methods that do not follow the Task-based Asynchronous Pattern (TAP). Using &apos;Async&apos; implies they do follow the pattern, which would be misleading..
         /// </summary>
-        internal static string MiKo_1047_Description {
+        public static string MiKo_1047_Description {
             get {
                 return ResourceManager.GetString("MiKo_1047_Description", resourceCulture);
             }
@@ -1852,7 +1852,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.
         /// </summary>
-        internal static string MiKo_1047_HelpLinkUri {
+        public static string MiKo_1047_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1047_HelpLinkUri", resourceCulture);
             }
@@ -1861,7 +1861,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1047_MessageFormat {
+        public static string MiKo_1047_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1047_MessageFormat", resourceCulture);
             }
@@ -1870,7 +1870,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods not following the Task-based Asynchronous Pattern (TAP) should not lie about being asynchronous.
         /// </summary>
-        internal static string MiKo_1047_Title {
+        public static string MiKo_1047_Title {
             get {
                 return ResourceManager.GetString("MiKo_1047_Title", resourceCulture);
             }
@@ -1879,7 +1879,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append &apos;Converter&apos; suffix.
         /// </summary>
-        internal static string MiKo_1048_CodeFixTitle {
+        public static string MiKo_1048_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1048_CodeFixTitle", resourceCulture);
             }
@@ -1888,7 +1888,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify maintenance, all class names for value converters should end with the suffix &apos;Converter.&apos; This consistency helps quickly identify their role and purpose..
         /// </summary>
-        internal static string MiKo_1048_Description {
+        public static string MiKo_1048_Description {
             get {
                 return ResourceManager.GetString("MiKo_1048_Description", resourceCulture);
             }
@@ -1897,7 +1897,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End name with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1048_MessageFormat {
+        public static string MiKo_1048_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1048_MessageFormat", resourceCulture);
             }
@@ -1906,7 +1906,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Classes that are value converters should end with a specific suffix.
         /// </summary>
-        internal static string MiKo_1048_Title {
+        public static string MiKo_1048_Title {
             get {
                 return ResourceManager.GetString("MiKo_1048_Title", resourceCulture);
             }
@@ -1915,7 +1915,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace requirement term.
         /// </summary>
-        internal static string MiKo_1049_CodeFixTitle {
+        public static string MiKo_1049_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1049_CodeFixTitle", resourceCulture);
             }
@@ -1924,7 +1924,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using terms like &apos;Must&apos;, &apos;Need&apos;, &apos;Shall&apos;, &apos;Should&apos;, &apos;Will&apos;, or &apos;Would&apos; in names is not clear enough. Instead, go for positive verbs or adjectives like &apos;Is&apos;, &apos;Has&apos;, or &apos;Can.&apos; These make the names more explicit and easier to understand..
         /// </summary>
-        internal static string MiKo_1049_Description {
+        public static string MiKo_1049_Description {
             get {
                 return ResourceManager.GetString("MiKo_1049_Description", resourceCulture);
             }
@@ -1933,7 +1933,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{1}&apos; in name.
         /// </summary>
-        internal static string MiKo_1049_MessageFormat {
+        public static string MiKo_1049_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1049_MessageFormat", resourceCulture);
             }
@@ -1942,7 +1942,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use requirement terms such as &apos;Shall&apos;, &apos;Should&apos;, &apos;Must&apos; or &apos;Need&apos; for names.
         /// </summary>
-        internal static string MiKo_1049_Title {
+        public static string MiKo_1049_Title {
             get {
                 return ResourceManager.GetString("MiKo_1049_Title", resourceCulture);
             }
@@ -1951,7 +1951,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename return value.
         /// </summary>
-        internal static string MiKo_1050_CodeFixTitle {
+        public static string MiKo_1050_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1050_CodeFixTitle", resourceCulture);
             }
@@ -1961,7 +1961,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Return variables should clearly describe the data they hold, not their technical aspect.
         ///So, use meaningful names instead of vague ones like &apos;ret&apos;, &apos;retVal&apos;, or &apos;returnValue&apos;. It makes the code more readable and understandable..
         /// </summary>
-        internal static string MiKo_1050_Description {
+        public static string MiKo_1050_Description {
             get {
                 return ResourceManager.GetString("MiKo_1050_Description", resourceCulture);
             }
@@ -1970,7 +1970,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a more descriptive name than &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1050_MessageFormat {
+        public static string MiKo_1050_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1050_MessageFormat", resourceCulture);
             }
@@ -1979,7 +1979,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Return values should have descriptive names.
         /// </summary>
-        internal static string MiKo_1050_Title {
+        public static string MiKo_1050_Title {
             get {
                 return ResourceManager.GetString("MiKo_1050_Title", resourceCulture);
             }
@@ -1988,7 +1988,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;callback&apos;.
         /// </summary>
-        internal static string MiKo_1051_CodeFixTitle {
+        public static string MiKo_1051_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1051_CodeFixTitle", resourceCulture);
             }
@@ -1997,7 +1997,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using the delegate type as a suffix for parameter names is redundant and unhelpful. Instead, use descriptive names like &apos;callback&apos;, &apos;filter&apos;, or &apos;map&apos; to provide clearer context..
         /// </summary>
-        internal static string MiKo_1051_Description {
+        public static string MiKo_1051_Description {
             get {
                 return ResourceManager.GetString("MiKo_1051_Description", resourceCulture);
             }
@@ -2006,7 +2006,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a better matching name instead.
         /// </summary>
-        internal static string MiKo_1051_MessageFormat {
+        public static string MiKo_1051_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1051_MessageFormat", resourceCulture);
             }
@@ -2015,7 +2015,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suffix parameters with delegate types.
         /// </summary>
-        internal static string MiKo_1051_Title {
+        public static string MiKo_1051_Title {
             get {
                 return ResourceManager.GetString("MiKo_1051_Title", resourceCulture);
             }
@@ -2024,7 +2024,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;callback&apos;.
         /// </summary>
-        internal static string MiKo_1052_CodeFixTitle {
+        public static string MiKo_1052_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1052_CodeFixTitle", resourceCulture);
             }
@@ -2033,7 +2033,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using the delegate type as a suffix for variable names is redundant and unhelpful. Instead, use descriptive names like &apos;callback&apos;, &apos;filter&apos;, or &apos;map&apos; to provide clearer context..
         /// </summary>
-        internal static string MiKo_1052_Description {
+        public static string MiKo_1052_Description {
             get {
                 return ResourceManager.GetString("MiKo_1052_Description", resourceCulture);
             }
@@ -2042,7 +2042,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a better matching name instead.
         /// </summary>
-        internal static string MiKo_1052_MessageFormat {
+        public static string MiKo_1052_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1052_MessageFormat", resourceCulture);
             }
@@ -2051,7 +2051,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suffix variables with delegate types.
         /// </summary>
-        internal static string MiKo_1052_Title {
+        public static string MiKo_1052_Title {
             get {
                 return ResourceManager.GetString("MiKo_1052_Title", resourceCulture);
             }
@@ -2060,7 +2060,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename delegate field.
         /// </summary>
-        internal static string MiKo_1053_CodeFixTitle {
+        public static string MiKo_1053_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1053_CodeFixTitle", resourceCulture);
             }
@@ -2069,7 +2069,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using the delegate type as a suffix for field names is redundant and unhelpful. Instead, use descriptive names like &apos;callback&apos;, &apos;filter&apos;, or &apos;map&apos; to provide clearer context..
         /// </summary>
-        internal static string MiKo_1053_Description {
+        public static string MiKo_1053_Description {
             get {
                 return ResourceManager.GetString("MiKo_1053_Description", resourceCulture);
             }
@@ -2078,7 +2078,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a better matching name instead.
         /// </summary>
-        internal static string MiKo_1053_MessageFormat {
+        public static string MiKo_1053_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1053_MessageFormat", resourceCulture);
             }
@@ -2087,7 +2087,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suffix fields with delegate types.
         /// </summary>
-        internal static string MiKo_1053_Title {
+        public static string MiKo_1053_Title {
             get {
                 return ResourceManager.GetString("MiKo_1053_Title", resourceCulture);
             }
@@ -2096,7 +2096,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Utility&apos; marker suffix.
         /// </summary>
-        internal static string MiKo_1054_CodeFixTitle {
+        public static string MiKo_1054_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1054_CodeFixTitle", resourceCulture);
             }
@@ -2106,7 +2106,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Names like &apos;helper&apos; or &apos;utility&apos; are too vague and do not follow the Single Responsibility Principle (SRP). These types often end up having too broad a scope and do not clearly define what they do.
         ///Instead, use specific names that describe their exact purpose, making the code easier to understand and maintain..
         /// </summary>
-        internal static string MiKo_1054_Description {
+        public static string MiKo_1054_Description {
             get {
                 return ResourceManager.GetString("MiKo_1054_Description", resourceCulture);
             }
@@ -2115,7 +2115,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{1}&apos; from name.
         /// </summary>
-        internal static string MiKo_1054_MessageFormat {
+        public static string MiKo_1054_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1054_MessageFormat", resourceCulture);
             }
@@ -2124,7 +2124,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name types &apos;Helper&apos; or &apos;Utility&apos;.
         /// </summary>
-        internal static string MiKo_1054_Title {
+        public static string MiKo_1054_Title {
             get {
                 return ResourceManager.GetString("MiKo_1054_Title", resourceCulture);
             }
@@ -2133,7 +2133,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename dependency property.
         /// </summary>
-        internal static string MiKo_1055_CodeFixTitle {
+        public static string MiKo_1055_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1055_CodeFixTitle", resourceCulture);
             }
@@ -2142,7 +2142,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To show that fields are containers for specific dependency properties, add the suffix &apos;Property&apos; to their names. This aligns with the naming conventions in the .NET Framework..
         /// </summary>
-        internal static string MiKo_1055_Description {
+        public static string MiKo_1055_Description {
             get {
                 return ResourceManager.GetString("MiKo_1055_Description", resourceCulture);
             }
@@ -2151,7 +2151,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
         /// </summary>
-        internal static string MiKo_1055_HelpLinkUri {
+        public static string MiKo_1055_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1055_HelpLinkUri", resourceCulture);
             }
@@ -2160,7 +2160,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1055_MessageFormat {
+        public static string MiKo_1055_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1055_MessageFormat", resourceCulture);
             }
@@ -2169,7 +2169,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency properties should be suffixed with &apos;Property&apos; (as in the .NET Framework).
         /// </summary>
-        internal static string MiKo_1055_Title {
+        public static string MiKo_1055_Title {
             get {
                 return ResourceManager.GetString("MiKo_1055_Title", resourceCulture);
             }
@@ -2178,7 +2178,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To show that fields are containers for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework..
         /// </summary>
-        internal static string MiKo_1056_Description {
+        public static string MiKo_1056_Description {
             get {
                 return ResourceManager.GetString("MiKo_1056_Description", resourceCulture);
             }
@@ -2187,7 +2187,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
         /// </summary>
-        internal static string MiKo_1056_HelpLinkUri {
+        public static string MiKo_1056_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1056_HelpLinkUri", resourceCulture);
             }
@@ -2196,7 +2196,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it {1} instead.
         /// </summary>
-        internal static string MiKo_1056_MessageFormat {
+        public static string MiKo_1056_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1056_MessageFormat", resourceCulture);
             }
@@ -2205,7 +2205,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency properties should be prefixed with property names (as in the .NET Framework).
         /// </summary>
-        internal static string MiKo_1056_Title {
+        public static string MiKo_1056_Title {
             get {
                 return ResourceManager.GetString("MiKo_1056_Title", resourceCulture);
             }
@@ -2214,7 +2214,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename dependency property key.
         /// </summary>
-        internal static string MiKo_1057_CodeFixTitle {
+        public static string MiKo_1057_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1057_CodeFixTitle", resourceCulture);
             }
@@ -2223,7 +2223,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To show that fields are keys for specific dependency properties, add the suffix &apos;Key&apos; to their names. This aligns with the naming conventions in the .NET Framework..
         /// </summary>
-        internal static string MiKo_1057_Description {
+        public static string MiKo_1057_Description {
             get {
                 return ResourceManager.GetString("MiKo_1057_Description", resourceCulture);
             }
@@ -2232,7 +2232,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
         /// </summary>
-        internal static string MiKo_1057_HelpLinkUri {
+        public static string MiKo_1057_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1057_HelpLinkUri", resourceCulture);
             }
@@ -2241,7 +2241,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1057_MessageFormat {
+        public static string MiKo_1057_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1057_MessageFormat", resourceCulture);
             }
@@ -2250,7 +2250,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency property keys should be suffixed with &apos;Key&apos; (as in the .NET Framework).
         /// </summary>
-        internal static string MiKo_1057_Title {
+        public static string MiKo_1057_Title {
             get {
                 return ResourceManager.GetString("MiKo_1057_Title", resourceCulture);
             }
@@ -2259,7 +2259,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To show that fields are keys for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework..
         /// </summary>
-        internal static string MiKo_1058_Description {
+        public static string MiKo_1058_Description {
             get {
                 return ResourceManager.GetString("MiKo_1058_Description", resourceCulture);
             }
@@ -2268,7 +2268,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
         /// </summary>
-        internal static string MiKo_1058_HelpLinkUri {
+        public static string MiKo_1058_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1058_HelpLinkUri", resourceCulture);
             }
@@ -2277,7 +2277,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it {1} instead.
         /// </summary>
-        internal static string MiKo_1058_MessageFormat {
+        public static string MiKo_1058_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1058_MessageFormat", resourceCulture);
             }
@@ -2286,7 +2286,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency property keys should be prefixed with property names (as in the .NET Framework).
         /// </summary>
-        internal static string MiKo_1058_Title {
+        public static string MiKo_1058_Title {
             get {
                 return ResourceManager.GetString("MiKo_1058_Title", resourceCulture);
             }
@@ -2295,7 +2295,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Impl&apos; marker suffix.
         /// </summary>
-        internal static string MiKo_1059_CodeFixTitle {
+        public static string MiKo_1059_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1059_CodeFixTitle", resourceCulture);
             }
@@ -2304,7 +2304,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;Impl&apos; or &apos;Implementation&apos; in type names is unnecessary and unhelpful. It&apos;s better to name types directly after the interface they implement, without adding an &apos;Impl&apos; marker. This keeps names clear and concise..
         /// </summary>
-        internal static string MiKo_1059_Description {
+        public static string MiKo_1059_Description {
             get {
                 return ResourceManager.GetString("MiKo_1059_Description", resourceCulture);
             }
@@ -2313,7 +2313,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{1}&apos; from name.
         /// </summary>
-        internal static string MiKo_1059_MessageFormat {
+        public static string MiKo_1059_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1059_MessageFormat", resourceCulture);
             }
@@ -2322,7 +2322,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name types &apos;Impl&apos; or &apos;Implementation&apos;.
         /// </summary>
-        internal static string MiKo_1059_Title {
+        public static string MiKo_1059_Title {
             get {
                 return ResourceManager.GetString("MiKo_1059_Title", resourceCulture);
             }
@@ -2331,7 +2331,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change to &apos;NotFound&apos;.
         /// </summary>
-        internal static string MiKo_1060_CodeFixTitle {
+        public static string MiKo_1060_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1060_CodeFixTitle", resourceCulture);
             }
@@ -2343,7 +2343,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Similarly, using &apos;XyzMissingException&apos; is also misleading. &apos;Missing&apos; implies it should be there but is not, whe [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_1060_Description {
+        public static string MiKo_1060_Description {
             get {
                 return ResourceManager.GetString("MiKo_1060_Description", resourceCulture);
             }
@@ -2352,7 +2352,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Consider to name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1060_MessageFormat {
+        public static string MiKo_1060_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1060_MessageFormat", resourceCulture);
             }
@@ -2361,7 +2361,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;&lt;Entity&gt;NotFound&apos; instead of &apos;Get&lt;Entity&gt;Failed&apos; or &apos;&lt;Entity&gt;Missing&apos;.
         /// </summary>
-        internal static string MiKo_1060_Title {
+        public static string MiKo_1060_Title {
             get {
                 return ResourceManager.GetString("MiKo_1060_Title", resourceCulture);
             }
@@ -2370,7 +2370,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename out parameter.
         /// </summary>
-        internal static string MiKo_1061_CodeFixTitle {
+        public static string MiKo_1061_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1061_CodeFixTitle", resourceCulture);
             }
@@ -2383,7 +2383,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///For example, in the &apos;TryGetMyValue&apos; method, the parameter should be named &apos;myValue&apos;. This keeps names precise and clear..
         /// </summary>
-        internal static string MiKo_1061_Description {
+        public static string MiKo_1061_Description {
             get {
                 return ResourceManager.GetString("MiKo_1061_Description", resourceCulture);
             }
@@ -2392,7 +2392,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1061_MessageFormat {
+        public static string MiKo_1061_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1061_MessageFormat", resourceCulture);
             }
@@ -2401,7 +2401,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The name of &apos;Try&apos; method&apos;s [out] parameter should be specific.
         /// </summary>
-        internal static string MiKo_1061_Title {
+        public static string MiKo_1061_Title {
             get {
                 return ResourceManager.GetString("MiKo_1061_Title", resourceCulture);
             }
@@ -2411,7 +2411,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Detection methods, properties, or fields like &apos;Can&apos;, &apos;Has&apos;, or &apos;Contains&apos; should be concise, like &apos;HasConnection&apos; or &apos;ContainsKey&apos;.
         ///If their names are longer, it likely means they are misplaced and violate the Single Responsibility Principle (SRP)..
         /// </summary>
-        internal static string MiKo_1062_Description {
+        public static string MiKo_1062_Description {
             get {
                 return ResourceManager.GetString("MiKo_1062_Description", resourceCulture);
             }
@@ -2420,7 +2420,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid name with more than {1} words.
         /// </summary>
-        internal static string MiKo_1062_MessageFormat {
+        public static string MiKo_1062_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1062_MessageFormat", resourceCulture);
             }
@@ -2429,7 +2429,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Can/Has/Contains&apos; methods, properties or fields shall consist of only a few words.
         /// </summary>
-        internal static string MiKo_1062_Title {
+        public static string MiKo_1062_Title {
             get {
                 return ResourceManager.GetString("MiKo_1062_Title", resourceCulture);
             }
@@ -2438,7 +2438,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace abbreviations in name.
         /// </summary>
-        internal static string MiKo_1063_CodeFixTitle {
+        public static string MiKo_1063_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1063_CodeFixTitle", resourceCulture);
             }
@@ -2447,7 +2447,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using abbreviations in names is bad practice. It makes it difficult for new developers to understand the code. Plus, abbreviations distract readers, as they have to constantly translate their meaning..
         /// </summary>
-        internal static string MiKo_1063_Description {
+        public static string MiKo_1063_Description {
             get {
                 return ResourceManager.GetString("MiKo_1063_Description", resourceCulture);
             }
@@ -2456,7 +2456,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{2}&apos; instead of abbreviation &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1063_MessageFormat {
+        public static string MiKo_1063_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1063_MessageFormat", resourceCulture);
             }
@@ -2465,7 +2465,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use abbreviations in names.
         /// </summary>
-        internal static string MiKo_1063_Title {
+        public static string MiKo_1063_Title {
             get {
                 return ResourceManager.GetString("MiKo_1063_Title", resourceCulture);
             }
@@ -2474,7 +2474,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, base parameter names on their meaning, not their type. This keeps the code more intuitive and easier to understand..
         /// </summary>
-        internal static string MiKo_1064_Description {
+        public static string MiKo_1064_Description {
             get {
                 return ResourceManager.GetString("MiKo_1064_Description", resourceCulture);
             }
@@ -2483,7 +2483,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name parameter based on its meaning instead of its type.
         /// </summary>
-        internal static string MiKo_1064_MessageFormat {
+        public static string MiKo_1064_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1064_MessageFormat", resourceCulture);
             }
@@ -2492,7 +2492,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameter names reflect their meaning and not their type.
         /// </summary>
-        internal static string MiKo_1064_Title {
+        public static string MiKo_1064_Title {
             get {
                 return ResourceManager.GetString("MiKo_1064_Title", resourceCulture);
             }
@@ -2501,7 +2501,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename operator parameter.
         /// </summary>
-        internal static string MiKo_1065_CodeFixTitle {
+        public static string MiKo_1065_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1065_CodeFixTitle", resourceCulture);
             }
@@ -2514,7 +2514,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This ensures clarity and consistency in your code..
         /// </summary>
-        internal static string MiKo_1065_Description {
+        public static string MiKo_1065_Description {
             get {
                 return ResourceManager.GetString("MiKo_1065_Description", resourceCulture);
             }
@@ -2523,7 +2523,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters.
         /// </summary>
-        internal static string MiKo_1065_HelpLinkUri {
+        public static string MiKo_1065_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1065_HelpLinkUri", resourceCulture);
             }
@@ -2532,7 +2532,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1065_MessageFormat {
+        public static string MiKo_1065_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1065_MessageFormat", resourceCulture);
             }
@@ -2541,7 +2541,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Operator parameters should be named according the .NET Framework Design Guidelines for operator overloads.
         /// </summary>
-        internal static string MiKo_1065_Title {
+        public static string MiKo_1065_Title {
             get {
                 return ResourceManager.GetString("MiKo_1065_Title", resourceCulture);
             }
@@ -2550,7 +2550,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename parameter to match its property.
         /// </summary>
-        internal static string MiKo_1066_CodeFixTitle {
+        public static string MiKo_1066_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1066_CodeFixTitle", resourceCulture);
             }
@@ -2559,7 +2559,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease usage of a class, constructor parameters that get assigned directly to properties should have the same name as the property. So a client of the class easily knows what the parameter is used for..
         /// </summary>
-        internal static string MiKo_1066_Description {
+        public static string MiKo_1066_Description {
             get {
                 return ResourceManager.GetString("MiKo_1066_Description", resourceCulture);
             }
@@ -2568,7 +2568,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name parameter according to the assigned property.
         /// </summary>
-        internal static string MiKo_1066_MessageFormat {
+        public static string MiKo_1066_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1066_MessageFormat", resourceCulture);
             }
@@ -2577,7 +2577,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Constructor parameters that are assigned to a property should be named after the property.
         /// </summary>
-        internal static string MiKo_1066_Title {
+        public static string MiKo_1066_Title {
             get {
                 return ResourceManager.GetString("MiKo_1066_Title", resourceCulture);
             }
@@ -2586,7 +2586,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Perform&apos; from name.
         /// </summary>
-        internal static string MiKo_1067_CodeFixTitle {
+        public static string MiKo_1067_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1067_CodeFixTitle", resourceCulture);
             }
@@ -2595,7 +2595,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The purpose of methods is to execute code, so it&apos;s useless and repetitive to have &apos;Perform&apos; in their names..
         /// </summary>
-        internal static string MiKo_1067_Description {
+        public static string MiKo_1067_Description {
             get {
                 return ResourceManager.GetString("MiKo_1067_Description", resourceCulture);
             }
@@ -2604,7 +2604,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Perform&apos; from name.
         /// </summary>
-        internal static string MiKo_1067_MessageFormat {
+        public static string MiKo_1067_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1067_MessageFormat", resourceCulture);
             }
@@ -2613,7 +2613,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not contain &apos;Perform&apos; in their names.
         /// </summary>
-        internal static string MiKo_1067_Title {
+        public static string MiKo_1067_Title {
             get {
                 return ResourceManager.GetString("MiKo_1067_Title", resourceCulture);
             }
@@ -2622,7 +2622,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Workflows, being high-level constructs within the business layer, should have methods named &apos;CanRun&apos; or &apos;Run&apos;, much like commands that use &apos;CanExecute&apos; and &apos;Execute&apos;. This naming convention keeps things consistent and clear..
         /// </summary>
-        internal static string MiKo_1068_Description {
+        public static string MiKo_1068_Description {
             get {
                 return ResourceManager.GetString("MiKo_1068_Description", resourceCulture);
             }
@@ -2631,7 +2631,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1068_MessageFormat {
+        public static string MiKo_1068_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1068_MessageFormat", resourceCulture);
             }
@@ -2640,7 +2640,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Workflow methods should be named &apos;CanRun&apos; or &apos;Run&apos;.
         /// </summary>
-        internal static string MiKo_1068_Title {
+        public static string MiKo_1068_Title {
             get {
                 return ResourceManager.GetString("MiKo_1068_Title", resourceCulture);
             }
@@ -2649,7 +2649,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, property names should be based on the property&apos;s meaning rather than its type..
         /// </summary>
-        internal static string MiKo_1069_Description {
+        public static string MiKo_1069_Description {
             get {
                 return ResourceManager.GetString("MiKo_1069_Description", resourceCulture);
             }
@@ -2658,7 +2658,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name property based on its meaning instead of its type.
         /// </summary>
-        internal static string MiKo_1069_MessageFormat {
+        public static string MiKo_1069_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1069_MessageFormat", resourceCulture);
             }
@@ -2667,7 +2667,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Property names reflect their meaning and not their type.
         /// </summary>
-        internal static string MiKo_1069_Title {
+        public static string MiKo_1069_Title {
             get {
                 return ResourceManager.GetString("MiKo_1069_Title", resourceCulture);
             }
@@ -2676,7 +2676,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename variable into plural.
         /// </summary>
-        internal static string MiKo_1070_CodeFixTitle {
+        public static string MiKo_1070_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1070_CodeFixTitle", resourceCulture);
             }
@@ -2686,7 +2686,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Local variables for collections (like those implementing &apos;IEnumerable&apos;) should have plural names that describe the contents, not the collection itself.
         ///For example, instead of naming a variable &apos;userCollection&apos;, name it &apos;users&apos; to clearly indicate it holds multiple user entities..
         /// </summary>
-        internal static string MiKo_1070_Description {
+        public static string MiKo_1070_Description {
             get {
                 return ResourceManager.GetString("MiKo_1070_Description", resourceCulture);
             }
@@ -2695,7 +2695,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1070_MessageFormat {
+        public static string MiKo_1070_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1070_MessageFormat", resourceCulture);
             }
@@ -2704,7 +2704,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local collection variables shall use plural name.
         /// </summary>
-        internal static string MiKo_1070_Title {
+        public static string MiKo_1070_Title {
             get {
                 return ResourceManager.GetString("MiKo_1070_Title", resourceCulture);
             }
@@ -2721,7 +2721,7 @@ namespace MiKoSolutions.Analyzers {
         ///   &apos;if (isDeviceOnline) DoSomething();&apos; is harder to read
         ///   &apos;if (deviceIsOnline) DoSomething();&apos; is more fluent to read..
         /// </summary>
-        internal static string MiKo_1071_Description {
+        public static string MiKo_1071_Description {
             get {
                 return ResourceManager.GetString("MiKo_1071_Description", resourceCulture);
             }
@@ -2730,7 +2730,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Formulate question as statement.
         /// </summary>
-        internal static string MiKo_1071_MessageFormat {
+        public static string MiKo_1071_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1071_MessageFormat", resourceCulture);
             }
@@ -2739,7 +2739,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local boolean variables should be named as statements and not as questions.
         /// </summary>
-        internal static string MiKo_1071_Title {
+        public static string MiKo_1071_Title {
             get {
                 return ResourceManager.GetString("MiKo_1071_Title", resourceCulture);
             }
@@ -2756,7 +2756,7 @@ namespace MiKoSolutions.Analyzers {
         ///   &apos;if (IsDeviceOnline) DoSomething();&apos; is harder to read
         ///   &apos;if (DeviceIsOnline) DoSomething();&apos; is more fluent to read..
         /// </summary>
-        internal static string MiKo_1072_Description {
+        public static string MiKo_1072_Description {
             get {
                 return ResourceManager.GetString("MiKo_1072_Description", resourceCulture);
             }
@@ -2765,7 +2765,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Formulate question as statement.
         /// </summary>
-        internal static string MiKo_1072_MessageFormat {
+        public static string MiKo_1072_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1072_MessageFormat", resourceCulture);
             }
@@ -2774,7 +2774,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Boolean properties or methods should be named as statements and not as questions.
         /// </summary>
-        internal static string MiKo_1072_Title {
+        public static string MiKo_1072_Title {
             get {
                 return ResourceManager.GetString("MiKo_1072_Title", resourceCulture);
             }
@@ -2791,7 +2791,7 @@ namespace MiKoSolutions.Analyzers {
         ///   &apos;if (IsDeviceOnline) DoSomething();&apos; is harder to read
         ///   &apos;if (DeviceIsOnline) DoSomething();&apos; is more fluent to read..
         /// </summary>
-        internal static string MiKo_1073_Description {
+        public static string MiKo_1073_Description {
             get {
                 return ResourceManager.GetString("MiKo_1073_Description", resourceCulture);
             }
@@ -2800,7 +2800,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Formulate question as statement.
         /// </summary>
-        internal static string MiKo_1073_MessageFormat {
+        public static string MiKo_1073_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1073_MessageFormat", resourceCulture);
             }
@@ -2809,7 +2809,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Boolean fields should be named as statements and not as questions.
         /// </summary>
-        internal static string MiKo_1073_Title {
+        public static string MiKo_1073_Title {
             get {
                 return ResourceManager.GetString("MiKo_1073_Title", resourceCulture);
             }
@@ -2818,7 +2818,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If an object is used for synchronizing threads with lock statements, add the suffix &apos;Lock&apos; to its name. This makes it clear that the object is used as a synchronization mechanism..
         /// </summary>
-        internal static string MiKo_1074_Description {
+        public static string MiKo_1074_Description {
             get {
                 return ResourceManager.GetString("MiKo_1074_Description", resourceCulture);
             }
@@ -2827,7 +2827,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suffix field with &apos;Lock&apos; because it is used as lock object.
         /// </summary>
-        internal static string MiKo_1074_MessageFormat {
+        public static string MiKo_1074_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1074_MessageFormat", resourceCulture);
             }
@@ -2836,7 +2836,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Objects used to lock on should be suffixed with &apos;Lock&apos;.
         /// </summary>
-        internal static string MiKo_1074_Title {
+        public static string MiKo_1074_Title {
             get {
                 return ResourceManager.GetString("MiKo_1074_Title", resourceCulture);
             }
@@ -2845,7 +2845,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove suffix &apos;EventArgs&apos;.
         /// </summary>
-        internal static string MiKo_1075_CodeFixTitle {
+        public static string MiKo_1075_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1075_CodeFixTitle", resourceCulture);
             }
@@ -2854,7 +2854,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event argument types should inherit from &apos;System.EventArgs&apos; and have names ending with &apos;EventArgs&apos;. If a type ends with &apos;EventArgs&apos; but does not follow this pattern, it&apos;s misleading and should not use &apos;EventArgs&apos; in its name..
         /// </summary>
-        internal static string MiKo_1075_Description {
+        public static string MiKo_1075_Description {
             get {
                 return ResourceManager.GetString("MiKo_1075_Description", resourceCulture);
             }
@@ -2863,7 +2863,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1075_MessageFormat {
+        public static string MiKo_1075_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1075_MessageFormat", resourceCulture);
             }
@@ -2872,7 +2872,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Non-&apos;System.EventArgs&apos; types should not be suffixed with &apos;EventArgs&apos;.
         /// </summary>
-        internal static string MiKo_1075_Title {
+        public static string MiKo_1075_Title {
             get {
                 return ResourceManager.GetString("MiKo_1075_Title", resourceCulture);
             }
@@ -2881,7 +2881,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change suffix to &apos;Event&apos;.
         /// </summary>
-        internal static string MiKo_1076_CodeFixTitle {
+        public static string MiKo_1076_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1076_CodeFixTitle", resourceCulture);
             }
@@ -2890,7 +2890,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prism event types follow the pattern defined by Prism and end their names with &apos;Event&apos;..
         /// </summary>
-        internal static string MiKo_1076_Description {
+        public static string MiKo_1076_Description {
             get {
                 return ResourceManager.GetString("MiKo_1076_Description", resourceCulture);
             }
@@ -2899,7 +2899,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1076_MessageFormat {
+        public static string MiKo_1076_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1076_MessageFormat", resourceCulture);
             }
@@ -2908,7 +2908,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prism event types should be suffixed with &apos;Event&apos;.
         /// </summary>
-        internal static string MiKo_1076_Title {
+        public static string MiKo_1076_Title {
             get {
                 return ResourceManager.GetString("MiKo_1076_Title", resourceCulture);
             }
@@ -2917,7 +2917,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Enum&apos; suffix.
         /// </summary>
-        internal static string MiKo_1077_CodeFixTitle {
+        public static string MiKo_1077_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1077_CodeFixTitle", resourceCulture);
             }
@@ -2926,7 +2926,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Indicating that an enum member is an enum member by using &apos;Enum&apos; as its suffix does not make sense..
         /// </summary>
-        internal static string MiKo_1077_Description {
+        public static string MiKo_1077_Description {
             get {
                 return ResourceManager.GetString("MiKo_1077_Description", resourceCulture);
             }
@@ -2935,7 +2935,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_1077_MessageFormat {
+        public static string MiKo_1077_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1077_MessageFormat", resourceCulture);
             }
@@ -2944,7 +2944,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Enum members should not be suffixed with &apos;Enum&apos;.
         /// </summary>
-        internal static string MiKo_1077_Title {
+        public static string MiKo_1077_Title {
             get {
                 return ResourceManager.GetString("MiKo_1077_Title", resourceCulture);
             }
@@ -2953,7 +2953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename builder method.
         /// </summary>
-        internal static string MiKo_1078_CodeFixTitle {
+        public static string MiKo_1078_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1078_CodeFixTitle", resourceCulture);
             }
@@ -2962,7 +2962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The method belongs to a builder and therefore its name should be started with &apos;Build&apos;..
         /// </summary>
-        internal static string MiKo_1078_Description {
+        public static string MiKo_1078_Description {
             get {
                 return ResourceManager.GetString("MiKo_1078_Description", resourceCulture);
             }
@@ -2971,7 +2971,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start name with &apos;Build&apos;.
         /// </summary>
-        internal static string MiKo_1078_MessageFormat {
+        public static string MiKo_1078_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1078_MessageFormat", resourceCulture);
             }
@@ -2980,16 +2980,52 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Builder method names should start with &apos;Build&apos;.
         /// </summary>
-        internal static string MiKo_1078_Title {
+        public static string MiKo_1078_Title {
             get {
                 return ResourceManager.GetString("MiKo_1078_Title", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove suffix &apos;Repository&apos;.
+        /// </summary>
+        public static string MiKo_1079_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1079_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DDD defines repository classes. However, those classes should not be suffixed with &apos;Repository&apos; as everybody understands different things as a repository..
+        /// </summary>
+        public static string MiKo_1079_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1079_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove suffix &apos;Repository&apos;.
+        /// </summary>
+        public static string MiKo_1079_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1079_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repositories should not be suffixed with &apos;Repository&apos;.
+        /// </summary>
+        public static string MiKo_1079_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1079_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to It is much easier to read a number inside a name if it is written as number and not its spelling (e.g. &apos;issue42&apos; in contrast to &apos;issueFortyTwo&apos;)..
         /// </summary>
-        internal static string MiKo_1080_Description {
+        public static string MiKo_1080_Description {
             get {
                 return ResourceManager.GetString("MiKo_1080_Description", resourceCulture);
             }
@@ -2998,7 +3034,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use number instead of spelling.
         /// </summary>
-        internal static string MiKo_1080_MessageFormat {
+        public static string MiKo_1080_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1080_MessageFormat", resourceCulture);
             }
@@ -3007,7 +3043,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Names should contain numbers instead of their spellings.
         /// </summary>
-        internal static string MiKo_1080_Title {
+        public static string MiKo_1080_Title {
             get {
                 return ResourceManager.GetString("MiKo_1080_Title", resourceCulture);
             }
@@ -3016,7 +3052,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove number.
         /// </summary>
-        internal static string MiKo_1081_CodeFixTitle {
+        public static string MiKo_1081_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1081_CodeFixTitle", resourceCulture);
             }
@@ -3025,7 +3061,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using numbers at the end of method names makes it confusing for users to understand which method to use or if they need to use them together. Instead, give methods clear, descriptive names..
         /// </summary>
-        internal static string MiKo_1081_Description {
+        public static string MiKo_1081_Description {
             get {
                 return ResourceManager.GetString("MiKo_1081_Description", resourceCulture);
             }
@@ -3034,7 +3070,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as suffix.
         /// </summary>
-        internal static string MiKo_1081_MessageFormat {
+        public static string MiKo_1081_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1081_MessageFormat", resourceCulture);
             }
@@ -3043,7 +3079,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be suffixed with a number.
         /// </summary>
-        internal static string MiKo_1081_Title {
+        public static string MiKo_1081_Title {
             get {
                 return ResourceManager.GetString("MiKo_1081_Title", resourceCulture);
             }
@@ -3052,7 +3088,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove number.
         /// </summary>
-        internal static string MiKo_1082_CodeFixTitle {
+        public static string MiKo_1082_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1082_CodeFixTitle", resourceCulture);
             }
@@ -3061,7 +3097,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding numbers to the end of property names (especially if the returned type also has a number) makes them hard to read. Usually, the number can just be left out, making the names clearer and to the point..
         /// </summary>
-        internal static string MiKo_1082_Description {
+        public static string MiKo_1082_Description {
             get {
                 return ResourceManager.GetString("MiKo_1082_Description", resourceCulture);
             }
@@ -3070,7 +3106,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as suffix.
         /// </summary>
-        internal static string MiKo_1082_MessageFormat {
+        public static string MiKo_1082_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1082_MessageFormat", resourceCulture);
             }
@@ -3079,7 +3115,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Properties should not be suffixed with a number if their types have number suffixes.
         /// </summary>
-        internal static string MiKo_1082_Title {
+        public static string MiKo_1082_Title {
             get {
                 return ResourceManager.GetString("MiKo_1082_Title", resourceCulture);
             }
@@ -3088,7 +3124,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove number.
         /// </summary>
-        internal static string MiKo_1083_CodeFixTitle {
+        public static string MiKo_1083_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1083_CodeFixTitle", resourceCulture);
             }
@@ -3097,7 +3133,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding numbers to the end of fiekd names (especially if the type also has a number) makes them hard to read. Usually, the number can just be left out, making the names clearer and to the point..
         /// </summary>
-        internal static string MiKo_1083_Description {
+        public static string MiKo_1083_Description {
             get {
                 return ResourceManager.GetString("MiKo_1083_Description", resourceCulture);
             }
@@ -3106,7 +3142,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as suffix.
         /// </summary>
-        internal static string MiKo_1083_MessageFormat {
+        public static string MiKo_1083_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1083_MessageFormat", resourceCulture);
             }
@@ -3115,7 +3151,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fields should not be suffixed with a number if their types have number suffixes.
         /// </summary>
-        internal static string MiKo_1083_Title {
+        public static string MiKo_1083_Title {
             get {
                 return ResourceManager.GetString("MiKo_1083_Title", resourceCulture);
             }
@@ -3124,7 +3160,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove number.
         /// </summary>
-        internal static string MiKo_1084_CodeFixTitle {
+        public static string MiKo_1084_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1084_CodeFixTitle", resourceCulture);
             }
@@ -3133,7 +3169,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Adding numbers to the end of variable names (especially if the type also has a number) makes them hard to read. Usually, the number can just be left out, making the names clearer and to the point..
         /// </summary>
-        internal static string MiKo_1084_Description {
+        public static string MiKo_1084_Description {
             get {
                 return ResourceManager.GetString("MiKo_1084_Description", resourceCulture);
             }
@@ -3142,7 +3178,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as suffix.
         /// </summary>
-        internal static string MiKo_1084_MessageFormat {
+        public static string MiKo_1084_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1084_MessageFormat", resourceCulture);
             }
@@ -3151,7 +3187,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variables should not be suffixed with a number if their types have number suffixes.
         /// </summary>
-        internal static string MiKo_1084_Title {
+        public static string MiKo_1084_Title {
             get {
                 return ResourceManager.GetString("MiKo_1084_Title", resourceCulture);
             }
@@ -3160,7 +3196,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove number.
         /// </summary>
-        internal static string MiKo_1085_CodeFixTitle {
+        public static string MiKo_1085_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1085_CodeFixTitle", resourceCulture);
             }
@@ -3169,7 +3205,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using numbers in parameter names provides no benefit. Instead, give parameters clear and descriptive names to make them easier to understand and use..
         /// </summary>
-        internal static string MiKo_1085_Description {
+        public static string MiKo_1085_Description {
             get {
                 return ResourceManager.GetString("MiKo_1085_Description", resourceCulture);
             }
@@ -3178,7 +3214,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as suffix.
         /// </summary>
-        internal static string MiKo_1085_MessageFormat {
+        public static string MiKo_1085_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1085_MessageFormat", resourceCulture);
             }
@@ -3187,7 +3223,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should not be suffixed with a number.
         /// </summary>
-        internal static string MiKo_1085_Title {
+        public static string MiKo_1085_Title {
             get {
                 return ResourceManager.GetString("MiKo_1085_Title", resourceCulture);
             }
@@ -3196,7 +3232,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using numbers in method names such &apos;Send2You&apos; or &apos;Do4You&apos; is slang and should be avoided. Instead, the correct words &apos;To&apos; or &apos;For&apos; should be used..
         /// </summary>
-        internal static string MiKo_1086_Description {
+        public static string MiKo_1086_Description {
             get {
                 return ResourceManager.GetString("MiKo_1086_Description", resourceCulture);
             }
@@ -3205,7 +3241,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a number as slang.
         /// </summary>
-        internal static string MiKo_1086_MessageFormat {
+        public static string MiKo_1086_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1086_MessageFormat", resourceCulture);
             }
@@ -3214,7 +3250,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should not be named using numbers as slang.
         /// </summary>
-        internal static string MiKo_1086_Title {
+        public static string MiKo_1086_Title {
             get {
                 return ResourceManager.GetString("MiKo_1086_Title", resourceCulture);
             }
@@ -3223,7 +3259,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename constructor parameter after counterpart in base class.
         /// </summary>
-        internal static string MiKo_1087_CodeFixTitle {
+        public static string MiKo_1087_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1087_CodeFixTitle", resourceCulture);
             }
@@ -3232,7 +3268,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease usage and avoid misunderstandings, the names of constructor parameters should be identical to the names of constructors of the base class..
         /// </summary>
-        internal static string MiKo_1087_Description {
+        public static string MiKo_1087_Description {
             get {
                 return ResourceManager.GetString("MiKo_1087_Description", resourceCulture);
             }
@@ -3241,7 +3277,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name constructor parameter &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1087_MessageFormat {
+        public static string MiKo_1087_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1087_MessageFormat", resourceCulture);
             }
@@ -3250,7 +3286,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name constructor parameters after their counterparts in the base class.
         /// </summary>
-        internal static string MiKo_1087_Title {
+        public static string MiKo_1087_Title {
             get {
                 return ResourceManager.GetString("MiKo_1087_Title", resourceCulture);
             }
@@ -3259,7 +3295,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To indicate that something is a singleton, the specific property or field should be named &apos;Instance&apos; as convention. That makes it easier to spot..
         /// </summary>
-        internal static string MiKo_1088_Description {
+        public static string MiKo_1088_Description {
             get {
                 return ResourceManager.GetString("MiKo_1088_Description", resourceCulture);
             }
@@ -3268,7 +3304,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;Instance&apos;.
         /// </summary>
-        internal static string MiKo_1088_MessageFormat {
+        public static string MiKo_1088_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1088_MessageFormat", resourceCulture);
             }
@@ -3277,7 +3313,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Singleton instances should be named &apos;Instance&apos;.
         /// </summary>
-        internal static string MiKo_1088_Title {
+        public static string MiKo_1088_Title {
             get {
                 return ResourceManager.GetString("MiKo_1088_Title", resourceCulture);
             }
@@ -3286,7 +3322,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename parameter.
         /// </summary>
-        internal static string MiKo_1090_CodeFixTitle {
+        public static string MiKo_1090_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1090_CodeFixTitle", resourceCulture);
             }
@@ -3295,7 +3331,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Instead of adding a type suffix to a parameter name (like &apos;xyzComparer&apos;), just name it after its function (like &apos;comparer&apos;). The type already tells you what it is, so adding that information again is redundant..
         /// </summary>
-        internal static string MiKo_1090_Description {
+        public static string MiKo_1090_Description {
             get {
                 return ResourceManager.GetString("MiKo_1090_Description", resourceCulture);
             }
@@ -3304,7 +3340,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1090_MessageFormat {
+        public static string MiKo_1090_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1090_MessageFormat", resourceCulture);
             }
@@ -3313,7 +3349,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should not be suffixed with specific types.
         /// </summary>
-        internal static string MiKo_1090_Title {
+        public static string MiKo_1090_Title {
             get {
                 return ResourceManager.GetString("MiKo_1090_Title", resourceCulture);
             }
@@ -3322,7 +3358,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove variable suffix.
         /// </summary>
-        internal static string MiKo_1091_CodeFixTitle {
+        public static string MiKo_1091_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1091_CodeFixTitle", resourceCulture);
             }
@@ -3331,7 +3367,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Instead of adding a type suffix to a variable name (like &apos;xyzComparer&apos;), just name it after its function (like &apos;comparer&apos;). The type already tells you what it is, so adding that information again is redundant..
         /// </summary>
-        internal static string MiKo_1091_Description {
+        public static string MiKo_1091_Description {
             get {
                 return ResourceManager.GetString("MiKo_1091_Description", resourceCulture);
             }
@@ -3340,7 +3376,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1091_MessageFormat {
+        public static string MiKo_1091_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1091_MessageFormat", resourceCulture);
             }
@@ -3349,7 +3385,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variables should not be suffixed with specific types.
         /// </summary>
-        internal static string MiKo_1091_Title {
+        public static string MiKo_1091_Title {
             get {
                 return ResourceManager.GetString("MiKo_1091_Title", resourceCulture);
             }
@@ -3358,7 +3394,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove suffix.
         /// </summary>
-        internal static string MiKo_1092_CodeFixTitle {
+        public static string MiKo_1092_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1092_CodeFixTitle", resourceCulture);
             }
@@ -3367,7 +3403,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Instead of suffixing an &apos;ability&apos; type with redundant information (such as &apos;ComparableItem&apos;), the redundant information should be left out of the name of the type (such as &apos;Comparable&apos;)..
         /// </summary>
-        internal static string MiKo_1092_Description {
+        public static string MiKo_1092_Description {
             get {
                 return ResourceManager.GetString("MiKo_1092_Description", resourceCulture);
             }
@@ -3376,7 +3412,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1092_MessageFormat {
+        public static string MiKo_1092_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1092_MessageFormat", resourceCulture);
             }
@@ -3385,7 +3421,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Ability&apos; Types should not be suffixed with redundant information.
         /// </summary>
-        internal static string MiKo_1092_Title {
+        public static string MiKo_1092_Title {
             get {
                 return ResourceManager.GetString("MiKo_1092_Title", resourceCulture);
             }
@@ -3394,7 +3430,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove suffix &apos;Object&apos; or &apos;Struct&apos;.
         /// </summary>
-        internal static string MiKo_1093_CodeFixTitle {
+        public static string MiKo_1093_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1093_CodeFixTitle", resourceCulture);
             }
@@ -3403,7 +3439,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using &apos;Object&apos; or &apos;Struct&apos; as suffixes in identifiers. Often, better names can be chosen that don&apos;t include these terms, like &apos;Identifier&apos; instead of &apos;IdentificationObject&apos;..
         /// </summary>
-        internal static string MiKo_1093_Description {
+        public static string MiKo_1093_Description {
             get {
                 return ResourceManager.GetString("MiKo_1093_Description", resourceCulture);
             }
@@ -3412,7 +3448,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use suffix &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1093_MessageFormat {
+        public static string MiKo_1093_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1093_MessageFormat", resourceCulture);
             }
@@ -3421,7 +3457,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use the suffix &apos;Object&apos; or &apos;Struct&apos;.
         /// </summary>
-        internal static string MiKo_1093_Title {
+        public static string MiKo_1093_Title {
             get {
                 return ResourceManager.GetString("MiKo_1093_Title", resourceCulture);
             }
@@ -3431,7 +3467,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Types should have active suffixes that clearly identify them as types. Avoid using passive suffixes like &apos;Management&apos; or &apos;Handling&apos; and opt for more active terms like &apos;Manager&apos; or &apos;Handler&apos;.
         ///Keep the passive suffixes for namespaces..
         /// </summary>
-        internal static string MiKo_1094_Description {
+        public static string MiKo_1094_Description {
             get {
                 return ResourceManager.GetString("MiKo_1094_Description", resourceCulture);
             }
@@ -3440,7 +3476,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1094_MessageFormat {
+        public static string MiKo_1094_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1094_MessageFormat", resourceCulture);
             }
@@ -3449,7 +3485,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suffix types with passive namespace names.
         /// </summary>
-        internal static string MiKo_1094_Title {
+        public static string MiKo_1094_Title {
             get {
                 return ResourceManager.GetString("MiKo_1094_Title", resourceCulture);
             }
@@ -3463,7 +3499,7 @@ namespace MiKoSolutions.Analyzers {
         ///So, do not mix these terms in documentation and naming.
         ///For instance, do not name a method &apos;RemoveUser&apos; if the documentation states it &apos;Deletes the user from the database.&apos; ..
         /// </summary>
-        internal static string MiKo_1095_Description {
+        public static string MiKo_1095_Description {
             get {
                 return ResourceManager.GetString("MiKo_1095_Description", resourceCulture);
             }
@@ -3472,7 +3508,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Choose wisely between &apos;Delete&apos; and &apos;Remove&apos;.
         /// </summary>
-        internal static string MiKo_1095_MessageFormat {
+        public static string MiKo_1095_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1095_MessageFormat", resourceCulture);
             }
@@ -3481,7 +3517,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;Delete&apos; and &apos;Remove&apos; both in names and documentation.
         /// </summary>
-        internal static string MiKo_1095_Title {
+        public static string MiKo_1095_Title {
             get {
                 return ResourceManager.GetString("MiKo_1095_Title", resourceCulture);
             }
@@ -3490,7 +3526,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To be more explicit and direct, names should use &apos;Failed&apos; instead of &apos;NotSuccesful&apos;..
         /// </summary>
-        internal static string MiKo_1096_Description {
+        public static string MiKo_1096_Description {
             get {
                 return ResourceManager.GetString("MiKo_1096_Description", resourceCulture);
             }
@@ -3499,7 +3535,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Failed&apos; instead of &apos;NotSuccessful&apos;.
         /// </summary>
-        internal static string MiKo_1096_MessageFormat {
+        public static string MiKo_1096_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1096_MessageFormat", resourceCulture);
             }
@@ -3508,7 +3544,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Names should use &apos;Failed&apos; instead of &apos;NotSuccessful&apos;.
         /// </summary>
-        internal static string MiKo_1096_Title {
+        public static string MiKo_1096_Title {
             get {
                 return ResourceManager.GetString("MiKo_1096_Title", resourceCulture);
             }
@@ -3517,7 +3553,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove field prefix.
         /// </summary>
-        internal static string MiKo_1097_CodeFixTitle {
+        public static string MiKo_1097_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1097_CodeFixTitle", resourceCulture);
             }
@@ -3526,7 +3562,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should not use the same prefixes as fields because that would be make them difficult to distinguish from fields. Reviewers probably are not aware of such and might come to wrong conclusions when reading the code..
         /// </summary>
-        internal static string MiKo_1097_Description {
+        public static string MiKo_1097_Description {
             get {
                 return ResourceManager.GetString("MiKo_1097_Description", resourceCulture);
             }
@@ -3535,7 +3571,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use field prefix &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1097_MessageFormat {
+        public static string MiKo_1097_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1097_MessageFormat", resourceCulture);
             }
@@ -3544,7 +3580,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameter names should not follow the naming scheme for fields.
         /// </summary>
-        internal static string MiKo_1097_Title {
+        public static string MiKo_1097_Title {
             get {
                 return ResourceManager.GetString("MiKo_1097_Title", resourceCulture);
             }
@@ -3553,7 +3589,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When a type implements a business interface, its name should reflect that. This makes it easier for developers to identify and use the type. For instance, if a type implements the &apos;IPart&apos; interface, it should be named something like &apos;XyzPart&apos;..
         /// </summary>
-        internal static string MiKo_1098_Description {
+        public static string MiKo_1098_Description {
             get {
                 return ResourceManager.GetString("MiKo_1098_Description", resourceCulture);
             }
@@ -3562,7 +3598,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suffix type name according to one of the following interfaces: {1}.
         /// </summary>
-        internal static string MiKo_1098_MessageFormat {
+        public static string MiKo_1098_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1098_MessageFormat", resourceCulture);
             }
@@ -3571,7 +3607,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type names should reflect the business interface(s) they implement.
         /// </summary>
-        internal static string MiKo_1098_Title {
+        public static string MiKo_1098_Title {
             get {
                 return ResourceManager.GetString("MiKo_1098_Title", resourceCulture);
             }
@@ -3580,7 +3616,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename parameter to match overload.
         /// </summary>
-        internal static string MiKo_1099_CodeFixTitle {
+        public static string MiKo_1099_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1099_CodeFixTitle", resourceCulture);
             }
@@ -3589,7 +3625,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters on method overloads should have the same name. The reason is that most likely these parameters represent the same inputs accross the different overloads which should be reflected in their names..
         /// </summary>
-        internal static string MiKo_1099_Description {
+        public static string MiKo_1099_Description {
             get {
                 return ResourceManager.GetString("MiKo_1099_Description", resourceCulture);
             }
@@ -3598,7 +3634,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; to match overload.
         /// </summary>
-        internal static string MiKo_1099_MessageFormat {
+        public static string MiKo_1099_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1099_MessageFormat", resourceCulture);
             }
@@ -3607,7 +3643,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Matching parameters on method overloads should have identical names.
         /// </summary>
-        internal static string MiKo_1099_Title {
+        public static string MiKo_1099_Title {
             get {
                 return ResourceManager.GetString("MiKo_1099_Title", resourceCulture);
             }
@@ -3616,7 +3652,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A unit test class should clearly indicate the type it tests by naming it with the type&apos;s name as a prefix, followed by &apos;Tests&apos;. For example, if testing &apos;MyXyzClass&apos;, the test class should be named &apos;MyXyzClassTests&apos;. This makes it easy to identify what is being tested..
         /// </summary>
-        internal static string MiKo_1100_Description {
+        public static string MiKo_1100_Description {
             get {
                 return ResourceManager.GetString("MiKo_1100_Description", resourceCulture);
             }
@@ -3625,7 +3661,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1100_MessageFormat {
+        public static string MiKo_1100_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1100_MessageFormat", resourceCulture);
             }
@@ -3634,7 +3670,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test classes should start with the name of the type under test.
         /// </summary>
-        internal static string MiKo_1100_Title {
+        public static string MiKo_1100_Title {
             get {
                 return ResourceManager.GetString("MiKo_1100_Title", resourceCulture);
             }
@@ -3643,7 +3679,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append &apos;Tests&apos; suffix.
         /// </summary>
-        internal static string MiKo_1101_CodeFixTitle {
+        public static string MiKo_1101_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1101_CodeFixTitle", resourceCulture);
             }
@@ -3652,7 +3688,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A unit test class should use the suffix &apos;Tests&apos; rather than &apos;Test&apos;, since it typically contains multiple tests..
         /// </summary>
-        internal static string MiKo_1101_Description {
+        public static string MiKo_1101_Description {
             get {
                 return ResourceManager.GetString("MiKo_1101_Description", resourceCulture);
             }
@@ -3661,7 +3697,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1101_MessageFormat {
+        public static string MiKo_1101_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1101_MessageFormat", resourceCulture);
             }
@@ -3670,7 +3706,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test classes should end with &apos;Tests&apos;.
         /// </summary>
-        internal static string MiKo_1101_Title {
+        public static string MiKo_1101_Title {
             get {
                 return ResourceManager.GetString("MiKo_1101_Title", resourceCulture);
             }
@@ -3679,7 +3715,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove test marker from name.
         /// </summary>
-        internal static string MiKo_1102_CodeFixTitle {
+        public static string MiKo_1102_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1102_CodeFixTitle", resourceCulture);
             }
@@ -3688,7 +3724,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods marked as unit tests should not need &apos;Test&apos; in their name. It&apos;s redundant, as the unit test framework already indicates they are tests. Keep the names clear and descriptive without &apos;Test&apos;..
         /// </summary>
-        internal static string MiKo_1102_Description {
+        public static string MiKo_1102_Description {
             get {
                 return ResourceManager.GetString("MiKo_1102_Description", resourceCulture);
             }
@@ -3697,7 +3733,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{1}&apos; from name.
         /// </summary>
-        internal static string MiKo_1102_MessageFormat {
+        public static string MiKo_1102_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1102_MessageFormat", resourceCulture);
             }
@@ -3706,7 +3742,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not contain &apos;Test&apos; in their names.
         /// </summary>
-        internal static string MiKo_1102_Title {
+        public static string MiKo_1102_Title {
             get {
                 return ResourceManager.GetString("MiKo_1102_Title", resourceCulture);
             }
@@ -3715,7 +3751,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename to &apos;PrepareTest&apos;.
         /// </summary>
-        internal static string MiKo_1103_CodeFixTitle {
+        public static string MiKo_1103_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1103_CodeFixTitle", resourceCulture);
             }
@@ -3724,7 +3760,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A unit test initialization method should be named &apos;PrepareTest&apos; to clearly indicate its purpose in preparing the test environment. This naming makes the code easy to read and understand..
         /// </summary>
-        internal static string MiKo_1103_Description {
+        public static string MiKo_1103_Description {
             get {
                 return ResourceManager.GetString("MiKo_1103_Description", resourceCulture);
             }
@@ -3733,7 +3769,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1103_MessageFormat {
+        public static string MiKo_1103_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1103_MessageFormat", resourceCulture);
             }
@@ -3742,7 +3778,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test initialization methods should be named &apos;PrepareTest&apos;.
         /// </summary>
-        internal static string MiKo_1103_Title {
+        public static string MiKo_1103_Title {
             get {
                 return ResourceManager.GetString("MiKo_1103_Title", resourceCulture);
             }
@@ -3751,7 +3787,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename to &apos;CleanupTest&apos;.
         /// </summary>
-        internal static string MiKo_1104_CodeFixTitle {
+        public static string MiKo_1104_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1104_CodeFixTitle", resourceCulture);
             }
@@ -3760,7 +3796,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A unit test cleanup method should be named &apos;CleanupTest&apos; to clearly indicate its purpose in tidying up the test environment after the test runs. This naming makes the code easy to read and understand..
         /// </summary>
-        internal static string MiKo_1104_Description {
+        public static string MiKo_1104_Description {
             get {
                 return ResourceManager.GetString("MiKo_1104_Description", resourceCulture);
             }
@@ -3769,7 +3805,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1104_MessageFormat {
+        public static string MiKo_1104_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1104_MessageFormat", resourceCulture);
             }
@@ -3778,7 +3814,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test cleanup methods should be named &apos;CleanupTest&apos;.
         /// </summary>
-        internal static string MiKo_1104_Title {
+        public static string MiKo_1104_Title {
             get {
                 return ResourceManager.GetString("MiKo_1104_Title", resourceCulture);
             }
@@ -3787,7 +3823,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename to &apos;PrepareTestEnvironment&apos;.
         /// </summary>
-        internal static string MiKo_1105_CodeFixTitle {
+        public static string MiKo_1105_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1105_CodeFixTitle", resourceCulture);
             }
@@ -3796,7 +3832,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A one-time unit test initialization method should be named &apos;PrepareTestEnvironment&apos; to clearly indicate its role in setting up the test environment just once before all tests run. This ensures clarity and consistency in the test setup process..
         /// </summary>
-        internal static string MiKo_1105_Description {
+        public static string MiKo_1105_Description {
             get {
                 return ResourceManager.GetString("MiKo_1105_Description", resourceCulture);
             }
@@ -3805,7 +3841,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1105_MessageFormat {
+        public static string MiKo_1105_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1105_MessageFormat", resourceCulture);
             }
@@ -3814,7 +3850,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-time test initialization methods should be named &apos;PrepareTestEnvironment&apos;.
         /// </summary>
-        internal static string MiKo_1105_Title {
+        public static string MiKo_1105_Title {
             get {
                 return ResourceManager.GetString("MiKo_1105_Title", resourceCulture);
             }
@@ -3823,7 +3859,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename to &apos;CleanupTestEnvironment&apos;.
         /// </summary>
-        internal static string MiKo_1106_CodeFixTitle {
+        public static string MiKo_1106_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1106_CodeFixTitle", resourceCulture);
             }
@@ -3832,7 +3868,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A one-time unit test cleanup method should be named &apos;CleanupTestEnvironment&apos; to clearly indicate its role in cleaning up the test environment after all tests have run. This helps maintain consistency and clarity in your test suite..
         /// </summary>
-        internal static string MiKo_1106_Description {
+        public static string MiKo_1106_Description {
             get {
                 return ResourceManager.GetString("MiKo_1106_Description", resourceCulture);
             }
@@ -3841,7 +3877,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1106_MessageFormat {
+        public static string MiKo_1106_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1106_MessageFormat", resourceCulture);
             }
@@ -3850,7 +3886,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-time test cleanup methods should be named &apos;CleanupTestEnvironment&apos;.
         /// </summary>
-        internal static string MiKo_1106_Title {
+        public static string MiKo_1106_Title {
             get {
                 return ResourceManager.GetString("MiKo_1106_Title", resourceCulture);
             }
@@ -3859,7 +3895,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use underscores instead of Pascal-casing.
         /// </summary>
-        internal static string MiKo_1107_CodeFixTitle {
+        public static string MiKo_1107_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1107_CodeFixTitle", resourceCulture);
             }
@@ -3868,7 +3904,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, avoid using Pascal-casing for test method names. Instead, use underscores to separate the different words. This improves readability and makes the code easier to understand..
         /// </summary>
-        internal static string MiKo_1107_Description {
+        public static string MiKo_1107_Description {
             get {
                 return ResourceManager.GetString("MiKo_1107_Description", resourceCulture);
             }
@@ -3877,7 +3913,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use underscores instead of Pascal-casing.
         /// </summary>
-        internal static string MiKo_1107_MessageFormat {
+        public static string MiKo_1107_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1107_MessageFormat", resourceCulture);
             }
@@ -3886,7 +3922,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not be in Pascal-casing.
         /// </summary>
-        internal static string MiKo_1107_Title {
+        public static string MiKo_1107_Title {
             get {
                 return ResourceManager.GetString("MiKo_1107_Title", resourceCulture);
             }
@@ -3895,7 +3931,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove Mock suffix.
         /// </summary>
-        internal static string MiKo_1108_CodeFixTitle {
+        public static string MiKo_1108_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1108_CodeFixTitle", resourceCulture);
             }
@@ -3906,7 +3942,7 @@ namespace MiKoSolutions.Analyzers {
         ///Using names like &apos;Mock&apos;, &apos;Stub&apos;, &apos;Fake&apos;, or &apos;Shim&apos; adds clutter and distracts developers from the actual purpose of the code.
         ///Clear, meaningful names keep the focus on what the code does..
         /// </summary>
-        internal static string MiKo_1108_Description {
+        public static string MiKo_1108_Description {
             get {
                 return ResourceManager.GetString("MiKo_1108_Description", resourceCulture);
             }
@@ -3915,7 +3951,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name it &apos;Mock&apos;, &apos;Stub&apos;, &apos;Fake&apos; or &apos;Shim&apos;.
         /// </summary>
-        internal static string MiKo_1108_MessageFormat {
+        public static string MiKo_1108_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1108_MessageFormat", resourceCulture);
             }
@@ -3924,7 +3960,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name variables, parameters, fields and properties &apos;Mock&apos;, &apos;Stub&apos;, &apos;Fake&apos; or &apos;Shim&apos;.
         /// </summary>
-        internal static string MiKo_1108_Title {
+        public static string MiKo_1108_Title {
             get {
                 return ResourceManager.GetString("MiKo_1108_Title", resourceCulture);
             }
@@ -3933,7 +3969,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefix with &apos;Testable&apos; instead of suffix &apos;Ut&apos;.
         /// </summary>
-        internal static string MiKo_1109_CodeFixTitle {
+        public static string MiKo_1109_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1109_CodeFixTitle", resourceCulture);
             }
@@ -3945,7 +3981,7 @@ namespace MiKoSolutions.Analyzers {
         ///These specially introduced types should have the same name as the original, prefixed with &apos;Testable&apos; (instead of using the confusing &apos;Ut&apos; suffix).
         ///This approach is clearer and makes the test code more readable..
         /// </summary>
-        internal static string MiKo_1109_Description {
+        public static string MiKo_1109_Description {
             get {
                 return ResourceManager.GetString("MiKo_1109_Description", resourceCulture);
             }
@@ -3954,7 +3990,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1109_MessageFormat {
+        public static string MiKo_1109_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1109_MessageFormat", resourceCulture);
             }
@@ -3963,7 +3999,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefix testable types with &apos;Testable&apos; instead of using the &apos;Ut&apos; suffix.
         /// </summary>
-        internal static string MiKo_1109_Title {
+        public static string MiKo_1109_Title {
             get {
                 return ResourceManager.GetString("MiKo_1109_Title", resourceCulture);
             }
@@ -3972,7 +4008,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append underscore.
         /// </summary>
-        internal static string MiKo_1110_CodeFixTitle {
+        public static string MiKo_1110_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1110_CodeFixTitle", resourceCulture);
             }
@@ -3982,7 +4018,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to For easier maintenance, parameterized test methods should be clear and parameters should stand out. To achieve this, add an underscore before the parameters.
         ///For example, &apos;Do_something_for_value_(42)&apos; is easier to read than &apos;Do_something_for_value(42)&apos; due to the extra space before the parenthesis. This makes the method more readable..
         /// </summary>
-        internal static string MiKo_1110_Description {
+        public static string MiKo_1110_Description {
             get {
                 return ResourceManager.GetString("MiKo_1110_Description", resourceCulture);
             }
@@ -3991,7 +4027,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suffix name with underscore.
         /// </summary>
-        internal static string MiKo_1110_MessageFormat {
+        public static string MiKo_1110_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1110_MessageFormat", resourceCulture);
             }
@@ -4000,7 +4036,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods with parameters should be suffixed with underscore.
         /// </summary>
-        internal static string MiKo_1110_Title {
+        public static string MiKo_1110_Title {
             get {
                 return ResourceManager.GetString("MiKo_1110_Title", resourceCulture);
             }
@@ -4009,7 +4045,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove underscore.
         /// </summary>
-        internal static string MiKo_1111_CodeFixTitle {
+        public static string MiKo_1111_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1111_CodeFixTitle", resourceCulture);
             }
@@ -4019,7 +4055,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to For easier maintenance, parameterless test methods should be clear and easy to read. Unlike parameterized methods, they should not have underscores before the parentheses.
         ///For example, &apos;Do_something_for_value()&apos; is more readable than &apos;Do_something_for_value_()&apos;..
         /// </summary>
-        internal static string MiKo_1111_Description {
+        public static string MiKo_1111_Description {
             get {
                 return ResourceManager.GetString("MiKo_1111_Description", resourceCulture);
             }
@@ -4028,7 +4064,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suffix name with underscore.
         /// </summary>
-        internal static string MiKo_1111_MessageFormat {
+        public static string MiKo_1111_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1111_MessageFormat", resourceCulture);
             }
@@ -4037,7 +4073,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods without parameters should not be suffixed with underscore.
         /// </summary>
-        internal static string MiKo_1111_Title {
+        public static string MiKo_1111_Title {
             get {
                 return ResourceManager.GetString("MiKo_1111_Title", resourceCulture);
             }
@@ -4046,7 +4082,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;arbitrary&apos; from name.
         /// </summary>
-        internal static string MiKo_1112_CodeFixTitle {
+        public static string MiKo_1112_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1112_CodeFixTitle", resourceCulture);
             }
@@ -4055,7 +4091,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to In tests, the term &apos;arbitrary&apos; adds no real value to field, parameter, or variable names since test data is inherently arbitrary. Removing it keeps the names simpler and just as clear..
         /// </summary>
-        internal static string MiKo_1112_Description {
+        public static string MiKo_1112_Description {
             get {
                 return ResourceManager.GetString("MiKo_1112_Description", resourceCulture);
             }
@@ -4064,7 +4100,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;arbitrary&apos; from name.
         /// </summary>
-        internal static string MiKo_1112_MessageFormat {
+        public static string MiKo_1112_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1112_MessageFormat", resourceCulture);
             }
@@ -4073,7 +4109,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name test data &apos;arbitrary&apos;.
         /// </summary>
-        internal static string MiKo_1112_Title {
+        public static string MiKo_1112_Title {
             get {
                 return ResourceManager.GetString("MiKo_1112_Title", resourceCulture);
             }
@@ -4082,7 +4118,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &quot;Given... When... Then...&quot; BDD style is meant for non-developer stakeholders. Since unit tests are for developers, this style can make them harder to read and understand. Therefore, avoid using BDD style in unit tests for better clarity..
         /// </summary>
-        internal static string MiKo_1113_Description {
+        public static string MiKo_1113_Description {
             get {
                 return ResourceManager.GetString("MiKo_1113_Description", resourceCulture);
             }
@@ -4091,7 +4127,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name BDD style.
         /// </summary>
-        internal static string MiKo_1113_MessageFormat {
+        public static string MiKo_1113_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1113_MessageFormat", resourceCulture);
             }
@@ -4100,7 +4136,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not be named according BDD style.
         /// </summary>
-        internal static string MiKo_1113_Title {
+        public static string MiKo_1113_Title {
             get {
                 return ResourceManager.GetString("MiKo_1113_Title", resourceCulture);
             }
@@ -4109,7 +4145,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should be named based on the specific scenarios they test, rather than labeling them as &apos;happy path&apos; or &apos;bad path&apos;. This approach makes the purpose of each test clearer and more understandable..
         /// </summary>
-        internal static string MiKo_1114_Description {
+        public static string MiKo_1114_Description {
             get {
                 return ResourceManager.GetString("MiKo_1114_Description", resourceCulture);
             }
@@ -4118,7 +4154,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not name &apos;{0}&apos; a happy or bad path.
         /// </summary>
-        internal static string MiKo_1114_MessageFormat {
+        public static string MiKo_1114_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1114_MessageFormat", resourceCulture);
             }
@@ -4127,7 +4163,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not be named &apos;HappyPath&apos; or &apos;BadPath&apos;.
         /// </summary>
-        internal static string MiKo_1114_Title {
+        public static string MiKo_1114_Title {
             get {
                 return ResourceManager.GetString("MiKo_1114_Title", resourceCulture);
             }
@@ -4136,7 +4172,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix &quot;Yoda-speak&quot; method name.
         /// </summary>
-        internal static string MiKo_1115_CodeFixTitle {
+        public static string MiKo_1115_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1115_CodeFixTitle", resourceCulture);
             }
@@ -4147,7 +4183,7 @@ namespace MiKoSolutions.Analyzers {
         ///Avoid &apos;Yoda&apos; style names like &quot;Send_EMailAddressValid_SendsMail&quot;.
         ///A clearer name would be &quot;Send_sends_email_to_valid_address&quot;, which is easier to read and understand..
         /// </summary>
-        internal static string MiKo_1115_Description {
+        public static string MiKo_1115_Description {
             get {
                 return ResourceManager.GetString("MiKo_1115_Description", resourceCulture);
             }
@@ -4156,7 +4192,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &quot;Yoda-speak&quot; for method names.
         /// </summary>
-        internal static string MiKo_1115_MessageFormat {
+        public static string MiKo_1115_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1115_MessageFormat", resourceCulture);
             }
@@ -4165,7 +4201,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should be named in a fluent way.
         /// </summary>
-        internal static string MiKo_1115_Title {
+        public static string MiKo_1115_Title {
             get {
                 return ResourceManager.GetString("MiKo_1115_Title", resourceCulture);
             }
@@ -4174,7 +4210,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename exception.
         /// </summary>
-        internal static string MiKo_1200_CodeFixTitle {
+        public static string MiKo_1200_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1200_CodeFixTitle", resourceCulture);
             }
@@ -4183,7 +4219,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, name exceptions consistently across all catch blocks. Use the same name each time to keep the code clear..
         /// </summary>
-        internal static string MiKo_1200_Description {
+        public static string MiKo_1200_Description {
             get {
                 return ResourceManager.GetString("MiKo_1200_Description", resourceCulture);
             }
@@ -4192,7 +4228,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1200_MessageFormat {
+        public static string MiKo_1200_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1200_MessageFormat", resourceCulture);
             }
@@ -4201,7 +4237,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name exceptions in catch blocks consistently.
         /// </summary>
-        internal static string MiKo_1200_Title {
+        public static string MiKo_1200_Title {
             get {
                 return ResourceManager.GetString("MiKo_1200_Title", resourceCulture);
             }
@@ -4210,7 +4246,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename exception.
         /// </summary>
-        internal static string MiKo_1201_CodeFixTitle {
+        public static string MiKo_1201_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1201_CodeFixTitle", resourceCulture);
             }
@@ -4219,7 +4255,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, exceptions passed as parameters should always have the same name. This consistency helps keep the code clear..
         /// </summary>
-        internal static string MiKo_1201_Description {
+        public static string MiKo_1201_Description {
             get {
                 return ResourceManager.GetString("MiKo_1201_Description", resourceCulture);
             }
@@ -4228,7 +4264,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; or &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_1201_MessageFormat {
+        public static string MiKo_1201_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1201_MessageFormat", resourceCulture);
             }
@@ -4237,7 +4273,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name exceptions as parameters consistently.
         /// </summary>
-        internal static string MiKo_1201_Title {
+        public static string MiKo_1201_Title {
             get {
                 return ResourceManager.GetString("MiKo_1201_Title", resourceCulture);
             }
@@ -4246,7 +4282,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;_&apos;.
         /// </summary>
-        internal static string MiKo_1300_CodeFixTitle {
+        public static string MiKo_1300_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_1300_CodeFixTitle", resourceCulture);
             }
@@ -4255,7 +4291,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier and reduce visual clutter, consistently name unimportant lambda parameters as &apos;_&apos;. This helps keep the code clean and easy to read..
         /// </summary>
-        internal static string MiKo_1300_Description {
+        public static string MiKo_1300_Description {
             get {
                 return ResourceManager.GetString("MiKo_1300_Description", resourceCulture);
             }
@@ -4264,7 +4300,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;_&apos; instead.
         /// </summary>
-        internal static string MiKo_1300_MessageFormat {
+        public static string MiKo_1300_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1300_MessageFormat", resourceCulture);
             }
@@ -4273,7 +4309,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Unimportant identifiers in lambda statements should be named &apos;_&apos;.
         /// </summary>
-        internal static string MiKo_1300_Title {
+        public static string MiKo_1300_Title {
             get {
                 return ResourceManager.GetString("MiKo_1300_Title", resourceCulture);
             }
@@ -4282,7 +4318,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces group functionalities, so their names should be plural. This makes it clear that they encompass multiple related functions or classes, enhancing readability and organization..
         /// </summary>
-        internal static string MiKo_1400_Description {
+        public static string MiKo_1400_Description {
             get {
                 return ResourceManager.GetString("MiKo_1400_Description", resourceCulture);
             }
@@ -4291,7 +4327,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces.
         /// </summary>
-        internal static string MiKo_1400_HelpLinkUri {
+        public static string MiKo_1400_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_1400_HelpLinkUri", resourceCulture);
             }
@@ -4300,7 +4336,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use plural for namespace, such as &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1400_MessageFormat {
+        public static string MiKo_1400_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1400_MessageFormat", resourceCulture);
             }
@@ -4309,7 +4345,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespace names should be in plural.
         /// </summary>
-        internal static string MiKo_1400_Title {
+        public static string MiKo_1400_Title {
             get {
                 return ResourceManager.GetString("MiKo_1400_Title", resourceCulture);
             }
@@ -4318,7 +4354,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid including language-specific terms like &apos;Interfaces&apos;, &apos;Exceptions&apos;, or &apos;Enums&apos; in namespace names. Namespaces should focus on grouping related functionalities, not the technical aspects of the code. This keeps them clear and more universal..
         /// </summary>
-        internal static string MiKo_1401_Description {
+        public static string MiKo_1401_Description {
             get {
                 return ResourceManager.GetString("MiKo_1401_Description", resourceCulture);
             }
@@ -4327,7 +4363,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use technical name &apos;{0}&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1401_MessageFormat {
+        public static string MiKo_1401_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1401_MessageFormat", resourceCulture);
             }
@@ -4336,7 +4372,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not contain technical language names.
         /// </summary>
-        internal static string MiKo_1401_Title {
+        public static string MiKo_1401_Title {
             get {
                 return ResourceManager.GetString("MiKo_1401_Title", resourceCulture);
             }
@@ -4345,7 +4381,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not be named after WPF-specific design patterns like &apos;Commands&apos;, &apos;Models&apos;, &apos;ViewModels&apos;, or &apos;Views.&apos; Models are entities, while commands, view models, and views are UI-specific components that belong together. Clear and descriptive names help keep the code organized and more understandable..
         /// </summary>
-        internal static string MiKo_1402_Description {
+        public static string MiKo_1402_Description {
             get {
                 return ResourceManager.GetString("MiKo_1402_Description", resourceCulture);
             }
@@ -4354,7 +4390,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use WPF design pattern name &apos;{0}&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1402_MessageFormat {
+        public static string MiKo_1402_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1402_MessageFormat", resourceCulture);
             }
@@ -4363,7 +4399,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not be named after WPF-specific design patterns.
         /// </summary>
-        internal static string MiKo_1402_Title {
+        public static string MiKo_1402_Title {
             get {
                 return ResourceManager.GetString("MiKo_1402_Title", resourceCulture);
             }
@@ -4372,7 +4408,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To prevent redundancy and confusion, avoid naming namespaces after parent namespaces. Instead, choose names that clearly indicate the namespace&apos;s purpose and the functionalities it contains. This helps developers easily understand and navigate the code structure..
         /// </summary>
-        internal static string MiKo_1403_Description {
+        public static string MiKo_1403_Description {
             get {
                 return ResourceManager.GetString("MiKo_1403_Description", resourceCulture);
             }
@@ -4381,7 +4417,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not re-use &apos;{0}&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1403_MessageFormat {
+        public static string MiKo_1403_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1403_MessageFormat", resourceCulture);
             }
@@ -4390,7 +4426,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not be named after any of their parent namespaces.
         /// </summary>
-        internal static string MiKo_1403_Title {
+        public static string MiKo_1403_Title {
             get {
                 return ResourceManager.GetString("MiKo_1403_Title", resourceCulture);
             }
@@ -4399,7 +4435,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using vague names like &apos;Miscellaneous&apos; or &apos;Utilities&apos; for namespaces. Instead, choose specific names that clearly describe the functionalitiesthey contain. This helps developers easily understand and navigate the code structure..
         /// </summary>
-        internal static string MiKo_1404_Description {
+        public static string MiKo_1404_Description {
             get {
                 return ResourceManager.GetString("MiKo_1404_Description", resourceCulture);
             }
@@ -4408,7 +4444,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{0}&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1404_MessageFormat {
+        public static string MiKo_1404_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1404_MessageFormat", resourceCulture);
             }
@@ -4417,7 +4453,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not contain unspecific names.
         /// </summary>
-        internal static string MiKo_1404_Title {
+        public static string MiKo_1404_Title {
             get {
                 return ResourceManager.GetString("MiKo_1404_Title", resourceCulture);
             }
@@ -4427,7 +4463,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Namespaces should be named based on the features they provide, not deployment details.
         ///For example, using a &apos;Lib&apos; suffix just indicates the assembly is a DLL, which is not helpful. Instead, focus on naming namespaces to reflect the functionality they offer, regardless of whether they&apos;re part of a library or an executable..
         /// </summary>
-        internal static string MiKo_1405_Description {
+        public static string MiKo_1405_Description {
             get {
                 return ResourceManager.GetString("MiKo_1405_Description", resourceCulture);
             }
@@ -4436,7 +4472,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{1}&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1405_MessageFormat {
+        public static string MiKo_1405_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1405_MessageFormat", resourceCulture);
             }
@@ -4445,7 +4481,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should not contain &apos;Lib&apos;.
         /// </summary>
-        internal static string MiKo_1405_Title {
+        public static string MiKo_1405_Title {
             get {
                 return ResourceManager.GetString("MiKo_1405_Title", resourceCulture);
             }
@@ -4454,7 +4490,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Value converters should be placed in and grouped under a specific namespace called &apos;Converters&apos; to make them easier to find. This keeps the code organized and more navigable..
         /// </summary>
-        internal static string MiKo_1406_Description {
+        public static string MiKo_1406_Description {
             get {
                 return ResourceManager.GetString("MiKo_1406_Description", resourceCulture);
             }
@@ -4463,7 +4499,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place in &apos;Converters&apos; namespace.
         /// </summary>
-        internal static string MiKo_1406_MessageFormat {
+        public static string MiKo_1406_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1406_MessageFormat", resourceCulture);
             }
@@ -4472,7 +4508,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Value converters should be placed in &apos;Converters&apos; namespace.
         /// </summary>
-        internal static string MiKo_1406_Title {
+        public static string MiKo_1406_Title {
             get {
                 return ResourceManager.GetString("MiKo_1406_Title", resourceCulture);
             }
@@ -4481,7 +4517,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A test should reside in the same namespace as the class it tests. This makes it easier to find and relate the test to the class, enhancing organization and clarity..
         /// </summary>
-        internal static string MiKo_1407_Description {
+        public static string MiKo_1407_Description {
             get {
                 return ResourceManager.GetString("MiKo_1407_Description", resourceCulture);
             }
@@ -4490,7 +4526,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;Test&apos; in namespace.
         /// </summary>
-        internal static string MiKo_1407_MessageFormat {
+        public static string MiKo_1407_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1407_MessageFormat", resourceCulture);
             }
@@ -4499,7 +4535,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test namespaces should not contain &apos;Test&apos;.
         /// </summary>
-        internal static string MiKo_1407_Title {
+        public static string MiKo_1407_Title {
             get {
                 return ResourceManager.GetString("MiKo_1407_Title", resourceCulture);
             }
@@ -4508,7 +4544,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make usage easier, place extension method classes in the same namespace as the types they extend. This helps developers easily detect and use them with IntelliSense..
         /// </summary>
-        internal static string MiKo_1408_Description {
+        public static string MiKo_1408_Description {
             get {
                 return ResourceManager.GetString("MiKo_1408_Description", resourceCulture);
             }
@@ -4517,7 +4553,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place class in namespace &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_1408_MessageFormat {
+        public static string MiKo_1408_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1408_MessageFormat", resourceCulture);
             }
@@ -4526,7 +4562,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Extension methods should be placed in same namespace as the extended types.
         /// </summary>
-        internal static string MiKo_1408_Title {
+        public static string MiKo_1408_Title {
             get {
                 return ResourceManager.GetString("MiKo_1408_Title", resourceCulture);
             }
@@ -4535,7 +4571,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespaces should be made up of full words without any leading or trailing underscores. This helps developers easily understand and navigate the code structure..
         /// </summary>
-        internal static string MiKo_1409_Description {
+        public static string MiKo_1409_Description {
             get {
                 return ResourceManager.GetString("MiKo_1409_Description", resourceCulture);
             }
@@ -4544,7 +4580,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_1409_MessageFormat {
+        public static string MiKo_1409_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_1409_MessageFormat", resourceCulture);
             }
@@ -4553,7 +4589,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not prefix or suffix namespaces with underscores.
         /// </summary>
-        internal static string MiKo_1409_Title {
+        public static string MiKo_1409_Title {
             get {
                 return ResourceManager.GetString("MiKo_1409_Title", resourceCulture);
             }
@@ -4562,7 +4598,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
-        internal static string MiKo_2000_CodeFixTitle {
+        public static string MiKo_2000_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2000_CodeFixTitle", resourceCulture);
             }
@@ -4571,7 +4607,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should be valid XML to generate API documentation and support IntelliSense. This helps developers understand and use the code better, ensuring the documentation is accurate and accessible..
         /// </summary>
-        internal static string MiKo_2000_Description {
+        public static string MiKo_2000_Description {
             get {
                 return ResourceManager.GetString("MiKo_2000_Description", resourceCulture);
             }
@@ -4580,7 +4616,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation is malformed (contains invalid characters, e.g. &apos;&amp;&apos;, &apos;&gt;&apos;, &apos;&lt;&apos;).
         /// </summary>
-        internal static string MiKo_2000_MessageFormat {
+        public static string MiKo_2000_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2000_MessageFormat", resourceCulture);
             }
@@ -4589,7 +4625,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should be valid XML.
         /// </summary>
-        internal static string MiKo_2000_Title {
+        public static string MiKo_2000_Title {
             get {
                 return ResourceManager.GetString("MiKo_2000_Title", resourceCulture);
             }
@@ -4598,7 +4634,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;Occurs &apos;.
         /// </summary>
-        internal static string MiKo_2001_CodeFixTitle {
+        public static string MiKo_2001_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2001_CodeFixTitle", resourceCulture);
             }
@@ -4607,7 +4643,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events should be documented using the phrase &apos;Occurs...&apos; to clearly indicate that they occur. This makes the documentation more precise..
         /// </summary>
-        internal static string MiKo_2001_Description {
+        public static string MiKo_2001_Description {
             get {
                 return ResourceManager.GetString("MiKo_2001_Description", resourceCulture);
             }
@@ -4616,7 +4652,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2001_MessageFormat {
+        public static string MiKo_2001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2001_MessageFormat", resourceCulture);
             }
@@ -4625,7 +4661,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events should be documented properly.
         /// </summary>
-        internal static string MiKo_2001_Title {
+        public static string MiKo_2001_Title {
             get {
                 return ResourceManager.GetString("MiKo_2001_Title", resourceCulture);
             }
@@ -4634,7 +4670,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply &apos;Provides data for the &lt;see cref=&quot;TODO&quot;/&gt; event.&apos; comment.
         /// </summary>
-        internal static string MiKo_2002_CodeFixTitle {
+        public static string MiKo_2002_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2002_CodeFixTitle", resourceCulture);
             }
@@ -4643,7 +4679,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make maintenance easier, classes inheriting from &apos;System.EventArgs&apos; should include documentation stating &apos;Provides data for the &lt;see cref=&quot;XYZ&quot; /&gt; event.&apos; This clarifies which event they relate to, ensuring the documentation is clear and helpful..
         /// </summary>
-        internal static string MiKo_2002_Description {
+        public static string MiKo_2002_Description {
             get {
                 return ResourceManager.GetString("MiKo_2002_Description", resourceCulture);
             }
@@ -4652,7 +4688,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should follow pattern: &apos;{1} ... {2}&apos;.
         /// </summary>
-        internal static string MiKo_2002_MessageFormat {
+        public static string MiKo_2002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2002_MessageFormat", resourceCulture);
             }
@@ -4661,7 +4697,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to EventArgs should be documented properly.
         /// </summary>
-        internal static string MiKo_2002_Title {
+        public static string MiKo_2002_Title {
             get {
                 return ResourceManager.GetString("MiKo_2002_Title", resourceCulture);
             }
@@ -4670,7 +4706,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;Handles the &apos;.
         /// </summary>
-        internal static string MiKo_2003_CodeFixTitle {
+        public static string MiKo_2003_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2003_CodeFixTitle", resourceCulture);
             }
@@ -4679,7 +4715,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for an event handler should begin with a standard phrase that explains which event it handles..
         /// </summary>
-        internal static string MiKo_2003_Description {
+        public static string MiKo_2003_Description {
             get {
                 return ResourceManager.GetString("MiKo_2003_Description", resourceCulture);
             }
@@ -4688,7 +4724,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2003_MessageFormat {
+        public static string MiKo_2003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2003_MessageFormat", resourceCulture);
             }
@@ -4697,7 +4733,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of event handlers should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2003_Title {
+        public static string MiKo_2003_Title {
             get {
                 return ResourceManager.GetString("MiKo_2003_Title", resourceCulture);
             }
@@ -4706,7 +4742,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment of event handler parameter.
         /// </summary>
-        internal static string MiKo_2004_CodeFixTitle {
+        public static string MiKo_2004_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2004_CodeFixTitle", resourceCulture);
             }
@@ -4715,7 +4751,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event handler parameter names should adhere to the .NET Framework Design Guidelines for event handlers. They should clearly define their purpose, making the documentation straightforward and easy to understand..
         /// </summary>
-        internal static string MiKo_2004_Description {
+        public static string MiKo_2004_Description {
             get {
                 return ResourceManager.GetString("MiKo_2004_Description", resourceCulture);
             }
@@ -4724,7 +4760,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change documentation to: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2004_MessageFormat {
+        public static string MiKo_2004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2004_MessageFormat", resourceCulture);
             }
@@ -4733,7 +4769,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of event handler parameter names should follow .NET Framework Design Guidelines for event handlers.
         /// </summary>
-        internal static string MiKo_2004_Title {
+        public static string MiKo_2004_Title {
             get {
                 return ResourceManager.GetString("MiKo_2004_Title", resourceCulture);
             }
@@ -4742,7 +4778,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should avoid using &apos;event arg&apos;. Instead, directly reference the specific class like this: &apos;&lt;see cref=&quot;XyzEventArgs&quot; /&gt;&apos;. This approach provides clarity and allows easy navigation to the related event argument type..
         /// </summary>
-        internal static string MiKo_2005_Description {
+        public static string MiKo_2005_Description {
             get {
                 return ResourceManager.GetString("MiKo_2005_Description", resourceCulture);
             }
@@ -4751,7 +4787,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use term &apos;event arg&apos;.
         /// </summary>
-        internal static string MiKo_2005_MessageFormat {
+        public static string MiKo_2005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2005_MessageFormat", resourceCulture);
             }
@@ -4760,7 +4796,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Textual references to EventArgs should be documented properly.
         /// </summary>
-        internal static string MiKo_2005_Title {
+        public static string MiKo_2005_Title {
             get {
                 return ResourceManager.GetString("MiKo_2005_Title", resourceCulture);
             }
@@ -4769,7 +4805,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment to RoutedEvent.
         /// </summary>
-        internal static string MiKo_2006_CodeFixTitle {
+        public static string MiKo_2006_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2006_CodeFixTitle", resourceCulture);
             }
@@ -4778,7 +4814,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Routed events should follow the same documentation style as the .NET Framework. This consistency ensures clarity, making it easier for developers to understand and work with these events..
         /// </summary>
-        internal static string MiKo_2006_Description {
+        public static string MiKo_2006_Description {
             get {
                 return ResourceManager.GetString("MiKo_2006_Description", resourceCulture);
             }
@@ -4787,7 +4823,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;{1}&gt; should be: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2006_MessageFormat {
+        public static string MiKo_2006_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2006_MessageFormat", resourceCulture);
             }
@@ -4796,7 +4832,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Routed events should be documented as done by the .NET Framework.
         /// </summary>
-        internal static string MiKo_2006_Title {
+        public static string MiKo_2006_Title {
             get {
                 return ResourceManager.GetString("MiKo_2006_Title", resourceCulture);
             }
@@ -4805,7 +4841,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append sealed text to comment.
         /// </summary>
-        internal static string MiKo_2010_CodeFixTitle {
+        public static string MiKo_2010_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2010_CodeFixTitle", resourceCulture);
             }
@@ -4814,7 +4850,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To simplify their use in inheritance scenarios, sealed classes should clearly document that they are sealed. This helps developers understand their constraints and usage better..
         /// </summary>
-        internal static string MiKo_2010_Description {
+        public static string MiKo_2010_Description {
             get {
                 return ResourceManager.GetString("MiKo_2010_Description", resourceCulture);
             }
@@ -4823,7 +4859,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2010_MessageFormat {
+        public static string MiKo_2010_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2010_MessageFormat", resourceCulture);
             }
@@ -4832,7 +4868,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sealed classes should document being sealed.
         /// </summary>
-        internal static string MiKo_2010_Title {
+        public static string MiKo_2010_Title {
             get {
                 return ResourceManager.GetString("MiKo_2010_Title", resourceCulture);
             }
@@ -4841,7 +4877,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove sealed text to comment.
         /// </summary>
-        internal static string MiKo_2011_CodeFixTitle {
+        public static string MiKo_2011_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2011_CodeFixTitle", resourceCulture);
             }
@@ -4850,7 +4886,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Unsealed classes should not mention being sealed since they are not. This keeps things clear and straightforward for developers..
         /// </summary>
-        internal static string MiKo_2011_Description {
+        public static string MiKo_2011_Description {
             get {
                 return ResourceManager.GetString("MiKo_2011_Description", resourceCulture);
             }
@@ -4859,7 +4895,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not contain: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2011_MessageFormat {
+        public static string MiKo_2011_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2011_MessageFormat", resourceCulture);
             }
@@ -4868,7 +4904,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Unsealed classes should not lie about sealing.
         /// </summary>
-        internal static string MiKo_2011_Title {
+        public static string MiKo_2011_Title {
             get {
                 return ResourceManager.GetString("MiKo_2011_Title", resourceCulture);
             }
@@ -4877,7 +4913,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix meaningless phrase.
         /// </summary>
-        internal static string MiKo_2012_CodeFixTitle {
+        public static string MiKo_2012_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2012_CodeFixTitle", resourceCulture);
             }
@@ -4888,7 +4924,7 @@ namespace MiKoSolutions.Analyzers {
         ///Except for callback interfaces, it should avoid meaningless phrases like &apos;Used to&apos;. Instead, start with phrases like &apos;Allows to&apos;, &apos;Represents&apos;, or &apos;Provides&apos;.
         ///This approach keeps the documentation clear and user-focused..
         /// </summary>
-        internal static string MiKo_2012_Description {
+        public static string MiKo_2012_Description {
             get {
                 return ResourceManager.GetString("MiKo_2012_Description", resourceCulture);
             }
@@ -4897,7 +4933,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not {1} meaningless phrase: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2012_MessageFormat {
+        public static string MiKo_2012_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2012_MessageFormat", resourceCulture);
             }
@@ -4906,7 +4942,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should describe the type&apos;s responsibility.
         /// </summary>
-        internal static string MiKo_2012_Title {
+        public static string MiKo_2012_Title {
             get {
                 return ResourceManager.GetString("MiKo_2012_Title", resourceCulture);
             }
@@ -4915,7 +4951,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2013_CodeFixTitle {
+        public static string MiKo_2013_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2013_CodeFixTitle", resourceCulture);
             }
@@ -4924,7 +4960,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make enums easier to use, they should clearly specify the types of values they define. This adds clarity and helps developers understand their purpose more quickly..
         /// </summary>
-        internal static string MiKo_2013_Description {
+        public static string MiKo_2013_Description {
             get {
                 return ResourceManager.GetString("MiKo_2013_Description", resourceCulture);
             }
@@ -4933,7 +4969,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2013_MessageFormat {
+        public static string MiKo_2013_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2013_MessageFormat", resourceCulture);
             }
@@ -4942,7 +4978,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of Enums should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2013_Title {
+        public static string MiKo_2013_Title {
             get {
                 return ResourceManager.GetString("MiKo_2013_Title", resourceCulture);
             }
@@ -4951,7 +4987,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard &apos;Dispose&apos; comment.
         /// </summary>
-        internal static string MiKo_2014_CodeFixTitle {
+        public static string MiKo_2014_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2014_CodeFixTitle", resourceCulture);
             }
@@ -4960,7 +4996,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dispose methods should follow the .NET Framework&apos;s documentation style. This ensures consistency and clarity, making it easier for developers to understand and implement disposal patterns correctly..
         /// </summary>
-        internal static string MiKo_2014_Description {
+        public static string MiKo_2014_Description {
             get {
                 return ResourceManager.GetString("MiKo_2014_Description", resourceCulture);
             }
@@ -4969,7 +5005,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change documentation to: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2014_MessageFormat {
+        public static string MiKo_2014_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2014_MessageFormat", resourceCulture);
             }
@@ -4978,7 +5014,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dispose methods should be documented as done by the .NET Framework.
         /// </summary>
-        internal static string MiKo_2014_Title {
+        public static string MiKo_2014_Title {
             get {
                 return ResourceManager.GetString("MiKo_2014_Title", resourceCulture);
             }
@@ -4987,7 +5023,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace term &apos;fire&apos;.
         /// </summary>
-        internal static string MiKo_2015_CodeFixTitle {
+        public static string MiKo_2015_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2015_CodeFixTitle", resourceCulture);
             }
@@ -4996,7 +5032,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The word &apos;Fire&apos; has negative connotations, like firing employees or guns. It&apos;s not appropriate for events or exceptions. Instead, use &apos;Raise&apos; for events and &apos;Throw&apos; for exceptions, as it conveys a more neutral and accurate action..
         /// </summary>
-        internal static string MiKo_2015_Description {
+        public static string MiKo_2015_Description {
             get {
                 return ResourceManager.GetString("MiKo_2015_Description", resourceCulture);
             }
@@ -5005,7 +5041,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use {1} instead of {2} in documentation.
         /// </summary>
-        internal static string MiKo_2015_MessageFormat {
+        public static string MiKo_2015_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2015_MessageFormat", resourceCulture);
             }
@@ -5014,7 +5050,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use &apos;raise&apos; or &apos;throw&apos; instead of &apos;fire&apos;.
         /// </summary>
-        internal static string MiKo_2015_Title {
+        public static string MiKo_2015_Title {
             get {
                 return ResourceManager.GetString("MiKo_2015_Title", resourceCulture);
             }
@@ -5023,7 +5059,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2016_CodeFixTitle {
+        public static string MiKo_2016_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2016_CodeFixTitle", resourceCulture);
             }
@@ -5032,7 +5068,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for asynchronous methods should state that the method runs asynchronously. Start with &apos;Asynchronously...&apos; to clearly convey this. This ensures developers immediately understand the method&apos;s behavior..
         /// </summary>
-        internal static string MiKo_2016_Description {
+        public static string MiKo_2016_Description {
             get {
                 return ResourceManager.GetString("MiKo_2016_Description", resourceCulture);
             }
@@ -5041,7 +5077,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2016_MessageFormat {
+        public static string MiKo_2016_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2016_MessageFormat", resourceCulture);
             }
@@ -5050,7 +5086,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for asynchronous methods should start with specific phrase.
         /// </summary>
-        internal static string MiKo_2016_Title {
+        public static string MiKo_2016_Title {
             get {
                 return ResourceManager.GetString("MiKo_2016_Title", resourceCulture);
             }
@@ -5059,7 +5095,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment to DependencyProperty.
         /// </summary>
-        internal static string MiKo_2017_CodeFixTitle {
+        public static string MiKo_2017_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2017_CodeFixTitle", resourceCulture);
             }
@@ -5068,7 +5104,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency properties should follow the same documentation style used by the .NET Framework. This consistency ensures clarity and makes it easier for developers to understand and work with these properties..
         /// </summary>
-        internal static string MiKo_2017_Description {
+        public static string MiKo_2017_Description {
             get {
                 return ResourceManager.GetString("MiKo_2017_Description", resourceCulture);
             }
@@ -5077,7 +5113,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;{1}&gt; should be: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2017_MessageFormat {
+        public static string MiKo_2017_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2017_MessageFormat", resourceCulture);
             }
@@ -5086,7 +5122,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dependency properties should be documented as done by the .NET Framework.
         /// </summary>
-        internal static string MiKo_2017_Title {
+        public static string MiKo_2017_Title {
             get {
                 return ResourceManager.GetString("MiKo_2017_Title", resourceCulture);
             }
@@ -5095,7 +5131,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2018_CodeFixTitle {
+        public static string MiKo_2018_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2018_CodeFixTitle", resourceCulture);
             }
@@ -5105,7 +5141,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Terms like &apos;Check&apos; or &apos;Test&apos; can be vague. When validating parameters, use &apos;Validates&apos;. When verifying something, use &apos;Verifies&apos;. If the method needs to determine some condition or situation, use &apos;Determines whether.&apos;
         ///This ensures clarity and precision in your code..
         /// </summary>
-        internal static string MiKo_2018_Description {
+        public static string MiKo_2018_Description {
             get {
                 return ResourceManager.GetString("MiKo_2018_Description", resourceCulture);
             }
@@ -5114,7 +5150,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2018_MessageFormat {
+        public static string MiKo_2018_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2018_MessageFormat", resourceCulture);
             }
@@ -5123,7 +5159,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not use the ambiguous terms &apos;Check&apos; or &apos;Test&apos;.
         /// </summary>
-        internal static string MiKo_2018_Title {
+        public static string MiKo_2018_Title {
             get {
                 return ResourceManager.GetString("MiKo_2018_Title", resourceCulture);
             }
@@ -5132,7 +5168,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should always begin with a third person singular verb, such as &quot;Provides&quot;. This concise description of the functionality that the class, property, etc. offers or represents ensures clarity and helps maintain a uniform documentation style..
         /// </summary>
-        internal static string MiKo_2019_Description {
+        public static string MiKo_2019_Description {
             get {
                 return ResourceManager.GetString("MiKo_2019_Description", resourceCulture);
             }
@@ -5141,7 +5177,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with a third person singular verb.
         /// </summary>
-        internal static string MiKo_2019_MessageFormat {
+        public static string MiKo_2019_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2019_MessageFormat", resourceCulture);
             }
@@ -5150,7 +5186,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should start with a third person singular verb (for example &quot;Provides &quot;).
         /// </summary>
-        internal static string MiKo_2019_Title {
+        public static string MiKo_2019_Title {
             get {
                 return ResourceManager.GetString("MiKo_2019_Title", resourceCulture);
             }
@@ -5159,7 +5195,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;inheritdoc/&gt;.
         /// </summary>
-        internal static string MiKo_2020_CodeFixTitle {
+        public static string MiKo_2020_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2020_CodeFixTitle", resourceCulture);
             }
@@ -5168,7 +5204,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using a &lt;summary&gt; documentation that solely references something else with &lt;see cref=&quot;...&quot; /&gt; is not effective, since IntelliSense does not display these descriptions. For such cases, the &lt;inheritdoc /&gt; tag should be used, as it&apos;s specifically designed for this purpose. This ensures the documentation is properly shown in IntelliSense and makes it more useful for developers..
         /// </summary>
-        internal static string MiKo_2020_Description {
+        public static string MiKo_2020_Description {
             get {
                 return ResourceManager.GetString("MiKo_2020_Description", resourceCulture);
             }
@@ -5177,7 +5213,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;inheritdoc /&gt; instead.
         /// </summary>
-        internal static string MiKo_2020_MessageFormat {
+        public static string MiKo_2020_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2020_MessageFormat", resourceCulture);
             }
@@ -5186,7 +5222,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Inherited documentation should be used with &lt;inheritdoc /&gt; marker.
         /// </summary>
-        internal static string MiKo_2020_Title {
+        public static string MiKo_2020_Title {
             get {
                 return ResourceManager.GetString("MiKo_2020_Title", resourceCulture);
             }
@@ -5195,7 +5231,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start documentation with &apos;The &apos;.
         /// </summary>
-        internal static string MiKo_2021_CodeFixTitle {
+        public static string MiKo_2021_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2021_CodeFixTitle", resourceCulture);
             }
@@ -5204,7 +5240,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of parameters should describe what they represent..
         /// </summary>
-        internal static string MiKo_2021_Description {
+        public static string MiKo_2021_Description {
             get {
                 return ResourceManager.GetString("MiKo_2021_Description", resourceCulture);
             }
@@ -5213,7 +5249,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start documentation with: {1}.
         /// </summary>
-        internal static string MiKo_2021_MessageFormat {
+        public static string MiKo_2021_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2021_MessageFormat", resourceCulture);
             }
@@ -5222,7 +5258,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of parameter should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2021_Title {
+        public static string MiKo_2021_Title {
             get {
                 return ResourceManager.GetString("MiKo_2021_Title", resourceCulture);
             }
@@ -5231,7 +5267,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment start of [out] parameter.
         /// </summary>
-        internal static string MiKo_2022_CodeFixTitle {
+        public static string MiKo_2022_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2022_CodeFixTitle", resourceCulture);
             }
@@ -5240,7 +5276,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For [out] parameter documentation, start with the success case, such as &quot;On successful return, contains...&quot;. This approach aligns with the .NET framework documentation and ensures clarity for developers..
         /// </summary>
-        internal static string MiKo_2022_Description {
+        public static string MiKo_2022_Description {
             get {
                 return ResourceManager.GetString("MiKo_2022_Description", resourceCulture);
             }
@@ -5249,7 +5285,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start documentation with: {1}.
         /// </summary>
-        internal static string MiKo_2022_MessageFormat {
+        public static string MiKo_2022_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2022_MessageFormat", resourceCulture);
             }
@@ -5258,7 +5294,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of [out] parameters should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2022_Title {
+        public static string MiKo_2022_Title {
             get {
                 return ResourceManager.GetString("MiKo_2022_Title", resourceCulture);
             }
@@ -5267,7 +5303,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment start of Boolean parameter.
         /// </summary>
-        internal static string MiKo_2023_CodeFixTitle {
+        public static string MiKo_2023_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2023_CodeFixTitle", resourceCulture);
             }
@@ -5276,7 +5312,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For Boolean parameters, documentation should explicitly describe the &apos;true&apos; case followed by the &apos;false&apos; case. Use the format &apos;&lt;see langword=&quot;true&quot;/&gt; to indicate that ...; otherwise, &lt;see langword=&quot;false&quot;/&gt;.&apos;. This aligns with best practices and provides clarity for developers..
         /// </summary>
-        internal static string MiKo_2023_Description {
+        public static string MiKo_2023_Description {
             get {
                 return ResourceManager.GetString("MiKo_2023_Description", resourceCulture);
             }
@@ -5285,7 +5321,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should follow pattern: &apos;{1} ... {2}&apos;.
         /// </summary>
-        internal static string MiKo_2023_MessageFormat {
+        public static string MiKo_2023_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2023_MessageFormat", resourceCulture);
             }
@@ -5294,7 +5330,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Boolean parameters should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2023_Title {
+        public static string MiKo_2023_Title {
             get {
                 return ResourceManager.GetString("MiKo_2023_Title", resourceCulture);
             }
@@ -5303,7 +5339,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment start of Enum parameter.
         /// </summary>
-        internal static string MiKo_2024_CodeFixTitle {
+        public static string MiKo_2024_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2024_CodeFixTitle", resourceCulture);
             }
@@ -5312,7 +5348,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The Enum parameter documentation should begin with a phrase specifying the action to be taken with the Enum. This ensures clarity about how the Enum will be used and what it represents..
         /// </summary>
-        internal static string MiKo_2024_Description {
+        public static string MiKo_2024_Description {
             get {
                 return ResourceManager.GetString("MiKo_2024_Description", resourceCulture);
             }
@@ -5321,7 +5357,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start documentation with: {1}.
         /// </summary>
-        internal static string MiKo_2024_MessageFormat {
+        public static string MiKo_2024_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2024_MessageFormat", resourceCulture);
             }
@@ -5330,7 +5366,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Enum parameters should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2024_Title {
+        public static string MiKo_2024_Title {
             get {
                 return ResourceManager.GetString("MiKo_2024_Title", resourceCulture);
             }
@@ -5339,7 +5375,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment start of CancellationToken.
         /// </summary>
-        internal static string MiKo_2025_CodeFixTitle {
+        public static string MiKo_2025_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2025_CodeFixTitle", resourceCulture);
             }
@@ -5348,7 +5384,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for &apos;CancellationToken&apos; parameters should begin with a phrase that outlines its usage, like: &apos;The token to monitor for cancellation requests.&apos; This keeps the documentation clear and consistent, aiding developers in understanding its purpose..
         /// </summary>
-        internal static string MiKo_2025_Description {
+        public static string MiKo_2025_Description {
             get {
                 return ResourceManager.GetString("MiKo_2025_Description", resourceCulture);
             }
@@ -5357,7 +5393,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start documentation with: {1}.
         /// </summary>
-        internal static string MiKo_2025_MessageFormat {
+        public static string MiKo_2025_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2025_MessageFormat", resourceCulture);
             }
@@ -5366,7 +5402,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of &apos;CancellationToken&apos; parameters should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2025_Title {
+        public static string MiKo_2025_Title {
             get {
                 return ResourceManager.GetString("MiKo_2025_Title", resourceCulture);
             }
@@ -5375,7 +5411,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation must always be accurate. If a parameter is still in use, it should never be labeled as unused. Keeping documentation truthful and clear is crucial for effective maintenance and development..
         /// </summary>
-        internal static string MiKo_2026_Description {
+        public static string MiKo_2026_Description {
             get {
                 return ResourceManager.GetString("MiKo_2026_Description", resourceCulture);
             }
@@ -5384,7 +5420,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation lies about being unused.
         /// </summary>
-        internal static string MiKo_2026_MessageFormat {
+        public static string MiKo_2026_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2026_MessageFormat", resourceCulture);
             }
@@ -5393,7 +5429,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Used parameters should not be documented to be unused.
         /// </summary>
-        internal static string MiKo_2026_Title {
+        public static string MiKo_2026_Title {
             get {
                 return ResourceManager.GetString("MiKo_2026_Title", resourceCulture);
             }
@@ -5402,7 +5438,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment start of parameter of serialization constructor.
         /// </summary>
-        internal static string MiKo_2027_CodeFixTitle {
+        public static string MiKo_2027_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2027_CodeFixTitle", resourceCulture);
             }
@@ -5411,7 +5447,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease the usage, the documentation of the parameters of the serialization constructors shall have a specific phrase that describes what they contain..
         /// </summary>
-        internal static string MiKo_2027_Description {
+        public static string MiKo_2027_Description {
             get {
                 return ResourceManager.GetString("MiKo_2027_Description", resourceCulture);
             }
@@ -5420,7 +5456,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change documentation to: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2027_MessageFormat {
+        public static string MiKo_2027_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2027_MessageFormat", resourceCulture);
             }
@@ -5429,7 +5465,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Serialization constructor parameters shall be documented with a specific phrase.
         /// </summary>
-        internal static string MiKo_2027_Title {
+        public static string MiKo_2027_Title {
             get {
                 return ResourceManager.GetString("MiKo_2027_Title", resourceCulture);
             }
@@ -5438,7 +5474,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation must go beyond just listing parameter names. It should clearly describe what the parameters represent and how they are used. Simply stating the parameter&apos;s name doesn&apos;t provide enough context or information. Accurate and detailed documentation makes code easier to understand and maintain..
         /// </summary>
-        internal static string MiKo_2028_Description {
+        public static string MiKo_2028_Description {
             get {
                 return ResourceManager.GetString("MiKo_2028_Description", resourceCulture);
             }
@@ -5447,7 +5483,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should contain more than just the parameter name.
         /// </summary>
-        internal static string MiKo_2028_MessageFormat {
+        public static string MiKo_2028_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2028_MessageFormat", resourceCulture);
             }
@@ -5456,7 +5492,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of parameter should not just contain the name of the parameter.
         /// </summary>
-        internal static string MiKo_2028_Title {
+        public static string MiKo_2028_Title {
             get {
                 return ResourceManager.GetString("MiKo_2028_Title", resourceCulture);
             }
@@ -5465,7 +5501,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;cref&apos; value from &lt;inheritdoc/&gt;.
         /// </summary>
-        internal static string MiKo_2029_CodeFixTitle {
+        public static string MiKo_2029_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2029_CodeFixTitle", resourceCulture);
             }
@@ -5474,7 +5510,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Instead of using &lt;inheritdoc&gt; with a &apos;cref&apos; to itself, provide a clear and well-written &lt;summary&gt; XML documentation..
         /// </summary>
-        internal static string MiKo_2029_Description {
+        public static string MiKo_2029_Description {
             get {
                 return ResourceManager.GetString("MiKo_2029_Description", resourceCulture);
             }
@@ -5483,7 +5519,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &lt;inheritdoc cref=&quot;{0}&quot; /&gt;.
         /// </summary>
-        internal static string MiKo_2029_MessageFormat {
+        public static string MiKo_2029_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2029_MessageFormat", resourceCulture);
             }
@@ -5492,7 +5528,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;inheritdoc&gt; documentation should not use a &apos;cref&apos; to itself.
         /// </summary>
-        internal static string MiKo_2029_Title {
+        public static string MiKo_2029_Title {
             get {
                 return ResourceManager.GetString("MiKo_2029_Title", resourceCulture);
             }
@@ -5501,7 +5537,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for a return value should start with a default phrase that provides a detailed description of what the returned value is. This approach helps clarify the purpose and use of the return value for developers..
         /// </summary>
-        internal static string MiKo_2030_Description {
+        public static string MiKo_2030_Description {
             get {
                 return ResourceManager.GetString("MiKo_2030_Description", resourceCulture);
             }
@@ -5510,7 +5546,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2030_MessageFormat {
+        public static string MiKo_2030_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2030_MessageFormat", resourceCulture);
             }
@@ -5519,7 +5555,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of return value should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2030_Title {
+        public static string MiKo_2030_Title {
             get {
                 return ResourceManager.GetString("MiKo_2030_Title", resourceCulture);
             }
@@ -5528,7 +5564,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix return comment.
         /// </summary>
-        internal static string MiKo_2031_CodeFixTitle {
+        public static string MiKo_2031_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2031_CodeFixTitle", resourceCulture);
             }
@@ -5537,7 +5573,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation for a &apos;Task&apos; return value should start with a phrase that describes what the task represents and what result data it provides. This helps developers quickly understand the purpose and output of the task..
         /// </summary>
-        internal static string MiKo_2031_Description {
+        public static string MiKo_2031_Description {
             get {
                 return ResourceManager.GetString("MiKo_2031_Description", resourceCulture);
             }
@@ -5546,7 +5582,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2031_MessageFormat {
+        public static string MiKo_2031_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2031_MessageFormat", resourceCulture);
             }
@@ -5555,7 +5591,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Task return value should have a specific (starting) phrase.
         /// </summary>
-        internal static string MiKo_2031_Title {
+        public static string MiKo_2031_Title {
             get {
                 return ResourceManager.GetString("MiKo_2031_Title", resourceCulture);
             }
@@ -5564,7 +5600,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix return comment.
         /// </summary>
-        internal static string MiKo_2032_CodeFixTitle {
+        public static string MiKo_2032_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2032_CodeFixTitle", resourceCulture);
             }
@@ -5573,7 +5609,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For Boolean return values, documentation should explicitly describe the &apos;true&apos; case followed by the &apos;false&apos; case. Use the format &apos;&lt;see langword=&quot;true&quot;/&gt; if ...; otherwise, &lt;see langword=&quot;false&quot;/&gt;.&apos;. This aligns with best practices, ensures clarity and helps developers understand the possible outcomes of the method..
         /// </summary>
-        internal static string MiKo_2032_Description {
+        public static string MiKo_2032_Description {
             get {
                 return ResourceManager.GetString("MiKo_2032_Description", resourceCulture);
             }
@@ -5582,7 +5618,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;{1}&gt; should follow pattern: &apos;{2} ... {3}&apos;.
         /// </summary>
-        internal static string MiKo_2032_MessageFormat {
+        public static string MiKo_2032_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2032_MessageFormat", resourceCulture);
             }
@@ -5591,7 +5627,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Boolean return value should have a specific phrase.
         /// </summary>
-        internal static string MiKo_2032_Title {
+        public static string MiKo_2032_Title {
             get {
                 return ResourceManager.GetString("MiKo_2032_Title", resourceCulture);
             }
@@ -5600,7 +5636,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix return comment.
         /// </summary>
-        internal static string MiKo_2033_CodeFixTitle {
+        public static string MiKo_2033_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2033_CodeFixTitle", resourceCulture);
             }
@@ -5609,7 +5645,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of a String as return value should have a specific phrase..
         /// </summary>
-        internal static string MiKo_2033_Description {
+        public static string MiKo_2033_Description {
             get {
                 return ResourceManager.GetString("MiKo_2033_Description", resourceCulture);
             }
@@ -5618,7 +5654,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2033_MessageFormat {
+        public static string MiKo_2033_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2033_MessageFormat", resourceCulture);
             }
@@ -5627,7 +5663,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of String return value should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2033_Title {
+        public static string MiKo_2033_Title {
             get {
                 return ResourceManager.GetString("MiKo_2033_Title", resourceCulture);
             }
@@ -5636,7 +5672,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix return comment.
         /// </summary>
-        internal static string MiKo_2034_CodeFixTitle {
+        public static string MiKo_2034_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2034_CodeFixTitle", resourceCulture);
             }
@@ -5645,7 +5681,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of an Enum as return value should have a specific phrase..
         /// </summary>
-        internal static string MiKo_2034_Description {
+        public static string MiKo_2034_Description {
             get {
                 return ResourceManager.GetString("MiKo_2034_Description", resourceCulture);
             }
@@ -5654,7 +5690,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2034_MessageFormat {
+        public static string MiKo_2034_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2034_MessageFormat", resourceCulture);
             }
@@ -5663,7 +5699,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Enum return value should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2034_Title {
+        public static string MiKo_2034_Title {
             get {
                 return ResourceManager.GetString("MiKo_2034_Title", resourceCulture);
             }
@@ -5672,7 +5708,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix return comment.
         /// </summary>
-        internal static string MiKo_2035_CodeFixTitle {
+        public static string MiKo_2035_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2035_CodeFixTitle", resourceCulture);
             }
@@ -5681,7 +5717,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of a collection as return value should have a specific phrase..
         /// </summary>
-        internal static string MiKo_2035_Description {
+        public static string MiKo_2035_Description {
             get {
                 return ResourceManager.GetString("MiKo_2035_Description", resourceCulture);
             }
@@ -5690,7 +5726,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2035_MessageFormat {
+        public static string MiKo_2035_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2035_MessageFormat", resourceCulture);
             }
@@ -5699,7 +5735,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of collection return value should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2035_Title {
+        public static string MiKo_2035_Title {
             get {
                 return ResourceManager.GetString("MiKo_2035_Title", resourceCulture);
             }
@@ -5708,7 +5744,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment for default value &apos;false&apos;.
         /// </summary>
-        internal static string MiKo_2036_CodeFixTitle_DefaultFalse {
+        public static string MiKo_2036_CodeFixTitle_DefaultFalse {
             get {
                 return ResourceManager.GetString("MiKo_2036_CodeFixTitle_DefaultFalse", resourceCulture);
             }
@@ -5717,7 +5753,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment for default value &apos;true&apos;.
         /// </summary>
-        internal static string MiKo_2036_CodeFixTitle_DefaultTrue {
+        public static string MiKo_2036_CodeFixTitle_DefaultTrue {
             get {
                 return ResourceManager.GetString("MiKo_2036_CodeFixTitle_DefaultTrue", resourceCulture);
             }
@@ -5726,7 +5762,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment for enum default value.
         /// </summary>
-        internal static string MiKo_2036_CodeFixTitle_Enum {
+        public static string MiKo_2036_CodeFixTitle_Enum {
             get {
                 return ResourceManager.GetString("MiKo_2036_CodeFixTitle_Enum", resourceCulture);
             }
@@ -5735,7 +5771,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment for no default value.
         /// </summary>
-        internal static string MiKo_2036_CodeFixTitle_NoDefault {
+        public static string MiKo_2036_CodeFixTitle_NoDefault {
             get {
                 return ResourceManager.GetString("MiKo_2036_CodeFixTitle_NoDefault", resourceCulture);
             }
@@ -5744,7 +5780,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Boolean or Enum property documentation should conclude with a phrase detailing the default return value. This helps developers quickly understand the property&apos;s typical output..
         /// </summary>
-        internal static string MiKo_2036_Description {
+        public static string MiKo_2036_Description {
             get {
                 return ResourceManager.GetString("MiKo_2036_Description", resourceCulture);
             }
@@ -5754,7 +5790,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to End &lt;{1}&gt; with: &apos;{2}&apos;
         ///Or with: &apos;{3}&apos;.
         /// </summary>
-        internal static string MiKo_2036_MessageFormat {
+        public static string MiKo_2036_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2036_MessageFormat", resourceCulture);
             }
@@ -5763,7 +5799,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of Boolean or Enum property shall describe the default value.
         /// </summary>
-        internal static string MiKo_2036_Title {
+        public static string MiKo_2036_Title {
             get {
                 return ResourceManager.GetString("MiKo_2036_Title", resourceCulture);
             }
@@ -5772,7 +5808,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment to command property.
         /// </summary>
-        internal static string MiKo_2037_CodeFixTitle {
+        public static string MiKo_2037_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2037_CodeFixTitle", resourceCulture);
             }
@@ -5781,7 +5817,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation for a property that returns a command should begin with a phrase that clearly describes what the command does, making the documentation more helpful and precise for developers..
         /// </summary>
-        internal static string MiKo_2037_Description {
+        public static string MiKo_2037_Description {
             get {
                 return ResourceManager.GetString("MiKo_2037_Description", resourceCulture);
             }
@@ -5790,7 +5826,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2037_MessageFormat {
+        public static string MiKo_2037_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2037_MessageFormat", resourceCulture);
             }
@@ -5799,7 +5835,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of command properties should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2037_Title {
+        public static string MiKo_2037_Title {
             get {
                 return ResourceManager.GetString("MiKo_2037_Title", resourceCulture);
             }
@@ -5808,7 +5844,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment to command.
         /// </summary>
-        internal static string MiKo_2038_CodeFixTitle {
+        public static string MiKo_2038_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2038_CodeFixTitle", resourceCulture);
             }
@@ -5817,7 +5853,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation for a command should start with a standard phrase such as &apos;Represents a command that can...&apos;. This clearly describes the command&apos;s functionality and ensures consistency and clarity for developers..
         /// </summary>
-        internal static string MiKo_2038_Description {
+        public static string MiKo_2038_Description {
             get {
                 return ResourceManager.GetString("MiKo_2038_Description", resourceCulture);
             }
@@ -5826,7 +5862,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2038_MessageFormat {
+        public static string MiKo_2038_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2038_MessageFormat", resourceCulture);
             }
@@ -5835,7 +5871,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of command should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2038_Title {
+        public static string MiKo_2038_Title {
             get {
                 return ResourceManager.GetString("MiKo_2038_Title", resourceCulture);
             }
@@ -5844,7 +5880,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard extension methods comment to class.
         /// </summary>
-        internal static string MiKo_2039_CodeFixTitle {
+        public static string MiKo_2039_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2039_CodeFixTitle", resourceCulture);
             }
@@ -5854,7 +5890,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to The documentation for a class that contains extension methods should begin with the phrase &apos;Provides a set of &lt;see langword=&quot;static&quot;/&gt; methods for...&apos;
         ///This format clearly describes the purpose of the class and its functionality, making the documentation straightforward and helpful for developers..
         /// </summary>
-        internal static string MiKo_2039_Description {
+        public static string MiKo_2039_Description {
             get {
                 return ResourceManager.GetString("MiKo_2039_Description", resourceCulture);
             }
@@ -5863,7 +5899,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2039_MessageFormat {
+        public static string MiKo_2039_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2039_MessageFormat", resourceCulture);
             }
@@ -5872,7 +5908,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of classes that contain extension methods should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2039_Title {
+        public static string MiKo_2039_Title {
             get {
                 return ResourceManager.GetString("MiKo_2039_Title", resourceCulture);
             }
@@ -5881,7 +5917,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;see langword=&quot;...&quot;/&gt;.
         /// </summary>
-        internal static string MiKo_2040_CodeFixTitle {
+        public static string MiKo_2040_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2040_CodeFixTitle", resourceCulture);
             }
@@ -5890,7 +5926,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To support other .NET languages beyond C#, documentation should use &apos;&lt;see langword=&quot;...&quot;/&gt;&apos; instead of &apos;&lt;c&gt;...&lt;/c&gt;&apos;. This ensures that language-specific terms are accurately translated into the correct terminology for each language, making the codebase more inclusive and accessible to non-C# developers..
         /// </summary>
-        internal static string MiKo_2040_Description {
+        public static string MiKo_2040_Description {
             get {
                 return ResourceManager.GetString("MiKo_2040_Description", resourceCulture);
             }
@@ -5899,7 +5935,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{2}&apos; instead of &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2040_MessageFormat {
+        public static string MiKo_2040_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2040_MessageFormat", resourceCulture);
             }
@@ -5908,7 +5944,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;see langword=&quot;...&quot;/&gt; should be used instead of &lt;c&gt;...&lt;/c&gt;.
         /// </summary>
-        internal static string MiKo_2040_Title {
+        public static string MiKo_2040_Title {
             get {
                 return ResourceManager.GetString("MiKo_2040_Title", resourceCulture);
             }
@@ -5917,7 +5953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place XML tag outside &lt;summary&gt;.
         /// </summary>
-        internal static string MiKo_2041_CodeFixTitle {
+        public static string MiKo_2041_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2041_CodeFixTitle", resourceCulture);
             }
@@ -5926,7 +5962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation should be concise and only contain a brief summary description. Other information should be included in the appropriate XML tags alongside the &lt;summary&gt;. This ensures clarity and organization in the documentation..
         /// </summary>
-        internal static string MiKo_2041_Description {
+        public static string MiKo_2041_Description {
             get {
                 return ResourceManager.GetString("MiKo_2041_Description", resourceCulture);
             }
@@ -5935,7 +5971,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.
         /// </summary>
-        internal static string MiKo_2041_HelpLinkUri {
+        public static string MiKo_2041_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_2041_HelpLinkUri", resourceCulture);
             }
@@ -5944,7 +5980,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not contain: &apos;&lt;{0}/&gt;&apos;.
         /// </summary>
-        internal static string MiKo_2041_MessageFormat {
+        public static string MiKo_2041_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2041_MessageFormat", resourceCulture);
             }
@@ -5953,7 +5989,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not contain other documentation tags.
         /// </summary>
-        internal static string MiKo_2041_Title {
+        public static string MiKo_2041_Title {
             get {
                 return ResourceManager.GetString("MiKo_2041_Title", resourceCulture);
             }
@@ -5962,7 +5998,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &lt;br/&gt; with &lt;para/&gt;.
         /// </summary>
-        internal static string MiKo_2042_CodeFixTitle {
+        public static string MiKo_2042_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2042_CodeFixTitle", resourceCulture);
             }
@@ -5971,7 +6007,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the &apos;&lt;para/&gt;&apos; XML tags instead of &apos;&lt;br/&gt;&apos; or &apos;&lt;p/&gt;&apos; HTML tags. This ensures a consistent format, suitable for XML-based documentation tools and frameworks..
         /// </summary>
-        internal static string MiKo_2042_Description {
+        public static string MiKo_2042_Description {
             get {
                 return ResourceManager.GetString("MiKo_2042_Description", resourceCulture);
             }
@@ -5980,7 +6016,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/para.
         /// </summary>
-        internal static string MiKo_2042_HelpLinkUri {
+        public static string MiKo_2042_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_2042_HelpLinkUri", resourceCulture);
             }
@@ -5989,7 +6025,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;&lt;para/&gt;&apos; instead of &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2042_MessageFormat {
+        public static string MiKo_2042_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2042_MessageFormat", resourceCulture);
             }
@@ -5998,7 +6034,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use &apos;&lt;para/&gt;&apos; XML tags instead of &apos;&lt;br/&gt;&apos; HTML tags.
         /// </summary>
-        internal static string MiKo_2042_Title {
+        public static string MiKo_2042_Title {
             get {
                 return ResourceManager.GetString("MiKo_2042_Title", resourceCulture);
             }
@@ -6007,7 +6043,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Encapsulates a method that &apos;.
         /// </summary>
-        internal static string MiKo_2043_CodeFixTitle {
+        public static string MiKo_2043_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2043_CodeFixTitle", resourceCulture);
             }
@@ -6017,7 +6053,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Custom delegate type documentation should start with &apos;Encapsulates a method that...&apos;. This phrase is crucial because a delegate refers to either a static method or an instance method of a class.
         ///Declaring a delegate type sets a contract specifying the method signatures it can encapsulate, clarifying its purpose and usage for developers..
         /// </summary>
-        internal static string MiKo_2043_Description {
+        public static string MiKo_2043_Description {
             get {
                 return ResourceManager.GetString("MiKo_2043_Description", resourceCulture);
             }
@@ -6026,7 +6062,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2043_MessageFormat {
+        public static string MiKo_2043_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2043_MessageFormat", resourceCulture);
             }
@@ -6035,7 +6071,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of custom delegates should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2043_Title {
+        public static string MiKo_2043_Title {
             get {
                 return ResourceManager.GetString("MiKo_2043_Title", resourceCulture);
             }
@@ -6044,7 +6080,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;paramref&gt; tag for parameter.
         /// </summary>
-        internal static string MiKo_2044_CodeFixTitle {
+        public static string MiKo_2044_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2044_CodeFixTitle", resourceCulture);
             }
@@ -6053,7 +6089,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method parameters should be referenced using &lt;paramref name=&quot;...&quot;/&gt; in the documentation, not &lt;param name=&quot;...&quot;/&gt; or plain text. This allows the documentation to update automatically if the parameter is renamed or deleted..
         /// </summary>
-        internal static string MiKo_2044_Description {
+        public static string MiKo_2044_Description {
             get {
                 return ResourceManager.GetString("MiKo_2044_Description", resourceCulture);
             }
@@ -6062,7 +6098,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix incorrect parameter reference &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2044_MessageFormat {
+        public static string MiKo_2044_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2044_MessageFormat", resourceCulture);
             }
@@ -6071,7 +6107,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation references method parameters correctly.
         /// </summary>
-        internal static string MiKo_2044_Title {
+        public static string MiKo_2044_Title {
             get {
                 return ResourceManager.GetString("MiKo_2044_Title", resourceCulture);
             }
@@ -6080,7 +6116,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix parameter reference.
         /// </summary>
-        internal static string MiKo_2045_CodeFixTitle {
+        public static string MiKo_2045_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2045_CodeFixTitle", resourceCulture);
             }
@@ -6089,7 +6125,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation should not reference method parameters. Its sole purpose is to provide a brief overview. Including parameter details would be too specific for this high-level summary..
         /// </summary>
-        internal static string MiKo_2045_Description {
+        public static string MiKo_2045_Description {
             get {
                 return ResourceManager.GetString("MiKo_2045_Description", resourceCulture);
             }
@@ -6098,7 +6134,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not contain parameter reference &apos; {0} &apos;.
         /// </summary>
-        internal static string MiKo_2045_MessageFormat {
+        public static string MiKo_2045_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2045_MessageFormat", resourceCulture);
             }
@@ -6107,7 +6143,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not reference parameters.
         /// </summary>
-        internal static string MiKo_2045_Title {
+        public static string MiKo_2045_Title {
             get {
                 return ResourceManager.GetString("MiKo_2045_Title", resourceCulture);
             }
@@ -6116,7 +6152,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace invalid type parameter reference.
         /// </summary>
-        internal static string MiKo_2046_CodeFixTitle {
+        public static string MiKo_2046_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2046_CodeFixTitle", resourceCulture);
             }
@@ -6125,7 +6161,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The XML documentation should reference type parameters properly via &apos;&lt;typeparamref name=&quot;...&quot; /&gt;&apos;..
         /// </summary>
-        internal static string MiKo_2046_Description {
+        public static string MiKo_2046_Description {
             get {
                 return ResourceManager.GetString("MiKo_2046_Description", resourceCulture);
             }
@@ -6134,7 +6170,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace invalid type parameter reference.
         /// </summary>
-        internal static string MiKo_2046_MessageFormat {
+        public static string MiKo_2046_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2046_MessageFormat", resourceCulture);
             }
@@ -6143,7 +6179,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should reference type parameters correctly.
         /// </summary>
-        internal static string MiKo_2046_Title {
+        public static string MiKo_2046_Title {
             get {
                 return ResourceManager.GetString("MiKo_2046_Title", resourceCulture);
             }
@@ -6152,7 +6188,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of an Attribute should start with a specific phrase that describes its purpose..
         /// </summary>
-        internal static string MiKo_2047_Description {
+        public static string MiKo_2047_Description {
             get {
                 return ResourceManager.GetString("MiKo_2047_Description", resourceCulture);
             }
@@ -6161,7 +6197,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: {1}.
         /// </summary>
-        internal static string MiKo_2047_MessageFormat {
+        public static string MiKo_2047_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2047_MessageFormat", resourceCulture);
             }
@@ -6170,7 +6206,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of Attributes should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2047_Title {
+        public static string MiKo_2047_Title {
             get {
                 return ResourceManager.GetString("MiKo_2047_Title", resourceCulture);
             }
@@ -6179,7 +6215,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2048_CodeFixTitle {
+        public static string MiKo_2048_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2048_CodeFixTitle", resourceCulture);
             }
@@ -6188,7 +6224,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of a value converters should start with a specific phrase that describes what they convert..
         /// </summary>
-        internal static string MiKo_2048_Description {
+        public static string MiKo_2048_Description {
             get {
                 return ResourceManager.GetString("MiKo_2048_Description", resourceCulture);
             }
@@ -6197,7 +6233,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2048_MessageFormat {
+        public static string MiKo_2048_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2048_MessageFormat", resourceCulture);
             }
@@ -6206,7 +6242,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of value converters should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2048_Title {
+        public static string MiKo_2048_Title {
             get {
                 return ResourceManager.GetString("MiKo_2048_Title", resourceCulture);
             }
@@ -6215,7 +6251,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;will be&apos; with &apos;is&apos;.
         /// </summary>
-        internal static string MiKo_2049_CodeFixTitle {
+        public static string MiKo_2049_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2049_CodeFixTitle", resourceCulture);
             }
@@ -6225,7 +6261,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to The term &apos;will be&apos; is not specific enough and it uses the future tense, which is not accurate for describing the current behavior or state of the code. Using &apos;is&apos; instead gets straight to the point and employs the present tense, accurately reflecting the current behavior.
         ///This practice ensures clarity and precision, making your code&apos;s behavior easier to understand..
         /// </summary>
-        internal static string MiKo_2049_Description {
+        public static string MiKo_2049_Description {
             get {
                 return ResourceManager.GetString("MiKo_2049_Description", resourceCulture);
             }
@@ -6234,7 +6270,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;{0}&apos; with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2049_MessageFormat {
+        public static string MiKo_2049_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2049_MessageFormat", resourceCulture);
             }
@@ -6243,7 +6279,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should be more explicit and not use &apos;will be&apos;.
         /// </summary>
-        internal static string MiKo_2049_Title {
+        public static string MiKo_2049_Title {
             get {
                 return ResourceManager.GetString("MiKo_2049_Title", resourceCulture);
             }
@@ -6252,7 +6288,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard exception comment.
         /// </summary>
-        internal static string MiKo_2050_CodeFixTitle {
+        public static string MiKo_2050_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2050_CodeFixTitle", resourceCulture);
             }
@@ -6261,7 +6297,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for exceptions should follow the .NET Framework guidelines. This consistency ensures that the information is clear, precise, and familiar to developers, making it easier to understand and maintain..
         /// </summary>
-        internal static string MiKo_2050_Description {
+        public static string MiKo_2050_Description {
             get {
                 return ResourceManager.GetString("MiKo_2050_Description", resourceCulture);
             }
@@ -6270,7 +6306,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2050_MessageFormat {
+        public static string MiKo_2050_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2050_MessageFormat", resourceCulture);
             }
@@ -6279,7 +6315,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Exceptions should be documented following the .NET Framework.
         /// </summary>
-        internal static string MiKo_2050_Title {
+        public static string MiKo_2050_Title {
             get {
                 return ResourceManager.GetString("MiKo_2050_Title", resourceCulture);
             }
@@ -6288,7 +6324,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix exception comment.
         /// </summary>
-        internal static string MiKo_2051_CodeFixTitle {
+        public static string MiKo_2051_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2051_CodeFixTitle", resourceCulture);
             }
@@ -6297,7 +6333,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When documenting a thrown exception, use a simple condition phrase like: &apos;The item is not available.&apos; Avoid phrases like &apos;Thrown if&apos; or &apos;throws if&apos; since it&apos;s already clear that the exception is thrown under those conditions. This keeps the documentation concise and to the point..
         /// </summary>
-        internal static string MiKo_2051_Description {
+        public static string MiKo_2051_Description {
             get {
                 return ResourceManager.GetString("MiKo_2051_Description", resourceCulture);
             }
@@ -6306,7 +6342,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use condition form to document thrown exception.
         /// </summary>
-        internal static string MiKo_2051_MessageFormat {
+        public static string MiKo_2051_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2051_MessageFormat", resourceCulture);
             }
@@ -6315,7 +6351,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thrown Exceptions should be documented as kind of a condition (such as &apos;&lt;paramref name=&quot;xyz&quot;/&gt; is &lt;c&gt;42&lt;/c&gt;&apos;).
         /// </summary>
-        internal static string MiKo_2051_Title {
+        public static string MiKo_2051_Title {
             get {
                 return ResourceManager.GetString("MiKo_2051_Title", resourceCulture);
             }
@@ -6324,7 +6360,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix exception comment.
         /// </summary>
-        internal static string MiKo_2052_CodeFixTitle {
+        public static string MiKo_2052_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2052_CodeFixTitle", resourceCulture);
             }
@@ -6334,7 +6370,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to When documenting an ArgumentNullException, use the specific phrase: &apos;&lt;paramref name=&quot;value&quot;/&gt; is &lt;see langword=&quot;null&quot;/&gt;.&apos;
         ///This approach ensures clarity and consistency, helping developers understand the condition under which the exception is thrown..
         /// </summary>
-        internal static string MiKo_2052_Description {
+        public static string MiKo_2052_Description {
             get {
                 return ResourceManager.GetString("MiKo_2052_Description", resourceCulture);
             }
@@ -6345,7 +6381,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///{2}.
         /// </summary>
-        internal static string MiKo_2052_MessageFormat {
+        public static string MiKo_2052_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2052_MessageFormat", resourceCulture);
             }
@@ -6354,7 +6390,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throwing of ArgumentNullException should be documented using a default phrase.
         /// </summary>
-        internal static string MiKo_2052_Title {
+        public static string MiKo_2052_Title {
             get {
                 return ResourceManager.GetString("MiKo_2052_Title", resourceCulture);
             }
@@ -6363,7 +6399,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to An ArgumentNullException should not be documented for value-type parameters as value types inherently cannot have a null value..
         /// </summary>
-        internal static string MiKo_2053_Description {
+        public static string MiKo_2053_Description {
             get {
                 return ResourceManager.GetString("MiKo_2053_Description", resourceCulture);
             }
@@ -6372,7 +6408,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{2}&apos; from &lt;exception cref=&quot;ArgumentNullException&quot;/&gt; as &apos;{1}&apos; is a value type.
         /// </summary>
-        internal static string MiKo_2053_MessageFormat {
+        public static string MiKo_2053_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2053_MessageFormat", resourceCulture);
             }
@@ -6381,7 +6417,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throwing of ArgumentNullException should be documented only for reference type parameters.
         /// </summary>
-        internal static string MiKo_2053_Title {
+        public static string MiKo_2053_Title {
             get {
                 return ResourceManager.GetString("MiKo_2053_Title", resourceCulture);
             }
@@ -6390,7 +6426,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix exception comment.
         /// </summary>
-        internal static string MiKo_2054_CodeFixTitle {
+        public static string MiKo_2054_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2054_CodeFixTitle", resourceCulture);
             }
@@ -6400,7 +6436,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to When documenting an ArgumentException being thrown, the documentation should start with the specific phrase: &apos;&lt;paramref name=&quot;value&quot;/&gt; is ...&apos;.
         ///This approach ensures clarity and consistency, helping developers understand the condition under which the exception is thrown..
         /// </summary>
-        internal static string MiKo_2054_Description {
+        public static string MiKo_2054_Description {
             get {
                 return ResourceManager.GetString("MiKo_2054_Description", resourceCulture);
             }
@@ -6410,7 +6446,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to {1} should be something like:
         ///{2}.
         /// </summary>
-        internal static string MiKo_2054_MessageFormat {
+        public static string MiKo_2054_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2054_MessageFormat", resourceCulture);
             }
@@ -6419,7 +6455,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throwing of ArgumentException should be documented using a default starting phrase.
         /// </summary>
-        internal static string MiKo_2054_Title {
+        public static string MiKo_2054_Title {
             get {
                 return ResourceManager.GetString("MiKo_2054_Title", resourceCulture);
             }
@@ -6428,7 +6464,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix exception comment.
         /// </summary>
-        internal static string MiKo_2055_CodeFixTitle {
+        public static string MiKo_2055_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2055_CodeFixTitle", resourceCulture);
             }
@@ -6438,7 +6474,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to When documenting an ArgumentOutOfRangeException being thrown, the documentation should start with the specific phrase: &apos;&lt;paramref name=&quot;value&quot;/&gt; is ...&apos;.
         ///This approach ensures clarity and consistency, helping developers understand under what condition the argument is considered out of range..
         /// </summary>
-        internal static string MiKo_2055_Description {
+        public static string MiKo_2055_Description {
             get {
                 return ResourceManager.GetString("MiKo_2055_Description", resourceCulture);
             }
@@ -6448,7 +6484,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to {1} should be something like:
         ///{2}.
         /// </summary>
-        internal static string MiKo_2055_MessageFormat {
+        public static string MiKo_2055_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2055_MessageFormat", resourceCulture);
             }
@@ -6457,7 +6493,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throwing of ArgumentOutOfRangeException should be documented using a default starting phrase.
         /// </summary>
-        internal static string MiKo_2055_Title {
+        public static string MiKo_2055_Title {
             get {
                 return ResourceManager.GetString("MiKo_2055_Title", resourceCulture);
             }
@@ -6466,7 +6502,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply default ending comment to documentation of thrown &apos;ObjectDisposedException&apos;.
         /// </summary>
-        internal static string MiKo_2056_CodeFixTitle {
+        public static string MiKo_2056_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2056_CodeFixTitle", resourceCulture);
             }
@@ -6476,7 +6512,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to When documenting an ObjectDisposedException being thrown, the documentation should end with the specific phrase &quot;... has been disposed.&quot; If the class includes a &apos;Close&apos; method, it should end with &quot;... has been closed.&quot;
         ///This distinction clearly indicates the reason for the exception and helps developers understand the status of the object..
         /// </summary>
-        internal static string MiKo_2056_Description {
+        public static string MiKo_2056_Description {
             get {
                 return ResourceManager.GetString("MiKo_2056_Description", resourceCulture);
             }
@@ -6485,7 +6521,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to {1} should end with: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2056_MessageFormat {
+        public static string MiKo_2056_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2056_MessageFormat", resourceCulture);
             }
@@ -6494,7 +6530,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throwing of ObjectDisposedException should be documented using a default ending phrase.
         /// </summary>
-        internal static string MiKo_2056_Title {
+        public static string MiKo_2056_Title {
             get {
                 return ResourceManager.GetString("MiKo_2056_Title", resourceCulture);
             }
@@ -6503,7 +6539,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove exception comment.
         /// </summary>
-        internal static string MiKo_2057_CodeFixTitle {
+        public static string MiKo_2057_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2057_CodeFixTitle", resourceCulture);
             }
@@ -6512,7 +6548,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Types that do not inherit from &apos;IDisposable&apos; cannot be disposed. Therefore, they should not document throwing an &apos;ObjectDisposedException&apos;. This keeps the documentation accurate and logical..
         /// </summary>
-        internal static string MiKo_2057_Description {
+        public static string MiKo_2057_Description {
             get {
                 return ResourceManager.GetString("MiKo_2057_Description", resourceCulture);
             }
@@ -6521,7 +6557,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{1}&apos; because type does not inherit from &apos;IDisposable&apos;.
         /// </summary>
-        internal static string MiKo_2057_MessageFormat {
+        public static string MiKo_2057_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2057_MessageFormat", resourceCulture);
             }
@@ -6530,7 +6566,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Types that are not disposable shall not throw an ObjectDisposedException.
         /// </summary>
-        internal static string MiKo_2057_Title {
+        public static string MiKo_2057_Title {
             get {
                 return ResourceManager.GetString("MiKo_2057_Title", resourceCulture);
             }
@@ -6539,7 +6575,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Consolidate exception documentation.
         /// </summary>
-        internal static string MiKo_2059_CodeFixTitle {
+        public static string MiKo_2059_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2059_CodeFixTitle", resourceCulture);
             }
@@ -6548,7 +6584,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve readability and maintenance, document thrown exceptions only once, consolidating them instead of listing multiple separate instances. This approach helps developers find specific information more easily and keeps the documentation clean and efficient..
         /// </summary>
-        internal static string MiKo_2059_Description {
+        public static string MiKo_2059_Description {
             get {
                 return ResourceManager.GetString("MiKo_2059_Description", resourceCulture);
             }
@@ -6557,7 +6593,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Consolidate the documentation of &lt;exception cref=&apos;{1}&apos;&gt;.
         /// </summary>
-        internal static string MiKo_2059_MessageFormat {
+        public static string MiKo_2059_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2059_MessageFormat", resourceCulture);
             }
@@ -6566,7 +6602,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Multiple documentation of same exception should be consolidated into one.
         /// </summary>
-        internal static string MiKo_2059_Title {
+        public static string MiKo_2059_Title {
             get {
                 return ResourceManager.GetString("MiKo_2059_Title", resourceCulture);
             }
@@ -6575,7 +6611,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment to factory.
         /// </summary>
-        internal static string MiKo_2060_CodeFixTitle {
+        public static string MiKo_2060_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2060_CodeFixTitle", resourceCulture);
             }
@@ -6584,7 +6620,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of factories should be uniform and consistent..
         /// </summary>
-        internal static string MiKo_2060_Description {
+        public static string MiKo_2060_Description {
             get {
                 return ResourceManager.GetString("MiKo_2060_Description", resourceCulture);
             }
@@ -6593,7 +6629,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2060_MessageFormat {
+        public static string MiKo_2060_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2060_MessageFormat", resourceCulture);
             }
@@ -6602,7 +6638,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Factories should be documented in an uniform way.
         /// </summary>
-        internal static string MiKo_2060_Title {
+        public static string MiKo_2060_Title {
             get {
                 return ResourceManager.GetString("MiKo_2060_Title", resourceCulture);
             }
@@ -6611,7 +6647,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;Return&apos; in comment.
         /// </summary>
-        internal static string MiKo_2070_CodeFixTitle {
+        public static string MiKo_2070_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2070_CodeFixTitle", resourceCulture);
             }
@@ -6620,7 +6656,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If method documentation starts with &apos;Returns&apos;, it shifts focus to the return value rather than the method&apos;s purpose. Instead, describe the method&apos;s intended function, not what it returns. This ensures clarity about the method&apos;s primary responsibility..
         /// </summary>
-        internal static string MiKo_2070_Description {
+        public static string MiKo_2070_Description {
             get {
                 return ResourceManager.GetString("MiKo_2070_Description", resourceCulture);
             }
@@ -6629,7 +6665,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2070_MessageFormat {
+        public static string MiKo_2070_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2070_MessageFormat", resourceCulture);
             }
@@ -6638,7 +6674,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not start with &apos;Returns&apos;.
         /// </summary>
-        internal static string MiKo_2070_Title {
+        public static string MiKo_2070_Title {
             get {
                 return ResourceManager.GetString("MiKo_2070_Title", resourceCulture);
             }
@@ -6647,7 +6683,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation for methods returning Enum types should avoid phrases meant for boolean types. Enum values are not booleans, so the documentation should not use terms like &apos;indicates whether&apos;, which imply a boolean context. This ensures the documentation accurately reflects the nature of the Enum type..
         /// </summary>
-        internal static string MiKo_2071_Description {
+        public static string MiKo_2071_Description {
             get {
                 return ResourceManager.GetString("MiKo_2071_Description", resourceCulture);
             }
@@ -6656,7 +6692,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{0}&apos; in &lt;summary&gt;.
         /// </summary>
-        internal static string MiKo_2071_MessageFormat {
+        public static string MiKo_2071_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2071_MessageFormat", resourceCulture);
             }
@@ -6665,7 +6701,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation for methods that return Enum types should not contain phrase for boolean type.
         /// </summary>
-        internal static string MiKo_2071_Title {
+        public static string MiKo_2071_Title {
             get {
                 return ResourceManager.GetString("MiKo_2071_Title", resourceCulture);
             }
@@ -6674,7 +6710,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Attempts to&apos;.
         /// </summary>
-        internal static string MiKo_2072_CodeFixTitle {
+        public static string MiKo_2072_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2072_CodeFixTitle", resourceCulture);
             }
@@ -6683,7 +6719,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Try&apos; methods attempt to achieve something. Therefore, their &lt;summary&gt; documentation should start with &apos;Attempts to...&apos; This clearly indicates the method&apos;s purpose and conveys its intent..
         /// </summary>
-        internal static string MiKo_2072_Description {
+        public static string MiKo_2072_Description {
             get {
                 return ResourceManager.GetString("MiKo_2072_Description", resourceCulture);
             }
@@ -6692,7 +6728,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Attempts to &apos;.
         /// </summary>
-        internal static string MiKo_2072_MessageFormat {
+        public static string MiKo_2072_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2072_MessageFormat", resourceCulture);
             }
@@ -6701,7 +6737,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not start with &apos;Try&apos;.
         /// </summary>
-        internal static string MiKo_2072_Title {
+        public static string MiKo_2072_Title {
             get {
                 return ResourceManager.GetString("MiKo_2072_Title", resourceCulture);
             }
@@ -6710,7 +6746,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Determines whether&apos;.
         /// </summary>
-        internal static string MiKo_2073_CodeFixTitle {
+        public static string MiKo_2073_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2073_CodeFixTitle", resourceCulture);
             }
@@ -6719,7 +6755,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation of &apos;Contain&apos; methods should start with the phrase &apos;Determines whether...&apos;. This is because they attempt to determine if something exists within something else. This phrase sets a clear expectation for the method&apos;s functionality..
         /// </summary>
-        internal static string MiKo_2073_Description {
+        public static string MiKo_2073_Description {
             get {
                 return ResourceManager.GetString("MiKo_2073_Description", resourceCulture);
             }
@@ -6728,7 +6764,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with &apos;Determines whether&apos;.
         /// </summary>
-        internal static string MiKo_2073_MessageFormat {
+        public static string MiKo_2073_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2073_MessageFormat", resourceCulture);
             }
@@ -6737,7 +6773,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of &apos;Contains&apos; methods should start with &apos;Determines whether &apos;.
         /// </summary>
-        internal static string MiKo_2073_Title {
+        public static string MiKo_2073_Title {
             get {
                 return ResourceManager.GetString("MiKo_2073_Title", resourceCulture);
             }
@@ -6746,7 +6782,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comment of parameter.
         /// </summary>
-        internal static string MiKo_2074_CodeFixTitle {
+        public static string MiKo_2074_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2074_CodeFixTitle", resourceCulture);
             }
@@ -6755,7 +6791,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation of &apos;Contain&apos; methods should end with the phrase &apos; to seek.&apos;. This is because they attempt to determine if a given parameter&apos;s value exists within something. This phrasing clearly communicates the intent and functionality of the parameter within the method..
         /// </summary>
-        internal static string MiKo_2074_Description {
+        public static string MiKo_2074_Description {
             get {
                 return ResourceManager.GetString("MiKo_2074_Description", resourceCulture);
             }
@@ -6764,7 +6800,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;param name=&quot;{0}&quot;&gt; should end with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2074_MessageFormat {
+        public static string MiKo_2074_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2074_MessageFormat", resourceCulture);
             }
@@ -6773,7 +6809,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of parameter of &apos;Contains&apos; method should have a default ending phrase.
         /// </summary>
-        internal static string MiKo_2074_Title {
+        public static string MiKo_2074_Title {
             get {
                 return ResourceManager.GetString("MiKo_2074_Title", resourceCulture);
             }
@@ -6782,7 +6818,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change to &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2075_CodeFixTitle {
+        public static string MiKo_2075_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2075_CodeFixTitle", resourceCulture);
             }
@@ -6791,7 +6827,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation is for other developers. When you refer to &apos;Action&apos; or &apos;Function&apos; delegates, there&apos;s no need to call them &apos;action&apos;, &apos;func&apos;, or &apos;function&apos;, as the type info is already clear. Instead, refer to them as &apos;callback&apos; since these delegates act as references to specific methods and serve as callbacks within the code..
         /// </summary>
-        internal static string MiKo_2075_Description {
+        public static string MiKo_2075_Description {
             get {
                 return ResourceManager.GetString("MiKo_2075_Description", resourceCulture);
             }
@@ -6800,7 +6836,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;{0}&apos; with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2075_MessageFormat {
+        public static string MiKo_2075_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2075_MessageFormat", resourceCulture);
             }
@@ -6809,7 +6845,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the term &apos;callback&apos; instead of &apos;action&apos;, &apos;func&apos; or &apos;function&apos;.
         /// </summary>
-        internal static string MiKo_2075_Title {
+        public static string MiKo_2075_Title {
             get {
                 return ResourceManager.GetString("MiKo_2075_Title", resourceCulture);
             }
@@ -6818,7 +6854,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Document default value.
         /// </summary>
-        internal static string MiKo_2076_CodeFixTitle {
+        public static string MiKo_2076_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2076_CodeFixTitle", resourceCulture);
             }
@@ -6827,7 +6863,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to In case a parameter is an optional one it is important to document its default value. This is because the values of those optional parameters are &quot;baked into&quot; the calling code..
         /// </summary>
-        internal static string MiKo_2076_Description {
+        public static string MiKo_2076_Description {
             get {
                 return ResourceManager.GetString("MiKo_2076_Description", resourceCulture);
             }
@@ -6836,7 +6872,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Document the default value via &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2076_MessageFormat {
+        public static string MiKo_2076_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2076_MessageFormat", resourceCulture);
             }
@@ -6845,7 +6881,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should document default values of optional parameters.
         /// </summary>
-        internal static string MiKo_2076_Title {
+        public static string MiKo_2076_Title {
             get {
                 return ResourceManager.GetString("MiKo_2076_Title", resourceCulture);
             }
@@ -6854,7 +6890,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not include &lt;code&gt; snippets. The summary should be brief. Code snippets, which typically serve as examples, should be placed in the &lt;example&gt; section instead..
         /// </summary>
-        internal static string MiKo_2077_Description {
+        public static string MiKo_2077_Description {
             get {
                 return ResourceManager.GetString("MiKo_2077_Description", resourceCulture);
             }
@@ -6863,7 +6899,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not contain &lt;code&gt;.
         /// </summary>
-        internal static string MiKo_2077_MessageFormat {
+        public static string MiKo_2077_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2077_MessageFormat", resourceCulture);
             }
@@ -6872,7 +6908,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not contain &lt;code&gt;.
         /// </summary>
-        internal static string MiKo_2077_Title {
+        public static string MiKo_2077_Title {
             get {
                 return ResourceManager.GetString("MiKo_2077_Title", resourceCulture);
             }
@@ -6881,7 +6917,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;code&gt; documentation should not include XML tags. Code snippets usually serve as examples and typically contain source code. If they contain plain XML, the XML won&apos;t be converted into documentation. Consequently, the resulting online help or IntelliSense will not display them..
         /// </summary>
-        internal static string MiKo_2078_Description {
+        public static string MiKo_2078_Description {
             get {
                 return ResourceManager.GetString("MiKo_2078_Description", resourceCulture);
             }
@@ -6890,7 +6926,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;code&gt; should not contain XML.
         /// </summary>
-        internal static string MiKo_2078_MessageFormat {
+        public static string MiKo_2078_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2078_MessageFormat", resourceCulture);
             }
@@ -6899,7 +6935,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;code&gt; documentation should not contain XML tags.
         /// </summary>
-        internal static string MiKo_2078_Title {
+        public static string MiKo_2078_Title {
             get {
                 return ResourceManager.GetString("MiKo_2078_Title", resourceCulture);
             }
@@ -6908,7 +6944,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove obvious comment.
         /// </summary>
-        internal static string MiKo_2079_CodeFixTitle {
+        public static string MiKo_2079_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2079_CodeFixTitle", resourceCulture);
             }
@@ -6917,7 +6953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments that merely state the name of a property and that it gets or sets provide no meaningful information. Such redundant comments should be removed to keep the code clean and focused on more valuable insights. Clear and concise documentation improves overall readability and maintenance..
         /// </summary>
-        internal static string MiKo_2079_Description {
+        public static string MiKo_2079_Description {
             get {
                 return ResourceManager.GetString("MiKo_2079_Description", resourceCulture);
             }
@@ -6926,7 +6962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comment is obvious and provides no value.
         /// </summary>
-        internal static string MiKo_2079_MessageFormat {
+        public static string MiKo_2079_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2079_MessageFormat", resourceCulture);
             }
@@ -6935,7 +6971,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of properties should not have obvious text.
         /// </summary>
-        internal static string MiKo_2079_Title {
+        public static string MiKo_2079_Title {
             get {
                 return ResourceManager.GetString("MiKo_2079_Title", resourceCulture);
             }
@@ -6944,7 +6980,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start field with default phrase.
         /// </summary>
-        internal static string MiKo_2080_CodeFixTitle {
+        public static string MiKo_2080_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2080_CodeFixTitle", resourceCulture);
             }
@@ -6953,7 +6989,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The documentation of fields should start with a default phrase..
         /// </summary>
-        internal static string MiKo_2080_Description {
+        public static string MiKo_2080_Description {
             get {
                 return ResourceManager.GetString("MiKo_2080_Description", resourceCulture);
             }
@@ -6962,7 +6998,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2080_MessageFormat {
+        public static string MiKo_2080_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2080_MessageFormat", resourceCulture);
             }
@@ -6971,7 +7007,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of fields should have a default starting phrase.
         /// </summary>
-        internal static string MiKo_2080_Title {
+        public static string MiKo_2080_Title {
             get {
                 return ResourceManager.GetString("MiKo_2080_Title", resourceCulture);
             }
@@ -6980,7 +7016,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Append read-only text.
         /// </summary>
-        internal static string MiKo_2081_CodeFixTitle {
+        public static string MiKo_2081_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2081_CodeFixTitle", resourceCulture);
             }
@@ -6989,7 +7025,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For public-visible read-only fields, the documentation should clearly state that the field is read-only. This detail informs developers about the field&apos;s immutability and intended usage..
         /// </summary>
-        internal static string MiKo_2081_Description {
+        public static string MiKo_2081_Description {
             get {
                 return ResourceManager.GetString("MiKo_2081_Description", resourceCulture);
             }
@@ -6998,7 +7034,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End &lt;summary&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2081_MessageFormat {
+        public static string MiKo_2081_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2081_MessageFormat", resourceCulture);
             }
@@ -7007,7 +7043,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of public-visible read-only fields should have a default ending phrase.
         /// </summary>
-        internal static string MiKo_2081_Title {
+        public static string MiKo_2081_Title {
             get {
                 return ResourceManager.GetString("MiKo_2081_Title", resourceCulture);
             }
@@ -7016,7 +7052,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix enum member starting phrase.
         /// </summary>
-        internal static string MiKo_2082_CodeFixTitle {
+        public static string MiKo_2082_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2082_CodeFixTitle", resourceCulture);
             }
@@ -7026,7 +7062,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation of an Enum member should avoid phrases used in the Enum&apos;s own summary - like &apos;Defines&apos;, &apos;Indicates&apos;, or &apos;Specifies.&apos; Instead, it should focus on describing the meaning and purpose of the individual member, providing clear and specific details.
         ///This ensures the documentation is precise and informative, helping developers understand each member&apos;s role and functionality..
         /// </summary>
-        internal static string MiKo_2082_Description {
+        public static string MiKo_2082_Description {
             get {
                 return ResourceManager.GetString("MiKo_2082_Description", resourceCulture);
             }
@@ -7035,7 +7071,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not start &lt;summary&gt; with: &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2082_MessageFormat {
+        public static string MiKo_2082_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2082_MessageFormat", resourceCulture);
             }
@@ -7044,7 +7080,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation of Enum members should not start with default starting phrases of Enum &lt;summary&gt; documentation.
         /// </summary>
-        internal static string MiKo_2082_Title {
+        public static string MiKo_2082_Title {
             get {
                 return ResourceManager.GetString("MiKo_2082_Title", resourceCulture);
             }
@@ -7053,7 +7089,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment.
         /// </summary>
-        internal static string MiKo_2090_CodeFixTitle {
+        public static string MiKo_2090_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2090_CodeFixTitle", resourceCulture);
             }
@@ -7062,7 +7098,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For smoother development and usage, XML documentation for equality operators should use a standard default phrase, like in the .NET framework. This keeps things consistent and makes it easier for developers to understand and implement these operators correctly..
         /// </summary>
-        internal static string MiKo_2090_Description {
+        public static string MiKo_2090_Description {
             get {
                 return ResourceManager.GetString("MiKo_2090_Description", resourceCulture);
             }
@@ -7071,7 +7107,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;{1}&gt; should be: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2090_MessageFormat {
+        public static string MiKo_2090_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2090_MessageFormat", resourceCulture);
             }
@@ -7080,7 +7116,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for equality operator shall have default phrase.
         /// </summary>
-        internal static string MiKo_2090_Title {
+        public static string MiKo_2090_Title {
             get {
                 return ResourceManager.GetString("MiKo_2090_Title", resourceCulture);
             }
@@ -7089,7 +7125,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply standard comment.
         /// </summary>
-        internal static string MiKo_2091_CodeFixTitle {
+        public static string MiKo_2091_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2091_CodeFixTitle", resourceCulture);
             }
@@ -7098,7 +7134,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For smoother development and usage, XML documentation for inequality operators should use a standard default phrase, like in the .NET framework. This keeps things consistent and makes it easier for developers to understand and implement these operators correctly..
         /// </summary>
-        internal static string MiKo_2091_Description {
+        public static string MiKo_2091_Description {
             get {
                 return ResourceManager.GetString("MiKo_2091_Description", resourceCulture);
             }
@@ -7107,7 +7143,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;{1}&gt; should be: &apos;{2}&apos;.
         /// </summary>
-        internal static string MiKo_2091_MessageFormat {
+        public static string MiKo_2091_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2091_MessageFormat", resourceCulture);
             }
@@ -7116,7 +7152,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation for inequality operator shall have default phrase.
         /// </summary>
-        internal static string MiKo_2091_Title {
+        public static string MiKo_2091_Title {
             get {
                 return ResourceManager.GetString("MiKo_2091_Title", resourceCulture);
             }
@@ -7125,7 +7161,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start comment with &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2100_CodeFixTitle {
+        public static string MiKo_2100_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2100_CodeFixTitle", resourceCulture);
             }
@@ -7134,7 +7170,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make example documentation more user-friendly, it should begin with a brief phrase that explains what the example demonstrates. This provides clarity and helps developers quickly understand the purpose of the example..
         /// </summary>
-        internal static string MiKo_2100_Description {
+        public static string MiKo_2100_Description {
             get {
                 return ResourceManager.GetString("MiKo_2100_Description", resourceCulture);
             }
@@ -7143,7 +7179,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;example&gt; with: &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2100_MessageFormat {
+        public static string MiKo_2100_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2100_MessageFormat", resourceCulture);
             }
@@ -7152,7 +7188,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;example&gt; documentation should start with descriptive default phrase.
         /// </summary>
-        internal static string MiKo_2100_Title {
+        public static string MiKo_2100_Title {
             get {
                 return ResourceManager.GetString("MiKo_2100_Title", resourceCulture);
             }
@@ -7161,7 +7197,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround sample code with &apos;&lt;code&gt;&apos;.
         /// </summary>
-        internal static string MiKo_2101_CodeFixTitle {
+        public static string MiKo_2101_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2101_CodeFixTitle", resourceCulture);
             }
@@ -7170,7 +7206,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For better readability, example documentation should enclose code samples within &lt;code&gt; tags. This allows IntelliSense or any XML documentation tool to format them properly, making the examples easier to understand and visually distinct..
         /// </summary>
-        internal static string MiKo_2101_Description {
+        public static string MiKo_2101_Description {
             get {
                 return ResourceManager.GetString("MiKo_2101_Description", resourceCulture);
             }
@@ -7179,7 +7215,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place sample code in &lt;example&gt; inside &apos;&lt;code&gt;&apos; tags.
         /// </summary>
-        internal static string MiKo_2101_MessageFormat {
+        public static string MiKo_2101_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2101_MessageFormat", resourceCulture);
             }
@@ -7188,7 +7224,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;example&gt; documentation should show code example in &lt;code&gt; tags.
         /// </summary>
-        internal static string MiKo_2101_Title {
+        public static string MiKo_2101_Title {
             get {
                 return ResourceManager.GetString("MiKo_2101_Title", resourceCulture);
             }
@@ -7197,7 +7233,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use capitalized letter.
         /// </summary>
-        internal static string MiKo_2200_CodeFixTitle {
+        public static string MiKo_2200_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2200_CodeFixTitle", resourceCulture);
             }
@@ -7206,7 +7242,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should always start with a capitalized letter to form a complete sentence. This ensures clarity and professionalism, making the documentation easy to read and understand. Full sentences convey complete thoughts, which is essential for accurate and effective communication..
         /// </summary>
-        internal static string MiKo_2200_Description {
+        public static string MiKo_2200_Description {
             get {
                 return ResourceManager.GetString("MiKo_2200_Description", resourceCulture);
             }
@@ -7215,7 +7251,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start &lt;{1}&gt; with capitalized letter.
         /// </summary>
-        internal static string MiKo_2200_MessageFormat {
+        public static string MiKo_2200_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2200_MessageFormat", resourceCulture);
             }
@@ -7224,7 +7260,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a capitalized letter to start the comment.
         /// </summary>
-        internal static string MiKo_2200_Title {
+        public static string MiKo_2200_Title {
             get {
                 return ResourceManager.GetString("MiKo_2200_Title", resourceCulture);
             }
@@ -7233,7 +7269,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sentences within documentation should always begin with a capitalized letter to form a complete sentence. This ensures clarity, readability, and professionalism, making the documentation easier to understand and more effective. Full sentences convey clear, complete thoughts, which is essential for precise communication..
         /// </summary>
-        internal static string MiKo_2201_Description {
+        public static string MiKo_2201_Description {
             get {
                 return ResourceManager.GetString("MiKo_2201_Description", resourceCulture);
             }
@@ -7242,7 +7278,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Start the sentence(s) in &lt;{1}&gt; with capitalized letter.
         /// </summary>
-        internal static string MiKo_2201_MessageFormat {
+        public static string MiKo_2201_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2201_MessageFormat", resourceCulture);
             }
@@ -7251,7 +7287,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a capitalized letter to start the sentences in the comment.
         /// </summary>
-        internal static string MiKo_2201_Title {
+        public static string MiKo_2201_Title {
             get {
                 return ResourceManager.GetString("MiKo_2201_Title", resourceCulture);
             }
@@ -7260,7 +7296,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;id&apos; into &apos;identifier&apos;.
         /// </summary>
-        internal static string MiKo_2202_CodeFixTitle {
+        public static string MiKo_2202_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2202_CodeFixTitle", resourceCulture);
             }
@@ -7269,7 +7305,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should avoid using the abbreviation &apos;id&apos; and instead clearly state &apos;identifier&apos; as they actually are identifiers. This ensures clarity and precision, making the documentation more understandable and accessible for developers..
         /// </summary>
-        internal static string MiKo_2202_Description {
+        public static string MiKo_2202_Description {
             get {
                 return ResourceManager.GetString("MiKo_2202_Description", resourceCulture);
             }
@@ -7278,7 +7314,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;identifier&apos; instead of &apos;id&apos;.
         /// </summary>
-        internal static string MiKo_2202_MessageFormat {
+        public static string MiKo_2202_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2202_MessageFormat", resourceCulture);
             }
@@ -7287,7 +7323,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the term &apos;identifier&apos; instead of &apos;id&apos;.
         /// </summary>
-        internal static string MiKo_2202_Title {
+        public static string MiKo_2202_Title {
             get {
                 return ResourceManager.GetString("MiKo_2202_Title", resourceCulture);
             }
@@ -7296,7 +7332,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;GUID&apos; into &apos;unique identifier&apos;.
         /// </summary>
-        internal static string MiKo_2203_CodeFixTitle {
+        public static string MiKo_2203_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2203_CodeFixTitle", resourceCulture);
             }
@@ -7305,7 +7341,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should avoid using the abbreviation &apos;guid&apos; and instead clearly state &apos;unique identifier&apos; as they actually are globally unique identifiers. This ensures clarity and precision, making the documentation more understandable and accessible for developers..
         /// </summary>
-        internal static string MiKo_2203_Description {
+        public static string MiKo_2203_Description {
             get {
                 return ResourceManager.GetString("MiKo_2203_Description", resourceCulture);
             }
@@ -7314,7 +7350,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;unique identifier&apos; instead of &apos;guid&apos;.
         /// </summary>
-        internal static string MiKo_2203_MessageFormat {
+        public static string MiKo_2203_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2203_MessageFormat", resourceCulture);
             }
@@ -7323,7 +7359,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the term &apos;unique identifier&apos; instead of &apos;guid&apos;.
         /// </summary>
-        internal static string MiKo_2203_Title {
+        public static string MiKo_2203_Title {
             get {
                 return ResourceManager.GetString("MiKo_2203_Title", resourceCulture);
             }
@@ -7332,7 +7368,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items.
         /// </summary>
-        internal static string MiKo_2204_CodeFixTitle {
+        public static string MiKo_2204_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2204_CodeFixTitle", resourceCulture);
             }
@@ -7342,7 +7378,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to XML documentation should use the &lt;list&gt; tag for enumerating items. Avoid using terms like 1.), 2.), etc., directly because IntelliSense and XML documentation tools cannot recognize these and may format comments awkwardly.
         ///Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lists, ordered lists, etc., making documentation clear and easy to read..
         /// </summary>
-        internal static string MiKo_2204_Description {
+        public static string MiKo_2204_Description {
             get {
                 return ResourceManager.GetString("MiKo_2204_Description", resourceCulture);
             }
@@ -7351,7 +7387,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/list.
         /// </summary>
-        internal static string MiKo_2204_HelpLinkUri {
+        public static string MiKo_2204_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_2204_HelpLinkUri", resourceCulture);
             }
@@ -7360,7 +7396,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items in documentation.
         /// </summary>
-        internal static string MiKo_2204_MessageFormat {
+        public static string MiKo_2204_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2204_MessageFormat", resourceCulture);
             }
@@ -7369,7 +7405,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use &lt;list&gt; for enumerations.
         /// </summary>
-        internal static string MiKo_2204_Title {
+        public static string MiKo_2204_Title {
             get {
                 return ResourceManager.GetString("MiKo_2204_Title", resourceCulture);
             }
@@ -7378,7 +7414,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should utilize the &lt;note&gt; tag for important information. Avoid using terms like &apos;Important&apos; or &apos;Attention&apos; directly. This approach allows XML documentation tools to recognize and format the information in a distinct and noticeable way, ensuring clarity and emphasis..
         /// </summary>
-        internal static string MiKo_2205_Description {
+        public static string MiKo_2205_Description {
             get {
                 return ResourceManager.GetString("MiKo_2205_Description", resourceCulture);
             }
@@ -7387,7 +7423,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;note&gt; for important information in documentation.
         /// </summary>
-        internal static string MiKo_2205_MessageFormat {
+        public static string MiKo_2205_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2205_MessageFormat", resourceCulture);
             }
@@ -7396,7 +7432,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use &lt;note&gt; for important information.
         /// </summary>
-        internal static string MiKo_2205_Title {
+        public static string MiKo_2205_Title {
             get {
                 return ResourceManager.GetString("MiKo_2205_Title", resourceCulture);
             }
@@ -7405,7 +7441,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should avoid using the term &apos;flag&apos; for boolean values. Instead, rephrase the documentation to eliminate the need for this term. This ensures clarity and precision, making it easier for developers to understand the context and purpose of the boolean value..
         /// </summary>
-        internal static string MiKo_2206_Description {
+        public static string MiKo_2206_Description {
             get {
                 return ResourceManager.GetString("MiKo_2206_Description", resourceCulture);
             }
@@ -7414,7 +7450,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;{0}&apos; from documentation.
         /// </summary>
-        internal static string MiKo_2206_MessageFormat {
+        public static string MiKo_2206_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2206_MessageFormat", resourceCulture);
             }
@@ -7423,7 +7459,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not use the term &apos;flag&apos;.
         /// </summary>
-        internal static string MiKo_2206_Title {
+        public static string MiKo_2206_Title {
             get {
                 return ResourceManager.GetString("MiKo_2206_Title", resourceCulture);
             }
@@ -7432,7 +7468,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;summary&gt; documentation should be brief and descriptive, providing an overview of the functionality. For more detailed information, use the &lt;remarks&gt; section. This keeps the summary concise and the documentation well-organized, making it easier for developers to understand..
         /// </summary>
-        internal static string MiKo_2207_Description {
+        public static string MiKo_2207_Description {
             get {
                 return ResourceManager.GetString("MiKo_2207_Description", resourceCulture);
             }
@@ -7441,7 +7477,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; is too long, use &lt;remarks&gt; section for all the details.
         /// </summary>
-        internal static string MiKo_2207_MessageFormat {
+        public static string MiKo_2207_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2207_MessageFormat", resourceCulture);
             }
@@ -7450,7 +7486,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation shall be short.
         /// </summary>
-        internal static string MiKo_2207_Title {
+        public static string MiKo_2207_Title {
             get {
                 return ResourceManager.GetString("MiKo_2207_Title", resourceCulture);
             }
@@ -7459,7 +7495,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;an instance of&apos;.
         /// </summary>
-        internal static string MiKo_2208_CodeFixTitle {
+        public static string MiKo_2208_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2208_CodeFixTitle", resourceCulture);
             }
@@ -7468,7 +7504,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use a more meaningful description than &apos;an instance of&apos;. A concrete description helps developers better understand the meaning. Clear and specific language enhances comprehension and usability..
         /// </summary>
-        internal static string MiKo_2208_Description {
+        public static string MiKo_2208_Description {
             get {
                 return ResourceManager.GetString("MiKo_2208_Description", resourceCulture);
             }
@@ -7477,7 +7513,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a better description than &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2208_MessageFormat {
+        public static string MiKo_2208_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2208_MessageFormat", resourceCulture);
             }
@@ -7486,7 +7522,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not use the term &apos;an instance of&apos;.
         /// </summary>
-        internal static string MiKo_2208_Title {
+        public static string MiKo_2208_Title {
             get {
                 return ResourceManager.GetString("MiKo_2208_Title", resourceCulture);
             }
@@ -7495,7 +7531,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;..&apos; from documentation.
         /// </summary>
-        internal static string MiKo_2209_CodeFixTitle {
+        public static string MiKo_2209_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2209_CodeFixTitle", resourceCulture);
             }
@@ -7504,7 +7540,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation is for other developers and should be clear and easy to read. It must include all important information without any typos or confusing comments to avoid misleading developers..
         /// </summary>
-        internal static string MiKo_2209_Description {
+        public static string MiKo_2209_Description {
             get {
                 return ResourceManager.GetString("MiKo_2209_Description", resourceCulture);
             }
@@ -7513,7 +7549,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;..&apos; from documentation.
         /// </summary>
-        internal static string MiKo_2209_MessageFormat {
+        public static string MiKo_2209_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2209_MessageFormat", resourceCulture);
             }
@@ -7522,7 +7558,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use double periods in documentation.
         /// </summary>
-        internal static string MiKo_2209_Title {
+        public static string MiKo_2209_Title {
             get {
                 return ResourceManager.GetString("MiKo_2209_Title", resourceCulture);
             }
@@ -7531,7 +7567,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;info&apos; into &apos;information&apos;.
         /// </summary>
-        internal static string MiKo_2210_CodeFixTitle {
+        public static string MiKo_2210_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2210_CodeFixTitle", resourceCulture);
             }
@@ -7540,7 +7576,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should avoid the abbreviation &apos;info&apos; and instead use &apos;information&apos;. This practice ensures clarity and professionalism in documentation, making it easier for developers to understand and follow..
         /// </summary>
-        internal static string MiKo_2210_Description {
+        public static string MiKo_2210_Description {
             get {
                 return ResourceManager.GetString("MiKo_2210_Description", resourceCulture);
             }
@@ -7549,7 +7585,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;information&apos; instead of &apos;info&apos;.
         /// </summary>
-        internal static string MiKo_2210_MessageFormat {
+        public static string MiKo_2210_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2210_MessageFormat", resourceCulture);
             }
@@ -7558,7 +7594,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the term &apos;information&apos; instead of &apos;info&apos;.
         /// </summary>
-        internal static string MiKo_2210_Title {
+        public static string MiKo_2210_Title {
             get {
                 return ResourceManager.GetString("MiKo_2210_Title", resourceCulture);
             }
@@ -7567,7 +7603,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Move remarks comment into summary.
         /// </summary>
-        internal static string MiKo_2211_CodeFixTitle {
+        public static string MiKo_2211_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2211_CodeFixTitle", resourceCulture);
             }
@@ -7578,7 +7614,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///To ensure developers have all the necessary information, it&apos;s best to place this information inside the &lt;summary&gt; section instead. This guarantees that all essential details are included in the outp [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_2211_Description {
+        public static string MiKo_2211_Description {
             get {
                 return ResourceManager.GetString("MiKo_2211_Description", resourceCulture);
             }
@@ -7587,7 +7623,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;summary&gt; instead of &lt;remarks&gt;.
         /// </summary>
-        internal static string MiKo_2211_MessageFormat {
+        public static string MiKo_2211_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2211_MessageFormat", resourceCulture);
             }
@@ -7596,7 +7632,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Enum members should not have &lt;remarks&gt; sections.
         /// </summary>
-        internal static string MiKo_2211_Title {
+        public static string MiKo_2211_Title {
             get {
                 return ResourceManager.GetString("MiKo_2211_Title", resourceCulture);
             }
@@ -7605,7 +7641,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;was not successful&apos; to &apos;failed&apos;.
         /// </summary>
-        internal static string MiKo_2212_CodeFixTitle {
+        public static string MiKo_2212_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2212_CodeFixTitle", resourceCulture);
             }
@@ -7614,7 +7650,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make documentation concise and precise, use &apos;failed&apos; instead of &apos;was not successful&apos;. This keeps it brief and straight to the point, making it easier for developers to understand quickly..
         /// </summary>
-        internal static string MiKo_2212_Description {
+        public static string MiKo_2212_Description {
             get {
                 return ResourceManager.GetString("MiKo_2212_Description", resourceCulture);
             }
@@ -7623,7 +7659,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;failed&apos; instead of &apos;was not successful&apos;.
         /// </summary>
-        internal static string MiKo_2212_MessageFormat {
+        public static string MiKo_2212_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2212_MessageFormat", resourceCulture);
             }
@@ -7632,7 +7668,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the phrase &apos;failed&apos; instead of &apos;was not successful&apos;.
         /// </summary>
-        internal static string MiKo_2212_Title {
+        public static string MiKo_2212_Title {
             get {
                 return ResourceManager.GetString("MiKo_2212_Title", resourceCulture);
             }
@@ -7641,7 +7677,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &quot;n&apos;t&quot; to &quot; not&quot;.
         /// </summary>
-        internal static string MiKo_2213_CodeFixTitle {
+        public static string MiKo_2213_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2213_CodeFixTitle", resourceCulture);
             }
@@ -7650,7 +7686,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sometimes, contractions are missed, causing unintentional errors. To prevent this, it&apos;s best to avoid them entirely..
         /// </summary>
-        internal static string MiKo_2213_Description {
+        public static string MiKo_2213_Description {
             get {
                 return ResourceManager.GetString("MiKo_2213_Description", resourceCulture);
             }
@@ -7659,7 +7695,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_2213_MessageFormat {
+        public static string MiKo_2213_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2213_MessageFormat", resourceCulture);
             }
@@ -7668,7 +7704,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not use the contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_2213_Title {
+        public static string MiKo_2213_Title {
             get {
                 return ResourceManager.GetString("MiKo_2213_Title", resourceCulture);
             }
@@ -7677,7 +7713,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace empty line with &lt;para/&gt;.
         /// </summary>
-        internal static string MiKo_2214_CodeFixTitle {
+        public static string MiKo_2214_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2214_CodeFixTitle", resourceCulture);
             }
@@ -7687,7 +7723,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to To avoid dense text in generated documentation (e.g., IntelliSense), empty lines should not be used. Developers often insert them to create paragraphs, but they get ignored and removed.
         ///Instead, use &lt;para&gt; tags, which are designed to mark paragraphs properly, ensuring the generated documentation remains clear and well-structured..
         /// </summary>
-        internal static string MiKo_2214_Description {
+        public static string MiKo_2214_Description {
             get {
                 return ResourceManager.GetString("MiKo_2214_Description", resourceCulture);
             }
@@ -7696,7 +7732,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace empty line with &lt;para/&gt;.
         /// </summary>
-        internal static string MiKo_2214_MessageFormat {
+        public static string MiKo_2214_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2214_MessageFormat", resourceCulture);
             }
@@ -7705,7 +7741,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not contain empty lines.
         /// </summary>
-        internal static string MiKo_2214_Title {
+        public static string MiKo_2214_Title {
             get {
                 return ResourceManager.GetString("MiKo_2214_Title", resourceCulture);
             }
@@ -7714,7 +7750,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Keep documentation sentences up to 15 words. Shorter sentences are clearer and more descriptive. Longer sentences can be hard to read and may bore readers. This approach ensures effective communication..
         /// </summary>
-        internal static string MiKo_2215_Description {
+        public static string MiKo_2215_Description {
             get {
                 return ResourceManager.GetString("MiKo_2215_Description", resourceCulture);
             }
@@ -7723,7 +7759,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Shorten sentences to contain up to 15 words each.
         /// </summary>
-        internal static string MiKo_2215_MessageFormat {
+        public static string MiKo_2215_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2215_MessageFormat", resourceCulture);
             }
@@ -7732,7 +7768,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sentences in documentation shall be short.
         /// </summary>
-        internal static string MiKo_2215_Title {
+        public static string MiKo_2215_Title {
             get {
                 return ResourceManager.GetString("MiKo_2215_Title", resourceCulture);
             }
@@ -7741,7 +7777,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &lt;param&gt; to &lt;paramref&gt;.
         /// </summary>
-        internal static string MiKo_2216_CodeFixTitle {
+        public static string MiKo_2216_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2216_CodeFixTitle", resourceCulture);
             }
@@ -7750,7 +7786,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &lt;param&gt; tag is for describing parameters, whereas the &lt;paramref&gt; tag is used to indicate that a word in the code comments refers to a parameter. When referencing a parameter in sections like &lt;remarks&gt;, use the &lt;paramref&gt; tag to maintain clarity and proper documentation standards..
         /// </summary>
-        internal static string MiKo_2216_Description {
+        public static string MiKo_2216_Description {
             get {
                 return ResourceManager.GetString("MiKo_2216_Description", resourceCulture);
             }
@@ -7759,7 +7795,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;paramref&gt; instead of &lt;param&gt;.
         /// </summary>
-        internal static string MiKo_2216_MessageFormat {
+        public static string MiKo_2216_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2216_MessageFormat", resourceCulture);
             }
@@ -7768,7 +7804,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;paramref&gt; instead of &lt;param&gt; to reference parameters.
         /// </summary>
-        internal static string MiKo_2216_Title {
+        public static string MiKo_2216_Title {
             get {
                 return ResourceManager.GetString("MiKo_2216_Title", resourceCulture);
             }
@@ -7777,7 +7813,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix &apos;&lt;list&gt;&apos;.
         /// </summary>
-        internal static string MiKo_2217_CodeFixTitle {
+        public static string MiKo_2217_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2217_CodeFixTitle", resourceCulture);
             }
@@ -7792,7 +7828,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///- For &apos;bullet&apos; or &apos;number&apos; lists, each &lt;item&gt; can contain a single, optional &lt;term&gt; and a single, re [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_2217_Description {
+        public static string MiKo_2217_Description {
             get {
                 return ResourceManager.GetString("MiKo_2217_Description", resourceCulture);
             }
@@ -7801,7 +7837,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to http://www.blackwasp.co.uk/DocumentationLists.aspx.
         /// </summary>
-        internal static string MiKo_2217_HelpLinkUri {
+        public static string MiKo_2217_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_2217_HelpLinkUri", resourceCulture);
             }
@@ -7810,7 +7846,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;description&gt; is missing.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_MissingDescription {
+        public static string MiKo_2217_MessageArgument_MissingDescription {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_MissingDescription", resourceCulture);
             }
@@ -7819,7 +7855,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;description&gt; or &lt;term&gt; is missing.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_MissingTermOrDescription {
+        public static string MiKo_2217_MessageArgument_MissingTermOrDescription {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_MissingTermOrDescription", resourceCulture);
             }
@@ -7828,7 +7864,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;listheader&gt; is not allowed for this type of &lt;list&gt;.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_NoHeaderAllowed {
+        public static string MiKo_2217_MessageArgument_NoHeaderAllowed {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_NoHeaderAllowed", resourceCulture);
             }
@@ -7837,7 +7873,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;description&gt; is not allowed to occur multiple times for this type of &lt;list&gt;.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_OnlySingleDescriptionAllowed {
+        public static string MiKo_2217_MessageArgument_OnlySingleDescriptionAllowed {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_OnlySingleDescriptionAllowed", resourceCulture);
             }
@@ -7846,7 +7882,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;term&gt; is not allowed to occur multiple times for this type of &lt;list&gt;.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_OnlySingleTermAllowed {
+        public static string MiKo_2217_MessageArgument_OnlySingleTermAllowed {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_OnlySingleTermAllowed", resourceCulture);
             }
@@ -7855,7 +7891,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;type&apos; attribute contains the unknown type {0}.
         /// </summary>
-        internal static string MiKo_2217_MessageArgument_UnknownTypeSpecified {
+        public static string MiKo_2217_MessageArgument_UnknownTypeSpecified {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageArgument_UnknownTypeSpecified", resourceCulture);
             }
@@ -7864,7 +7900,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; properly: {1}.
         /// </summary>
-        internal static string MiKo_2217_MessageFormat {
+        public static string MiKo_2217_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2217_MessageFormat", resourceCulture);
             }
@@ -7873,7 +7909,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;list&gt; documentation is done properly.
         /// </summary>
-        internal static string MiKo_2217_Title {
+        public static string MiKo_2217_Title {
             get {
                 return ResourceManager.GetString("MiKo_2217_Title", resourceCulture);
             }
@@ -7882,7 +7918,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Shorten term.
         /// </summary>
-        internal static string MiKo_2218_CodeFixTitle {
+        public static string MiKo_2218_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2218_CodeFixTitle", resourceCulture);
             }
@@ -7891,7 +7927,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Phrases like &apos;that is used to&apos; or &apos;which shall be used to&apos; are unnecessarily wordy. They should be shortened to the more concise term &apos;to&apos;. This enhances readability and streamlines documentation, making it clearer and more direct for developers..
         /// </summary>
-        internal static string MiKo_2218_Description {
+        public static string MiKo_2218_Description {
             get {
                 return ResourceManager.GetString("MiKo_2218_Description", resourceCulture);
             }
@@ -7900,7 +7936,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;{0}&apos; with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_2218_MessageFormat {
+        public static string MiKo_2218_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2218_MessageFormat", resourceCulture);
             }
@@ -7909,7 +7945,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use shorter terms instead of longer term &apos;used to/in/by&apos;.
         /// </summary>
-        internal static string MiKo_2218_Title {
+        public static string MiKo_2218_Title {
             get {
                 return ResourceManager.GetString("MiKo_2218_Title", resourceCulture);
             }
@@ -7924,7 +7960,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This ensures clarity and usability in your documentation, making it straightforward for developers to follow..
         /// </summary>
-        internal static string MiKo_2219_Description {
+        public static string MiKo_2219_Description {
             get {
                 return ResourceManager.GetString("MiKo_2219_Description", resourceCulture);
             }
@@ -7933,7 +7969,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{0}&apos; in documentation.
         /// </summary>
-        internal static string MiKo_2219_MessageFormat {
+        public static string MiKo_2219_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2219_MessageFormat", resourceCulture);
             }
@@ -7942,7 +7978,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use question or explamation marks in documentation.
         /// </summary>
-        internal static string MiKo_2219_Title {
+        public static string MiKo_2219_Title {
             get {
                 return ResourceManager.GetString("MiKo_2219_Title", resourceCulture);
             }
@@ -7951,7 +7987,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace with &apos;to seek&apos;.
         /// </summary>
-        internal static string MiKo_2220_CodeFixTitle {
+        public static string MiKo_2220_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2220_CodeFixTitle", resourceCulture);
             }
@@ -7960,7 +7996,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Phrases like &apos;to look for&apos;, &apos;to inspect for&apos;, or &apos;to test for&apos; all convey the same idea: to seek something. Therefore, they should be replaced with the term &apos;to seek&apos;. This streamlines documentation, making it clearer and more concise for developers..
         /// </summary>
-        internal static string MiKo_2220_Description {
+        public static string MiKo_2220_Description {
             get {
                 return ResourceManager.GetString("MiKo_2220_Description", resourceCulture);
             }
@@ -7969,7 +8005,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;to seek&apos; instead.
         /// </summary>
-        internal static string MiKo_2220_MessageFormat {
+        public static string MiKo_2220_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2220_MessageFormat", resourceCulture);
             }
@@ -7978,7 +8014,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use &apos;to seek&apos; instead of &apos;to look for&apos;, &apos;to inspect for&apos; or &apos;to test for&apos;.
         /// </summary>
-        internal static string MiKo_2220_Title {
+        public static string MiKo_2220_Title {
             get {
                 return ResourceManager.GetString("MiKo_2220_Title", resourceCulture);
             }
@@ -7987,7 +8023,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to An empty documentation is a code smell. It indicates that the developer created the XML documentation tag intentionally but failed to provide any actual content. This suggests a potential oversight or lack of attention to detail. Proper documentation is crucial for code clarity and maintenance..
         /// </summary>
-        internal static string MiKo_2221_Description {
+        public static string MiKo_2221_Description {
             get {
                 return ResourceManager.GetString("MiKo_2221_Description", resourceCulture);
             }
@@ -7996,7 +8032,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide a documentation for &lt;{1}/&gt;.
         /// </summary>
-        internal static string MiKo_2221_MessageFormat {
+        public static string MiKo_2221_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2221_MessageFormat", resourceCulture);
             }
@@ -8005,7 +8041,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not use empty XML tags.
         /// </summary>
-        internal static string MiKo_2221_Title {
+        public static string MiKo_2221_Title {
             get {
                 return ResourceManager.GetString("MiKo_2221_Title", resourceCulture);
             }
@@ -8014,7 +8050,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;ident&apos; into identification&apos;.
         /// </summary>
-        internal static string MiKo_2222_CodeFixTitle {
+        public static string MiKo_2222_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2222_CodeFixTitle", resourceCulture);
             }
@@ -8023,7 +8059,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should avoid the abbreviation &apos;ident&apos; and instead use the term &apos;identification&apos;. This ensures clarity and precision, making the documentation more understandable and professional. Clear terminology helps prevent confusion and enhances readability for developers..
         /// </summary>
-        internal static string MiKo_2222_Description {
+        public static string MiKo_2222_Description {
             get {
                 return ResourceManager.GetString("MiKo_2222_Description", resourceCulture);
             }
@@ -8032,7 +8068,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;identification&apos; instead of &apos;ident&apos;.
         /// </summary>
-        internal static string MiKo_2222_MessageFormat {
+        public static string MiKo_2222_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2222_MessageFormat", resourceCulture);
             }
@@ -8041,7 +8077,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use the term &apos;identification&apos; instead of &apos;ident&apos;.
         /// </summary>
-        internal static string MiKo_2222_Title {
+        public static string MiKo_2222_Title {
             get {
                 return ResourceManager.GetString("MiKo_2222_Title", resourceCulture);
             }
@@ -8050,7 +8086,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML documentation should link references like methods or types using &lt;see cref=&quot;...&quot;/&gt; instead of plain text. This approach ensures refactoring tools can update these references during renames, preventing the documentation from pointing to non-existent code..
         /// </summary>
-        internal static string MiKo_2223_Description {
+        public static string MiKo_2223_Description {
             get {
                 return ResourceManager.GetString("MiKo_2223_Description", resourceCulture);
             }
@@ -8059,7 +8095,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;&lt;see cref=&quot;{0}&quot;/&gt;&apos; instead.
         /// </summary>
-        internal static string MiKo_2223_MessageFormat {
+        public static string MiKo_2223_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2223_MessageFormat", resourceCulture);
             }
@@ -8068,7 +8104,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation links references via &lt;see cref=&quot;...&quot;/&gt;.
         /// </summary>
-        internal static string MiKo_2223_Title {
+        public static string MiKo_2223_Title {
             get {
                 return ResourceManager.GetString("MiKo_2223_Title", resourceCulture);
             }
@@ -8077,7 +8113,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place on separate line.
         /// </summary>
-        internal static string MiKo_2224_CodeFixTitle {
+        public static string MiKo_2224_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2224_CodeFixTitle", resourceCulture);
             }
@@ -8086,7 +8122,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve usability and readability, place XML tags and their corresponding texts on separate lines in your documentation. This formatting makes it easier for developers to read and navigate the documentation, ensuring clarity and better organization..
         /// </summary>
-        internal static string MiKo_2224_Description {
+        public static string MiKo_2224_Description {
             get {
                 return ResourceManager.GetString("MiKo_2224_Description", resourceCulture);
             }
@@ -8095,7 +8131,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;{0}&apos; on separate line.
         /// </summary>
-        internal static string MiKo_2224_MessageFormat {
+        public static string MiKo_2224_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2224_MessageFormat", resourceCulture);
             }
@@ -8104,7 +8140,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should have XML tags and texts placed on separate lines.
         /// </summary>
-        internal static string MiKo_2224_Title {
+        public static string MiKo_2224_Title {
             get {
                 return ResourceManager.GetString("MiKo_2224_Title", resourceCulture);
             }
@@ -8113,7 +8149,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place on same line.
         /// </summary>
-        internal static string MiKo_2225_CodeFixTitle {
+        public static string MiKo_2225_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2225_CodeFixTitle", resourceCulture);
             }
@@ -8122,7 +8158,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &lt;c&gt; tag to mark text within a description as code, but only for single lines. For multiple lines of code, you should use the &lt;code&gt; tag. This ensures the formatting is clear and the documentation remains organized and readable..
         /// </summary>
-        internal static string MiKo_2225_Description {
+        public static string MiKo_2225_Description {
             get {
                 return ResourceManager.GetString("MiKo_2225_Description", resourceCulture);
             }
@@ -8131,7 +8167,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#c.
         /// </summary>
-        internal static string MiKo_2225_HelpLinkUri {
+        public static string MiKo_2225_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_2225_HelpLinkUri", resourceCulture);
             }
@@ -8140,7 +8176,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;&lt;c&gt;&apos; tag with its content on same line.
         /// </summary>
-        internal static string MiKo_2225_MessageFormat {
+        public static string MiKo_2225_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2225_MessageFormat", resourceCulture);
             }
@@ -8149,7 +8185,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code marked with &lt;c&gt; tags should be placed on single line.
         /// </summary>
-        internal static string MiKo_2225_Title {
+        public static string MiKo_2225_Title {
             get {
                 return ResourceManager.GetString("MiKo_2225_Title", resourceCulture);
             }
@@ -8159,7 +8195,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Instead of simply stating *that* an intention exists, documentation should clearly explain *what* the intention actually is. This provides developers with valuable background information, enabling them to make more informed decisions based on that context.
         ///Clear intentions help convey the purpose and reasoning behind code, which is crucial for effective collaboration and maintenance..
         /// </summary>
-        internal static string MiKo_2226_Description {
+        public static string MiKo_2226_Description {
             get {
                 return ResourceManager.GetString("MiKo_2226_Description", resourceCulture);
             }
@@ -8168,7 +8204,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Explain what the intention behind actually is.
         /// </summary>
-        internal static string MiKo_2226_MessageFormat {
+        public static string MiKo_2226_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2226_MessageFormat", resourceCulture);
             }
@@ -8177,7 +8213,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should explain the &apos;Why&apos; and not the &apos;That&apos;.
         /// </summary>
-        internal static string MiKo_2226_Title {
+        public static string MiKo_2226_Title {
             get {
                 return ResourceManager.GetString("MiKo_2226_Title", resourceCulture);
             }
@@ -8187,7 +8223,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to ReSharper allows you to suppress certain rules using inline comments like // ReSharper disable or // ReSharper disable once. These suppressions can apply either once or until the document&apos;s end, or until the rule is re-enabled.
         ///However, these suppressions should remain inline comments and must not be part of the XML documentation. This keeps your documentation clean and professional, ensuring it&apos;s not cluttered with tool-specific directives..
         /// </summary>
-        internal static string MiKo_2227_Description {
+        public static string MiKo_2227_Description {
             get {
                 return ResourceManager.GetString("MiKo_2227_Description", resourceCulture);
             }
@@ -8196,7 +8232,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove from documentation and use inline comment instead.
         /// </summary>
-        internal static string MiKo_2227_MessageFormat {
+        public static string MiKo_2227_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2227_MessageFormat", resourceCulture);
             }
@@ -8205,7 +8241,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not contain ReSharper suppressions.
         /// </summary>
-        internal static string MiKo_2227_Title {
+        public static string MiKo_2227_Title {
             get {
                 return ResourceManager.GetString("MiKo_2227_Title", resourceCulture);
             }
@@ -8214,7 +8250,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Negative wording can be confusing, especially when combined with other negative terms (e.g., &quot;You cannot do this if it is not empty&quot;). Positive wording is clearer and more direct, making the documentation straightforward and to the point. This approach enhances readability and comprehension, helping developers easily grasp the information..
         /// </summary>
-        internal static string MiKo_2228_Description {
+        public static string MiKo_2228_Description {
             get {
                 return ResourceManager.GetString("MiKo_2228_Description", resourceCulture);
             }
@@ -8223,7 +8259,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use positive wording instead of negative.
         /// </summary>
-        internal static string MiKo_2228_MessageFormat {
+        public static string MiKo_2228_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2228_MessageFormat", resourceCulture);
             }
@@ -8232,7 +8268,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should use positive wording instead of negative.
         /// </summary>
-        internal static string MiKo_2228_Title {
+        public static string MiKo_2228_Title {
             get {
                 return ResourceManager.GetString("MiKo_2228_Title", resourceCulture);
             }
@@ -8241,7 +8277,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Delete XML fragment.
         /// </summary>
-        internal static string MiKo_2229_CodeFixTitle {
+        public static string MiKo_2229_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2229_CodeFixTitle", resourceCulture);
             }
@@ -8250,7 +8286,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML fragments in documentation often go unnoticed by developers but can end up in publicly available documentation. Therefore, it&apos;s best to avoid them to ensure clean, professional, and comprehensible documentation. This approach keeps the documentation neat and free from unwanted remnants..
         /// </summary>
-        internal static string MiKo_2229_Description {
+        public static string MiKo_2229_Description {
             get {
                 return ResourceManager.GetString("MiKo_2229_Description", resourceCulture);
             }
@@ -8259,7 +8295,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Delete XML fragment &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_2229_MessageFormat {
+        public static string MiKo_2229_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2229_MessageFormat", resourceCulture);
             }
@@ -8268,7 +8304,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation should not contain left-over XML fragments.
         /// </summary>
-        internal static string MiKo_2229_Title {
+        public static string MiKo_2229_Title {
             get {
                 return ResourceManager.GetString("MiKo_2229_Title", resourceCulture);
             }
@@ -8277,7 +8313,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;inheritdoc/&gt;.
         /// </summary>
-        internal static string MiKo_2231_CodeFixTitle {
+        public static string MiKo_2231_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2231_CodeFixTitle", resourceCulture);
             }
@@ -8286,7 +8322,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The main role of overridden &apos;GetHashCode()&apos; methods is to provide a hash code. Therefore, there&apos;s no need to create separate documentation for them. Instead, use the &apos;&lt;inheritdoc/&gt;&apos; marker to keep it simple and clean. This ensures the method inherits the documentation from its base class, maintaining consistency and clarity..
         /// </summary>
-        internal static string MiKo_2231_Description {
+        public static string MiKo_2231_Description {
             get {
                 return ResourceManager.GetString("MiKo_2231_Description", resourceCulture);
             }
@@ -8295,7 +8331,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &lt;inheritdoc/&gt; instead.
         /// </summary>
-        internal static string MiKo_2231_MessageFormat {
+        public static string MiKo_2231_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2231_MessageFormat", resourceCulture);
             }
@@ -8304,7 +8340,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Documentation of overridden &apos;GetHashCode()&apos; methods shall use &apos;&lt;inheritdoc /&gt;&apos; marker.
         /// </summary>
-        internal static string MiKo_2231_Title {
+        public static string MiKo_2231_Title {
             get {
                 return ResourceManager.GetString("MiKo_2231_Title", resourceCulture);
             }
@@ -8313,7 +8349,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove empty &lt;summary&gt;.
         /// </summary>
-        internal static string MiKo_2232_CodeFixTitle {
+        public static string MiKo_2232_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2232_CodeFixTitle", resourceCulture);
             }
@@ -8322,7 +8358,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Empty &lt;summary&gt; documentation adds no value and should be removed. It creates clutter and does not aid developers in understanding the code. Proper documentation should always provide meaningful and useful information..
         /// </summary>
-        internal static string MiKo_2232_Description {
+        public static string MiKo_2232_Description {
             get {
                 return ResourceManager.GetString("MiKo_2232_Description", resourceCulture);
             }
@@ -8331,7 +8367,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove empty &lt;summary&gt;.
         /// </summary>
-        internal static string MiKo_2232_MessageFormat {
+        public static string MiKo_2232_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2232_MessageFormat", resourceCulture);
             }
@@ -8340,7 +8376,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should not be empty.
         /// </summary>
-        internal static string MiKo_2232_Title {
+        public static string MiKo_2232_Title {
             get {
                 return ResourceManager.GetString("MiKo_2232_Title", resourceCulture);
             }
@@ -8349,7 +8385,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place on same line.
         /// </summary>
-        internal static string MiKo_2233_CodeFixTitle {
+        public static string MiKo_2233_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2233_CodeFixTitle", resourceCulture);
             }
@@ -8358,7 +8394,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when XML tags span a single line. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_2233_Description {
+        public static string MiKo_2233_Description {
             get {
                 return ResourceManager.GetString("MiKo_2233_Description", resourceCulture);
             }
@@ -8367,7 +8403,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place XML tag on single line.
         /// </summary>
-        internal static string MiKo_2233_MessageFormat {
+        public static string MiKo_2233_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2233_MessageFormat", resourceCulture);
             }
@@ -8376,7 +8412,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to XML tags should be placed on single line.
         /// </summary>
-        internal static string MiKo_2233_Title {
+        public static string MiKo_2233_Title {
             get {
                 return ResourceManager.GetString("MiKo_2233_Title", resourceCulture);
             }
@@ -8386,7 +8422,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>
-        internal static string MiKo_2300_Description {
+        public static string MiKo_2300_Description {
             get {
                 return ResourceManager.GetString("MiKo_2300_Description", resourceCulture);
             }
@@ -8395,7 +8431,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove comment or describe why exactly the code is the way it is.
         /// </summary>
-        internal static string MiKo_2300_MessageFormat {
+        public static string MiKo_2300_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2300_MessageFormat", resourceCulture);
             }
@@ -8404,7 +8440,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments should explain the &apos;Why&apos; and not the &apos;How&apos;.
         /// </summary>
-        internal static string MiKo_2300_Title {
+        public static string MiKo_2300_Title {
             get {
                 return ResourceManager.GetString("MiKo_2300_Title", resourceCulture);
             }
@@ -8413,7 +8449,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove obvious AAA comment.
         /// </summary>
-        internal static string MiKo_2301_CodeFixTitle {
+        public static string MiKo_2301_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2301_CodeFixTitle", resourceCulture);
             }
@@ -8422,7 +8458,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to In test code following the Arrange/Act/Assert style, comments like &apos;// arrange&apos;, &apos;// act&apos;, and &apos;// assert&apos; are redundant. They do not add any value since the structure is already clear. Removing them keeps your code clean and focused on the actual logic, enhancing readability and maintainability..
         /// </summary>
-        internal static string MiKo_2301_Description {
+        public static string MiKo_2301_Description {
             get {
                 return ResourceManager.GetString("MiKo_2301_Description", resourceCulture);
             }
@@ -8431,7 +8467,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove obvious AAA comment.
         /// </summary>
-        internal static string MiKo_2301_MessageFormat {
+        public static string MiKo_2301_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2301_MessageFormat", resourceCulture);
             }
@@ -8440,7 +8476,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use obvious comments in AAA-Tests.
         /// </summary>
-        internal static string MiKo_2301_Title {
+        public static string MiKo_2301_Title {
             get {
                 return ResourceManager.GetString("MiKo_2301_Title", resourceCulture);
             }
@@ -8450,7 +8486,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to The longer code remains commented out, the more likely it becomes outdated and un-compilable. Since code should be committed to Source Control Systems, developers can rely on the SCS history to retrieve older versions if needed.
         ///Therefore, there&apos;s no need to keep commented-out code in the codebase, keeping the code clean and maintainable..
         /// </summary>
-        internal static string MiKo_2302_Description {
+        public static string MiKo_2302_Description {
             get {
                 return ResourceManager.GetString("MiKo_2302_Description", resourceCulture);
             }
@@ -8459,7 +8495,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove commented out code.
         /// </summary>
-        internal static string MiKo_2302_MessageFormat {
+        public static string MiKo_2302_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2302_MessageFormat", resourceCulture);
             }
@@ -8468,7 +8504,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not keep code that is commented out.
         /// </summary>
-        internal static string MiKo_2302_Title {
+        public static string MiKo_2302_Title {
             get {
                 return ResourceManager.GetString("MiKo_2302_Title", resourceCulture);
             }
@@ -8477,7 +8513,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove ending period from comment.
         /// </summary>
-        internal static string MiKo_2303_CodeFixTitle {
+        public static string MiKo_2303_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2303_CodeFixTitle", resourceCulture);
             }
@@ -8488,7 +8524,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This rule contradicts MiKo_2306..
         /// </summary>
-        internal static string MiKo_2303_Description {
+        public static string MiKo_2303_Description {
             get {
                 return ResourceManager.GetString("MiKo_2303_Description", resourceCulture);
             }
@@ -8497,7 +8533,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not end comment with period.
         /// </summary>
-        internal static string MiKo_2303_MessageFormat {
+        public static string MiKo_2303_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2303_MessageFormat", resourceCulture);
             }
@@ -8506,7 +8542,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not end comments with a period.
         /// </summary>
-        internal static string MiKo_2303_Title {
+        public static string MiKo_2303_Title {
             get {
                 return ResourceManager.GetString("MiKo_2303_Title", resourceCulture);
             }
@@ -8515,7 +8551,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments should clarify the code and the reasoning behind it, never posing questions. If questions appear in comments, it signals unresolved issues and makes the code hard to maintain over time, as these questions often remain unanswered. Proper documentation ensures long-term clarity and maintainability..
         /// </summary>
-        internal static string MiKo_2304_Description {
+        public static string MiKo_2304_Description {
             get {
                 return ResourceManager.GetString("MiKo_2304_Description", resourceCulture);
             }
@@ -8524,7 +8560,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comment should explain, not ask.
         /// </summary>
-        internal static string MiKo_2304_MessageFormat {
+        public static string MiKo_2304_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2304_MessageFormat", resourceCulture);
             }
@@ -8533,7 +8569,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not formulate comments as questions.
         /// </summary>
-        internal static string MiKo_2304_Title {
+        public static string MiKo_2304_Title {
             get {
                 return ResourceManager.GetString("MiKo_2304_Title", resourceCulture);
             }
@@ -8542,7 +8578,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;..&apos; from comment.
         /// </summary>
-        internal static string MiKo_2305_CodeFixTitle {
+        public static string MiKo_2305_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2305_CodeFixTitle", resourceCulture);
             }
@@ -8551,7 +8587,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Inline comments are meant for team members, unlike API documentation. They should be concise and contain important information, avoiding double dots at the end. This keeps the communication clear and efficient for quick understanding within the team..
         /// </summary>
-        internal static string MiKo_2305_Description {
+        public static string MiKo_2305_Description {
             get {
                 return ResourceManager.GetString("MiKo_2305_Description", resourceCulture);
             }
@@ -8560,7 +8596,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;..&apos; from comment.
         /// </summary>
-        internal static string MiKo_2305_MessageFormat {
+        public static string MiKo_2305_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2305_MessageFormat", resourceCulture);
             }
@@ -8569,7 +8605,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use double periods in comments.
         /// </summary>
-        internal static string MiKo_2305_Title {
+        public static string MiKo_2305_Title {
             get {
                 return ResourceManager.GetString("MiKo_2305_Title", resourceCulture);
             }
@@ -8580,7 +8616,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This rule contradicts MiKo_2303..
         /// </summary>
-        internal static string MiKo_2306_Description {
+        public static string MiKo_2306_Description {
             get {
                 return ResourceManager.GetString("MiKo_2306_Description", resourceCulture);
             }
@@ -8589,7 +8625,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End comment with period.
         /// </summary>
-        internal static string MiKo_2306_MessageFormat {
+        public static string MiKo_2306_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2306_MessageFormat", resourceCulture);
             }
@@ -8598,7 +8634,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End comments with a period.
         /// </summary>
-        internal static string MiKo_2306_Title {
+        public static string MiKo_2306_Title {
             get {
                 return ResourceManager.GetString("MiKo_2306_Title", resourceCulture);
             }
@@ -8607,7 +8643,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace with &apos;failed&apos;.
         /// </summary>
-        internal static string MiKo_2307_CodeFixTitle {
+        public static string MiKo_2307_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2307_CodeFixTitle", resourceCulture);
             }
@@ -8616,7 +8652,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To make comments concise and precise, use &apos;failed&apos; instead of &apos;was not successful&apos;. This keeps it brief and straight to the point, making it easier for developers to understand quickly..
         /// </summary>
-        internal static string MiKo_2307_Description {
+        public static string MiKo_2307_Description {
             get {
                 return ResourceManager.GetString("MiKo_2307_Description", resourceCulture);
             }
@@ -8625,7 +8661,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;failed&apos; instead of &apos;was not successful&apos;.
         /// </summary>
-        internal static string MiKo_2307_MessageFormat {
+        public static string MiKo_2307_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2307_MessageFormat", resourceCulture);
             }
@@ -8634,7 +8670,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments should use the phrase &apos;failed&apos; instead of &apos;was not successful&apos;.
         /// </summary>
-        internal static string MiKo_2307_Title {
+        public static string MiKo_2307_Title {
             get {
                 return ResourceManager.GetString("MiKo_2307_Title", resourceCulture);
             }
@@ -8643,7 +8679,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place comment before code.
         /// </summary>
-        internal static string MiKo_2308_CodeFixTitle {
+        public static string MiKo_2308_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2308_CodeFixTitle", resourceCulture);
             }
@@ -8652,7 +8688,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments typically describe something related to an operation. Therefore, they should be placed before the operation, not after. This placement ensures that the reader can easily associate the comment with the corresponding operation, eliminating any guesswork about their relation and keeping everything clear and straightforward..
         /// </summary>
-        internal static string MiKo_2308_Description {
+        public static string MiKo_2308_Description {
             get {
                 return ResourceManager.GetString("MiKo_2308_Description", resourceCulture);
             }
@@ -8661,7 +8697,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place comment before code.
         /// </summary>
-        internal static string MiKo_2308_MessageFormat {
+        public static string MiKo_2308_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2308_MessageFormat", resourceCulture);
             }
@@ -8670,7 +8706,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not place comment on single line before closing brace but after code.
         /// </summary>
-        internal static string MiKo_2308_Title {
+        public static string MiKo_2308_Title {
             get {
                 return ResourceManager.GetString("MiKo_2308_Title", resourceCulture);
             }
@@ -8679,7 +8715,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &quot;n&apos;t&quot; to &quot; not&quot;.
         /// </summary>
-        internal static string MiKo_2309_CodeFixTitle {
+        public static string MiKo_2309_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2309_CodeFixTitle", resourceCulture);
             }
@@ -8688,7 +8724,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sometimes, contractions are missed, causing unintentional errors. To prevent this, it&apos;s best to avoid them entirely..
         /// </summary>
-        internal static string MiKo_2309_Description {
+        public static string MiKo_2309_Description {
             get {
                 return ResourceManager.GetString("MiKo_2309_Description", resourceCulture);
             }
@@ -8697,7 +8733,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_2309_MessageFormat {
+        public static string MiKo_2309_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2309_MessageFormat", resourceCulture);
             }
@@ -8706,7 +8742,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments should not use the contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_2309_Title {
+        public static string MiKo_2309_Title {
             get {
                 return ResourceManager.GetString("MiKo_2309_Title", resourceCulture);
             }
@@ -8716,7 +8752,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Instead of simply stating *that* an intention exists, documentation should clearly explain *what* the intention actually is. This provides developers with valuable background information, enabling them to make more informed decisions based on that context.
         ///Clear intentions help convey the purpose and reasoning behind code, which is crucial for effective collaboration and maintenance..
         /// </summary>
-        internal static string MiKo_2310_Description {
+        public static string MiKo_2310_Description {
             get {
                 return ResourceManager.GetString("MiKo_2310_Description", resourceCulture);
             }
@@ -8725,7 +8761,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Explain what the intention behind actually is.
         /// </summary>
-        internal static string MiKo_2310_MessageFormat {
+        public static string MiKo_2310_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2310_MessageFormat", resourceCulture);
             }
@@ -8734,7 +8770,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comments should explain the &apos;Why&apos; and not the &apos;That&apos;.
         /// </summary>
-        internal static string MiKo_2310_Title {
+        public static string MiKo_2310_Title {
             get {
                 return ResourceManager.GetString("MiKo_2310_Title", resourceCulture);
             }
@@ -8743,7 +8779,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove separator comment.
         /// </summary>
-        internal static string MiKo_2311_CodeFixTitle {
+        public static string MiKo_2311_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_2311_CodeFixTitle", resourceCulture);
             }
@@ -8753,7 +8789,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Comments should provide insight into the rationale behind the code, explaining why it is written that way. Using comments to separate code is not their intended purpose.
         ///Instead, comments should enhance understanding, giving context and reasoning for better comprehension and maintainability and keeping everything focused and informative..
         /// </summary>
-        internal static string MiKo_2311_Description {
+        public static string MiKo_2311_Description {
             get {
                 return ResourceManager.GetString("MiKo_2311_Description", resourceCulture);
             }
@@ -8762,7 +8798,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove separator comment.
         /// </summary>
-        internal static string MiKo_2311_MessageFormat {
+        public static string MiKo_2311_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_2311_MessageFormat", resourceCulture);
             }
@@ -8771,7 +8807,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use separator comments.
         /// </summary>
-        internal static string MiKo_2311_Title {
+        public static string MiKo_2311_Title {
             get {
                 return ResourceManager.GetString("MiKo_2311_Title", resourceCulture);
             }
@@ -8780,7 +8816,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If #region directives are used, avoid any empty #region. They just clutter the code without adding any value. When regions are truly needed, keep them meaningful and populated to ensure the code remains clean and efficient. This approach maintains clarity and organization in the codebase..
         /// </summary>
-        internal static string MiKo_3000_Description {
+        public static string MiKo_3000_Description {
             get {
                 return ResourceManager.GetString("MiKo_3000_Description", resourceCulture);
             }
@@ -8789,7 +8825,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove empty {0}.
         /// </summary>
-        internal static string MiKo_3000_MessageFormat {
+        public static string MiKo_3000_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3000_MessageFormat", resourceCulture);
             }
@@ -8798,7 +8834,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use empty regions.
         /// </summary>
-        internal static string MiKo_3000_Title {
+        public static string MiKo_3000_Title {
             get {
                 return ResourceManager.GetString("MiKo_3000_Title", resourceCulture);
             }
@@ -8807,7 +8843,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, use the pre-defined .NET Framework delegate types such as &apos;Action&apos;, &apos;Func&apos; or &apos;Expression&apos; instead of custom delegates..
         /// </summary>
-        internal static string MiKo_3001_Description {
+        public static string MiKo_3001_Description {
             get {
                 return ResourceManager.GetString("MiKo_3001_Description", resourceCulture);
             }
@@ -8816,7 +8852,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks.
         /// </summary>
-        internal static string MiKo_3001_HelpLinkUri {
+        public static string MiKo_3001_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3001_HelpLinkUri", resourceCulture);
             }
@@ -8825,7 +8861,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Action&apos;, &apos;Func&apos; or &apos;Expression&apos; instead.
         /// </summary>
-        internal static string MiKo_3001_MessageFormat {
+        public static string MiKo_3001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3001_MessageFormat", resourceCulture);
             }
@@ -8834,7 +8870,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Custom delegates should not be used.
         /// </summary>
-        internal static string MiKo_3001_Title {
+        public static string MiKo_3001_Title {
             get {
                 return ResourceManager.GetString("MiKo_3001_Title", resourceCulture);
             }
@@ -8843,7 +8879,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If a class has too many dependencies, it&apos;s taking on too many responsibilities and violating the Single Responsibility Principle (SRP). This indicates a need for refactoring the class into smaller, more focused units, ensuring the codebase remains clean and manageable..
         /// </summary>
-        internal static string MiKo_3002_Description {
+        public static string MiKo_3002_Description {
             get {
                 return ResourceManager.GetString("MiKo_3002_Description", resourceCulture);
             }
@@ -8852,7 +8888,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Too many MEF dependencies: {1,4} (allowed are max. {2}).
         /// </summary>
-        internal static string MiKo_3002_MessageFormat {
+        public static string MiKo_3002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3002_MessageFormat", resourceCulture);
             }
@@ -8861,7 +8897,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Classes should not have too many dependencies.
         /// </summary>
-        internal static string MiKo_3002_Title {
+        public static string MiKo_3002_Title {
             get {
                 return ResourceManager.GetString("MiKo_3002_Title", resourceCulture);
             }
@@ -8870,7 +8906,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease usage, events should follow the .NET Framework Design Guidelines for Event Design..
         /// </summary>
-        internal static string MiKo_3003_Description {
+        public static string MiKo_3003_Description {
             get {
                 return ResourceManager.GetString("MiKo_3003_Description", resourceCulture);
             }
@@ -8879,7 +8915,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
         /// </summary>
-        internal static string MiKo_3003_HelpLinkUri {
+        public static string MiKo_3003_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3003_HelpLinkUri", resourceCulture);
             }
@@ -8888,7 +8924,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;EventHandler&apos; or &apos;EventHandler&lt;T&gt;&apos; instead.
         /// </summary>
-        internal static string MiKo_3003_MessageFormat {
+        public static string MiKo_3003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3003_MessageFormat", resourceCulture);
             }
@@ -8897,7 +8933,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Events should follow .NET Framework Design Guidelines for events.
         /// </summary>
-        internal static string MiKo_3003_Title {
+        public static string MiKo_3003_Title {
             get {
                 return ResourceManager.GetString("MiKo_3003_Title", resourceCulture);
             }
@@ -8908,7 +8944,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///To prevent this, make EventArgs properties read-only or only privately settable. If you need to set the event data, provide a method that acts as a circuit breaker, allowing the data to be set only once. This approach ensures consistent and reliable behavior..
         /// </summary>
-        internal static string MiKo_3004_Description {
+        public static string MiKo_3004_Description {
             get {
                 return ResourceManager.GetString("MiKo_3004_Description", resourceCulture);
             }
@@ -8917,7 +8953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make setter private or property read-only.
         /// </summary>
-        internal static string MiKo_3004_MessageFormat {
+        public static string MiKo_3004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3004_MessageFormat", resourceCulture);
             }
@@ -8926,7 +8962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Property setters of EventArgs shall be private.
         /// </summary>
-        internal static string MiKo_3004_Title {
+        public static string MiKo_3004_Title {
             get {
                 return ResourceManager.GetString("MiKo_3004_Title", resourceCulture);
             }
@@ -8936,7 +8972,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to &apos;Try&apos; methods should follow the Try-Doer pattern to ease maintenance. They should return a Boolean and use the last parameter as an [out] parameter for the result. If successful, the method returns &apos;true&apos; and provides valid output; otherwise, it returns &apos;false&apos;.
         ///This pattern keeps methods consistent and predictable, enhancing readability and reliability..
         /// </summary>
-        internal static string MiKo_3005_Description {
+        public static string MiKo_3005_Description {
             get {
                 return ResourceManager.GetString("MiKo_3005_Description", resourceCulture);
             }
@@ -8945,7 +8981,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Follow the Trier-Doer-Pattern.
         /// </summary>
-        internal static string MiKo_3005_MessageFormat {
+        public static string MiKo_3005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3005_MessageFormat", resourceCulture);
             }
@@ -8954,7 +8990,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods named &apos;Try&apos; should follow the Trier-Doer-Pattern.
         /// </summary>
-        internal static string MiKo_3005_Title {
+        public static string MiKo_3005_Title {
             get {
                 return ResourceManager.GetString("MiKo_3005_Title", resourceCulture);
             }
@@ -8963,7 +8999,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ensure consistency with .NET Framework classes and ease maintenance, place &apos;CancellationToken&apos; parameters after all other method parameters. This practice keeps your codebase predictable and aligned with established conventions, making it easier for developers to understand and maintain..
         /// </summary>
-        internal static string MiKo_3006_Description {
+        public static string MiKo_3006_Description {
             get {
                 return ResourceManager.GetString("MiKo_3006_Description", resourceCulture);
             }
@@ -8972,7 +9008,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;{0}&apos; as last parameter.
         /// </summary>
-        internal static string MiKo_3006_MessageFormat {
+        public static string MiKo_3006_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3006_MessageFormat", resourceCulture);
             }
@@ -8981,7 +9017,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;CancellationToken&apos; parameter should be last method parameter.
         /// </summary>
-        internal static string MiKo_3006_Title {
+        public static string MiKo_3006_Title {
             get {
                 return ResourceManager.GetString("MiKo_3006_Title", resourceCulture);
             }
@@ -8990,7 +9026,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve maintainability and readability, stick to a single language when writing methods. Avoid mixing LINQ method syntax with declarative query syntax within the same method. This practice ensures consistency, making the code clean, easier to read, and more straightforward to maintain..
         /// </summary>
-        internal static string MiKo_3007_Description {
+        public static string MiKo_3007_Description {
             get {
                 return ResourceManager.GetString("MiKo_3007_Description", resourceCulture);
             }
@@ -8999,7 +9035,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not mix LINQ syntax.
         /// </summary>
-        internal static string MiKo_3007_MessageFormat {
+        public static string MiKo_3007_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3007_MessageFormat", resourceCulture);
             }
@@ -9008,7 +9044,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use LINQ method and declarative query syntax in same method.
         /// </summary>
-        internal static string MiKo_3007_Title {
+        public static string MiKo_3007_Title {
             get {
                 return ResourceManager.GetString("MiKo_3007_Title", resourceCulture);
             }
@@ -9017,7 +9053,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should avoid returning mutable collections like &apos;ICollection&lt;T&gt;&apos; since these can be modified from outside the method. Instead, they should return read-only variants like &apos;IReadOnlyCollection&lt;T&gt;&apos;. This practice ensures data integrity and encapsulation, making the code more secure and predictable..
         /// </summary>
-        internal static string MiKo_3008_Description {
+        public static string MiKo_3008_Description {
             get {
                 return ResourceManager.GetString("MiKo_3008_Description", resourceCulture);
             }
@@ -9026,7 +9062,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a read-only immutable variant or &apos;IEnumerable&lt;T&gt;&apos; instead.
         /// </summary>
-        internal static string MiKo_3008_MessageFormat {
+        public static string MiKo_3008_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3008_MessageFormat", resourceCulture);
             }
@@ -9035,7 +9071,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Method should not return collections that can be changed from outside.
         /// </summary>
-        internal static string MiKo_3008_Title {
+        public static string MiKo_3008_Title {
             get {
                 return ResourceManager.GetString("MiKo_3008_Title", resourceCulture);
             }
@@ -9044,7 +9080,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using anonymous lambdas for methods invoked by commands. They can be hard to read, understand, and maintain. Instead, use named methods with meaningful names. This practice enhances code readability and maintainability, making the code clear and straightforward for developers..
         /// </summary>
-        internal static string MiKo_3009_Description {
+        public static string MiKo_3009_Description {
             get {
                 return ResourceManager.GetString("MiKo_3009_Description", resourceCulture);
             }
@@ -9053,7 +9089,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use named method instead.
         /// </summary>
-        internal static string MiKo_3009_MessageFormat {
+        public static string MiKo_3009_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3009_MessageFormat", resourceCulture);
             }
@@ -9062,7 +9098,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Commands should invoke only named methods and no lambda expressions.
         /// </summary>
-        internal static string MiKo_3009_Title {
+        public static string MiKo_3009_Title {
             get {
                 return ResourceManager.GetString("MiKo_3009_Title", resourceCulture);
             }
@@ -9071,7 +9107,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Certain exceptions are reserved for and thrown by the Common Language Runtime (CLR) and often signal bugs. Developers should not throw these exceptions themselves to maintain code cleanliness and avoid confusion. Following this principle ensures clear and robust code management..
         /// </summary>
-        internal static string MiKo_3010_Description {
+        public static string MiKo_3010_Description {
             get {
                 return ResourceManager.GetString("MiKo_3010_Description", resourceCulture);
             }
@@ -9080,7 +9116,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
         /// </summary>
-        internal static string MiKo_3010_HelpLinkUri {
+        public static string MiKo_3010_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3010_HelpLinkUri", resourceCulture);
             }
@@ -9089,7 +9125,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create a &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3010_MessageFormat {
+        public static string MiKo_3010_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3010_MessageFormat", resourceCulture);
             }
@@ -9098,7 +9134,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create or throw reserved exception types.
         /// </summary>
-        internal static string MiKo_3010_Title {
+        public static string MiKo_3010_Title {
             get {
                 return ResourceManager.GetString("MiKo_3010_Title", resourceCulture);
             }
@@ -9107,7 +9143,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add &apos;paramName&apos; parameter.
         /// </summary>
-        internal static string MiKo_3011_CodeFixTitle {
+        public static string MiKo_3011_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3011_CodeFixTitle", resourceCulture);
             }
@@ -9116,7 +9152,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thrown ArgumentExceptions (or its subtypes) should always include the name of the parameter that caused the exception. This practice helps other developers quickly identify the problematic argument, facilitating easier debugging and improving overall code maintainability..
         /// </summary>
-        internal static string MiKo_3011_Description {
+        public static string MiKo_3011_Description {
             get {
                 return ResourceManager.GetString("MiKo_3011_Description", resourceCulture);
             }
@@ -9125,7 +9161,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types#argumentexception-argumentnullexception-and-argumentoutofrangeexception.
         /// </summary>
-        internal static string MiKo_3011_HelpLinkUri {
+        public static string MiKo_3011_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3011_HelpLinkUri", resourceCulture);
             }
@@ -9134,7 +9170,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &apos;paramName&apos; parameter to {1}.
         /// </summary>
-        internal static string MiKo_3011_MessageFormat {
+        public static string MiKo_3011_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3011_MessageFormat", resourceCulture);
             }
@@ -9143,7 +9179,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thrown ArgumentExceptions (or its subtypes) shall provide the correct parameter name.
         /// </summary>
-        internal static string MiKo_3011_Title {
+        public static string MiKo_3011_Title {
             get {
                 return ResourceManager.GetString("MiKo_3011_Title", resourceCulture);
             }
@@ -9152,7 +9188,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide actual value.
         /// </summary>
-        internal static string MiKo_3012_CodeFixTitle {
+        public static string MiKo_3012_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3012_CodeFixTitle", resourceCulture);
             }
@@ -9161,7 +9197,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thrown ArgumentOutOfRangeExceptions (or its subtypes) should always include the actual value of the parameter that caused the exception. This practice helps other developers quickly identify the problematic argument, facilitating easier debugging and improving overall code maintainability..
         /// </summary>
-        internal static string MiKo_3012_Description {
+        public static string MiKo_3012_Description {
             get {
                 return ResourceManager.GetString("MiKo_3012_Description", resourceCulture);
             }
@@ -9170,7 +9206,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide the actual value that causes the exception to be thrown.
         /// </summary>
-        internal static string MiKo_3012_MessageFormat {
+        public static string MiKo_3012_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3012_MessageFormat", resourceCulture);
             }
@@ -9179,7 +9215,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Thrown ArgumentOutOfRangeExceptions (or its subtypes) shall provide the actual value that causes the exception to be thrown.
         /// </summary>
-        internal static string MiKo_3012_Title {
+        public static string MiKo_3012_Title {
             get {
                 return ResourceManager.GetString("MiKo_3012_Title", resourceCulture);
             }
@@ -9188,7 +9224,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change to &apos;ArgumentOutOfRangeException&apos;.
         /// </summary>
-        internal static string MiKo_3013_CodeFixTitle {
+        public static string MiKo_3013_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3013_CodeFixTitle", resourceCulture);
             }
@@ -9197,7 +9233,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to In &apos;switch&apos; statements, the &apos;default&apos; clause should throw an ArgumentOutOfRangeException (or subtype) instead of an ArgumentException. This indicates that the argument provided is outside the expected range, ensuring error handling is clear and accurate. Keeps the code precise and informative for developers..
         /// </summary>
-        internal static string MiKo_3013_Description {
+        public static string MiKo_3013_Description {
             get {
                 return ResourceManager.GetString("MiKo_3013_Description", resourceCulture);
             }
@@ -9206,7 +9242,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw an &apos;ArgumentOutOfRangeException&apos; instead.
         /// </summary>
-        internal static string MiKo_3013_MessageFormat {
+        public static string MiKo_3013_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3013_MessageFormat", resourceCulture);
             }
@@ -9215,7 +9251,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;default&apos; clause in &apos;switch&apos; statements should throw an ArgumentOutOfRangeException (or subtype), but no ArgumentException.
         /// </summary>
-        internal static string MiKo_3013_Title {
+        public static string MiKo_3013_Title {
             get {
                 return ResourceManager.GetString("MiKo_3013_Title", resourceCulture);
             }
@@ -9224,7 +9260,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add a default reason.
         /// </summary>
-        internal static string MiKo_3014_CodeFixTitle {
+        public static string MiKo_3014_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3014_CodeFixTitle", resourceCulture);
             }
@@ -9234,7 +9270,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to For easier maintenance, include a reason when throwing an InvalidOperationException, NotImplementedException, or NotSupportedException. This reason should explain the circumstances of the exception and ideally provide guidance on how to resolve it.
         ///This practice ensures that developers understand why the exception was thrown and how to address it, making the code easier to maintain and debug..
         /// </summary>
-        internal static string MiKo_3014_Description {
+        public static string MiKo_3014_Description {
             get {
                 return ResourceManager.GetString("MiKo_3014_Description", resourceCulture);
             }
@@ -9243,7 +9279,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide a reason for the thrown &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3014_MessageFormat {
+        public static string MiKo_3014_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3014_MessageFormat", resourceCulture);
             }
@@ -9252,7 +9288,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to InvalidOperationException, NotImplementedException and NotSupportedException should have a reason as message.
         /// </summary>
-        internal static string MiKo_3014_Title {
+        public static string MiKo_3014_Title {
             get {
                 return ResourceManager.GetString("MiKo_3014_Title", resourceCulture);
             }
@@ -9261,7 +9297,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change to &apos;InvalidOperationException&apos;.
         /// </summary>
-        internal static string MiKo_3015_CodeFixTitle {
+        public static string MiKo_3015_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3015_CodeFixTitle", resourceCulture);
             }
@@ -9270,7 +9306,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid throwing ArgumentException (or its subtypes) in parameterless methods. If a method does not take any arguments, or if the failure is not related to the arguments themselves, use InvalidOperationException instead. This keeps exception handling logical and context-appropriate, making the code cleaner and easier to maintain..
         /// </summary>
-        internal static string MiKo_3015_Description {
+        public static string MiKo_3015_Description {
             get {
                 return ResourceManager.GetString("MiKo_3015_Description", resourceCulture);
             }
@@ -9279,7 +9315,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
         /// </summary>
-        internal static string MiKo_3015_HelpLinkUri {
+        public static string MiKo_3015_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3015_HelpLinkUri", resourceCulture);
             }
@@ -9288,7 +9324,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw an &apos;InvalidOperationException&apos; instead.
         /// </summary>
-        internal static string MiKo_3015_MessageFormat {
+        public static string MiKo_3015_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3015_MessageFormat", resourceCulture);
             }
@@ -9297,7 +9333,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw InvalidOperationExceptions (instead of ArgumentExceptions or its subtypes) to indicate inappropriate states of parameterless methods.
         /// </summary>
-        internal static string MiKo_3015_Title {
+        public static string MiKo_3015_Title {
             get {
                 return ResourceManager.GetString("MiKo_3015_Title", resourceCulture);
             }
@@ -9306,7 +9342,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change to &apos;ArgumentException&apos; or &apos;InvalidOperationException&apos;.
         /// </summary>
-        internal static string MiKo_3016_CodeFixTitle {
+        public static string MiKo_3016_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3016_CodeFixTitle", resourceCulture);
             }
@@ -9320,7 +9356,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This approach ensures that the exception thrown accurately reflects the nature of the issue, making your code more robust and understandable..
         /// </summary>
-        internal static string MiKo_3016_Description {
+        public static string MiKo_3016_Description {
             get {
                 return ResourceManager.GetString("MiKo_3016_Description", resourceCulture);
             }
@@ -9329,7 +9365,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
         /// </summary>
-        internal static string MiKo_3016_HelpLinkUri {
+        public static string MiKo_3016_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3016_HelpLinkUri", resourceCulture);
             }
@@ -9338,7 +9374,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw an &apos;ArgumentException&apos; or &apos;InvalidOperationException&apos; instead.
         /// </summary>
-        internal static string MiKo_3016_MessageFormat {
+        public static string MiKo_3016_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3016_MessageFormat", resourceCulture);
             }
@@ -9347,7 +9383,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not throw ArgumentNullException for inappropriate states of property return values.
         /// </summary>
-        internal static string MiKo_3016_Title {
+        public static string MiKo_3016_Title {
             get {
                 return ResourceManager.GetString("MiKo_3016_Title", resourceCulture);
             }
@@ -9356,7 +9392,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add inner exception.
         /// </summary>
-        internal static string MiKo_3017_CodeFixTitle {
+        public static string MiKo_3017_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3017_CodeFixTitle", resourceCulture);
             }
@@ -9365,7 +9401,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When catching an exception and throwing a new one, include the caught exception as an inner exception. This approach makes debugging easier by preserving the original exception, helping to trace the root cause efficiently..
         /// </summary>
-        internal static string MiKo_3017_Description {
+        public static string MiKo_3017_Description {
             get {
                 return ResourceManager.GetString("MiKo_3017_Description", resourceCulture);
             }
@@ -9374,7 +9410,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide exception as inner exception.
         /// </summary>
-        internal static string MiKo_3017_MessageFormat {
+        public static string MiKo_3017_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3017_MessageFormat", resourceCulture);
             }
@@ -9383,7 +9419,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not swallow exceptions when throwing new exceptions.
         /// </summary>
-        internal static string MiKo_3017_Title {
+        public static string MiKo_3017_Title {
             get {
                 return ResourceManager.GetString("MiKo_3017_Title", resourceCulture);
             }
@@ -9392,7 +9428,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Already disposed instances of disposable types should throw ObjectDisposedExceptions when methods are invoked on them. This practice makes it easier to identify bugs, as user code should never access already disposed types. Ensuring this indication helps maintain code integrity and prevents unintended errors..
         /// </summary>
-        internal static string MiKo_3018_Description {
+        public static string MiKo_3018_Description {
             get {
                 return ResourceManager.GetString("MiKo_3018_Description", resourceCulture);
             }
@@ -9401,7 +9437,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
         /// </summary>
-        internal static string MiKo_3018_HelpLinkUri {
+        public static string MiKo_3018_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3018_HelpLinkUri", resourceCulture);
             }
@@ -9410,7 +9446,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw ObjectDisposedException if disposed.
         /// </summary>
-        internal static string MiKo_3018_MessageFormat {
+        public static string MiKo_3018_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3018_MessageFormat", resourceCulture);
             }
@@ -9419,7 +9455,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw ObjectDisposedExceptions on publicly visible methods of disposable types.
         /// </summary>
-        internal static string MiKo_3018_Title {
+        public static string MiKo_3018_Title {
             get {
                 return ResourceManager.GetString("MiKo_3018_Title", resourceCulture);
             }
@@ -9428,7 +9464,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Task.CompletedTask&apos;.
         /// </summary>
-        internal static string MiKo_3020_CodeFixTitle {
+        public static string MiKo_3020_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3020_CodeFixTitle", resourceCulture);
             }
@@ -9437,7 +9473,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For better performance, use &apos;Task.CompletedTask&apos; instead of &apos;Task.FromResult()&apos;, as the returned task is internally cached. This helps improve efficiency in your code..
         /// </summary>
-        internal static string MiKo_3020_Description {
+        public static string MiKo_3020_Description {
             get {
                 return ResourceManager.GetString("MiKo_3020_Description", resourceCulture);
             }
@@ -9446,7 +9482,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Task.CompletedTask&apos; instead.
         /// </summary>
-        internal static string MiKo_3020_MessageFormat {
+        public static string MiKo_3020_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3020_MessageFormat", resourceCulture);
             }
@@ -9455,7 +9491,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Task.CompletedTask&apos; instead of &apos;Task.FromResult&apos;.
         /// </summary>
-        internal static string MiKo_3020_Title {
+        public static string MiKo_3020_Title {
             get {
                 return ResourceManager.GetString("MiKo_3020_Title", resourceCulture);
             }
@@ -9464,7 +9500,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If you&apos;re using &apos;Task.Run&apos; to return a Task for a long-running operation, you&apos;re likely making a mistake. Instead, use &apos;Task.Run&apos; to actually call the long-running operation. This approach aligns better with proper asynchronous programming practices and keeps your code efficient and manageable..
         /// </summary>
-        internal static string MiKo_3021_Description {
+        public static string MiKo_3021_Description {
             get {
                 return ResourceManager.GetString("MiKo_3021_Description", resourceCulture);
             }
@@ -9473,7 +9509,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-dont-use.html.
         /// </summary>
-        internal static string MiKo_3021_HelpLinkUri {
+        public static string MiKo_3021_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3021_HelpLinkUri", resourceCulture);
             }
@@ -9482,7 +9518,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{0}&apos; to invoke method &apos;{1}&apos;, but not inside.
         /// </summary>
-        internal static string MiKo_3021_MessageFormat {
+        public static string MiKo_3021_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3021_MessageFormat", resourceCulture);
             }
@@ -9491,7 +9527,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;Task.Run&apos; in the implementation.
         /// </summary>
-        internal static string MiKo_3021_Title {
+        public static string MiKo_3021_Title {
             get {
                 return ResourceManager.GetString("MiKo_3021_Title", resourceCulture);
             }
@@ -9500,7 +9536,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If a method returns &apos;Task&lt;IEnumerable&gt;&apos; or &apos;Task&lt;IEnumerable&lt;T&gt;&gt;&apos;, the enumerable is likely not evaluated until accessed in a foreach or LINQ call. This evaluation likely occurs on another thread (e.g., the main thread), which contradicts the idea of returning a dedicated task..
         /// </summary>
-        internal static string MiKo_3022_Description {
+        public static string MiKo_3022_Description {
             get {
                 return ResourceManager.GetString("MiKo_3022_Description", resourceCulture);
             }
@@ -9509,7 +9545,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_3022_MessageFormat {
+        public static string MiKo_3022_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3022_MessageFormat", resourceCulture);
             }
@@ -9518,7 +9554,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return Task&lt;IEnumerable&gt; or Task&lt;IEnumerable&lt;T&gt;&gt;.
         /// </summary>
-        internal static string MiKo_3022_Title {
+        public static string MiKo_3022_Title {
             get {
                 return ResourceManager.GetString("MiKo_3022_Title", resourceCulture);
             }
@@ -9527,7 +9563,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid passing around a &apos;CancellationTokenSource&apos;. Instead, pass the &apos;CancellationToken&apos; to propagate notifications for canceling operations. This approach keeps the code cleaner and maintains proper encapsulation, ensuring more manageable and readable code..
         /// </summary>
-        internal static string MiKo_3023_Description {
+        public static string MiKo_3023_Description {
             get {
                 return ResourceManager.GetString("MiKo_3023_Description", resourceCulture);
             }
@@ -9536,7 +9572,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_3023_MessageFormat {
+        public static string MiKo_3023_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3023_MessageFormat", resourceCulture);
             }
@@ -9545,7 +9581,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;CancellationTokenSource&apos; as parameter.
         /// </summary>
-        internal static string MiKo_3023_Title {
+        public static string MiKo_3023_Title {
             get {
                 return ResourceManager.GetString("MiKo_3023_Title", resourceCulture);
             }
@@ -9557,7 +9593,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Generally, this behavior is not desirable. The object reference should remain the same, with only the object itself being altered..
         /// </summary>
-        internal static string MiKo_3024_Description {
+        public static string MiKo_3024_Description {
             get {
                 return ResourceManager.GetString("MiKo_3024_Description", resourceCulture);
             }
@@ -9566,7 +9602,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;ref&apos;.
         /// </summary>
-        internal static string MiKo_3024_MessageFormat {
+        public static string MiKo_3024_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3024_MessageFormat", resourceCulture);
             }
@@ -9575,7 +9611,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use the [ref] keyword on reference parameters.
         /// </summary>
-        internal static string MiKo_3024_Title {
+        public static string MiKo_3024_Title {
             get {
                 return ResourceManager.GetString("MiKo_3024_Title", resourceCulture);
             }
@@ -9584,7 +9620,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Treat method parameters as read-only. Avoid re-assigning them to other values. If another value is needed, use a local variable instead. This approach keeps the method clean and predictable..
         /// </summary>
-        internal static string MiKo_3025_Description {
+        public static string MiKo_3025_Description {
             get {
                 return ResourceManager.GetString("MiKo_3025_Description", resourceCulture);
             }
@@ -9593,7 +9629,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not re-assign &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3025_MessageFormat {
+        public static string MiKo_3025_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3025_MessageFormat", resourceCulture);
             }
@@ -9602,7 +9638,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not re-assign method parameters.
         /// </summary>
-        internal static string MiKo_3025_Title {
+        public static string MiKo_3025_Title {
             get {
                 return ResourceManager.GetString("MiKo_3025_Title", resourceCulture);
             }
@@ -9611,7 +9647,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Unused parameters clutter the codebase and provide no benefit. They should be removed to keep the code clean and efficient. This ensures the code remains easy to read and maintain, enhancing overall quality and performance. Keeps everything lean and purposeful..
         /// </summary>
-        internal static string MiKo_3026_Description {
+        public static string MiKo_3026_Description {
             get {
                 return ResourceManager.GetString("MiKo_3026_Description", resourceCulture);
             }
@@ -9620,7 +9656,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameter is not used and can be safely removed.
         /// </summary>
-        internal static string MiKo_3026_MessageFormat {
+        public static string MiKo_3026_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3026_MessageFormat", resourceCulture);
             }
@@ -9629,7 +9665,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Unused parameters should be removed.
         /// </summary>
-        internal static string MiKo_3026_Title {
+        public static string MiKo_3026_Title {
             get {
                 return ResourceManager.GetString("MiKo_3026_Title", resourceCulture);
             }
@@ -9638,7 +9674,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Marking parameters for future use results in poor design. It&apos;s uncertain if the parameter will ever be used or if its type will fit future needs. Instead, override methods and add new parameters as needed. This approach maintains clarity and adaptability in your code, avoiding unnecessary clutter and potential issues. Keeps your codebase clean and efficient..
         /// </summary>
-        internal static string MiKo_3027_Description {
+        public static string MiKo_3027_Description {
             get {
                 return ResourceManager.GetString("MiKo_3027_Description", resourceCulture);
             }
@@ -9647,7 +9683,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design.
         /// </summary>
-        internal static string MiKo_3027_HelpLinkUri {
+        public static string MiKo_3027_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3027_HelpLinkUri", resourceCulture);
             }
@@ -9656,7 +9692,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not reserve &apos;{0}&apos; for future usage.
         /// </summary>
-        internal static string MiKo_3027_MessageFormat {
+        public static string MiKo_3027_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3027_MessageFormat", resourceCulture);
             }
@@ -9665,7 +9701,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameters should not be marked to be reserved for future usage.
         /// </summary>
-        internal static string MiKo_3027_Title {
+        public static string MiKo_3027_Title {
             get {
                 return ResourceManager.GetString("MiKo_3027_Title", resourceCulture);
             }
@@ -9674,7 +9710,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To clear a collection, use &apos;Clear()&apos;. Assigning &apos;null&apos; to a parameter will not work because the parameter is just a copy (reference) of the original. &apos;Clear()&apos; effectively empties the collection, maintaining clarity and correct functionality. Keeps everything working as expected..
         /// </summary>
-        internal static string MiKo_3028_Description {
+        public static string MiKo_3028_Description {
             get {
                 return ResourceManager.GetString("MiKo_3028_Description", resourceCulture);
             }
@@ -9683,7 +9719,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not assign null (is cleanup wanted here?).
         /// </summary>
-        internal static string MiKo_3028_MessageFormat {
+        public static string MiKo_3028_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3028_MessageFormat", resourceCulture);
             }
@@ -9692,7 +9728,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not assign null to lambda parameters.
         /// </summary>
-        internal static string MiKo_3028_Title {
+        public static string MiKo_3028_Title {
             get {
                 return ResourceManager.GetString("MiKo_3028_Title", resourceCulture);
             }
@@ -9701,7 +9737,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Forgetting to unregister from an event can lead to memory leaks, especially when the event is static or belongs to an object with a long lifetime. Always ensure you unregister from events to prevent these issues. Proper event handling maintains memory efficiency and keeps your applications running smoothly..
         /// </summary>
-        internal static string MiKo_3029_Description {
+        public static string MiKo_3029_Description {
             get {
                 return ResourceManager.GetString("MiKo_3029_Description", resourceCulture);
             }
@@ -9710,7 +9746,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assignment causes potential memory leak.
         /// </summary>
-        internal static string MiKo_3029_MessageFormat {
+        public static string MiKo_3029_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3029_MessageFormat", resourceCulture);
             }
@@ -9719,7 +9755,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event registrations should not cause memory leaks.
         /// </summary>
-        internal static string MiKo_3029_Title {
+        public static string MiKo_3029_Title {
             get {
                 return ResourceManager.GetString("MiKo_3029_Title", resourceCulture);
             }
@@ -9728,7 +9764,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, methods should make minimal assumptions about the structure or properties of the objects they use. They should work only with objects they receive directly and avoid reaching through these objects to access other objects or their services. This practice keeps methods focused, modular, and easier to maintain..
         /// </summary>
-        internal static string MiKo_3030_Description {
+        public static string MiKo_3030_Description {
             get {
                 return ResourceManager.GetString("MiKo_3030_Description", resourceCulture);
             }
@@ -9737,7 +9773,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://en.wikipedia.org/wiki/Law_of_Demeter.
         /// </summary>
-        internal static string MiKo_3030_HelpLinkUri {
+        public static string MiKo_3030_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3030_HelpLinkUri", resourceCulture);
             }
@@ -9746,7 +9782,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid to violate the Law of Demeter.
         /// </summary>
-        internal static string MiKo_3030_MessageFormat {
+        public static string MiKo_3030_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3030_MessageFormat", resourceCulture);
             }
@@ -9755,7 +9791,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods should follow the Law of Demeter.
         /// </summary>
-        internal static string MiKo_3030_Title {
+        public static string MiKo_3030_Title {
             get {
                 return ResourceManager.GetString("MiKo_3030_Title", resourceCulture);
             }
@@ -9764,7 +9800,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid implementing &apos;ICloneable.Clone()&apos; because the method does not specify whether it returns a deep or shallow copy, leading to potential inconsistencies. This ambiguity makes it unreliable, as there&apos;s a significant difference between deep and shallow copies. Ensuring clear, predictable behavior in your code is crucial..
         /// </summary>
-        internal static string MiKo_3031_Description {
+        public static string MiKo_3031_Description {
             get {
                 return ResourceManager.GetString("MiKo_3031_Description", resourceCulture);
             }
@@ -9773,7 +9809,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not implement &apos;ICloneable.Clone()&apos;.
         /// </summary>
-        internal static string MiKo_3031_MessageFormat {
+        public static string MiKo_3031_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3031_MessageFormat", resourceCulture);
             }
@@ -9782,7 +9818,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ICloneable.Clone() should not be implemented.
         /// </summary>
-        internal static string MiKo_3031_Title {
+        public static string MiKo_3031_Title {
             get {
                 return ResourceManager.GetString("MiKo_3031_Title", resourceCulture);
             }
@@ -9791,7 +9827,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3032_CodeFixTitle {
+        public static string MiKo_3032_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3032_CodeFixTitle", resourceCulture);
             }
@@ -9800,7 +9836,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator for property names passed into &apos;PropertyChangedEventArgs&apos; constructors, instead of strings. This avoids typos and invalid names and makes refactoring easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3032_Description {
+        public static string MiKo_3032_Description {
             get {
                 return ResourceManager.GetString("MiKo_3032_Description", resourceCulture);
             }
@@ -9809,7 +9845,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_3032_MessageFormat {
+        public static string MiKo_3032_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3032_MessageFormat", resourceCulture);
             }
@@ -9818,7 +9854,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; instead of Cinch for names of properties for created &apos;PropertyChangedEventArgs&apos; instances.
         /// </summary>
-        internal static string MiKo_3032_Title {
+        public static string MiKo_3032_Title {
             get {
                 return ResourceManager.GetString("MiKo_3032_Title", resourceCulture);
             }
@@ -9827,7 +9863,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3033_CodeFixTitle {
+        public static string MiKo_3033_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3033_CodeFixTitle", resourceCulture);
             }
@@ -9836,7 +9872,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator for property names passed into &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos; constructors, instead of strings. This avoids typos and invalid names and makes refactoring easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3033_Description {
+        public static string MiKo_3033_Description {
             get {
                 return ResourceManager.GetString("MiKo_3033_Description", resourceCulture);
             }
@@ -9845,7 +9881,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3033_MessageFormat {
+        public static string MiKo_3033_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3033_MessageFormat", resourceCulture);
             }
@@ -9854,7 +9890,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; for names of properties for created &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos; instances.
         /// </summary>
-        internal static string MiKo_3033_Title {
+        public static string MiKo_3033_Title {
             get {
                 return ResourceManager.GetString("MiKo_3033_Title", resourceCulture);
             }
@@ -9863,7 +9899,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply [CallerMemberName].
         /// </summary>
-        internal static string MiKo_3034_CodeFixTitle {
+        public static string MiKo_3034_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3034_CodeFixTitle", resourceCulture);
             }
@@ -9872,7 +9908,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When raising &apos;PropertyChanging&apos; or &apos;PropertyChanged&apos; events, use the [CallerMemberNameAttribute] to automatically specify the property name. This avoids using string arguments and ensures that the rename refactoring will update the property names correctly. This technique prevents errors and makes the code more maintainable and robust..
         /// </summary>
-        internal static string MiKo_3034_Description {
+        public static string MiKo_3034_Description {
             get {
                 return ResourceManager.GetString("MiKo_3034_Description", resourceCulture);
             }
@@ -9881,7 +9917,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply [CallerMemberName] attribute.
         /// </summary>
-        internal static string MiKo_3034_MessageFormat {
+        public static string MiKo_3034_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3034_MessageFormat", resourceCulture);
             }
@@ -9890,7 +9926,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to PropertyChanged event raiser shall use [CallerMemberName] attribute.
         /// </summary>
-        internal static string MiKo_3034_Title {
+        public static string MiKo_3034_Title {
             get {
                 return ResourceManager.GetString("MiKo_3034_Title", resourceCulture);
             }
@@ -9899,7 +9935,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;WaitOne&apos; methods are used to wait for a specific situation to occur. Waiting indefinitely can lead to deadlocks or livelocks. To prevent this, provide a TimeSpan to &apos;WaitOne&apos; to allow the wait to time out. This ensures better control and avoids potential blocking issues, keeping the system responsive and efficient..
         /// </summary>
-        internal static string MiKo_3035_Description {
+        public static string MiKo_3035_Description {
             get {
                 return ResourceManager.GetString("MiKo_3035_Description", resourceCulture);
             }
@@ -9908,7 +9944,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide a timeout value.
         /// </summary>
-        internal static string MiKo_3035_MessageFormat {
+        public static string MiKo_3035_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3035_MessageFormat", resourceCulture);
             }
@@ -9917,7 +9953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not invoke &apos;WaitOne&apos; methods without timeouts.
         /// </summary>
-        internal static string MiKo_3035_Title {
+        public static string MiKo_3035_Title {
             get {
                 return ResourceManager.GetString("MiKo_3035_Title", resourceCulture);
             }
@@ -9926,7 +9962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use factory method.
         /// </summary>
-        internal static string MiKo_3036_CodeFixTitle {
+        public static string MiKo_3036_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3036_CodeFixTitle", resourceCulture);
             }
@@ -9938,7 +9974,7 @@ namespace MiKoSolutions.Analyzers {
         ///Please note:
         ///It would be even better to use extension methods like &apos;Minutes()&apos; or &apos;Days()&apos;. This approach allows for more natural usage, such as &apos; var x = 5.Days(); &apos;..
         /// </summary>
-        internal static string MiKo_3036_Description {
+        public static string MiKo_3036_Description {
             get {
                 return ResourceManager.GetString("MiKo_3036_Description", resourceCulture);
             }
@@ -9947,7 +9983,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use factory or extension method instead.
         /// </summary>
-        internal static string MiKo_3036_MessageFormat {
+        public static string MiKo_3036_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3036_MessageFormat", resourceCulture);
             }
@@ -9956,7 +9992,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefer to use &apos;TimeSpan&apos; factory methods instead of constructors.
         /// </summary>
-        internal static string MiKo_3036_Title {
+        public static string MiKo_3036_Title {
             get {
                 return ResourceManager.GetString("MiKo_3036_Title", resourceCulture);
             }
@@ -9968,7 +10004,7 @@ namespace MiKoSolutions.Analyzers {
         ///Please note:
         ///It would be even better to use extension methods like &apos;Minutes()&apos; or &apos;Days()&apos;. This approach allows for more natural usage, such as &apos; xyz.WaitForExit(5.Days() [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_3037_Description {
+        public static string MiKo_3037_Description {
             get {
                 return ResourceManager.GetString("MiKo_3037_Description", resourceCulture);
             }
@@ -9977,7 +10013,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use magic number.
         /// </summary>
-        internal static string MiKo_3037_MessageFormat {
+        public static string MiKo_3037_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3037_MessageFormat", resourceCulture);
             }
@@ -9986,7 +10022,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use magic numbers for timeouts.
         /// </summary>
-        internal static string MiKo_3037_Title {
+        public static string MiKo_3037_Title {
             get {
                 return ResourceManager.GetString("MiKo_3037_Title", resourceCulture);
             }
@@ -9996,7 +10032,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Hard-coded numbers, often called &apos;magic&apos; numbers, can be unclear. To improve maintenance, avoid them. Instead, define these numbers as constants with meaningful names.
         ///This approach makes the code easier to read and understand, helping developers grasp the numbers&apos; purpose and context..
         /// </summary>
-        internal static string MiKo_3038_Description {
+        public static string MiKo_3038_Description {
             get {
                 return ResourceManager.GetString("MiKo_3038_Description", resourceCulture);
             }
@@ -10005,7 +10041,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Introduce constant for magic number {1}.
         /// </summary>
-        internal static string MiKo_3038_MessageFormat {
+        public static string MiKo_3038_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3038_MessageFormat", resourceCulture);
             }
@@ -10014,7 +10050,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use magic numbers.
         /// </summary>
-        internal static string MiKo_3038_Title {
+        public static string MiKo_3038_Title {
             get {
                 return ResourceManager.GetString("MiKo_3038_Title", resourceCulture);
             }
@@ -10024,7 +10060,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Properties using LINQ internally can behave unpredictably when accessed multiple times. Properties are meant to access fields with some safety checks, so this behavior contradicts their purpose and can cause unwanted side effects.
         ///Instead, use methods to make it clear that the behavior might differ between calls. This keeps your code predictable and maintains the intended functionality..
         /// </summary>
-        internal static string MiKo_3039_Description {
+        public static string MiKo_3039_Description {
             get {
                 return ResourceManager.GetString("MiKo_3039_Description", resourceCulture);
             }
@@ -10033,7 +10069,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{1}&apos; inside property.
         /// </summary>
-        internal static string MiKo_3039_MessageFormat {
+        public static string MiKo_3039_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3039_MessageFormat", resourceCulture);
             }
@@ -10042,7 +10078,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Properties should not use Linq or yield.
         /// </summary>
-        internal static string MiKo_3039_Title {
+        public static string MiKo_3039_Title {
             get {
                 return ResourceManager.GetString("MiKo_3039_Title", resourceCulture);
             }
@@ -10051,7 +10087,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease maintenance and improve readability, avoid using Booleans as parameters unless absolutely sure the value will never exceed two options. Instead, use an Enum. This practice ensures the code remains clear, flexible, and easier to maintain..
         /// </summary>
-        internal static string MiKo_3040_Description {
+        public static string MiKo_3040_Description {
             get {
                 return ResourceManager.GetString("MiKo_3040_Description", resourceCulture);
             }
@@ -10060,7 +10096,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design.
         /// </summary>
-        internal static string MiKo_3040_HelpLinkUri {
+        public static string MiKo_3040_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3040_HelpLinkUri", resourceCulture);
             }
@@ -10069,7 +10105,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use an Enum instead.
         /// </summary>
-        internal static string MiKo_3040_MessageFormat {
+        public static string MiKo_3040_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3040_MessageFormat", resourceCulture);
             }
@@ -10078,7 +10114,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use Booleans unless you are absolutely sure that you will never ever need more than 2 values.
         /// </summary>
-        internal static string MiKo_3040_Title {
+        public static string MiKo_3040_Title {
             get {
                 return ResourceManager.GetString("MiKo_3040_Title", resourceCulture);
             }
@@ -10087,7 +10123,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid using delegates like &apos;Action&apos; or &apos;Func&apos; in &apos;EventArgs&apos;. The callee must understand exactly how the delegate behaves. Failures within the delegate are difficult to debug, as exceptions are thrown in unrelated areas..
         /// </summary>
-        internal static string MiKo_3041_Description {
+        public static string MiKo_3041_Description {
             get {
                 return ResourceManager.GetString("MiKo_3041_Description", resourceCulture);
             }
@@ -10096,7 +10132,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a delegate.
         /// </summary>
-        internal static string MiKo_3041_MessageFormat {
+        public static string MiKo_3041_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3041_MessageFormat", resourceCulture);
             }
@@ -10105,7 +10141,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to EventArgs shall not use delegates.
         /// </summary>
-        internal static string MiKo_3041_Title {
+        public static string MiKo_3041_Title {
             get {
                 return ResourceManager.GetString("MiKo_3041_Title", resourceCulture);
             }
@@ -10114,7 +10150,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to EventArgs are standalone contracts. They should not implement any additional interfaces. This keeps their purpose clear and their usage straightforward, avoiding unnecessary complexity. Keeps the code clean and maintains the integrity of the event handling mechanism..
         /// </summary>
-        internal static string MiKo_3042_Description {
+        public static string MiKo_3042_Description {
             get {
                 return ResourceManager.GetString("MiKo_3042_Description", resourceCulture);
             }
@@ -10123,7 +10159,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not implement interface.
         /// </summary>
-        internal static string MiKo_3042_MessageFormat {
+        public static string MiKo_3042_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3042_MessageFormat", resourceCulture);
             }
@@ -10132,7 +10168,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to EventArgs shall not implement interfaces.
         /// </summary>
-        internal static string MiKo_3042_Title {
+        public static string MiKo_3042_Title {
             get {
                 return ResourceManager.GetString("MiKo_3042_Title", resourceCulture);
             }
@@ -10141,7 +10177,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3043_CodeFixTitle {
+        public static string MiKo_3043_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3043_CodeFixTitle", resourceCulture);
             }
@@ -10150,7 +10186,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator for event names registered on the &apos;WeakEventManager&apos; instead of strings. This prevents typos, ensures valid names, and makes rename refactoring much easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3043_Description {
+        public static string MiKo_3043_Description {
             get {
                 return ResourceManager.GetString("MiKo_3043_Description", resourceCulture);
             }
@@ -10159,7 +10195,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3043_MessageFormat {
+        public static string MiKo_3043_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3043_MessageFormat", resourceCulture);
             }
@@ -10168,7 +10204,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; for WeakEventManager event (de-)registrations.
         /// </summary>
-        internal static string MiKo_3043_Title {
+        public static string MiKo_3043_Title {
             get {
                 return ResourceManager.GetString("MiKo_3043_Title", resourceCulture);
             }
@@ -10177,7 +10213,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3044_CodeFixTitle {
+        public static string MiKo_3044_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3044_CodeFixTitle", resourceCulture);
             }
@@ -10186,7 +10222,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator to compare property names provided by &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos;. This avoids typos and invalid names and makes refactoring easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3044_Description {
+        public static string MiKo_3044_Description {
             get {
                 return ResourceManager.GetString("MiKo_3044_Description", resourceCulture);
             }
@@ -10195,7 +10231,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3044_MessageFormat {
+        public static string MiKo_3044_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3044_MessageFormat", resourceCulture);
             }
@@ -10204,7 +10240,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; to compare property names of &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos;.
         /// </summary>
-        internal static string MiKo_3044_Title {
+        public static string MiKo_3044_Title {
             get {
                 return ResourceManager.GetString("MiKo_3044_Title", resourceCulture);
             }
@@ -10213,7 +10249,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3045_CodeFixTitle {
+        public static string MiKo_3045_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3045_CodeFixTitle", resourceCulture);
             }
@@ -10222,7 +10258,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator for event names registered on the &apos;EventManager&apos; instead of strings. This prevents typos, ensures valid names, and makes rename refactoring much easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3045_Description {
+        public static string MiKo_3045_Description {
             get {
                 return ResourceManager.GetString("MiKo_3045_Description", resourceCulture);
             }
@@ -10231,7 +10267,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3045_MessageFormat {
+        public static string MiKo_3045_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3045_MessageFormat", resourceCulture);
             }
@@ -10240,7 +10276,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; for EventManager event registrations.
         /// </summary>
-        internal static string MiKo_3045_Title {
+        public static string MiKo_3045_Title {
             get {
                 return ResourceManager.GetString("MiKo_3045_Title", resourceCulture);
             }
@@ -10249,7 +10285,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3046_CodeFixTitle {
+        public static string MiKo_3046_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3046_CodeFixTitle", resourceCulture);
             }
@@ -10258,7 +10294,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator instead of strings to define the properties for event raising methods like &apos;OnPropertyChanged&apos;. This prevents typos, ensures valid names, and makes rename refactoring much easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3046_Description {
+        public static string MiKo_3046_Description {
             get {
                 return ResourceManager.GetString("MiKo_3046_Description", resourceCulture);
             }
@@ -10267,7 +10303,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3046_MessageFormat {
+        public static string MiKo_3046_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3046_MessageFormat", resourceCulture);
             }
@@ -10276,7 +10312,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; for property names of property raising methods.
         /// </summary>
-        internal static string MiKo_3046_Title {
+        public static string MiKo_3046_Title {
             get {
                 return ResourceManager.GetString("MiKo_3046_Title", resourceCulture);
             }
@@ -10285,7 +10321,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3047_CodeFixTitle {
+        public static string MiKo_3047_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3047_CodeFixTitle", resourceCulture);
             }
@@ -10294,7 +10330,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use the &apos;nameof&apos; operator instead of strings to define the properties for any applied [ContentProperty] attribute. This prevents typos, ensures valid names, and makes rename refactoring much easier, as &apos;nameof&apos; ensures property names are automatically updated during renames, unlike strings..
         /// </summary>
-        internal static string MiKo_3047_Description {
+        public static string MiKo_3047_Description {
             get {
                 return ResourceManager.GetString("MiKo_3047_Description", resourceCulture);
             }
@@ -10303,7 +10339,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3047_MessageFormat {
+        public static string MiKo_3047_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3047_MessageFormat", resourceCulture);
             }
@@ -10312,7 +10348,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos; for applied [ContentProperty] attributes.
         /// </summary>
-        internal static string MiKo_3047_Title {
+        public static string MiKo_3047_Title {
             get {
                 return ResourceManager.GetString("MiKo_3047_Title", resourceCulture);
             }
@@ -10321,7 +10357,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Decorate implementations of the IValueConverter interface with the [ValueConversion] attribute to signal to development tools the data types involved in a conversion. This practice enhances clarity and improves tool support, making the code easier to work with and maintain..
         /// </summary>
-        internal static string MiKo_3048_Description {
+        public static string MiKo_3048_Description {
             get {
                 return ResourceManager.GetString("MiKo_3048_Description", resourceCulture);
             }
@@ -10330,7 +10366,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply the [ValueConversion] attribute.
         /// </summary>
-        internal static string MiKo_3048_MessageFormat {
+        public static string MiKo_3048_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3048_MessageFormat", resourceCulture);
             }
@@ -10339,7 +10375,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ValueConverters shall have the [ValueConversion] attribute applied.
         /// </summary>
-        internal static string MiKo_3048_Title {
+        public static string MiKo_3048_Title {
             get {
                 return ResourceManager.GetString("MiKo_3048_Title", resourceCulture);
             }
@@ -10348,7 +10384,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to In C#, you might need a string description for an enum value. Achieve this by using the &apos;System.ComponentModel.DescriptionAttribute&apos; to decorate the enum member. This method associates descriptive text with enum values, enhancing both readability and usability..
         /// </summary>
-        internal static string MiKo_3049_Description {
+        public static string MiKo_3049_Description {
             get {
                 return ResourceManager.GetString("MiKo_3049_Description", resourceCulture);
             }
@@ -10357,7 +10393,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply a [Description] attribute with a proper description.
         /// </summary>
-        internal static string MiKo_3049_MessageFormat {
+        public static string MiKo_3049_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3049_MessageFormat", resourceCulture);
             }
@@ -10366,7 +10402,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Enum members shall have the [Description] attribute applied.
         /// </summary>
-        internal static string MiKo_3049_Title {
+        public static string MiKo_3049_Title {
             get {
                 return ResourceManager.GetString("MiKo_3049_Title", resourceCulture);
             }
@@ -10375,7 +10411,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make DependencyProperty &apos;public static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3050_CodeFixTitle {
+        public static string MiKo_3050_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3050_CodeFixTitle", resourceCulture);
             }
@@ -10384,7 +10420,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fields that are the back of a DependencyProperty should be made &apos;public static readonly&apos; to allow the .NET framework and other clients to find and access those fields..
         /// </summary>
-        internal static string MiKo_3050_Description {
+        public static string MiKo_3050_Description {
             get {
                 return ResourceManager.GetString("MiKo_3050_Description", resourceCulture);
             }
@@ -10393,7 +10429,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
         /// </summary>
-        internal static string MiKo_3050_HelpLinkUri {
+        public static string MiKo_3050_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3050_HelpLinkUri", resourceCulture);
             }
@@ -10402,7 +10438,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make it &apos;public static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3050_MessageFormat {
+        public static string MiKo_3050_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3050_MessageFormat", resourceCulture);
             }
@@ -10411,7 +10447,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to DependencyProperty fields should be &apos;public static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3050_Title {
+        public static string MiKo_3050_Title {
             get {
                 return ResourceManager.GetString("MiKo_3050_Title", resourceCulture);
             }
@@ -10420,7 +10456,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;nameof&apos;.
         /// </summary>
-        internal static string MiKo_3051_CodeFixTitle {
+        public static string MiKo_3051_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3051_CodeFixTitle", resourceCulture);
             }
@@ -10429,7 +10465,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To avoid typos, register fields backing a DependencyProperty using &apos;DependencyProperty.Register()&apos; and the &apos;nameof&apos; operator. Ensure you provide the correct property names, property types, and owning types..
         /// </summary>
-        internal static string MiKo_3051_Description {
+        public static string MiKo_3051_Description {
             get {
                 return ResourceManager.GetString("MiKo_3051_Description", resourceCulture);
             }
@@ -10438,7 +10474,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
         /// </summary>
-        internal static string MiKo_3051_HelpLinkUri {
+        public static string MiKo_3051_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3051_HelpLinkUri", resourceCulture);
             }
@@ -10447,7 +10483,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_3051_MessageFormat {
+        public static string MiKo_3051_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3051_MessageFormat", resourceCulture);
             }
@@ -10456,7 +10492,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to DependencyProperty fields should be properly registered.
         /// </summary>
-        internal static string MiKo_3051_Title {
+        public static string MiKo_3051_Title {
             get {
                 return ResourceManager.GetString("MiKo_3051_Title", resourceCulture);
             }
@@ -10465,7 +10501,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make DependencyPropertyKey &apos;private static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3052_CodeFixTitle {
+        public static string MiKo_3052_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3052_CodeFixTitle", resourceCulture);
             }
@@ -10474,7 +10510,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make fields backing a DependencyPropertyKey non-public, static, and readonly. This prevents clients from finding and accessing these fields, ensuring your code stays secure and well-encapsulated..
         /// </summary>
-        internal static string MiKo_3052_Description {
+        public static string MiKo_3052_Description {
             get {
                 return ResourceManager.GetString("MiKo_3052_Description", resourceCulture);
             }
@@ -10483,7 +10519,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
         /// </summary>
-        internal static string MiKo_3052_HelpLinkUri {
+        public static string MiKo_3052_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3052_HelpLinkUri", resourceCulture);
             }
@@ -10492,7 +10528,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make it non-public &apos;static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3052_MessageFormat {
+        public static string MiKo_3052_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3052_MessageFormat", resourceCulture);
             }
@@ -10501,7 +10537,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to DependencyPropertyKey fields should be non-public &apos;static readonly&apos;.
         /// </summary>
-        internal static string MiKo_3052_Title {
+        public static string MiKo_3052_Title {
             get {
                 return ResourceManager.GetString("MiKo_3052_Title", resourceCulture);
             }
@@ -10510,7 +10546,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To prevent typos, register fields that are the key of a DependencyProperty using &apos;DependencyProperty.RegisterReadOnly()&apos; and the &apos;nameof&apos; operator. Also, ensure you provide the correct property names, property types, and owning types..
         /// </summary>
-        internal static string MiKo_3053_Description {
+        public static string MiKo_3053_Description {
             get {
                 return ResourceManager.GetString("MiKo_3053_Description", resourceCulture);
             }
@@ -10519,7 +10555,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly.
         /// </summary>
-        internal static string MiKo_3053_HelpLinkUri {
+        public static string MiKo_3053_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3053_HelpLinkUri", resourceCulture);
             }
@@ -10528,7 +10564,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;{1}&apos; instead.
         /// </summary>
-        internal static string MiKo_3053_MessageFormat {
+        public static string MiKo_3053_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3053_MessageFormat", resourceCulture);
             }
@@ -10537,7 +10573,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to DependencyPropertyKey fields should be properly registered.
         /// </summary>
-        internal static string MiKo_3053_Title {
+        public static string MiKo_3053_Title {
             get {
                 return ResourceManager.GetString("MiKo_3053_Title", resourceCulture);
             }
@@ -10546,7 +10582,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Expose DependencyProperty identifier.
         /// </summary>
-        internal static string MiKo_3054_CodeFixTitle {
+        public static string MiKo_3054_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3054_CodeFixTitle", resourceCulture);
             }
@@ -10556,7 +10592,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Read-only dependency properties are defined by DependencyPropertyKey fields and should remain non-public. To make them accessible, expose a dependency property identifier for the read-only property. Do this by exposing the value of &apos;DependencyPropertyKey.DependencyProperty&apos; as a &apos;public static readonly&apos; field in the specific class.
         ///This maintains encapsulation while allowing access to the property..
         /// </summary>
-        internal static string MiKo_3054_Description {
+        public static string MiKo_3054_Description {
             get {
                 return ResourceManager.GetString("MiKo_3054_Description", resourceCulture);
             }
@@ -10565,7 +10601,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly.
         /// </summary>
-        internal static string MiKo_3054_HelpLinkUri {
+        public static string MiKo_3054_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3054_HelpLinkUri", resourceCulture);
             }
@@ -10574,7 +10610,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Expose a DependencyProperty identifier for the read-only dependency property &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3054_MessageFormat {
+        public static string MiKo_3054_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3054_MessageFormat", resourceCulture);
             }
@@ -10583,7 +10619,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A read-only DependencyProperty should have an exposed DependencyProperty identifier.
         /// </summary>
-        internal static string MiKo_3054_Title {
+        public static string MiKo_3054_Title {
             get {
                 return ResourceManager.GetString("MiKo_3054_Title", resourceCulture);
             }
@@ -10593,7 +10629,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to In WPF, view models use bindings. If a view model does not implement &apos;INotifyPropertyChanged&apos;, WPF uses reflection to detect changes, causing a memory leak. The binding instance (descriptor) stays in a static hash table for the app&apos;s lifetime.
         ///To avoid this, make sure types implement &apos;INotifyPropertyChanged&apos; and raise the corresponding events when changes occur..
         /// </summary>
-        internal static string MiKo_3055_Description {
+        public static string MiKo_3055_Description {
             get {
                 return ResourceManager.GetString("MiKo_3055_Description", resourceCulture);
             }
@@ -10602,7 +10638,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Implement INotifyPropertyChanged to avoid WPF binding memory leaks.
         /// </summary>
-        internal static string MiKo_3055_MessageFormat {
+        public static string MiKo_3055_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3055_MessageFormat", resourceCulture);
             }
@@ -10611,7 +10647,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ViewModels should implement INotifyPropertyChanged.
         /// </summary>
-        internal static string MiKo_3055_Title {
+        public static string MiKo_3055_Title {
             get {
                 return ResourceManager.GetString("MiKo_3055_Title", resourceCulture);
             }
@@ -10620,7 +10656,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove Assert call.
         /// </summary>
-        internal static string MiKo_3060_CodeFixTitle {
+        public static string MiKo_3060_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3060_CodeFixTitle", resourceCulture);
             }
@@ -10639,7 +10675,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Instead of using &apos;Debug.Assert()&apos; or &apos;Trace.Assert()&apos;, throw an exception like &apos;InvalidOperationException&apos;. This provides proper failure handling [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_3060_Description {
+        public static string MiKo_3060_Description {
             get {
                 return ResourceManager.GetString("MiKo_3060_Description", resourceCulture);
             }
@@ -10648,7 +10684,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_3060_MessageFormat {
+        public static string MiKo_3060_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3060_MessageFormat", resourceCulture);
             }
@@ -10657,7 +10693,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Debug.Assert or Trace.Assert shall not be used.
         /// </summary>
-        internal static string MiKo_3060_Title {
+        public static string MiKo_3060_Title {
             get {
                 return ResourceManager.GetString("MiKo_3060_Title", resourceCulture);
             }
@@ -10668,7 +10704,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Instead, request the logger via a string as the category. This approach ensures clear and organized logs, making analysis easier and more effective..
         /// </summary>
-        internal static string MiKo_3061_Description {
+        public static string MiKo_3061_Description {
             get {
                 return ResourceManager.GetString("MiKo_3061_Description", resourceCulture);
             }
@@ -10677,7 +10713,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a string as category instead.
         /// </summary>
-        internal static string MiKo_3061_MessageFormat {
+        public static string MiKo_3061_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3061_MessageFormat", resourceCulture);
             }
@@ -10686,7 +10722,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Loggers shall use a proper log category.
         /// </summary>
-        internal static string MiKo_3061_Title {
+        public static string MiKo_3061_Title {
             get {
                 return ResourceManager.GetString("MiKo_3061_Title", resourceCulture);
             }
@@ -10695,7 +10731,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log message with colon.
         /// </summary>
-        internal static string MiKo_3062_CodeFixTitle {
+        public static string MiKo_3062_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3062_CodeFixTitle", resourceCulture);
             }
@@ -10704,7 +10740,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log messages that log exceptions with a colon. This clearly indicates that an exception follows, making it easier for developers to identify and understand the context..
         /// </summary>
-        internal static string MiKo_3062_Description {
+        public static string MiKo_3062_Description {
             get {
                 return ResourceManager.GetString("MiKo_3062_Description", resourceCulture);
             }
@@ -10713,7 +10749,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log message with colon.
         /// </summary>
-        internal static string MiKo_3062_MessageFormat {
+        public static string MiKo_3062_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3062_MessageFormat", resourceCulture);
             }
@@ -10722,7 +10758,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log messages for exceptions with a colon.
         /// </summary>
-        internal static string MiKo_3062_Title {
+        public static string MiKo_3062_Title {
             get {
                 return ResourceManager.GetString("MiKo_3062_Title", resourceCulture);
             }
@@ -10731,7 +10767,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log message with dot.
         /// </summary>
-        internal static string MiKo_3063_CodeFixTitle {
+        public static string MiKo_3063_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3063_CodeFixTitle", resourceCulture);
             }
@@ -10740,7 +10776,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log messages that do not include exceptions with a dot. This keeps the focus clear and consistent, ensuring that logs are easy to read and understand. It helps distinguish between general log messages and those that include exception details, maintaining clarity in your logging practices..
         /// </summary>
-        internal static string MiKo_3063_Description {
+        public static string MiKo_3063_Description {
             get {
                 return ResourceManager.GetString("MiKo_3063_Description", resourceCulture);
             }
@@ -10749,7 +10785,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End log message with dot.
         /// </summary>
-        internal static string MiKo_3063_MessageFormat {
+        public static string MiKo_3063_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3063_MessageFormat", resourceCulture);
             }
@@ -10758,7 +10794,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to End non-exceptional log messages with a dot.
         /// </summary>
-        internal static string MiKo_3063_Title {
+        public static string MiKo_3063_Title {
             get {
                 return ResourceManager.GetString("MiKo_3063_Title", resourceCulture);
             }
@@ -10767,7 +10803,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change &quot;n&apos;t&quot; to &quot; not&quot;.
         /// </summary>
-        internal static string MiKo_3064_CodeFixTitle {
+        public static string MiKo_3064_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3064_CodeFixTitle", resourceCulture);
             }
@@ -10776,7 +10812,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Sometimes, contractions are missed, causing unintentional errors. To prevent this, it&apos;s best to avoid them entirely..
         /// </summary>
-        internal static string MiKo_3064_Description {
+        public static string MiKo_3064_Description {
             get {
                 return ResourceManager.GetString("MiKo_3064_Description", resourceCulture);
             }
@@ -10785,7 +10821,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_3064_MessageFormat {
+        public static string MiKo_3064_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3064_MessageFormat", resourceCulture);
             }
@@ -10794,7 +10830,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Log messages should not use the contraction &quot;n&apos;t&quot;.
         /// </summary>
-        internal static string MiKo_3064_Title {
+        public static string MiKo_3064_Title {
             get {
                 return ResourceManager.GetString("MiKo_3064_Title", resourceCulture);
             }
@@ -10803,7 +10839,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change interpolated string into normal string.
         /// </summary>
-        internal static string MiKo_3065_CodeFixTitle {
+        public static string MiKo_3065_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3065_CodeFixTitle", resourceCulture);
             }
@@ -10816,7 +10852,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Using interpolated strings instead of message templates prevents this filtering and contrad [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_3065_Description {
+        public static string MiKo_3065_Description {
             get {
                 return ResourceManager.GetString("MiKo_3065_Description", resourceCulture);
             }
@@ -10825,7 +10861,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use interpolated string.
         /// </summary>
-        internal static string MiKo_3065_MessageFormat {
+        public static string MiKo_3065_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3065_MessageFormat", resourceCulture);
             }
@@ -10834,7 +10870,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Microsoft Logging calls should not use interpolated strings.
         /// </summary>
-        internal static string MiKo_3065_Title {
+        public static string MiKo_3065_Title {
             get {
                 return ResourceManager.GetString("MiKo_3065_Title", resourceCulture);
             }
@@ -10843,7 +10879,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods returning &apos;IEnumerable&apos; are meant for foreach loops or LINQ queries. These methods should never return null, as it could lead to NullReferenceException or ArgumentNullException. Ensuring they do not return null keeps your code predictable and safe from unexpected runtime errors..
         /// </summary>
-        internal static string MiKo_3070_Description {
+        public static string MiKo_3070_Description {
             get {
                 return ResourceManager.GetString("MiKo_3070_Description", resourceCulture);
             }
@@ -10852,7 +10888,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return null.
         /// </summary>
-        internal static string MiKo_3070_MessageFormat {
+        public static string MiKo_3070_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3070_MessageFormat", resourceCulture);
             }
@@ -10861,7 +10897,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return null for an IEnumerable.
         /// </summary>
-        internal static string MiKo_3070_Title {
+        public static string MiKo_3070_Title {
             get {
                 return ResourceManager.GetString("MiKo_3070_Title", resourceCulture);
             }
@@ -10870,7 +10906,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods that return &apos;Task&apos; are intended for async calls. These methods should never return null, as this could lead to a NullReferenceException. Ensuring they do not return null keeps your code predictable and safe from unexpected runtime errors, maintaining reliability and smooth functionality..
         /// </summary>
-        internal static string MiKo_3071_Description {
+        public static string MiKo_3071_Description {
             get {
                 return ResourceManager.GetString("MiKo_3071_Description", resourceCulture);
             }
@@ -10879,7 +10915,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return null.
         /// </summary>
-        internal static string MiKo_3071_MessageFormat {
+        public static string MiKo_3071_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3071_MessageFormat", resourceCulture);
             }
@@ -10888,7 +10924,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return null for a Task.
         /// </summary>
-        internal static string MiKo_3071_Title {
+        public static string MiKo_3071_Title {
             get {
                 return ResourceManager.GetString("MiKo_3071_Title", resourceCulture);
             }
@@ -10897,7 +10933,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Public methods should return interfaces like &apos;IList&lt;&gt;&apos; or &apos;IDictionary&lt;&gt;&apos; instead of concrete types like &apos;List&lt;&gt;&apos; or &apos;Dictionary&lt;&gt;&apos;. This approach provides flexibility, allowing you to change the implementation of the return value without affecting the method&apos;s signature, keeping your code adaptable and maintainable..
         /// </summary>
-        internal static string MiKo_3072_Description {
+        public static string MiKo_3072_Description {
             get {
                 return ResourceManager.GetString("MiKo_3072_Description", resourceCulture);
             }
@@ -10906,7 +10942,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return {1}&lt;&gt;.
         /// </summary>
-        internal static string MiKo_3072_MessageFormat {
+        public static string MiKo_3072_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3072_MessageFormat", resourceCulture);
             }
@@ -10915,7 +10951,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Non-private methods should not return &apos;List&lt;&gt;&apos; or &apos;Dictionary&lt;&gt;&apos;.
         /// </summary>
-        internal static string MiKo_3072_Title {
+        public static string MiKo_3072_Title {
             get {
                 return ResourceManager.GetString("MiKo_3072_Title", resourceCulture);
             }
@@ -10924,7 +10960,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid returning from within a constructor. Constructors should execute fully, ensuring the objects are completely initialized. Partial initialization can lead to unpredictable behavior and inconsistencies..
         /// </summary>
-        internal static string MiKo_3073_Description {
+        public static string MiKo_3073_Description {
             get {
                 return ResourceManager.GetString("MiKo_3073_Description", resourceCulture);
             }
@@ -10933,7 +10969,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not return inside constructor.
         /// </summary>
-        internal static string MiKo_3073_MessageFormat {
+        public static string MiKo_3073_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3073_MessageFormat", resourceCulture);
             }
@@ -10942,7 +10978,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not leave objects partially initialized.
         /// </summary>
-        internal static string MiKo_3073_Title {
+        public static string MiKo_3073_Title {
             get {
                 return ResourceManager.GetString("MiKo_3073_Title", resourceCulture);
             }
@@ -10952,7 +10988,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to A constructor&apos;s main purpose is to create an initialized instance of its specific type. It should not be used to create instances of other types.
         ///Therefore, including [ref] or [out] parameters in a constructor contradicts this concept. These parameters should not exist to provide instances of other types, in addition to the instance created and initialized by the constructor..
         /// </summary>
-        internal static string MiKo_3074_Description {
+        public static string MiKo_3074_Description {
             get {
                 return ResourceManager.GetString("MiKo_3074_Description", resourceCulture);
             }
@@ -10961,7 +10997,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3074_MessageFormat {
+        public static string MiKo_3074_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3074_MessageFormat", resourceCulture);
             }
@@ -10970,7 +11006,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not define &apos;ref&apos; or &apos;out&apos; parameters on constructors.
         /// </summary>
-        internal static string MiKo_3074_Title {
+        public static string MiKo_3074_Title {
             get {
                 return ResourceManager.GetString("MiKo_3074_Title", resourceCulture);
             }
@@ -10979,7 +11015,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Seal class or make it static.
         /// </summary>
-        internal static string MiKo_3075_CodeFixTitle {
+        public static string MiKo_3075_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3075_CodeFixTitle", resourceCulture);
             }
@@ -10990,7 +11026,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///These types can be modified later if derivation becomes necessary. Keeping them static or sealed by default ensures clearer and more manageable code, still being adaptable for future changes..
         /// </summary>
-        internal static string MiKo_3075_Description {
+        public static string MiKo_3075_Description {
             get {
                 return ResourceManager.GetString("MiKo_3075_Description", resourceCulture);
             }
@@ -10999,7 +11035,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Seal class or make it static.
         /// </summary>
-        internal static string MiKo_3075_MessageFormat {
+        public static string MiKo_3075_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3075_MessageFormat", resourceCulture);
             }
@@ -11008,7 +11044,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Internal and private types should be either static or sealed unless derivation from them is required.
         /// </summary>
-        internal static string MiKo_3075_Title {
+        public static string MiKo_3075_Title {
             get {
                 return ResourceManager.GetString("MiKo_3075_Title", resourceCulture);
             }
@@ -11019,7 +11055,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///This can cause subtle bugs like &apos;TypeInitializerException&apos;s or incorrect values..
         /// </summary>
-        internal static string MiKo_3076_Description {
+        public static string MiKo_3076_Description {
             get {
                 return ResourceManager.GetString("MiKo_3076_Description", resourceCulture);
             }
@@ -11028,7 +11064,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Static member initializer refers to static member(s) {1} below or in other type part.
         /// </summary>
-        internal static string MiKo_3076_MessageFormat {
+        public static string MiKo_3076_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3076_MessageFormat", resourceCulture);
             }
@@ -11037,7 +11073,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not initialize static member with static member below or in other type part.
         /// </summary>
-        internal static string MiKo_3076_Title {
+        public static string MiKo_3076_Title {
             get {
                 return ResourceManager.GetString("MiKo_3076_Title", resourceCulture);
             }
@@ -11046,7 +11082,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply a default value.
         /// </summary>
-        internal static string MiKo_3077_CodeFixTitle {
+        public static string MiKo_3077_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3077_CodeFixTitle", resourceCulture);
             }
@@ -11056,7 +11092,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Explicitly setting values for properties that return an Enum helps easily identify the default value and any changes.
         ///This practice aids in ensuring the value is the intended one, keeping the code clear and helping to spot unintended changes quickly..
         /// </summary>
-        internal static string MiKo_3077_Description {
+        public static string MiKo_3077_Description {
             get {
                 return ResourceManager.GetString("MiKo_3077_Description", resourceCulture);
             }
@@ -11065,7 +11101,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Set a default value.
         /// </summary>
-        internal static string MiKo_3077_MessageFormat {
+        public static string MiKo_3077_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3077_MessageFormat", resourceCulture);
             }
@@ -11074,7 +11110,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Properties that return an Enum should have a default value.
         /// </summary>
-        internal static string MiKo_3077_Title {
+        public static string MiKo_3077_Title {
             get {
                 return ResourceManager.GetString("MiKo_3077_Title", resourceCulture);
             }
@@ -11083,7 +11119,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply a default value.
         /// </summary>
-        internal static string MiKo_3078_CodeFixTitle {
+        public static string MiKo_3078_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3078_CodeFixTitle", resourceCulture);
             }
@@ -11093,7 +11129,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Explicitly setting values for &apos;Enum&apos; members prevents changes in meaning when the Enum is modified, whether by adding, removing, renaming, or reordering values.
         ///This approach ensures stability and clarity, keeping the Enum&apos;s behavior consistent as it evolves. It makes everything reliable and easy to understand..
         /// </summary>
-        internal static string MiKo_3078_Description {
+        public static string MiKo_3078_Description {
             get {
                 return ResourceManager.GetString("MiKo_3078_Description", resourceCulture);
             }
@@ -11102,7 +11138,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Set a default value.
         /// </summary>
-        internal static string MiKo_3078_MessageFormat {
+        public static string MiKo_3078_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3078_MessageFormat", resourceCulture);
             }
@@ -11111,7 +11147,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Enum members should have a default value.
         /// </summary>
-        internal static string MiKo_3078_Title {
+        public static string MiKo_3078_Title {
             get {
                 return ResourceManager.GetString("MiKo_3078_Title", resourceCulture);
             }
@@ -11120,7 +11156,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace with hex value.
         /// </summary>
-        internal static string MiKo_3079_CodeFixTitle {
+        public static string MiKo_3079_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3079_CodeFixTitle", resourceCulture);
             }
@@ -11129,7 +11165,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Write HResults in hexadecimal, not as negative integers. It&apos;s much easier to recognize and search for &apos;0x80070005&apos; than &apos;-2147024891&apos;. Keeps the code clean and user-friendly..
         /// </summary>
-        internal static string MiKo_3079_Description {
+        public static string MiKo_3079_Description {
             get {
                 return ResourceManager.GetString("MiKo_3079_Description", resourceCulture);
             }
@@ -11138,7 +11174,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;unchecked((int)0x{1})&apos; instead for HResult.
         /// </summary>
-        internal static string MiKo_3079_MessageFormat {
+        public static string MiKo_3079_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3079_MessageFormat", resourceCulture);
             }
@@ -11147,7 +11183,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to HResults should be written in hexadecimal.
         /// </summary>
-        internal static string MiKo_3079_Title {
+        public static string MiKo_3079_Title {
             get {
                 return ResourceManager.GetString("MiKo_3079_Title", resourceCulture);
             }
@@ -11158,7 +11194,7 @@ namespace MiKoSolutions.Analyzers {
         ///Let each section of the switch return values directly, instead of assigning them to a shared variable and using break statements.
         ///This approach enhances clarity and maintainability..
         /// </summary>
-        internal static string MiKo_3080_Description {
+        public static string MiKo_3080_Description {
             get {
                 return ResourceManager.GetString("MiKo_3080_Description", resourceCulture);
             }
@@ -11167,7 +11203,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place switch statement in separate method and return value within case blocks.
         /// </summary>
-        internal static string MiKo_3080_MessageFormat {
+        public static string MiKo_3080_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3080_MessageFormat", resourceCulture);
             }
@@ -11176,7 +11212,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;switch ... return&apos; instead of &apos;switch ... break&apos; when assigning variables.
         /// </summary>
-        internal static string MiKo_3080_Title {
+        public static string MiKo_3080_Title {
             get {
                 return ResourceManager.GetString("MiKo_3080_Title", resourceCulture);
             }
@@ -11185,7 +11221,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply &apos;is false&apos; pattern.
         /// </summary>
-        internal static string MiKo_3081_CodeFixTitle {
+        public static string MiKo_3081_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3081_CodeFixTitle", resourceCulture);
             }
@@ -11194,7 +11230,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Logical NOT conditions using &apos;!&apos; can be hard to recognize. Use is false instead; it&apos;s easier to read and understand..
         /// </summary>
-        internal static string MiKo_3081_Description {
+        public static string MiKo_3081_Description {
             get {
                 return ResourceManager.GetString("MiKo_3081_Description", resourceCulture);
             }
@@ -11203,7 +11239,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use pattern &apos;is false&apos; instead of &apos; ! &apos;.
         /// </summary>
-        internal static string MiKo_3081_MessageFormat {
+        public static string MiKo_3081_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3081_MessageFormat", resourceCulture);
             }
@@ -11212,7 +11248,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefer pattern matching over a logical NOT condition.
         /// </summary>
-        internal static string MiKo_3081_Title {
+        public static string MiKo_3081_Title {
             get {
                 return ResourceManager.GetString("MiKo_3081_Title", resourceCulture);
             }
@@ -11221,7 +11257,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply &apos;is&apos; pattern.
         /// </summary>
-        internal static string MiKo_3082_CodeFixTitle {
+        public static string MiKo_3082_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3082_CodeFixTitle", resourceCulture);
             }
@@ -11230,7 +11266,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using the &apos;is&apos; pattern matching for logical comparisons is more natural and easier to read than the &apos;==&apos; equality operator. This approach enhances code clarity and comprehension, making your code cleaner and more intuitive..
         /// </summary>
-        internal static string MiKo_3082_Description {
+        public static string MiKo_3082_Description {
             get {
                 return ResourceManager.GetString("MiKo_3082_Description", resourceCulture);
             }
@@ -11239,7 +11275,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;is&apos; instead of &apos;==&apos;.
         /// </summary>
-        internal static string MiKo_3082_MessageFormat {
+        public static string MiKo_3082_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3082_MessageFormat", resourceCulture);
             }
@@ -11248,7 +11284,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefer pattern matching over a logical comparison with &apos;true&apos; or &apos;false&apos;.
         /// </summary>
-        internal static string MiKo_3082_Title {
+        public static string MiKo_3082_Title {
             get {
                 return ResourceManager.GetString("MiKo_3082_Title", resourceCulture);
             }
@@ -11257,7 +11293,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply &apos;is null&apos; pattern.
         /// </summary>
-        internal static string MiKo_3083_CodeFixTitle {
+        public static string MiKo_3083_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3083_CodeFixTitle", resourceCulture);
             }
@@ -11266,7 +11302,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;is&apos; pattern matching for null checks is more natural and easier to read than the &apos;==&apos; equality operator. This approach enhances code clarity and comprehension, making your code cleaner and more intuitive..
         /// </summary>
-        internal static string MiKo_3083_Description {
+        public static string MiKo_3083_Description {
             get {
                 return ResourceManager.GetString("MiKo_3083_Description", resourceCulture);
             }
@@ -11275,7 +11311,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;is&apos; instead of &apos;==&apos;.
         /// </summary>
-        internal static string MiKo_3083_MessageFormat {
+        public static string MiKo_3083_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3083_MessageFormat", resourceCulture);
             }
@@ -11284,7 +11320,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefer pattern matching for null checks.
         /// </summary>
-        internal static string MiKo_3083_Title {
+        public static string MiKo_3083_Title {
             get {
                 return ResourceManager.GetString("MiKo_3083_Title", resourceCulture);
             }
@@ -11293,7 +11329,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place constant value on right side.
         /// </summary>
-        internal static string MiKo_3084_CodeFixTitle {
+        public static string MiKo_3084_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3084_CodeFixTitle", resourceCulture);
             }
@@ -11302,7 +11338,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To increase readability, place constants on the right side of an operator, not the left. This makes the code look more intuitive and easier to understand..
         /// </summary>
-        internal static string MiKo_3084_Description {
+        public static string MiKo_3084_Description {
             get {
                 return ResourceManager.GetString("MiKo_3084_Description", resourceCulture);
             }
@@ -11311,7 +11347,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place it on right side of &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_3084_MessageFormat {
+        public static string MiKo_3084_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3084_MessageFormat", resourceCulture);
             }
@@ -11320,7 +11356,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not place constants on the left side for comparisons.
         /// </summary>
-        internal static string MiKo_3084_Title {
+        public static string MiKo_3084_Title {
             get {
                 return ResourceManager.GetString("MiKo_3084_Title", resourceCulture);
             }
@@ -11329,7 +11365,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Long conditional statements are hard to read and maintain. Keep them short for easy understanding at a glance, or refactor into if-else statements for clarity. This approach keeps your code clean and maintainable..
         /// </summary>
-        internal static string MiKo_3085_Description {
+        public static string MiKo_3085_Description {
             get {
                 return ResourceManager.GetString("MiKo_3085_Description", resourceCulture);
             }
@@ -11338,7 +11374,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Shorten conditional or use &apos;if ... else ...&apos; instead.
         /// </summary>
-        internal static string MiKo_3085_MessageFormat {
+        public static string MiKo_3085_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3085_MessageFormat", resourceCulture);
             }
@@ -11347,7 +11383,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Conditional statements should be short.
         /// </summary>
-        internal static string MiKo_3085_Title {
+        public static string MiKo_3085_Title {
             get {
                 return ResourceManager.GetString("MiKo_3085_Title", resourceCulture);
             }
@@ -11356,7 +11392,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Nested conditional or coalesce statements are difficult to read and understand. Avoid nesting them. Instead, use if-else statements to improve clarity. This approach keeps your code clean and maintainable..
         /// </summary>
-        internal static string MiKo_3086_Description {
+        public static string MiKo_3086_Description {
             get {
                 return ResourceManager.GetString("MiKo_3086_Description", resourceCulture);
             }
@@ -11365,7 +11401,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not nest conditional.
         /// </summary>
-        internal static string MiKo_3086_MessageFormat {
+        public static string MiKo_3086_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3086_MessageFormat", resourceCulture);
             }
@@ -11374,7 +11410,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not nest conditional statements.
         /// </summary>
-        internal static string MiKo_3086_Title {
+        public static string MiKo_3086_Title {
             get {
                 return ResourceManager.GetString("MiKo_3086_Title", resourceCulture);
             }
@@ -11383,7 +11419,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Complex conditions with negative logic are difficult to understand, cumbersome, and error-prone. Change them to positive logic to improve readability, simplify the code, and reduce errors. This approach ensures your code is clear and easier to maintain..
         /// </summary>
-        internal static string MiKo_3087_Description {
+        public static string MiKo_3087_Description {
             get {
                 return ResourceManager.GetString("MiKo_3087_Description", resourceCulture);
             }
@@ -11392,7 +11428,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Condition is difficult to understand, simplify or convert to positive logic.
         /// </summary>
-        internal static string MiKo_3087_MessageFormat {
+        public static string MiKo_3087_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3087_MessageFormat", resourceCulture);
             }
@@ -11401,7 +11437,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use negative complex conditions.
         /// </summary>
-        internal static string MiKo_3087_Title {
+        public static string MiKo_3087_Title {
             get {
                 return ResourceManager.GetString("MiKo_3087_Title", resourceCulture);
             }
@@ -11410,7 +11446,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Apply &apos;is not null&apos; pattern.
         /// </summary>
-        internal static string MiKo_3088_CodeFixTitle {
+        public static string MiKo_3088_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3088_CodeFixTitle", resourceCulture);
             }
@@ -11419,7 +11455,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Null checks using &apos;is not&apos; pattern matching are more intuitive and easier to read than the &apos;!=&apos; inequality operator. This makes them the preferred choice for clarity and comprehension..
         /// </summary>
-        internal static string MiKo_3088_Description {
+        public static string MiKo_3088_Description {
             get {
                 return ResourceManager.GetString("MiKo_3088_Description", resourceCulture);
             }
@@ -11428,7 +11464,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;is not&apos; instead of &apos;!=&apos;.
         /// </summary>
-        internal static string MiKo_3088_MessageFormat {
+        public static string MiKo_3088_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3088_MessageFormat", resourceCulture);
             }
@@ -11437,7 +11473,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Prefer pattern matching for not-null checks.
         /// </summary>
-        internal static string MiKo_3088_Title {
+        public static string MiKo_3088_Title {
             get {
                 return ResourceManager.GetString("MiKo_3088_Title", resourceCulture);
             }
@@ -11446,7 +11482,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Convert property pattern condition into normal condition.
         /// </summary>
-        internal static string MiKo_3089_CodeFixTitle {
+        public static string MiKo_3089_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3089_CodeFixTitle", resourceCulture);
             }
@@ -11455,7 +11491,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Normal conditions are easier to understand than property pattern conditions with constants. Therefore, convert these property conditions into normal ones. This approach keeps your code clear and readable..
         /// </summary>
-        internal static string MiKo_3089_Description {
+        public static string MiKo_3089_Description {
             get {
                 return ResourceManager.GetString("MiKo_3089_Description", resourceCulture);
             }
@@ -11464,7 +11500,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Convert property pattern condition into normal condition.
         /// </summary>
-        internal static string MiKo_3089_MessageFormat {
+        public static string MiKo_3089_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3089_MessageFormat", resourceCulture);
             }
@@ -11473,7 +11509,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use simple constant property patterns as conditions of &apos;if&apos; statements.
         /// </summary>
-        internal static string MiKo_3089_Title {
+        public static string MiKo_3089_Title {
             get {
                 return ResourceManager.GetString("MiKo_3089_Title", resourceCulture);
             }
@@ -11482,7 +11518,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Throw exceptions inside try or catch blocks, not within finally blocks. Finally blocks are meant for cleanup or to ensure certain code runs regardless of other factors. This maintains their intended purpose and keeps your code clear..
         /// </summary>
-        internal static string MiKo_3090_Description {
+        public static string MiKo_3090_Description {
             get {
                 return ResourceManager.GetString("MiKo_3090_Description", resourceCulture);
             }
@@ -11491,7 +11527,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not throw from finally block.
         /// </summary>
-        internal static string MiKo_3090_MessageFormat {
+        public static string MiKo_3090_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3090_MessageFormat", resourceCulture);
             }
@@ -11500,7 +11536,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not throw exceptions in finally blocks.
         /// </summary>
-        internal static string MiKo_3090_Title {
+        public static string MiKo_3090_Title {
             get {
                 return ResourceManager.GetString("MiKo_3090_Title", resourceCulture);
             }
@@ -11509,7 +11545,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Raise events within try or catch blocks, not finally blocks. Finally blocks are meant for cleanup, ensuring certain code always runs. This maintains their intended purpose and keeps your code clear..
         /// </summary>
-        internal static string MiKo_3091_Description {
+        public static string MiKo_3091_Description {
             get {
                 return ResourceManager.GetString("MiKo_3091_Description", resourceCulture);
             }
@@ -11518,7 +11554,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not raise &apos;{1}&apos; from finally block.
         /// </summary>
-        internal static string MiKo_3091_MessageFormat {
+        public static string MiKo_3091_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3091_MessageFormat", resourceCulture);
             }
@@ -11527,7 +11563,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not raise events in finally blocks.
         /// </summary>
-        internal static string MiKo_3091_Title {
+        public static string MiKo_3091_Title {
             get {
                 return ResourceManager.GetString("MiKo_3091_Title", resourceCulture);
             }
@@ -11536,7 +11572,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To avoid deadlocks, do not raise events inside lock statements. Instead, collect the event handlers and raise the event outside the lock. This practice ensures smooth and efficient code execution while avoiding potential deadlocks..
         /// </summary>
-        internal static string MiKo_3092_Description {
+        public static string MiKo_3092_Description {
             get {
                 return ResourceManager.GetString("MiKo_3092_Description", resourceCulture);
             }
@@ -11545,7 +11581,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not raise event inside lock.
         /// </summary>
-        internal static string MiKo_3092_MessageFormat {
+        public static string MiKo_3092_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3092_MessageFormat", resourceCulture);
             }
@@ -11554,7 +11590,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not raise events in locks.
         /// </summary>
-        internal static string MiKo_3092_Title {
+        public static string MiKo_3092_Title {
             get {
                 return ResourceManager.GetString("MiKo_3092_Title", resourceCulture);
             }
@@ -11563,7 +11599,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To avoid deadlocks, do not invoke delegates within lock statements. Collect the necessary information inside the lock, then invoke the delegate outside the lock. This practice ensures smooth and efficient code execution while avoiding potential deadlocks..
         /// </summary>
-        internal static string MiKo_3093_Description {
+        public static string MiKo_3093_Description {
             get {
                 return ResourceManager.GetString("MiKo_3093_Description", resourceCulture);
             }
@@ -11572,7 +11608,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not invoke delegate inside lock.
         /// </summary>
-        internal static string MiKo_3093_MessageFormat {
+        public static string MiKo_3093_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3093_MessageFormat", resourceCulture);
             }
@@ -11581,7 +11617,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not invoke delegates inside locks.
         /// </summary>
-        internal static string MiKo_3093_Title {
+        public static string MiKo_3093_Title {
             get {
                 return ResourceManager.GetString("MiKo_3093_Title", resourceCulture);
             }
@@ -11590,7 +11626,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To avoid deadlocks, do not invoke methods or properties of parameters within lock statements. This practice ensures smooth and efficient code execution while avoiding potential deadlocks..
         /// </summary>
-        internal static string MiKo_3094_Description {
+        public static string MiKo_3094_Description {
             get {
                 return ResourceManager.GetString("MiKo_3094_Description", resourceCulture);
             }
@@ -11599,7 +11635,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not invoke method or property inside lock.
         /// </summary>
-        internal static string MiKo_3094_MessageFormat {
+        public static string MiKo_3094_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3094_MessageFormat", resourceCulture);
             }
@@ -11608,7 +11644,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not invoke methods or properties of parameters inside locks.
         /// </summary>
-        internal static string MiKo_3094_Title {
+        public static string MiKo_3094_Title {
             get {
                 return ResourceManager.GetString("MiKo_3094_Title", resourceCulture);
             }
@@ -11617,7 +11653,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Empty code blocks should include a comment explaining why they are empty. This helps developers understand the reason and ensures the block is not empty by mistake..
         /// </summary>
-        internal static string MiKo_3095_Description {
+        public static string MiKo_3095_Description {
             get {
                 return ResourceManager.GetString("MiKo_3095_Description", resourceCulture);
             }
@@ -11626,7 +11662,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide a comment that reasons why the block is empty.
         /// </summary>
-        internal static string MiKo_3095_MessageFormat {
+        public static string MiKo_3095_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3095_MessageFormat", resourceCulture);
             }
@@ -11635,7 +11671,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code blocks should not be empty.
         /// </summary>
-        internal static string MiKo_3095_Title {
+        public static string MiKo_3095_Title {
             get {
                 return ResourceManager.GetString("MiKo_3095_Title", resourceCulture);
             }
@@ -11644,7 +11680,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For switch statements with many cases that map values, use a dictionary instead. This approach makes the code easier to read and maintain..
         /// </summary>
-        internal static string MiKo_3096_Description {
+        public static string MiKo_3096_Description {
             get {
                 return ResourceManager.GetString("MiKo_3096_Description", resourceCulture);
             }
@@ -11653,7 +11689,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use dictionary as map instead of switch.
         /// </summary>
-        internal static string MiKo_3096_MessageFormat {
+        public static string MiKo_3096_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3096_MessageFormat", resourceCulture);
             }
@@ -11662,7 +11698,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use dictionaries instead of large switch statements.
         /// </summary>
-        internal static string MiKo_3096_Title {
+        public static string MiKo_3096_Title {
             get {
                 return ResourceManager.GetString("MiKo_3096_Title", resourceCulture);
             }
@@ -11671,7 +11707,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Casting a value to a specific type and returning it when the return type is &apos;object&apos; offers no benefit. The cast is unnecessary and adds complexity without any gain..
         /// </summary>
-        internal static string MiKo_3097_Description {
+        public static string MiKo_3097_Description {
             get {
                 return ResourceManager.GetString("MiKo_3097_Description", resourceCulture);
             }
@@ -11680,7 +11716,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not cast to type when returning object.
         /// </summary>
-        internal static string MiKo_3097_MessageFormat {
+        public static string MiKo_3097_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3097_MessageFormat", resourceCulture);
             }
@@ -11689,7 +11725,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not cast to type and return object.
         /// </summary>
-        internal static string MiKo_3097_Title {
+        public static string MiKo_3097_Title {
             get {
                 return ResourceManager.GetString("MiKo_3097_Title", resourceCulture);
             }
@@ -11699,7 +11735,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to When suppressing messages with the [SuppressMessage] attribute, a justification must be provided. This justification should explain why the message was suppressed, helping future developers understand the reasoning. Just writing &quot;Reviewed.&quot; or providing no explanation is not sufficient.
         ///This practice ensures clarity and transparency in your codebase..
         /// </summary>
-        internal static string MiKo_3098_Description {
+        public static string MiKo_3098_Description {
             get {
                 return ResourceManager.GetString("MiKo_3098_Description", resourceCulture);
             }
@@ -11708,7 +11744,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Explain the reason why the message is suppressed.
         /// </summary>
-        internal static string MiKo_3098_MessageFormat {
+        public static string MiKo_3098_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3098_MessageFormat", resourceCulture);
             }
@@ -11717,7 +11753,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Justifications of suppressed messages shall explain.
         /// </summary>
-        internal static string MiKo_3098_Title {
+        public static string MiKo_3098_Title {
             get {
                 return ResourceManager.GetString("MiKo_3098_Title", resourceCulture);
             }
@@ -11726,7 +11762,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix comparison to null.
         /// </summary>
-        internal static string MiKo_3099_CodeFixTitle {
+        public static string MiKo_3099_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3099_CodeFixTitle", resourceCulture);
             }
@@ -11735,7 +11771,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comparing enum values to &apos;null&apos; is pointless because enums are value types and can never be &apos;null&apos;. Such comparisons will always fail..
         /// </summary>
-        internal static string MiKo_3099_Description {
+        public static string MiKo_3099_Description {
             get {
                 return ResourceManager.GetString("MiKo_3099_Description", resourceCulture);
             }
@@ -11744,7 +11780,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Enum can never be null.
         /// </summary>
-        internal static string MiKo_3099_MessageFormat {
+        public static string MiKo_3099_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3099_MessageFormat", resourceCulture);
             }
@@ -11753,7 +11789,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not compare enum values with null.
         /// </summary>
-        internal static string MiKo_3099_Title {
+        public static string MiKo_3099_Title {
             get {
                 return ResourceManager.GetString("MiKo_3099_Title", resourceCulture);
             }
@@ -11762,7 +11798,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To ease maintenance, place test classes in the same namespace as the type they test. This approach eliminates arbitrary &apos;using&apos; directives, mirrors the project structure, and makes discovering tests much easier..
         /// </summary>
-        internal static string MiKo_3100_Description {
+        public static string MiKo_3100_Description {
             get {
                 return ResourceManager.GetString("MiKo_3100_Description", resourceCulture);
             }
@@ -11771,7 +11807,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place test class in namespace &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_3100_MessageFormat {
+        public static string MiKo_3100_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3100_MessageFormat", resourceCulture);
             }
@@ -11780,7 +11816,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test classes and types under test belong in same namespace.
         /// </summary>
-        internal static string MiKo_3100_Title {
+        public static string MiKo_3100_Title {
             get {
                 return ResourceManager.GetString("MiKo_3100_Title", resourceCulture);
             }
@@ -11789,7 +11825,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to A unit test class should contain unit tests. This ensures the class fulfills its purpose and maintains clarity in your codebase..
         /// </summary>
-        internal static string MiKo_3101_Description {
+        public static string MiKo_3101_Description {
             get {
                 return ResourceManager.GetString("MiKo_3101_Description", resourceCulture);
             }
@@ -11798,7 +11834,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test class should contain tests.
         /// </summary>
-        internal static string MiKo_3101_MessageFormat {
+        public static string MiKo_3101_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3101_MessageFormat", resourceCulture);
             }
@@ -11807,7 +11843,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test classes should contain tests.
         /// </summary>
-        internal static string MiKo_3101_Title {
+        public static string MiKo_3101_Title {
             get {
                 return ResourceManager.GetString("MiKo_3101_Title", resourceCulture);
             }
@@ -11816,7 +11852,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Tests should focus on a specific scenario. Including a condition in a test means it&apos;s testing more than one scenario, which is a code smell. Keep tests simple and specific to ensure clarity and maintainability..
         /// </summary>
-        internal static string MiKo_3102_Description {
+        public static string MiKo_3102_Description {
             get {
                 return ResourceManager.GetString("MiKo_3102_Description", resourceCulture);
             }
@@ -11825,7 +11861,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Refactor test to remove condition.
         /// </summary>
-        internal static string MiKo_3102_MessageFormat {
+        public static string MiKo_3102_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3102_MessageFormat", resourceCulture);
             }
@@ -11834,7 +11870,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not contain conditional statements (such as &apos;if&apos;, &apos;switch&apos;, etc.).
         /// </summary>
-        internal static string MiKo_3102_Title {
+        public static string MiKo_3102_Title {
             get {
                 return ResourceManager.GetString("MiKo_3102_Title", resourceCulture);
             }
@@ -11843,7 +11879,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use hard-coded GUID.
         /// </summary>
-        internal static string MiKo_3103_CodeFixTitle {
+        public static string MiKo_3103_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3103_CodeFixTitle", resourceCulture);
             }
@@ -11852,7 +11888,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Tests should be specific to be reproducible and easy to maintain. Generated GUIDs are not reproducible and hard to track if a test fails. Instead, use a hard-coded GUID for consistency. This ensures tests are clear and reliable..
         /// </summary>
-        internal static string MiKo_3103_Description {
+        public static string MiKo_3103_Description {
             get {
                 return ResourceManager.GetString("MiKo_3103_Description", resourceCulture);
             }
@@ -11861,7 +11897,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a hard-coded GUID instead.
         /// </summary>
-        internal static string MiKo_3103_MessageFormat {
+        public static string MiKo_3103_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3103_MessageFormat", resourceCulture);
             }
@@ -11870,7 +11906,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not use &apos;Guid.NewGuid()&apos;.
         /// </summary>
-        internal static string MiKo_3103_Title {
+        public static string MiKo_3103_Title {
             get {
                 return ResourceManager.GetString("MiKo_3103_Title", resourceCulture);
             }
@@ -11879,7 +11915,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove [Combinatorial] attribute.
         /// </summary>
-        internal static string MiKo_3104_CodeFixTitle {
+        public static string MiKo_3104_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3104_CodeFixTitle", resourceCulture);
             }
@@ -11888,7 +11924,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use NUnit&apos;s [Combinatorial] attribute only when a test method has at least two parameters for combinatorial testing. If there&apos;s only one parameter, this attribute is unnecessary and adds no value..
         /// </summary>
-        internal static string MiKo_3104_Description {
+        public static string MiKo_3104_Description {
             get {
                 return ResourceManager.GetString("MiKo_3104_Description", resourceCulture);
             }
@@ -11897,7 +11933,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Wrong usage of [Combinatorial].
         /// </summary>
-        internal static string MiKo_3104_MessageFormat {
+        public static string MiKo_3104_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3104_MessageFormat", resourceCulture);
             }
@@ -11906,7 +11942,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use NUnit&apos;s [Combinatorial] attribute properly.
         /// </summary>
-        internal static string MiKo_3104_Title {
+        public static string MiKo_3104_Title {
             get {
                 return ResourceManager.GetString("MiKo_3104_Title", resourceCulture);
             }
@@ -11915,7 +11951,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That&apos;.
         /// </summary>
-        internal static string MiKo_3105_CodeFixTitle {
+        public static string MiKo_3105_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3105_CodeFixTitle", resourceCulture);
             }
@@ -11924,7 +11960,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to NUnit&apos;s constraint-based Assert model uses a single &apos;Assert.That&apos; method for all assertions, making it easier to understand. This helps developers avoid mixing up &apos;actual&apos; and &apos;expected&apos; values and makes the code more readable and intuitive..
         /// </summary>
-        internal static string MiKo_3105_Description {
+        public static string MiKo_3105_Description {
             get {
                 return ResourceManager.GetString("MiKo_3105_Description", resourceCulture);
             }
@@ -11933,7 +11969,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html.
         /// </summary>
-        internal static string MiKo_3105_HelpLinkUri {
+        public static string MiKo_3105_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3105_HelpLinkUri", resourceCulture);
             }
@@ -11942,7 +11978,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That&apos; instead.
         /// </summary>
-        internal static string MiKo_3105_MessageFormat {
+        public static string MiKo_3105_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3105_MessageFormat", resourceCulture);
             }
@@ -11951,7 +11987,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should use NUnit&apos;s fluent Assert approach.
         /// </summary>
-        internal static string MiKo_3105_Title {
+        public static string MiKo_3105_Title {
             get {
                 return ResourceManager.GetString("MiKo_3105_Title", resourceCulture);
             }
@@ -11964,7 +12000,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Instead, tests should immediately state the expected value (e.g., &apos;5&apos; was expected but  [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_3106_Description {
+        public static string MiKo_3106_Description {
             get {
                 return ResourceManager.GetString("MiKo_3106_Description", resourceCulture);
             }
@@ -11973,7 +12009,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{1}&apos; in assertion.
         /// </summary>
-        internal static string MiKo_3106_MessageFormat {
+        public static string MiKo_3106_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3106_MessageFormat", resourceCulture);
             }
@@ -11982,7 +12018,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertions should not use equality or comparison operators.
         /// </summary>
-        internal static string MiKo_3106_Title {
+        public static string MiKo_3106_Title {
             get {
                 return ResourceManager.GetString("MiKo_3106_Title", resourceCulture);
             }
@@ -11991,7 +12027,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change Moq call to default value.
         /// </summary>
-        internal static string MiKo_3107_CodeFixTitle {
+        public static string MiKo_3107_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3107_CodeFixTitle", resourceCulture);
             }
@@ -12000,7 +12036,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using Moq mocks improperly can cause issues. Use condition matchers on mocks to set up or verify conditions. Avoid using them on constructors or methods of non-mocks, as they don&apos;t make sense there. This ensures your mocking is effective and your code stays clear and accurate..
         /// </summary>
-        internal static string MiKo_3107_Description {
+        public static string MiKo_3107_Description {
             get {
                 return ResourceManager.GetString("MiKo_3107_Description", resourceCulture);
             }
@@ -12009,7 +12045,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a mock instead.
         /// </summary>
-        internal static string MiKo_3107_MessageFormat {
+        public static string MiKo_3107_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3107_MessageFormat", resourceCulture);
             }
@@ -12018,7 +12054,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Moq Mock condition matchers should be used on mocks only.
         /// </summary>
-        internal static string MiKo_3107_Title {
+        public static string MiKo_3107_Title {
             get {
                 return ResourceManager.GetString("MiKo_3107_Title", resourceCulture);
             }
@@ -12027,7 +12063,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Tests need assertions to verify code behavior. Without an assertion, the test does not check anything and is not useful. This ensures tests are effective and your code works as expected..
         /// </summary>
-        internal static string MiKo_3108_Description {
+        public static string MiKo_3108_Description {
             get {
                 return ResourceManager.GetString("MiKo_3108_Description", resourceCulture);
             }
@@ -12036,7 +12072,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add assertion to test.
         /// </summary>
-        internal static string MiKo_3108_MessageFormat {
+        public static string MiKo_3108_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3108_MessageFormat", resourceCulture);
             }
@@ -12045,7 +12081,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should use assertions.
         /// </summary>
-        internal static string MiKo_3108_Title {
+        public static string MiKo_3108_Title {
             get {
                 return ResourceManager.GetString("MiKo_3108_Title", resourceCulture);
             }
@@ -12054,7 +12090,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add default assertion message.
         /// </summary>
-        internal static string MiKo_3109_CodeFixTitle {
+        public static string MiKo_3109_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3109_CodeFixTitle", resourceCulture);
             }
@@ -12063,7 +12099,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertions should include messages explaining why something was expected but failed. This makes it easier to understand why a test failed, helping you quickly identify the issue..
         /// </summary>
-        internal static string MiKo_3109_Description {
+        public static string MiKo_3109_Description {
             get {
                 return ResourceManager.GetString("MiKo_3109_Description", resourceCulture);
             }
@@ -12072,7 +12108,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Provide an assertion message.
         /// </summary>
-        internal static string MiKo_3109_MessageFormat {
+        public static string MiKo_3109_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3109_MessageFormat", resourceCulture);
             }
@@ -12081,7 +12117,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Multiple assertions shall use assertion messages.
         /// </summary>
-        internal static string MiKo_3109_Title {
+        public static string MiKo_3109_Title {
             get {
                 return ResourceManager.GetString("MiKo_3109_Title", resourceCulture);
             }
@@ -12090,7 +12126,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That(..., Has...)&apos;.
         /// </summary>
-        internal static string MiKo_3110_CodeFixTitle {
+        public static string MiKo_3110_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3110_CodeFixTitle", resourceCulture);
             }
@@ -12103,7 +12139,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///In contrast, tests should state exactly what was expected and found (e.g., &apos;Expected items A, B, and C but found B and D&apos;). This approach makes failures much easier to under [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string MiKo_3110_Description {
+        public static string MiKo_3110_Description {
             get {
                 return ResourceManager.GetString("MiKo_3110_Description", resourceCulture);
             }
@@ -12112,7 +12148,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;{0}&apos; in assertion.
         /// </summary>
-        internal static string MiKo_3110_MessageFormat {
+        public static string MiKo_3110_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3110_MessageFormat", resourceCulture);
             }
@@ -12121,7 +12157,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertions should not use &apos;Count&apos; or &apos;Length&apos;.
         /// </summary>
-        internal static string MiKo_3110_Title {
+        public static string MiKo_3110_Title {
             get {
                 return ResourceManager.GetString("MiKo_3110_Title", resourceCulture);
             }
@@ -12130,7 +12166,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Zero&apos;.
         /// </summary>
-        internal static string MiKo_3111_CodeFixTitle {
+        public static string MiKo_3111_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3111_CodeFixTitle", resourceCulture);
             }
@@ -12139,7 +12175,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve clarity, use &apos;Is.Zero&apos; instead of &apos;Is.EqualTo(0)&apos; when asserting for zero in tests. This makes the code easier to read and understand..
         /// </summary>
-        internal static string MiKo_3111_Description {
+        public static string MiKo_3111_Description {
             get {
                 return ResourceManager.GetString("MiKo_3111_Description", resourceCulture);
             }
@@ -12148,7 +12184,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Zero&apos; instead.
         /// </summary>
-        internal static string MiKo_3111_MessageFormat {
+        public static string MiKo_3111_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3111_MessageFormat", resourceCulture);
             }
@@ -12157,7 +12193,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertions should use &apos;Is.Zero&apos; instead of &apos;Is.EqualTo(0)&apos;.
         /// </summary>
-        internal static string MiKo_3111_Title {
+        public static string MiKo_3111_Title {
             get {
                 return ResourceManager.GetString("MiKo_3111_Title", resourceCulture);
             }
@@ -12166,7 +12202,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Is.Empty&apos;.
         /// </summary>
-        internal static string MiKo_3112_CodeFixTitle {
+        public static string MiKo_3112_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3112_CodeFixTitle", resourceCulture);
             }
@@ -12175,7 +12211,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve clarity, use &apos;Is.Empty&apos; instead of &apos;Has.Count.Zero&apos; when asserting on collections for emptiness in tests. This makes the code easier to read and understand..
         /// </summary>
-        internal static string MiKo_3112_Description {
+        public static string MiKo_3112_Description {
             get {
                 return ResourceManager.GetString("MiKo_3112_Description", resourceCulture);
             }
@@ -12184,7 +12220,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Is.Empty&apos; instead.
         /// </summary>
-        internal static string MiKo_3112_MessageFormat {
+        public static string MiKo_3112_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3112_MessageFormat", resourceCulture);
             }
@@ -12193,7 +12229,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertions should use &apos;Is.Empty&apos; instead of &apos;Has.Count.Zero&apos;.
         /// </summary>
-        internal static string MiKo_3112_Title {
+        public static string MiKo_3112_Title {
             get {
                 return ResourceManager.GetString("MiKo_3112_Title", resourceCulture);
             }
@@ -12202,7 +12238,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That&apos;.
         /// </summary>
-        internal static string MiKo_3113_CodeFixTitle {
+        public static string MiKo_3113_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3113_CodeFixTitle", resourceCulture);
             }
@@ -12211,7 +12247,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to FluentAssertions uses a &apos;Should&apos; method followed by the assertion, which can make assertions harder to read and spot. In contrast, NUnit&apos;s fluent assertion approach using &apos;Assert.That&apos; is easier to spot and read. This makes NUnit&apos;s approach more user-friendly and accessible..
         /// </summary>
-        internal static string MiKo_3113_Description {
+        public static string MiKo_3113_Description {
             get {
                 return ResourceManager.GetString("MiKo_3113_Description", resourceCulture);
             }
@@ -12220,7 +12256,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That&apos; instead of &apos;Should&apos;.
         /// </summary>
-        internal static string MiKo_3113_MessageFormat {
+        public static string MiKo_3113_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3113_MessageFormat", resourceCulture);
             }
@@ -12229,7 +12265,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use FluentAssertions.
         /// </summary>
-        internal static string MiKo_3113_Title {
+        public static string MiKo_3113_Title {
             get {
                 return ResourceManager.GetString("MiKo_3113_Title", resourceCulture);
             }
@@ -12238,7 +12274,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Mock.Of&lt;T&gt;()&apos;.
         /// </summary>
-        internal static string MiKo_3114_CodeFixTitle {
+        public static string MiKo_3114_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3114_CodeFixTitle", resourceCulture);
             }
@@ -12247,7 +12283,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Mock.Of&lt;T&gt;()&apos; in tests instead of &apos;new Mock&lt;T&gt;().Object&apos;. This makes it easier to spot necessary but unimportant mocks and keeps the code cleaner and easier to read..
         /// </summary>
-        internal static string MiKo_3114_Description {
+        public static string MiKo_3114_Description {
             get {
                 return ResourceManager.GetString("MiKo_3114_Description", resourceCulture);
             }
@@ -12256,7 +12292,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Mock.Of&lt;T&gt;()&apos; instead.
         /// </summary>
-        internal static string MiKo_3114_MessageFormat {
+        public static string MiKo_3114_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3114_MessageFormat", resourceCulture);
             }
@@ -12265,7 +12301,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Mock.Of&lt;T&gt;()&apos; instead of &apos;new Mock&lt;T&gt;().Object&apos;.
         /// </summary>
-        internal static string MiKo_3114_Title {
+        public static string MiKo_3114_Title {
             get {
                 return ResourceManager.GetString("MiKo_3114_Title", resourceCulture);
             }
@@ -12276,7 +12312,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Commented-out code within these methods raises questions. If uncommented, it might cause the test to fail, indicating either a problem with the test code or an uncovered bug that needs addressing..
         /// </summary>
-        internal static string MiKo_3115_Description {
+        public static string MiKo_3115_Description {
             get {
                 return ResourceManager.GetString("MiKo_3115_Description", resourceCulture);
             }
@@ -12285,7 +12321,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Delete empty test method or implement a test.
         /// </summary>
-        internal static string MiKo_3115_MessageFormat {
+        public static string MiKo_3115_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3115_MessageFormat", resourceCulture);
             }
@@ -12294,7 +12330,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should contain code.
         /// </summary>
-        internal static string MiKo_3115_Title {
+        public static string MiKo_3115_Title {
             get {
                 return ResourceManager.GetString("MiKo_3115_Title", resourceCulture);
             }
@@ -12303,7 +12339,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Empty unit test initialization methods clutter the codebase and serve no purpose. They can be safely removed to keep the code clean and maintainable..
         /// </summary>
-        internal static string MiKo_3116_Description {
+        public static string MiKo_3116_Description {
             get {
                 return ResourceManager.GetString("MiKo_3116_Description", resourceCulture);
             }
@@ -12312,7 +12348,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Delete empty test initialization method.
         /// </summary>
-        internal static string MiKo_3116_MessageFormat {
+        public static string MiKo_3116_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3116_MessageFormat", resourceCulture);
             }
@@ -12321,7 +12357,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test initialization methods should contain code.
         /// </summary>
-        internal static string MiKo_3116_Title {
+        public static string MiKo_3116_Title {
             get {
                 return ResourceManager.GetString("MiKo_3116_Title", resourceCulture);
             }
@@ -12330,7 +12366,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Empty unit test cleanup methods clutter the codebase and serve no purpose. They can be safely removed to keep the code clean and maintainable..
         /// </summary>
-        internal static string MiKo_3117_Description {
+        public static string MiKo_3117_Description {
             get {
                 return ResourceManager.GetString("MiKo_3117_Description", resourceCulture);
             }
@@ -12339,7 +12375,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Delete empty test cleanup method.
         /// </summary>
-        internal static string MiKo_3117_MessageFormat {
+        public static string MiKo_3117_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3117_MessageFormat", resourceCulture);
             }
@@ -12348,7 +12384,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test cleanup methods should contain code.
         /// </summary>
-        internal static string MiKo_3117_Title {
+        public static string MiKo_3117_Title {
             get {
                 return ResourceManager.GetString("MiKo_3117_Title", resourceCulture);
             }
@@ -12359,7 +12395,7 @@ namespace MiKoSolutions.Analyzers {
         ///LINQ calls like &apos;Skip&apos;, &apos;Take&apos;, or &apos;FirstOrDefault&apos; are useful in production but can be unclear in tests. Using &apos;Skip&apos; in a test, for example, can confuse readers about why values are being skipped. This ambiguity requires extra effort to understand.
         ///Avoid this by being more explicit about the expected outcome..
         /// </summary>
-        internal static string MiKo_3118_Description {
+        public static string MiKo_3118_Description {
             get {
                 return ResourceManager.GetString("MiKo_3118_Description", resourceCulture);
             }
@@ -12368,7 +12404,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use ambiguous Linq call &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3118_MessageFormat {
+        public static string MiKo_3118_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3118_MessageFormat", resourceCulture);
             }
@@ -12377,7 +12413,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not use ambiguous Linq calls.
         /// </summary>
-        internal static string MiKo_3118_Title {
+        public static string MiKo_3118_Title {
             get {
                 return ResourceManager.GetString("MiKo_3118_Title", resourceCulture);
             }
@@ -12386,7 +12422,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change return type of test method to &apos;void&apos;.
         /// </summary>
-        internal static string MiKo_3119_CodeFixTitle {
+        public static string MiKo_3119_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3119_CodeFixTitle", resourceCulture);
             }
@@ -12395,7 +12431,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods returning non-generic tasks are meant to test asynchronous behavior. They should not return &apos;Task.CompletedTask&apos;. If they do, simply have them return void instead..
         /// </summary>
-        internal static string MiKo_3119_Description {
+        public static string MiKo_3119_Description {
             get {
                 return ResourceManager.GetString("MiKo_3119_Description", resourceCulture);
             }
@@ -12404,7 +12440,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Return void instead of Task.
         /// </summary>
-        internal static string MiKo_3119_MessageFormat {
+        public static string MiKo_3119_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3119_MessageFormat", resourceCulture);
             }
@@ -12413,7 +12449,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not simply return completed task.
         /// </summary>
-        internal static string MiKo_3119_Title {
+        public static string MiKo_3119_Title {
             get {
                 return ResourceManager.GetString("MiKo_3119_Title", resourceCulture);
             }
@@ -12422,7 +12458,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use value directly instead of condition matcher.
         /// </summary>
-        internal static string MiKo_3120_CodeFixTitle {
+        public static string MiKo_3120_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3120_CodeFixTitle", resourceCulture);
             }
@@ -12432,7 +12468,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Moq&apos;s condition matchers are meant to verify that parts of an argument meet specific criteria. However, they should not be used to test for exact value matches. In those cases, provide the exact values instead of using a condition matcher.
         ///This ensures precision in your tests and maintains clear expectations..
         /// </summary>
-        internal static string MiKo_3120_Description {
+        public static string MiKo_3120_Description {
             get {
                 return ResourceManager.GetString("MiKo_3120_Description", resourceCulture);
             }
@@ -12441,7 +12477,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use value directly instead of condition matcher.
         /// </summary>
-        internal static string MiKo_3120_MessageFormat {
+        public static string MiKo_3120_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3120_MessageFormat", resourceCulture);
             }
@@ -12450,7 +12486,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Moq mocks should use values instead of &apos;It.Is&lt;&gt;(...)&apos; condition matcher to verify exact values.
         /// </summary>
-        internal static string MiKo_3120_Title {
+        public static string MiKo_3120_Title {
             get {
                 return ResourceManager.GetString("MiKo_3120_Title", resourceCulture);
             }
@@ -12459,7 +12495,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For easier development and direct code access, use a concrete type for the object under test, not an interface. Otherwise, developers end up at the interface and have to find the actual implementation..
         /// </summary>
-        internal static string MiKo_3121_Description {
+        public static string MiKo_3121_Description {
             get {
                 return ResourceManager.GetString("MiKo_3121_Description", resourceCulture);
             }
@@ -12468,7 +12504,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test concrete type instead of interface.
         /// </summary>
-        internal static string MiKo_3121_MessageFormat {
+        public static string MiKo_3121_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3121_MessageFormat", resourceCulture);
             }
@@ -12477,7 +12513,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Tests should test concrete implementations and no interfaces.
         /// </summary>
-        internal static string MiKo_3121_Title {
+        public static string MiKo_3121_Title {
             get {
                 return ResourceManager.GetString("MiKo_3121_Title", resourceCulture);
             }
@@ -12486,7 +12522,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods with more than 2 parameters are often combined tests and can be hard to read. To improve readability, split these tests into separate ones. This makes them easier to understand and maintain..
         /// </summary>
-        internal static string MiKo_3122_Description {
+        public static string MiKo_3122_Description {
             get {
                 return ResourceManager.GetString("MiKo_3122_Description", resourceCulture);
             }
@@ -12495,7 +12531,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Split into multiple tests so that you do not need more than 2 parameters.
         /// </summary>
-        internal static string MiKo_3122_MessageFormat {
+        public static string MiKo_3122_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3122_MessageFormat", resourceCulture);
             }
@@ -12504,7 +12540,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test methods should not use more than 2 parameters.
         /// </summary>
-        internal static string MiKo_3122_Title {
+        public static string MiKo_3122_Title {
             get {
                 return ResourceManager.GetString("MiKo_3122_Title", resourceCulture);
             }
@@ -12513,7 +12549,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3201_CodeFixTitle {
+        public static string MiKo_3201_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3201_CodeFixTitle", resourceCulture);
             }
@@ -12522,7 +12558,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If a method has just a few statements and an &apos;if&apos; statement that returns, invert the &apos;if&apos; statement. This makes the method easier to read and understand..
         /// </summary>
-        internal static string MiKo_3201_Description {
+        public static string MiKo_3201_Description {
             get {
                 return ResourceManager.GetString("MiKo_3201_Description", resourceCulture);
             }
@@ -12531,7 +12567,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3201_MessageFormat {
+        public static string MiKo_3201_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3201_MessageFormat", resourceCulture);
             }
@@ -12540,7 +12576,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If statements can be inverted in short methods.
         /// </summary>
-        internal static string MiKo_3201_Title {
+        public static string MiKo_3201_Title {
             get {
                 return ResourceManager.GetString("MiKo_3201_Title", resourceCulture);
             }
@@ -12549,7 +12585,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert condition into positive.
         /// </summary>
-        internal static string MiKo_3202_CodeFixTitle {
+        public static string MiKo_3202_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3202_CodeFixTitle", resourceCulture);
             }
@@ -12558,7 +12594,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code is easier to read when using &apos;if&apos; statements or conditionals with positive conditions. This approach enhances readability and clarity..
         /// </summary>
-        internal static string MiKo_3202_Description {
+        public static string MiKo_3202_Description {
             get {
                 return ResourceManager.GetString("MiKo_3202_Description", resourceCulture);
             }
@@ -12567,7 +12603,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert condition into positive.
         /// </summary>
-        internal static string MiKo_3202_MessageFormat {
+        public static string MiKo_3202_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3202_MessageFormat", resourceCulture);
             }
@@ -12576,7 +12612,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use positive conditions when returning in all paths.
         /// </summary>
-        internal static string MiKo_3202_Title {
+        public static string MiKo_3202_Title {
             get {
                 return ResourceManager.GetString("MiKo_3202_Title", resourceCulture);
             }
@@ -12585,7 +12621,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3203_CodeFixTitle {
+        public static string MiKo_3203_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3203_CodeFixTitle", resourceCulture);
             }
@@ -12594,7 +12630,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If an &apos;if&apos; statement contains only a &apos;continue&apos; statement and is followed by a single line of code, invert the &apos;if&apos; statement. This makes the method easier to read and understand..
         /// </summary>
-        internal static string MiKo_3203_Description {
+        public static string MiKo_3203_Description {
             get {
                 return ResourceManager.GetString("MiKo_3203_Description", resourceCulture);
             }
@@ -12603,7 +12639,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3203_MessageFormat {
+        public static string MiKo_3203_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3203_MessageFormat", resourceCulture);
             }
@@ -12612,7 +12648,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If-continue statements can be inverted when followed by single line.
         /// </summary>
-        internal static string MiKo_3203_Title {
+        public static string MiKo_3203_Title {
             get {
                 return ResourceManager.GetString("MiKo_3203_Title", resourceCulture);
             }
@@ -12621,7 +12657,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3204_CodeFixTitle {
+        public static string MiKo_3204_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3204_CodeFixTitle", resourceCulture);
             }
@@ -12630,7 +12666,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If an &apos;if&apos; statement has a negative condition and an &apos;else&apos; clause, invert it into a positive condition. This makes the method easier to read and understand..
         /// </summary>
-        internal static string MiKo_3204_Description {
+        public static string MiKo_3204_Description {
             get {
                 return ResourceManager.GetString("MiKo_3204_Description", resourceCulture);
             }
@@ -12639,7 +12675,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
-        internal static string MiKo_3204_MessageFormat {
+        public static string MiKo_3204_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3204_MessageFormat", resourceCulture);
             }
@@ -12648,7 +12684,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Negative If statements can be inverted when they have an else clause.
         /// </summary>
-        internal static string MiKo_3204_Title {
+        public static string MiKo_3204_Title {
             get {
                 return ResourceManager.GetString("MiKo_3204_Title", resourceCulture);
             }
@@ -12659,7 +12695,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///When inheritance requires overriding such methods, override the overload with the most parameters. The same rule applies to abstract methods. This approach maintains consistency and clarity in your code..
         /// </summary>
-        internal static string MiKo_3210_Description {
+        public static string MiKo_3210_Description {
             get {
                 return ResourceManager.GetString("MiKo_3210_Description", resourceCulture);
             }
@@ -12668,7 +12704,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not make method &apos;{0}&apos;.
         /// </summary>
-        internal static string MiKo_3210_MessageFormat {
+        public static string MiKo_3210_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3210_MessageFormat", resourceCulture);
             }
@@ -12677,7 +12713,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Only the longest overloads should be virtual or abstract.
         /// </summary>
-        internal static string MiKo_3210_Title {
+        public static string MiKo_3210_Title {
             get {
                 return ResourceManager.GetString("MiKo_3210_Title", resourceCulture);
             }
@@ -12688,7 +12724,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Finalizers are challenging to implement correctly because they can&apos;t assume the state of the system during execution. This approach ensures proper management of finalizable resources..
         /// </summary>
-        internal static string MiKo_3211_Description {
+        public static string MiKo_3211_Description {
             get {
                 return ResourceManager.GetString("MiKo_3211_Description", resourceCulture);
             }
@@ -12697,7 +12733,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use a finalizer.
         /// </summary>
-        internal static string MiKo_3211_MessageFormat {
+        public static string MiKo_3211_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3211_MessageFormat", resourceCulture);
             }
@@ -12706,7 +12742,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Public types should not have finalizers.
         /// </summary>
-        internal static string MiKo_3211_Title {
+        public static string MiKo_3211_Title {
             get {
                 return ResourceManager.GetString("MiKo_3211_Title", resourceCulture);
             }
@@ -12715,7 +12751,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Stick to the basic Dispose pattern to avoid confusing developers. The only methods named &apos;Dispose&apos; should be void &apos;IDisposable.Dispose()&apos; and &apos;void Dispose(bool disposing)&apos;. Any other methods would deviate from the Dispose pattern and cause confusion..
         /// </summary>
-        internal static string MiKo_3212_Description {
+        public static string MiKo_3212_Description {
             get {
                 return ResourceManager.GetString("MiKo_3212_Description", resourceCulture);
             }
@@ -12724,7 +12760,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not provide such Dispose method.
         /// </summary>
-        internal static string MiKo_3212_MessageFormat {
+        public static string MiKo_3212_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3212_MessageFormat", resourceCulture);
             }
@@ -12733,7 +12769,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not confuse developers by providing other Dispose methods.
         /// </summary>
-        internal static string MiKo_3212_Title {
+        public static string MiKo_3212_Title {
             get {
                 return ResourceManager.GetString("MiKo_3212_Title", resourceCulture);
             }
@@ -12742,7 +12778,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The public &apos;Dispose()&apos; method should only call &apos;Dispose(bool disposing)&apos; with &apos;disposing&apos; set to &apos;true&apos;. All other disposal logic should reside in the &apos;Dispose(bool disposing)&apos; method. This keeps the Dispose pattern consistent and clear..
         /// </summary>
-        internal static string MiKo_3213_Description {
+        public static string MiKo_3213_Description {
             get {
                 return ResourceManager.GetString("MiKo_3213_Description", resourceCulture);
             }
@@ -12751,7 +12787,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Only invoke &apos;Dispose(false)&apos; but nothing more.
         /// </summary>
-        internal static string MiKo_3213_MessageFormat {
+        public static string MiKo_3213_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3213_MessageFormat", resourceCulture);
             }
@@ -12760,7 +12796,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Parameterless Dispose method follows Basic Dispose pattern.
         /// </summary>
-        internal static string MiKo_3213_Title {
+        public static string MiKo_3213_Title {
             get {
                 return ResourceManager.GetString("MiKo_3213_Title", resourceCulture);
             }
@@ -12771,7 +12807,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Instead, provide a method that returns an &apos;IDisposable&apos;. This way, developers can use a &apos;using&apos; statement to ensure the &apos;End&apos; method is always called, keeping everything clean and error-free..
         /// </summary>
-        internal static string MiKo_3214_Description {
+        public static string MiKo_3214_Description {
             get {
                 return ResourceManager.GetString("MiKo_3214_Description", resourceCulture);
             }
@@ -12780,7 +12816,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Rename scope-defining method to not start with &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_3214_MessageFormat {
+        public static string MiKo_3214_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3214_MessageFormat", resourceCulture);
             }
@@ -12789,7 +12825,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Interfaces do not contain &apos;Begin/End&apos; or &apos;Enter/Exit&apos; scope-defining methods.
         /// </summary>
-        internal static string MiKo_3214_Title {
+        public static string MiKo_3214_Title {
             get {
                 return ResourceManager.GetString("MiKo_3214_Title", resourceCulture);
             }
@@ -12798,7 +12834,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Convert &apos;Predicate&apos; into &apos;Func&apos;.
         /// </summary>
-        internal static string MiKo_3215_CodeFixTitle {
+        public static string MiKo_3215_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3215_CodeFixTitle", resourceCulture);
             }
@@ -12807,7 +12843,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To standardize delegates and adhere to .NET Framework Design Guidelines, use &apos;Func&lt;T, bool&gt;&apos; for callbacks instead of &apos;Predicate&lt;T&gt;&apos;. This approach ensures consistency and aligns with best practices..
         /// </summary>
-        internal static string MiKo_3215_Description {
+        public static string MiKo_3215_Description {
             get {
                 return ResourceManager.GetString("MiKo_3215_Description", resourceCulture);
             }
@@ -12816,7 +12852,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks.
         /// </summary>
-        internal static string MiKo_3215_HelpLinkUri {
+        public static string MiKo_3215_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_3215_HelpLinkUri", resourceCulture);
             }
@@ -12825,7 +12861,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Func&lt;{0}, bool&gt;&apos; instead of &apos;Predicate&lt;{0}&gt;&apos;.
         /// </summary>
-        internal static string MiKo_3215_MessageFormat {
+        public static string MiKo_3215_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3215_MessageFormat", resourceCulture);
             }
@@ -12834,7 +12870,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Callbacks should be &apos;Func&lt;T, bool&gt;&apos; instead of &apos;Predicate&lt;bool&gt;&apos;.
         /// </summary>
-        internal static string MiKo_3215_Title {
+        public static string MiKo_3215_Title {
             get {
                 return ResourceManager.GetString("MiKo_3215_Title", resourceCulture);
             }
@@ -12843,7 +12879,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make field read-only.
         /// </summary>
-        internal static string MiKo_3216_CodeFixTitle {
+        public static string MiKo_3216_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3216_CodeFixTitle", resourceCulture);
             }
@@ -12852,7 +12888,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Static fields with pre-assigned values are likely meant to remain unchanged. Therefore, make these fields &apos;readonly&apos;. This ensures their values remain constant and clearly communicates their intended use..
         /// </summary>
-        internal static string MiKo_3216_Description {
+        public static string MiKo_3216_Description {
             get {
                 return ResourceManager.GetString("MiKo_3216_Description", resourceCulture);
             }
@@ -12861,7 +12897,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Make field read-only.
         /// </summary>
-        internal static string MiKo_3216_MessageFormat {
+        public static string MiKo_3216_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3216_MessageFormat", resourceCulture);
             }
@@ -12870,7 +12906,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Static fields with initializers should be read-only.
         /// </summary>
-        internal static string MiKo_3216_Title {
+        public static string MiKo_3216_Title {
             get {
                 return ResourceManager.GetString("MiKo_3216_Title", resourceCulture);
             }
@@ -12881,7 +12917,7 @@ namespace MiKoSolutions.Analyzers {
         ///
         ///Instead, use non-generic types as type arguments. This approach makes the code&apos;s intent clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_3217_Description {
+        public static string MiKo_3217_Description {
             get {
                 return ResourceManager.GetString("MiKo_3217_Description", resourceCulture);
             }
@@ -12890,7 +12926,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use generic type with generic type arguments.
         /// </summary>
-        internal static string MiKo_3217_MessageFormat {
+        public static string MiKo_3217_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3217_MessageFormat", resourceCulture);
             }
@@ -12899,7 +12935,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use generic types that have other generic types as type arguments.
         /// </summary>
-        internal static string MiKo_3217_Title {
+        public static string MiKo_3217_Title {
             get {
                 return ResourceManager.GetString("MiKo_3217_Title", resourceCulture);
             }
@@ -12908,7 +12944,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Extension methods should only be in static types designed for that purpose. Avoid placing them in other types, as this can cause confusion. Keeping extension methods where they belong ensures clarity and consistency in your code..
         /// </summary>
-        internal static string MiKo_3218_Description {
+        public static string MiKo_3218_Description {
             get {
                 return ResourceManager.GetString("MiKo_3218_Description", resourceCulture);
             }
@@ -12917,7 +12953,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Change from extension method into normal static method.
         /// </summary>
-        internal static string MiKo_3218_MessageFormat {
+        public static string MiKo_3218_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3218_MessageFormat", resourceCulture);
             }
@@ -12926,7 +12962,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not define extension methods in unexpected places.
         /// </summary>
-        internal static string MiKo_3218_Title {
+        public static string MiKo_3218_Title {
             get {
                 return ResourceManager.GetString("MiKo_3218_Title", resourceCulture);
             }
@@ -12935,7 +12971,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Public members should offer the correct functionality for class consumers. If extensibility is needed, they should call a &apos;protected virtual&apos; member with the same name suffixed by &apos;Core&apos;. These serve as clear, easily identifiable extensibility points..
         /// </summary>
-        internal static string MiKo_3219_Description {
+        public static string MiKo_3219_Description {
             get {
                 return ResourceManager.GetString("MiKo_3219_Description", resourceCulture);
             }
@@ -12944,7 +12980,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove &apos;virtual&apos; and provide a &apos;protected virtual {0}&apos; member instead.
         /// </summary>
-        internal static string MiKo_3219_MessageFormat {
+        public static string MiKo_3219_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3219_MessageFormat", resourceCulture);
             }
@@ -12953,7 +12989,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Public members should not be &apos;virtual&apos;.
         /// </summary>
-        internal static string MiKo_3219_Title {
+        public static string MiKo_3219_Title {
             get {
                 return ResourceManager.GetString("MiKo_3219_Title", resourceCulture);
             }
@@ -12962,7 +12998,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify condition.
         /// </summary>
-        internal static string MiKo_3220_CodeFixTitle {
+        public static string MiKo_3220_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3220_CodeFixTitle", resourceCulture);
             }
@@ -12971,7 +13007,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify logical &apos;&amp;&amp;&apos; or &apos;||&apos; conditions by removing direct uses of &apos;true&apos; or &apos;false&apos;. This makes your code cleaner and easier to read..
         /// </summary>
-        internal static string MiKo_3220_Description {
+        public static string MiKo_3220_Description {
             get {
                 return ResourceManager.GetString("MiKo_3220_Description", resourceCulture);
             }
@@ -12980,7 +13016,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify condition.
         /// </summary>
-        internal static string MiKo_3220_MessageFormat {
+        public static string MiKo_3220_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3220_MessageFormat", resourceCulture);
             }
@@ -12989,7 +13025,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Logical &apos;&amp;&amp;&apos; or &apos;||&apos; conditions using &apos;true&apos; or &apos;false&apos; should be simplified.
         /// </summary>
-        internal static string MiKo_3220_Title {
+        public static string MiKo_3220_Title {
             get {
                 return ResourceManager.GetString("MiKo_3220_Title", resourceCulture);
             }
@@ -12998,7 +13034,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;HashCode.Combine&apos;.
         /// </summary>
-        internal static string MiKo_3221_CodeFixTitle {
+        public static string MiKo_3221_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3221_CodeFixTitle", resourceCulture);
             }
@@ -13007,7 +13043,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve the quality of the hash code returned by &apos;GetHashCode&apos;, use the &apos;HashCode.Combine&apos; method. This is especially useful when dealing with simple underlying data types like integers and keeps your hash codes robust and efficient..
         /// </summary>
-        internal static string MiKo_3221_Description {
+        public static string MiKo_3221_Description {
             get {
                 return ResourceManager.GetString("MiKo_3221_Description", resourceCulture);
             }
@@ -13016,7 +13052,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;HashCode.Combine&apos; instead.
         /// </summary>
-        internal static string MiKo_3221_MessageFormat {
+        public static string MiKo_3221_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3221_MessageFormat", resourceCulture);
             }
@@ -13025,7 +13061,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to GetHashCode overrides should use &apos;HashCode.Combine&apos;.
         /// </summary>
-        internal static string MiKo_3221_Title {
+        public static string MiKo_3221_Title {
             get {
                 return ResourceManager.GetString("MiKo_3221_Title", resourceCulture);
             }
@@ -13034,7 +13070,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify comparison.
         /// </summary>
-        internal static string MiKo_3222_CodeFixTitle {
+        public static string MiKo_3222_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3222_CodeFixTitle", resourceCulture);
             }
@@ -13043,7 +13079,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify string comparisons for equality by using specific methods from the .NET framework. This makes your code more readable and easier to understand..
         /// </summary>
-        internal static string MiKo_3222_Description {
+        public static string MiKo_3222_Description {
             get {
                 return ResourceManager.GetString("MiKo_3222_Description", resourceCulture);
             }
@@ -13052,7 +13088,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to String comparison can be simplified.
         /// </summary>
-        internal static string MiKo_3222_MessageFormat {
+        public static string MiKo_3222_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3222_MessageFormat", resourceCulture);
             }
@@ -13061,7 +13097,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to String comparisons can be simplified.
         /// </summary>
-        internal static string MiKo_3222_Title {
+        public static string MiKo_3222_Title {
             get {
                 return ResourceManager.GetString("MiKo_3222_Title", resourceCulture);
             }
@@ -13070,7 +13106,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify comparison.
         /// </summary>
-        internal static string MiKo_3223_CodeFixTitle {
+        public static string MiKo_3223_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3223_CodeFixTitle", resourceCulture);
             }
@@ -13079,7 +13115,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify equality comparisons on reference types by using specific .NET framework methods. This approach makes the code easier to read and understand..
         /// </summary>
-        internal static string MiKo_3223_Description {
+        public static string MiKo_3223_Description {
             get {
                 return ResourceManager.GetString("MiKo_3223_Description", resourceCulture);
             }
@@ -13088,7 +13124,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comparison can be simplified.
         /// </summary>
-        internal static string MiKo_3223_MessageFormat {
+        public static string MiKo_3223_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3223_MessageFormat", resourceCulture);
             }
@@ -13097,7 +13133,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Reference comparisons can be simplified.
         /// </summary>
-        internal static string MiKo_3223_Title {
+        public static string MiKo_3223_Title {
             get {
                 return ResourceManager.GetString("MiKo_3223_Title", resourceCulture);
             }
@@ -13106,7 +13142,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify comparison.
         /// </summary>
-        internal static string MiKo_3224_CodeFixTitle {
+        public static string MiKo_3224_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3224_CodeFixTitle", resourceCulture);
             }
@@ -13115,7 +13151,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify equality comparisons on value types by using specific .NET framework methods. This approach makes the code easier to read and understand..
         /// </summary>
-        internal static string MiKo_3224_Description {
+        public static string MiKo_3224_Description {
             get {
                 return ResourceManager.GetString("MiKo_3224_Description", resourceCulture);
             }
@@ -13124,7 +13160,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comparison can be simplified.
         /// </summary>
-        internal static string MiKo_3224_MessageFormat {
+        public static string MiKo_3224_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3224_MessageFormat", resourceCulture);
             }
@@ -13133,7 +13169,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Value comparisons can be simplified.
         /// </summary>
-        internal static string MiKo_3224_Title {
+        public static string MiKo_3224_Title {
             get {
                 return ResourceManager.GetString("MiKo_3224_Title", resourceCulture);
             }
@@ -13142,7 +13178,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Simplify redundant comparison.
         /// </summary>
-        internal static string MiKo_3225_CodeFixTitle {
+        public static string MiKo_3225_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3225_CodeFixTitle", resourceCulture);
             }
@@ -13151,7 +13187,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Boolean comparisons that check the same values on both sides are redundant. Simplify them by using just one side. This makes the code easier to read and understand..
         /// </summary>
-        internal static string MiKo_3225_Description {
+        public static string MiKo_3225_Description {
             get {
                 return ResourceManager.GetString("MiKo_3225_Description", resourceCulture);
             }
@@ -13160,7 +13196,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Redundant comparison can be simplified.
         /// </summary>
-        internal static string MiKo_3225_MessageFormat {
+        public static string MiKo_3225_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3225_MessageFormat", resourceCulture);
             }
@@ -13169,7 +13205,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Redundant comparisons can be simplified.
         /// </summary>
-        internal static string MiKo_3225_Title {
+        public static string MiKo_3225_Title {
             get {
                 return ResourceManager.GetString("MiKo_3225_Title", resourceCulture);
             }
@@ -13178,7 +13214,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
-        internal static string MiKo_3301_CodeFixTitle {
+        public static string MiKo_3301_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3301_CodeFixTitle", resourceCulture);
             }
@@ -13187,7 +13223,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For single-statement blocks, use lambda expressions with expression bodies instead of parenthesized ones. This avoids the noise of parentheses, making your code cleaner and easier to read..
         /// </summary>
-        internal static string MiKo_3301_Description {
+        public static string MiKo_3301_Description {
             get {
                 return ResourceManager.GetString("MiKo_3301_Description", resourceCulture);
             }
@@ -13196,7 +13232,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body instead.
         /// </summary>
-        internal static string MiKo_3301_MessageFormat {
+        public static string MiKo_3301_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3301_MessageFormat", resourceCulture);
             }
@@ -13205,7 +13241,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements.
         /// </summary>
-        internal static string MiKo_3301_Title {
+        public static string MiKo_3301_Title {
             get {
                 return ResourceManager.GetString("MiKo_3301_Title", resourceCulture);
             }
@@ -13214,7 +13250,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove braces around parameter.
         /// </summary>
-        internal static string MiKo_3302_CodeFixTitle {
+        public static string MiKo_3302_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3302_CodeFixTitle", resourceCulture);
             }
@@ -13223,7 +13259,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to For single-parameter lambda expressions, avoid using parentheses. Use simple lambda expressions with expression bodies instead. This keeps your code cleaner and easier to read..
         /// </summary>
-        internal static string MiKo_3302_Description {
+        public static string MiKo_3302_Description {
             get {
                 return ResourceManager.GetString("MiKo_3302_Description", resourceCulture);
             }
@@ -13232,7 +13268,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use simple lambda expression body instead.
         /// </summary>
-        internal static string MiKo_3302_MessageFormat {
+        public static string MiKo_3302_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3302_MessageFormat", resourceCulture);
             }
@@ -13241,7 +13277,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters.
         /// </summary>
-        internal static string MiKo_3302_Title {
+        public static string MiKo_3302_Title {
             get {
                 return ResourceManager.GetString("MiKo_3302_Title", resourceCulture);
             }
@@ -13250,7 +13286,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Keep namespace hierarchies shallow. If a namespace hierarchy becomes too deep, it likely means the namespaces are too specific or specialized. Flatten such namespaces to keep your codebase understandable and manageable..
         /// </summary>
-        internal static string MiKo_3401_Description {
+        public static string MiKo_3401_Description {
             get {
                 return ResourceManager.GetString("MiKo_3401_Description", resourceCulture);
             }
@@ -13259,7 +13295,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespace hierarchy too deep: {1,4} (max. {2}).
         /// </summary>
-        internal static string MiKo_3401_MessageFormat {
+        public static string MiKo_3401_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3401_MessageFormat", resourceCulture);
             }
@@ -13268,7 +13304,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Namespace hierarchies should not be too deep.
         /// </summary>
-        internal static string MiKo_3401_Title {
+        public static string MiKo_3401_Title {
             get {
                 return ResourceManager.GetString("MiKo_3401_Title", resourceCulture);
             }
@@ -13277,7 +13313,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove suppressed nullable warning.
         /// </summary>
-        internal static string MiKo_3501_CodeFixTitle {
+        public static string MiKo_3501_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3501_CodeFixTitle", resourceCulture);
             }
@@ -13286,7 +13322,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suppressing nullable warnings on null-conditional operators confuses developers. A value is either nullable or it&apos;s not; it can&apos;t be both..
         /// </summary>
-        internal static string MiKo_3501_Description {
+        public static string MiKo_3501_Description {
             get {
                 return ResourceManager.GetString("MiKo_3501_Description", resourceCulture);
             }
@@ -13295,7 +13331,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suppress nullable warning.
         /// </summary>
-        internal static string MiKo_3501_MessageFormat {
+        public static string MiKo_3501_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3501_MessageFormat", resourceCulture);
             }
@@ -13304,7 +13340,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suppress nullable warnings on Null-conditional operators.
         /// </summary>
-        internal static string MiKo_3501_Title {
+        public static string MiKo_3501_Title {
             get {
                 return ResourceManager.GetString("MiKo_3501_Title", resourceCulture);
             }
@@ -13313,7 +13349,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove suppressed nullable warning.
         /// </summary>
-        internal static string MiKo_3502_CodeFixTitle {
+        public static string MiKo_3502_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_3502_CodeFixTitle", resourceCulture);
             }
@@ -13322,7 +13358,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Suppressing nullable warnings on LINQ calls that can return &apos;null&apos; confuses developers. A value is either nullable or it&apos;s not; it can&apos;t be both..
         /// </summary>
-        internal static string MiKo_3502_Description {
+        public static string MiKo_3502_Description {
             get {
                 return ResourceManager.GetString("MiKo_3502_Description", resourceCulture);
             }
@@ -13331,7 +13367,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suppress nullable warning.
         /// </summary>
-        internal static string MiKo_3502_MessageFormat {
+        public static string MiKo_3502_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_3502_MessageFormat", resourceCulture);
             }
@@ -13340,7 +13376,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not suppress nullable warnings on Linq calls.
         /// </summary>
-        internal static string MiKo_3502_Title {
+        public static string MiKo_3502_Title {
             get {
                 return ResourceManager.GetString("MiKo_3502_Title", resourceCulture);
             }
@@ -13349,7 +13385,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place and order method side-by-side with overloads.
         /// </summary>
-        internal static string MiKo_4001_CodeFixTitle {
+        public static string MiKo_4001_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4001_CodeFixTitle", resourceCulture);
             }
@@ -13358,7 +13394,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Order methods with the same name but different parameters so that those with fewer parameters come first. This shows all overloads in logical order and improves readability, making the code easier to understand and maintain..
         /// </summary>
-        internal static string MiKo_4001_Description {
+        public static string MiKo_4001_Description {
             get {
                 return ResourceManager.GetString("MiKo_4001_Description", resourceCulture);
             }
@@ -13369,7 +13405,7 @@ namespace MiKoSolutions.Analyzers {
         ///{1}
         ///.
         /// </summary>
-        internal static string MiKo_4001_MessageFormat {
+        public static string MiKo_4001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4001_MessageFormat", resourceCulture);
             }
@@ -13378,7 +13414,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods with same name should be ordered based on the number of their parameters.
         /// </summary>
-        internal static string MiKo_4001_Title {
+        public static string MiKo_4001_Title {
             get {
                 return ResourceManager.GetString("MiKo_4001_Title", resourceCulture);
             }
@@ -13387,7 +13423,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place method side-by-side with overloads.
         /// </summary>
-        internal static string MiKo_4002_CodeFixTitle {
+        public static string MiKo_4002_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4002_CodeFixTitle", resourceCulture);
             }
@@ -13396,7 +13432,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place methods with the same name and accessibility side-by-side. This keeps them grouped together, making the code easier to find, understand, and maintain..
         /// </summary>
-        internal static string MiKo_4002_Description {
+        public static string MiKo_4002_Description {
             get {
                 return ResourceManager.GetString("MiKo_4002_Description", resourceCulture);
             }
@@ -13407,7 +13443,7 @@ namespace MiKoSolutions.Analyzers {
         ///{1}
         ///.
         /// </summary>
-        internal static string MiKo_4002_MessageFormat {
+        public static string MiKo_4002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4002_MessageFormat", resourceCulture);
             }
@@ -13416,7 +13452,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Methods with same name and accessibility should be placed side-by-side.
         /// </summary>
-        internal static string MiKo_4002_Title {
+        public static string MiKo_4002_Title {
             get {
                 return ResourceManager.GetString("MiKo_4002_Title", resourceCulture);
             }
@@ -13425,7 +13461,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;Dispose&apos; directly after all ctors and finalizers.
         /// </summary>
-        internal static string MiKo_4003_CodeFixTitle {
+        public static string MiKo_4003_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4003_CodeFixTitle", resourceCulture);
             }
@@ -13435,7 +13471,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Constructors, finalizers, and Dispose methods are all tied to an object&apos;s lifetime. They should be placed side by side to keep related code together.
         ///This organization ensures clarity and makes the code easier to find, understand and maintain..
         /// </summary>
-        internal static string MiKo_4003_Description {
+        public static string MiKo_4003_Description {
             get {
                 return ResourceManager.GetString("MiKo_4003_Description", resourceCulture);
             }
@@ -13444,7 +13480,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;Dispose&apos; directly after all ctors and finalizers.
         /// </summary>
-        internal static string MiKo_4003_MessageFormat {
+        public static string MiKo_4003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4003_MessageFormat", resourceCulture);
             }
@@ -13453,7 +13489,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dispose methods should be placed directly after constructors and finalizers.
         /// </summary>
-        internal static string MiKo_4003_Title {
+        public static string MiKo_4003_Title {
             get {
                 return ResourceManager.GetString("MiKo_4003_Title", resourceCulture);
             }
@@ -13462,7 +13498,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;Dispose&apos; method first.
         /// </summary>
-        internal static string MiKo_4004_CodeFixTitle {
+        public static string MiKo_4004_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4004_CodeFixTitle", resourceCulture);
             }
@@ -13472,7 +13508,7 @@ namespace MiKoSolutions.Analyzers {
         ///   Looks up a localized string similar to Dispose methods are tied to the object&apos;s lifetime. Therefore, place them before all other methods of the same accessibility to keep related code together.
         ///This organization ensures clarity and makes the code easier to find, understand and maintain..
         /// </summary>
-        internal static string MiKo_4004_Description {
+        public static string MiKo_4004_Description {
             get {
                 return ResourceManager.GetString("MiKo_4004_Description", resourceCulture);
             }
@@ -13481,7 +13517,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;Dispose&apos; method first.
         /// </summary>
-        internal static string MiKo_4004_MessageFormat {
+        public static string MiKo_4004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4004_MessageFormat", resourceCulture);
             }
@@ -13490,7 +13526,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dispose methods should be placed before all other methods of the same accessibility.
         /// </summary>
-        internal static string MiKo_4004_Title {
+        public static string MiKo_4004_Title {
             get {
                 return ResourceManager.GetString("MiKo_4004_Title", resourceCulture);
             }
@@ -13499,7 +13535,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place interface directly after type declaration.
         /// </summary>
-        internal static string MiKo_4005_CodeFixTitle {
+        public static string MiKo_4005_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4005_CodeFixTitle", resourceCulture);
             }
@@ -13508,7 +13544,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to List the interface that gives the type its name first, followed by all other implemented interfaces. This organization ensures clarity and makes the code easier to understand..
         /// </summary>
-        internal static string MiKo_4005_Description {
+        public static string MiKo_4005_Description {
             get {
                 return ResourceManager.GetString("MiKo_4005_Description", resourceCulture);
             }
@@ -13517,7 +13553,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;{1}&apos; as first interface directly after type declaration.
         /// </summary>
-        internal static string MiKo_4005_MessageFormat {
+        public static string MiKo_4005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4005_MessageFormat", resourceCulture);
             }
@@ -13526,7 +13562,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to The interface that gives a type its name should be placed directly after the type&apos;s declaration.
         /// </summary>
-        internal static string MiKo_4005_Title {
+        public static string MiKo_4005_Title {
             get {
                 return ResourceManager.GetString("MiKo_4005_Title", resourceCulture);
             }
@@ -13535,7 +13571,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place operator before methods.
         /// </summary>
-        internal static string MiKo_4007_CodeFixTitle {
+        public static string MiKo_4007_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4007_CodeFixTitle", resourceCulture);
             }
@@ -13544,7 +13580,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Operators are special static methods. They should be placed before all other methods and grouped together. This ensures clarity and makes the code easier to understand..
         /// </summary>
-        internal static string MiKo_4007_Description {
+        public static string MiKo_4007_Description {
             get {
                 return ResourceManager.GetString("MiKo_4007_Description", resourceCulture);
             }
@@ -13553,7 +13589,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place operator before methods.
         /// </summary>
-        internal static string MiKo_4007_MessageFormat {
+        public static string MiKo_4007_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4007_MessageFormat", resourceCulture);
             }
@@ -13562,7 +13598,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Operators should be placed before methods.
         /// </summary>
-        internal static string MiKo_4007_Title {
+        public static string MiKo_4007_Title {
             get {
                 return ResourceManager.GetString("MiKo_4007_Title", resourceCulture);
             }
@@ -13571,7 +13607,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;GetHashCode&apos; after &apos;Equals&apos;.
         /// </summary>
-        internal static string MiKo_4008_CodeFixTitle {
+        public static string MiKo_4008_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4008_CodeFixTitle", resourceCulture);
             }
@@ -13580,7 +13616,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;GetHashCode&apos; and &apos;Equals&apos; are used together to manage instances in dictionaries or hashsets. &apos;GetHashCode&apos; computes a hash, and if a collision occurs, &apos;Equals&apos; identifies the instance. Because they are closely related, they should be located near each other in your code..
         /// </summary>
-        internal static string MiKo_4008_Description {
+        public static string MiKo_4008_Description {
             get {
                 return ResourceManager.GetString("MiKo_4008_Description", resourceCulture);
             }
@@ -13589,7 +13625,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place &apos;GetHashCode&apos; after &apos;Equals&apos;.
         /// </summary>
-        internal static string MiKo_4008_MessageFormat {
+        public static string MiKo_4008_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4008_MessageFormat", resourceCulture);
             }
@@ -13598,7 +13634,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to GetHashCode methods should be placed directly after Equals methods.
         /// </summary>
-        internal static string MiKo_4008_Title {
+        public static string MiKo_4008_Title {
             get {
                 return ResourceManager.GetString("MiKo_4008_Title", resourceCulture);
             }
@@ -13607,7 +13643,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place method after one-time methods and before test cleanup and all other test methods.
         /// </summary>
-        internal static string MiKo_4101_CodeFixTitle {
+        public static string MiKo_4101_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4101_CodeFixTitle", resourceCulture);
             }
@@ -13616,7 +13652,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test initialization methods define the common parts of tests. To make them easy to find, place them directly after all one-time test initialization/cleanup methods and before all test methods..
         /// </summary>
-        internal static string MiKo_4101_Description {
+        public static string MiKo_4101_Description {
             get {
                 return ResourceManager.GetString("MiKo_4101_Description", resourceCulture);
             }
@@ -13625,7 +13661,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place test initialization method after [OneTimeSetUp] / [OneTimeTearDown] methods and before test cleanup and all other test methods.
         /// </summary>
-        internal static string MiKo_4101_MessageFormat {
+        public static string MiKo_4101_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4101_MessageFormat", resourceCulture);
             }
@@ -13634,7 +13670,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test initialization methods should be ordered directly after One-Time methods.
         /// </summary>
-        internal static string MiKo_4101_Title {
+        public static string MiKo_4101_Title {
             get {
                 return ResourceManager.GetString("MiKo_4101_Title", resourceCulture);
             }
@@ -13643,7 +13679,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place method after test initialization methods and before all test methods.
         /// </summary>
-        internal static string MiKo_4102_CodeFixTitle {
+        public static string MiKo_4102_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4102_CodeFixTitle", resourceCulture);
             }
@@ -13652,7 +13688,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test cleanup methods define common tasks to be executed after any test finishes. To make them easy to find, place them directly after any test initialization method and before all test methods..
         /// </summary>
-        internal static string MiKo_4102_Description {
+        public static string MiKo_4102_Description {
             get {
                 return ResourceManager.GetString("MiKo_4102_Description", resourceCulture);
             }
@@ -13661,7 +13697,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place test cleanup method after test initialization methods and before all test methods.
         /// </summary>
-        internal static string MiKo_4102_MessageFormat {
+        public static string MiKo_4102_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4102_MessageFormat", resourceCulture);
             }
@@ -13670,7 +13706,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test cleanup methods should be ordered after test initialization methods and before test methods.
         /// </summary>
-        internal static string MiKo_4102_Title {
+        public static string MiKo_4102_Title {
             get {
                 return ResourceManager.GetString("MiKo_4102_Title", resourceCulture);
             }
@@ -13679,7 +13715,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place method before all other methods.
         /// </summary>
-        internal static string MiKo_4103_CodeFixTitle {
+        public static string MiKo_4103_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4103_CodeFixTitle", resourceCulture);
             }
@@ -13688,7 +13724,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-time test initialization methods set up the key parts of the test environment. To make them easy to find, place these methods first..
         /// </summary>
-        internal static string MiKo_4103_Description {
+        public static string MiKo_4103_Description {
             get {
                 return ResourceManager.GetString("MiKo_4103_Description", resourceCulture);
             }
@@ -13697,7 +13733,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place [OneTimeSetUp] method before all other methods.
         /// </summary>
-        internal static string MiKo_4103_MessageFormat {
+        public static string MiKo_4103_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4103_MessageFormat", resourceCulture);
             }
@@ -13706,7 +13742,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-Time test initialization methods should be ordered before all other methods.
         /// </summary>
-        internal static string MiKo_4103_Title {
+        public static string MiKo_4103_Title {
             get {
                 return ResourceManager.GetString("MiKo_4103_Title", resourceCulture);
             }
@@ -13715,7 +13751,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place method directly after [OneTimeSetUp] method and before all other methods.
         /// </summary>
-        internal static string MiKo_4104_CodeFixTitle {
+        public static string MiKo_4104_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_4104_CodeFixTitle", resourceCulture);
             }
@@ -13724,7 +13760,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-time test cleanup methods handle the common tasks that must be executed after all tests are done to clean up the test environment. To make them easy to find, place them directly after the one-time test initialization methods..
         /// </summary>
-        internal static string MiKo_4104_Description {
+        public static string MiKo_4104_Description {
             get {
                 return ResourceManager.GetString("MiKo_4104_Description", resourceCulture);
             }
@@ -13733,7 +13769,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place [OneTimeTearDown] method directly after [OneTimeSetUp] method and before all other methods.
         /// </summary>
-        internal static string MiKo_4104_MessageFormat {
+        public static string MiKo_4104_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_4104_MessageFormat", resourceCulture);
             }
@@ -13742,7 +13778,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to One-Time test cleanup methods should be ordered directly after One-Time test initialization methods.
         /// </summary>
-        internal static string MiKo_4104_Title {
+        public static string MiKo_4104_Title {
             get {
                 return ResourceManager.GetString("MiKo_4104_Title", resourceCulture);
             }
@@ -13751,7 +13787,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place inside &apos;if&apos;.
         /// </summary>
-        internal static string MiKo_5001_CodeFixTitle {
+        public static string MiKo_5001_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5001_CodeFixTitle", resourceCulture);
             }
@@ -13760,7 +13796,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve performance, call &apos;IsDebugEnabled&apos; before invoking &apos;Debug&apos; or &apos;DebugFormat&apos;. This prevents creating unnecessary messages and garbage collection if the &apos;Debug&apos; log level isn&apos;t set..
         /// </summary>
-        internal static string MiKo_5001_Description {
+        public static string MiKo_5001_Description {
             get {
                 return ResourceManager.GetString("MiKo_5001_Description", resourceCulture);
             }
@@ -13769,7 +13805,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invoke &apos;{2}&apos; before invoking &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_5001_MessageFormat {
+        public static string MiKo_5001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5001_MessageFormat", resourceCulture);
             }
@@ -13778,7 +13814,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;Debug&apos; and &apos;DebugFormat&apos; methods should be invoked only after &apos;IsDebugEnabled&apos;.
         /// </summary>
-        internal static string MiKo_5001_Title {
+        public static string MiKo_5001_Title {
             get {
                 return ResourceManager.GetString("MiKo_5001_Title", resourceCulture);
             }
@@ -13787,7 +13823,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace with non-&apos;Format&apos; method.
         /// </summary>
-        internal static string MiKo_5002_CodeFixTitle {
+        public static string MiKo_5002_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5002_CodeFixTitle", resourceCulture);
             }
@@ -13796,7 +13832,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve performance, use &apos;xxxFormat&apos; methods (like &apos;DebugFormat&apos;) only with arguments for formatting the string. Otherwise, use the non-formatting methods (like &apos;Debug&apos;). This approach avoids unnecessary overhead and keeps your code efficient..
         /// </summary>
-        internal static string MiKo_5002_Description {
+        public static string MiKo_5002_Description {
             get {
                 return ResourceManager.GetString("MiKo_5002_Description", resourceCulture);
             }
@@ -13805,7 +13841,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invoke &apos;{2}&apos; instead.
         /// </summary>
-        internal static string MiKo_5002_MessageFormat {
+        public static string MiKo_5002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5002_MessageFormat", resourceCulture);
             }
@@ -13814,7 +13850,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;xxxFormat&apos; methods should be invoked with multiple arguments only.
         /// </summary>
-        internal static string MiKo_5002_Title {
+        public static string MiKo_5002_Title {
             get {
                 return ResourceManager.GetString("MiKo_5002_Title", resourceCulture);
             }
@@ -13823,7 +13859,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to When logging exceptions, use Log methods that accept an exception parameter (like &apos;Debug&apos;, &apos;Info&apos;, &apos;Warn&apos;, etc.). This allows the Log framework to capture not just the exception name but also additional details like the stack trace, keeping your logs detailed and informative..
         /// </summary>
-        internal static string MiKo_5003_Description {
+        public static string MiKo_5003_Description {
             get {
                 return ResourceManager.GetString("MiKo_5003_Description", resourceCulture);
             }
@@ -13832,7 +13868,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Invoke &apos;{1}&apos; overload with exception parameter.
         /// </summary>
-        internal static string MiKo_5003_MessageFormat {
+        public static string MiKo_5003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5003_MessageFormat", resourceCulture);
             }
@@ -13841,7 +13877,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Correct Log methods should be invoked for exceptions.
         /// </summary>
-        internal static string MiKo_5003_Title {
+        public static string MiKo_5003_Title {
             get {
                 return ResourceManager.GetString("MiKo_5003_Title", resourceCulture);
             }
@@ -13850,7 +13886,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Replace &apos;Equals&apos; by &apos;==&apos;.
         /// </summary>
-        internal static string MiKo_5010_CodeFixTitle {
+        public static string MiKo_5010_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5010_CodeFixTitle", resourceCulture);
             }
@@ -13859,7 +13895,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using &apos;object.Equals()&apos; on value types causes unnecessary boxing and unboxing, which pressures the garbage collector. Instead, use the equality operator for comparing value types. This improves performance by avoiding temporary object creation and garbage collection..
         /// </summary>
-        internal static string MiKo_5010_Description {
+        public static string MiKo_5010_Description {
             get {
                 return ResourceManager.GetString("MiKo_5010_Description", resourceCulture);
             }
@@ -13868,7 +13904,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;==&apos; operator instead of &apos;{1}&apos;.
         /// </summary>
-        internal static string MiKo_5010_MessageFormat {
+        public static string MiKo_5010_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5010_MessageFormat", resourceCulture);
             }
@@ -13877,7 +13913,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;object.Equals()&apos; on value types.
         /// </summary>
-        internal static string MiKo_5010_Title {
+        public static string MiKo_5010_Title {
             get {
                 return ResourceManager.GetString("MiKo_5010_Title", resourceCulture);
             }
@@ -13886,7 +13922,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use += for string concatenation. It creates unnecessary string allocations, putting pressure on the garbage collector. Instead, use &apos;string.Concat()&apos;, &apos;string.Join()&apos;, or &apos;StringBuilder&apos; to boost performance and reduce garbage collector load..
         /// </summary>
-        internal static string MiKo_5011_Description {
+        public static string MiKo_5011_Description {
             get {
                 return ResourceManager.GetString("MiKo_5011_Description", resourceCulture);
             }
@@ -13895,7 +13931,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;string.Concat()&apos; or &apos;string.Join()&apos; instead.
         /// </summary>
-        internal static string MiKo_5011_MessageFormat {
+        public static string MiKo_5011_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5011_MessageFormat", resourceCulture);
             }
@@ -13904,7 +13940,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not concatenate strings with += operator.
         /// </summary>
-        internal static string MiKo_5011_Title {
+        public static string MiKo_5011_Title {
             get {
                 return ResourceManager.GetString("MiKo_5011_Title", resourceCulture);
             }
@@ -13913,7 +13949,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve performance, avoid letting methods with yield call themselves recursively. This causes the underlying iterators to be called more times than expected, resulting in poor runtime performance..
         /// </summary>
-        internal static string MiKo_5012_Description {
+        public static string MiKo_5012_Description {
             get {
                 return ResourceManager.GetString("MiKo_5012_Description", resourceCulture);
             }
@@ -13922,7 +13958,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to https://stackoverflow.com/questions/3969963/when-not-to-use-yield-return.
         /// </summary>
-        internal static string MiKo_5012_HelpLinkUri {
+        public static string MiKo_5012_HelpLinkUri {
             get {
                 return ResourceManager.GetString("MiKo_5012_HelpLinkUri", resourceCulture);
             }
@@ -13931,7 +13967,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use yield recursively.
         /// </summary>
-        internal static string MiKo_5012_MessageFormat {
+        public static string MiKo_5012_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5012_MessageFormat", resourceCulture);
             }
@@ -13940,7 +13976,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not use &apos;yield return&apos; for recursively defined structures.
         /// </summary>
-        internal static string MiKo_5012_Title {
+        public static string MiKo_5012_Title {
             get {
                 return ResourceManager.GetString("MiKo_5012_Title", resourceCulture);
             }
@@ -13949,7 +13985,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Array.Empty&lt;&gt;()&apos;.
         /// </summary>
-        internal static string MiKo_5013_CodeFixTitle {
+        public static string MiKo_5013_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5013_CodeFixTitle", resourceCulture);
             }
@@ -13958,7 +13994,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid creating empty arrays manually to prevent unnecessary memory consumption and garbage collector pressure. Use &apos;Array.Empty&lt;T&gt;()&apos; or &apos;[]&apos; instead. This approach is more efficient..
         /// </summary>
-        internal static string MiKo_5013_Description {
+        public static string MiKo_5013_Description {
             get {
                 return ResourceManager.GetString("MiKo_5013_Description", resourceCulture);
             }
@@ -13967,7 +14003,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create empty array.
         /// </summary>
-        internal static string MiKo_5013_MessageFormat {
+        public static string MiKo_5013_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5013_MessageFormat", resourceCulture);
             }
@@ -13976,7 +14012,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create empty arrays.
         /// </summary>
-        internal static string MiKo_5013_Title {
+        public static string MiKo_5013_Title {
             get {
                 return ResourceManager.GetString("MiKo_5013_Title", resourceCulture);
             }
@@ -13985,7 +14021,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use &apos;Array.Empty&lt;&gt;()&apos;.
         /// </summary>
-        internal static string MiKo_5014_CodeFixTitle {
+        public static string MiKo_5014_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5014_CodeFixTitle", resourceCulture);
             }
@@ -13994,7 +14030,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Avoid creating empty lists manually to prevent unnecessary memory consumption and garbage collector pressure. Use &apos;Array.Empty&lt;T&gt;()&apos; or &apos;[]&apos; instead. This approach is more efficient..
         /// </summary>
-        internal static string MiKo_5014_Description {
+        public static string MiKo_5014_Description {
             get {
                 return ResourceManager.GetString("MiKo_5014_Description", resourceCulture);
             }
@@ -14003,7 +14039,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create empty lists.
         /// </summary>
-        internal static string MiKo_5014_MessageFormat {
+        public static string MiKo_5014_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5014_MessageFormat", resourceCulture);
             }
@@ -14012,7 +14048,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not create empty lists if the return value is read-only.
         /// </summary>
-        internal static string MiKo_5014_Title {
+        public static string MiKo_5014_Title {
             get {
                 return ResourceManager.GetString("MiKo_5014_Title", resourceCulture);
             }
@@ -14021,7 +14057,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Remove unneeded call to string.Intern().
         /// </summary>
-        internal static string MiKo_5015_CodeFixTitle {
+        public static string MiKo_5015_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5015_CodeFixTitle", resourceCulture);
             }
@@ -14030,7 +14066,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not intern string literals. They&apos;re already interned, so doing it again does not add any value..
         /// </summary>
-        internal static string MiKo_5015_Description {
+        public static string MiKo_5015_Description {
             get {
                 return ResourceManager.GetString("MiKo_5015_Description", resourceCulture);
             }
@@ -14039,7 +14075,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not intern string literal.
         /// </summary>
-        internal static string MiKo_5015_MessageFormat {
+        public static string MiKo_5015_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5015_MessageFormat", resourceCulture);
             }
@@ -14048,7 +14084,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Do not intern string literals.
         /// </summary>
-        internal static string MiKo_5015_Title {
+        public static string MiKo_5015_Title {
             get {
                 return ResourceManager.GetString("MiKo_5015_Title", resourceCulture);
             }
@@ -14057,7 +14093,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To improve performance, use &apos;Contains()&apos; on a &apos;HashSet&apos; inside &apos;List.RemoveAll(...)&apos; calls. HashSet lookup is O(1) while list lookup is O(n), which leads to better runtime performance. Using &apos;.Contains()&apos; on a list requires looping over it repeatedly, slowing things down..
         /// </summary>
-        internal static string MiKo_5016_Description {
+        public static string MiKo_5016_Description {
             get {
                 return ResourceManager.GetString("MiKo_5016_Description", resourceCulture);
             }
@@ -14066,7 +14102,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a HashSet for the lookup.
         /// </summary>
-        internal static string MiKo_5016_MessageFormat {
+        public static string MiKo_5016_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5016_MessageFormat", resourceCulture);
             }
@@ -14075,7 +14111,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Use a HashSet for lookups in &apos;List.RemoveAll&apos;.
         /// </summary>
-        internal static string MiKo_5016_Title {
+        public static string MiKo_5016_Title {
             get {
                 return ResourceManager.GetString("MiKo_5016_Title", resourceCulture);
             }
@@ -14084,7 +14120,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Convert to constant.
         /// </summary>
-        internal static string MiKo_5017_CodeFixTitle {
+        public static string MiKo_5017_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_5017_CodeFixTitle", resourceCulture);
             }
@@ -14093,7 +14129,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To avoid unnecessary memory consumption, make string literals used as field or variable values constant. This keeps memory usage efficient and ensures better performance..
         /// </summary>
-        internal static string MiKo_5017_Description {
+        public static string MiKo_5017_Description {
             get {
                 return ResourceManager.GetString("MiKo_5017_Description", resourceCulture);
             }
@@ -14102,7 +14138,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Convert to constant.
         /// </summary>
-        internal static string MiKo_5017_MessageFormat {
+        public static string MiKo_5017_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_5017_MessageFormat", resourceCulture);
             }
@@ -14111,7 +14147,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fields or variables assigned with string literals should be constant.
         /// </summary>
-        internal static string MiKo_5017_Title {
+        public static string MiKo_5017_Title {
             get {
                 return ResourceManager.GetString("MiKo_5017_Title", resourceCulture);
             }
@@ -14120,7 +14156,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6001_CodeFixTitle {
+        public static string MiKo_6001_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6001_CodeFixTitle", resourceCulture);
             }
@@ -14129,7 +14165,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround logging calls with blank lines to visually separate them from business code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6001_Description {
+        public static string MiKo_6001_Description {
             get {
                 return ResourceManager.GetString("MiKo_6001_Description", resourceCulture);
             }
@@ -14138,7 +14174,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround log statement(s) with blank lines.
         /// </summary>
-        internal static string MiKo_6001_MessageFormat {
+        public static string MiKo_6001_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6001_MessageFormat", resourceCulture);
             }
@@ -14147,7 +14183,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Log statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6001_Title {
+        public static string MiKo_6001_Title {
             get {
                 return ResourceManager.GetString("MiKo_6001_Title", resourceCulture);
             }
@@ -14156,7 +14192,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6002_CodeFixTitle {
+        public static string MiKo_6002_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6002_CodeFixTitle", resourceCulture);
             }
@@ -14165,7 +14201,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround assertions with blank lines to visually separate them from the test code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6002_Description {
+        public static string MiKo_6002_Description {
             get {
                 return ResourceManager.GetString("MiKo_6002_Description", resourceCulture);
             }
@@ -14174,7 +14210,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround assertion statement(s) with blank lines.
         /// </summary>
-        internal static string MiKo_6002_MessageFormat {
+        public static string MiKo_6002_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6002_MessageFormat", resourceCulture);
             }
@@ -14183,7 +14219,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assertion statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6002_Title {
+        public static string MiKo_6002_Title {
             get {
                 return ResourceManager.GetString("MiKo_6002_Title", resourceCulture);
             }
@@ -14192,7 +14228,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede with blank line.
         /// </summary>
-        internal static string MiKo_6003_CodeFixTitle {
+        public static string MiKo_6003_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6003_CodeFixTitle", resourceCulture);
             }
@@ -14201,7 +14237,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede local variables with blank lines to visually separate them from executing code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6003_Description {
+        public static string MiKo_6003_Description {
             get {
                 return ResourceManager.GetString("MiKo_6003_Description", resourceCulture);
             }
@@ -14210,7 +14246,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede local variable with a blank line.
         /// </summary>
-        internal static string MiKo_6003_MessageFormat {
+        public static string MiKo_6003_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6003_MessageFormat", resourceCulture);
             }
@@ -14219,7 +14255,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local variable statements should be preceded by blank lines.
         /// </summary>
-        internal static string MiKo_6003_Title {
+        public static string MiKo_6003_Title {
             get {
                 return ResourceManager.GetString("MiKo_6003_Title", resourceCulture);
             }
@@ -14228,7 +14264,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede with blank line.
         /// </summary>
-        internal static string MiKo_6004_CodeFixTitle {
+        public static string MiKo_6004_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6004_CodeFixTitle", resourceCulture);
             }
@@ -14237,7 +14273,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede variable assignments with blank lines to visually separate them from executing code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6004_Description {
+        public static string MiKo_6004_Description {
             get {
                 return ResourceManager.GetString("MiKo_6004_Description", resourceCulture);
             }
@@ -14246,7 +14282,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede variable assignment with a blank line.
         /// </summary>
-        internal static string MiKo_6004_MessageFormat {
+        public static string MiKo_6004_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6004_MessageFormat", resourceCulture);
             }
@@ -14255,7 +14291,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Variable assignment statements should be preceded by blank lines.
         /// </summary>
-        internal static string MiKo_6004_Title {
+        public static string MiKo_6004_Title {
             get {
                 return ResourceManager.GetString("MiKo_6004_Title", resourceCulture);
             }
@@ -14264,7 +14300,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede with blank line.
         /// </summary>
-        internal static string MiKo_6005_CodeFixTitle {
+        public static string MiKo_6005_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6005_CodeFixTitle", resourceCulture);
             }
@@ -14273,7 +14309,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede &apos;return&apos; statements with blank lines to visually separate them from the executing code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6005_Description {
+        public static string MiKo_6005_Description {
             get {
                 return ResourceManager.GetString("MiKo_6005_Description", resourceCulture);
             }
@@ -14282,7 +14318,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede return statement with a blank line.
         /// </summary>
-        internal static string MiKo_6005_MessageFormat {
+        public static string MiKo_6005_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6005_MessageFormat", resourceCulture);
             }
@@ -14291,7 +14327,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Return statements should be preceded by blank lines.
         /// </summary>
-        internal static string MiKo_6005_Title {
+        public static string MiKo_6005_Title {
             get {
                 return ResourceManager.GetString("MiKo_6005_Title", resourceCulture);
             }
@@ -14300,7 +14336,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6006_CodeFixTitle {
+        public static string MiKo_6006_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6006_CodeFixTitle", resourceCulture);
             }
@@ -14309,7 +14345,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround awaited statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6006_Description {
+        public static string MiKo_6006_Description {
             get {
                 return ResourceManager.GetString("MiKo_6006_Description", resourceCulture);
             }
@@ -14318,7 +14354,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround awaited statement with a blank line.
         /// </summary>
-        internal static string MiKo_6006_MessageFormat {
+        public static string MiKo_6006_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6006_MessageFormat", resourceCulture);
             }
@@ -14327,7 +14363,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Awaited statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6006_Title {
+        public static string MiKo_6006_Title {
             get {
                 return ResourceManager.GetString("MiKo_6006_Title", resourceCulture);
             }
@@ -14336,7 +14372,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6007_CodeFixTitle {
+        public static string MiKo_6007_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6007_CodeFixTitle", resourceCulture);
             }
@@ -14345,7 +14381,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround test statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6007_Description {
+        public static string MiKo_6007_Description {
             get {
                 return ResourceManager.GetString("MiKo_6007_Description", resourceCulture);
             }
@@ -14354,7 +14390,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround test statement with a blank line.
         /// </summary>
-        internal static string MiKo_6007_MessageFormat {
+        public static string MiKo_6007_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6007_MessageFormat", resourceCulture);
             }
@@ -14363,7 +14399,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Test statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6007_Title {
+        public static string MiKo_6007_Title {
             get {
                 return ResourceManager.GetString("MiKo_6007_Title", resourceCulture);
             }
@@ -14372,7 +14408,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede with blank line.
         /// </summary>
-        internal static string MiKo_6008_CodeFixTitle {
+        public static string MiKo_6008_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6008_CodeFixTitle", resourceCulture);
             }
@@ -14381,7 +14417,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede using directives for a specific namespace with blank lines to visually separate them from using directives for other namespaces. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6008_Description {
+        public static string MiKo_6008_Description {
             get {
                 return ResourceManager.GetString("MiKo_6008_Description", resourceCulture);
             }
@@ -14390,7 +14426,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Precede using directive with a blank line.
         /// </summary>
-        internal static string MiKo_6008_MessageFormat {
+        public static string MiKo_6008_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6008_MessageFormat", resourceCulture);
             }
@@ -14399,7 +14435,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Using directives should be preceded by blank lines.
         /// </summary>
-        internal static string MiKo_6008_Title {
+        public static string MiKo_6008_Title {
             get {
                 return ResourceManager.GetString("MiKo_6008_Title", resourceCulture);
             }
@@ -14408,7 +14444,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6009_CodeFixTitle {
+        public static string MiKo_6009_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6009_CodeFixTitle", resourceCulture);
             }
@@ -14417,7 +14453,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;try&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6009_Description {
+        public static string MiKo_6009_Description {
             get {
                 return ResourceManager.GetString("MiKo_6009_Description", resourceCulture);
             }
@@ -14426,7 +14462,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;try&apos; statement with a blank line.
         /// </summary>
-        internal static string MiKo_6009_MessageFormat {
+        public static string MiKo_6009_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6009_MessageFormat", resourceCulture);
             }
@@ -14435,7 +14471,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Try statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6009_Title {
+        public static string MiKo_6009_Title {
             get {
                 return ResourceManager.GetString("MiKo_6009_Title", resourceCulture);
             }
@@ -14444,7 +14480,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6010_CodeFixTitle {
+        public static string MiKo_6010_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6010_CodeFixTitle", resourceCulture);
             }
@@ -14453,7 +14489,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;if&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6010_Description {
+        public static string MiKo_6010_Description {
             get {
                 return ResourceManager.GetString("MiKo_6010_Description", resourceCulture);
             }
@@ -14462,7 +14498,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;if&apos; statement with a blank line.
         /// </summary>
-        internal static string MiKo_6010_MessageFormat {
+        public static string MiKo_6010_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6010_MessageFormat", resourceCulture);
             }
@@ -14471,7 +14507,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to If statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6010_Title {
+        public static string MiKo_6010_Title {
             get {
                 return ResourceManager.GetString("MiKo_6010_Title", resourceCulture);
             }
@@ -14480,7 +14516,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6011_CodeFixTitle {
+        public static string MiKo_6011_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6011_CodeFixTitle", resourceCulture);
             }
@@ -14489,7 +14525,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;lock&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6011_Description {
+        public static string MiKo_6011_Description {
             get {
                 return ResourceManager.GetString("MiKo_6011_Description", resourceCulture);
             }
@@ -14498,7 +14534,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;lock&apos; statement with a blank line.
         /// </summary>
-        internal static string MiKo_6011_MessageFormat {
+        public static string MiKo_6011_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6011_MessageFormat", resourceCulture);
             }
@@ -14507,7 +14543,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Lock statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6011_Title {
+        public static string MiKo_6011_Title {
             get {
                 return ResourceManager.GetString("MiKo_6011_Title", resourceCulture);
             }
@@ -14516,7 +14552,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6012_CodeFixTitle {
+        public static string MiKo_6012_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6012_CodeFixTitle", resourceCulture);
             }
@@ -14525,7 +14561,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;foreach&apos; loops with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6012_Description {
+        public static string MiKo_6012_Description {
             get {
                 return ResourceManager.GetString("MiKo_6012_Description", resourceCulture);
             }
@@ -14534,7 +14570,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;foreach&apos; loop with a blank line.
         /// </summary>
-        internal static string MiKo_6012_MessageFormat {
+        public static string MiKo_6012_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6012_MessageFormat", resourceCulture);
             }
@@ -14543,7 +14579,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to foreach loops should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6012_Title {
+        public static string MiKo_6012_Title {
             get {
                 return ResourceManager.GetString("MiKo_6012_Title", resourceCulture);
             }
@@ -14552,7 +14588,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6013_CodeFixTitle {
+        public static string MiKo_6013_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6013_CodeFixTitle", resourceCulture);
             }
@@ -14561,7 +14597,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround loops with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6013_Description {
+        public static string MiKo_6013_Description {
             get {
                 return ResourceManager.GetString("MiKo_6013_Description", resourceCulture);
             }
@@ -14570,7 +14606,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;for&apos; loop with a blank line.
         /// </summary>
-        internal static string MiKo_6013_MessageFormat {
+        public static string MiKo_6013_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6013_MessageFormat", resourceCulture);
             }
@@ -14579,7 +14615,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to for loops should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6013_Title {
+        public static string MiKo_6013_Title {
             get {
                 return ResourceManager.GetString("MiKo_6013_Title", resourceCulture);
             }
@@ -14588,7 +14624,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6014_CodeFixTitle {
+        public static string MiKo_6014_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6014_CodeFixTitle", resourceCulture);
             }
@@ -14597,7 +14633,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;while&apos; loops with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6014_Description {
+        public static string MiKo_6014_Description {
             get {
                 return ResourceManager.GetString("MiKo_6014_Description", resourceCulture);
             }
@@ -14606,7 +14642,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;while&apos; loop with a blank line.
         /// </summary>
-        internal static string MiKo_6014_MessageFormat {
+        public static string MiKo_6014_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6014_MessageFormat", resourceCulture);
             }
@@ -14615,7 +14651,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to while loops should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6014_Title {
+        public static string MiKo_6014_Title {
             get {
                 return ResourceManager.GetString("MiKo_6014_Title", resourceCulture);
             }
@@ -14624,7 +14660,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6015_CodeFixTitle {
+        public static string MiKo_6015_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6015_CodeFixTitle", resourceCulture);
             }
@@ -14633,7 +14669,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;do while&apos; loops with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6015_Description {
+        public static string MiKo_6015_Description {
             get {
                 return ResourceManager.GetString("MiKo_6015_Description", resourceCulture);
             }
@@ -14642,7 +14678,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;do/while&apos; loop with a blank line.
         /// </summary>
-        internal static string MiKo_6015_MessageFormat {
+        public static string MiKo_6015_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6015_MessageFormat", resourceCulture);
             }
@@ -14651,7 +14687,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to do/while loops should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6015_Title {
+        public static string MiKo_6015_Title {
             get {
                 return ResourceManager.GetString("MiKo_6015_Title", resourceCulture);
             }
@@ -14660,7 +14696,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6016_CodeFixTitle {
+        public static string MiKo_6016_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6016_CodeFixTitle", resourceCulture);
             }
@@ -14669,7 +14705,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;using&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6016_Description {
+        public static string MiKo_6016_Description {
             get {
                 return ResourceManager.GetString("MiKo_6016_Description", resourceCulture);
             }
@@ -14678,7 +14714,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;using&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6016_MessageFormat {
+        public static string MiKo_6016_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6016_MessageFormat", resourceCulture);
             }
@@ -14687,7 +14723,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to using statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6016_Title {
+        public static string MiKo_6016_Title {
             get {
                 return ResourceManager.GetString("MiKo_6016_Title", resourceCulture);
             }
@@ -14696,7 +14732,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6017_CodeFixTitle {
+        public static string MiKo_6017_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6017_CodeFixTitle", resourceCulture);
             }
@@ -14705,7 +14741,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;switch&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6017_Description {
+        public static string MiKo_6017_Description {
             get {
                 return ResourceManager.GetString("MiKo_6017_Description", resourceCulture);
             }
@@ -14714,7 +14750,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;switch&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6017_MessageFormat {
+        public static string MiKo_6017_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6017_MessageFormat", resourceCulture);
             }
@@ -14723,7 +14759,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to switch statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6017_Title {
+        public static string MiKo_6017_Title {
             get {
                 return ResourceManager.GetString("MiKo_6017_Title", resourceCulture);
             }
@@ -14732,7 +14768,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6018_CodeFixTitle {
+        public static string MiKo_6018_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6018_CodeFixTitle", resourceCulture);
             }
@@ -14741,7 +14777,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;break&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6018_Description {
+        public static string MiKo_6018_Description {
             get {
                 return ResourceManager.GetString("MiKo_6018_Description", resourceCulture);
             }
@@ -14750,7 +14786,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;break&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6018_MessageFormat {
+        public static string MiKo_6018_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6018_MessageFormat", resourceCulture);
             }
@@ -14759,7 +14795,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to break statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6018_Title {
+        public static string MiKo_6018_Title {
             get {
                 return ResourceManager.GetString("MiKo_6018_Title", resourceCulture);
             }
@@ -14768,7 +14804,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6019_CodeFixTitle {
+        public static string MiKo_6019_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6019_CodeFixTitle", resourceCulture);
             }
@@ -14777,7 +14813,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;continue&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6019_Description {
+        public static string MiKo_6019_Description {
             get {
                 return ResourceManager.GetString("MiKo_6019_Description", resourceCulture);
             }
@@ -14786,7 +14822,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;continue&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6019_MessageFormat {
+        public static string MiKo_6019_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6019_MessageFormat", resourceCulture);
             }
@@ -14795,7 +14831,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to continue statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6019_Title {
+        public static string MiKo_6019_Title {
             get {
                 return ResourceManager.GetString("MiKo_6019_Title", resourceCulture);
             }
@@ -14804,7 +14840,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6020_CodeFixTitle {
+        public static string MiKo_6020_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6020_CodeFixTitle", resourceCulture);
             }
@@ -14813,7 +14849,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;throw&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6020_Description {
+        public static string MiKo_6020_Description {
             get {
                 return ResourceManager.GetString("MiKo_6020_Description", resourceCulture);
             }
@@ -14822,7 +14858,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;throw&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6020_MessageFormat {
+        public static string MiKo_6020_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6020_MessageFormat", resourceCulture);
             }
@@ -14831,7 +14867,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to throw statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6020_Title {
+        public static string MiKo_6020_Title {
             get {
                 return ResourceManager.GetString("MiKo_6020_Title", resourceCulture);
             }
@@ -14840,7 +14876,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6021_CodeFixTitle {
+        public static string MiKo_6021_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6021_CodeFixTitle", resourceCulture);
             }
@@ -14849,7 +14885,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ArgumentNullException.ThrowIfNull&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6021_Description {
+        public static string MiKo_6021_Description {
             get {
                 return ResourceManager.GetString("MiKo_6021_Description", resourceCulture);
             }
@@ -14858,7 +14894,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ThrowIfNull&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6021_MessageFormat {
+        public static string MiKo_6021_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6021_MessageFormat", resourceCulture);
             }
@@ -14867,7 +14903,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ArgumentNullException.ThrowIfNull statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6021_Title {
+        public static string MiKo_6021_Title {
             get {
                 return ResourceManager.GetString("MiKo_6021_Title", resourceCulture);
             }
@@ -14876,7 +14912,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6022_CodeFixTitle {
+        public static string MiKo_6022_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6022_CodeFixTitle", resourceCulture);
             }
@@ -14885,7 +14921,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ArgumentException.ThrowIfNullOrEmpty&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6022_Description {
+        public static string MiKo_6022_Description {
             get {
                 return ResourceManager.GetString("MiKo_6022_Description", resourceCulture);
             }
@@ -14894,7 +14930,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ThrowIfNullOrEmpty&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6022_MessageFormat {
+        public static string MiKo_6022_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6022_MessageFormat", resourceCulture);
             }
@@ -14903,7 +14939,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ArgumentException.ThrowIfNullOrEmpty statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6022_Title {
+        public static string MiKo_6022_Title {
             get {
                 return ResourceManager.GetString("MiKo_6022_Title", resourceCulture);
             }
@@ -14912,7 +14948,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6023_CodeFixTitle {
+        public static string MiKo_6023_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6023_CodeFixTitle", resourceCulture);
             }
@@ -14921,7 +14957,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ArgumentOutOfRangeException.ThrowIf&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6023_Description {
+        public static string MiKo_6023_Description {
             get {
                 return ResourceManager.GetString("MiKo_6023_Description", resourceCulture);
             }
@@ -14930,7 +14966,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ThrowIf&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6023_MessageFormat {
+        public static string MiKo_6023_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6023_MessageFormat", resourceCulture);
             }
@@ -14939,7 +14975,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ArgumentOutOfRangeException.ThrowIf statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6023_Title {
+        public static string MiKo_6023_Title {
             get {
                 return ResourceManager.GetString("MiKo_6023_Title", resourceCulture);
             }
@@ -14948,7 +14984,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6024_CodeFixTitle {
+        public static string MiKo_6024_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6024_CodeFixTitle", resourceCulture);
             }
@@ -14957,7 +14993,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ObjectDisposedException.ThrowIf&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6024_Description {
+        public static string MiKo_6024_Description {
             get {
                 return ResourceManager.GetString("MiKo_6024_Description", resourceCulture);
             }
@@ -14966,7 +15002,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround &apos;ThrowIf&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6024_MessageFormat {
+        public static string MiKo_6024_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6024_MessageFormat", resourceCulture);
             }
@@ -14975,7 +15011,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to ObjectDisposedException.ThrowIf statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6024_Title {
+        public static string MiKo_6024_Title {
             get {
                 return ResourceManager.GetString("MiKo_6024_Title", resourceCulture);
             }
@@ -14984,7 +15020,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below type.
         /// </summary>
-        internal static string MiKo_6030_CodeFixTitle {
+        public static string MiKo_6030_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6030_CodeFixTitle", resourceCulture);
             }
@@ -14993,7 +15029,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place the open brace of an initializer directly below the type definition. This makes initializations clear, distinguishes them from other blocks like &apos;if&apos; blocks, and improves readability, making the code easier to follow..
         /// </summary>
-        internal static string MiKo_6030_Description {
+        public static string MiKo_6030_Description {
             get {
                 return ResourceManager.GetString("MiKo_6030_Description", resourceCulture);
             }
@@ -15002,7 +15038,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below type.
         /// </summary>
-        internal static string MiKo_6030_MessageFormat {
+        public static string MiKo_6030_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6030_MessageFormat", resourceCulture);
             }
@@ -15011,7 +15047,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Open braces of initializers should be placed directly below the corresponding type definition.
         /// </summary>
-        internal static string MiKo_6030_Title {
+        public static string MiKo_6030_Title {
             get {
                 return ResourceManager.GetString("MiKo_6030_Title", resourceCulture);
             }
@@ -15020,7 +15056,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align ternary operator directly below condition.
         /// </summary>
-        internal static string MiKo_6031_CodeFixTitle {
+        public static string MiKo_6031_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6031_CodeFixTitle", resourceCulture);
             }
@@ -15029,7 +15065,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place the question and colon tokens directly below the condition in ternary operators. This makes the two possibilities easy to spot, improves readability, and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6031_Description {
+        public static string MiKo_6031_Description {
             get {
                 return ResourceManager.GetString("MiKo_6031_Description", resourceCulture);
             }
@@ -15038,7 +15074,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align ternary operator directly below condition.
         /// </summary>
-        internal static string MiKo_6031_MessageFormat {
+        public static string MiKo_6031_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6031_MessageFormat", resourceCulture);
             }
@@ -15047,7 +15083,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Question and colon tokens of ternary operators should be placed directly below the corresponding condition.
         /// </summary>
-        internal static string MiKo_6031_Title {
+        public static string MiKo_6031_Title {
             get {
                 return ResourceManager.GetString("MiKo_6031_Title", resourceCulture);
             }
@@ -15056,7 +15092,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align parameter outdented below method.
         /// </summary>
-        internal static string MiKo_6032_CodeFixTitle {
+        public static string MiKo_6032_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6032_CodeFixTitle", resourceCulture);
             }
@@ -15065,7 +15101,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Outdent multi-line parameters below the method declaration to easily spot them. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6032_Description {
+        public static string MiKo_6032_Description {
             get {
                 return ResourceManager.GetString("MiKo_6032_Description", resourceCulture);
             }
@@ -15074,7 +15110,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align parameter &apos;{0}&apos; outdented below method.
         /// </summary>
-        internal static string MiKo_6032_MessageFormat {
+        public static string MiKo_6032_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6032_MessageFormat", resourceCulture);
             }
@@ -15083,7 +15119,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Multi-line parameters are positioned outdented at end of method.
         /// </summary>
-        internal static string MiKo_6032_Title {
+        public static string MiKo_6032_Title {
             get {
                 return ResourceManager.GetString("MiKo_6032_Title", resourceCulture);
             }
@@ -15092,7 +15128,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below case.
         /// </summary>
-        internal static string MiKo_6033_CodeFixTitle {
+        public static string MiKo_6033_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6033_CodeFixTitle", resourceCulture);
             }
@@ -15101,7 +15137,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Case sections in a switch statement are like conditions in &apos;if&apos; statements. When a condition matches, the corresponding block gets executed. Therefore, place the open brace of the block directly below the &apos;case&apos; keyword, just like &apos;if&apos; blocks..
         /// </summary>
-        internal static string MiKo_6033_Description {
+        public static string MiKo_6033_Description {
             get {
                 return ResourceManager.GetString("MiKo_6033_Description", resourceCulture);
             }
@@ -15110,7 +15146,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below case.
         /// </summary>
-        internal static string MiKo_6033_MessageFormat {
+        public static string MiKo_6033_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6033_MessageFormat", resourceCulture);
             }
@@ -15119,7 +15155,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Braces of blocks below case sections should be placed directly below the corresponding case keyword.
         /// </summary>
-        internal static string MiKo_6033_Title {
+        public static string MiKo_6033_Title {
             get {
                 return ResourceManager.GetString("MiKo_6033_Title", resourceCulture);
             }
@@ -15128,7 +15164,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place dot on same line.
         /// </summary>
-        internal static string MiKo_6034_CodeFixTitle {
+        public static string MiKo_6034_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6034_CodeFixTitle", resourceCulture);
             }
@@ -15137,7 +15173,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when dots are placed on the same lines as the invoked members. This makes the code easier to follow and understand..
         /// </summary>
-        internal static string MiKo_6034_Description {
+        public static string MiKo_6034_Description {
             get {
                 return ResourceManager.GetString("MiKo_6034_Description", resourceCulture);
             }
@@ -15146,7 +15182,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place dot on same line as member.
         /// </summary>
-        internal static string MiKo_6034_MessageFormat {
+        public static string MiKo_6034_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6034_MessageFormat", resourceCulture);
             }
@@ -15155,7 +15191,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Dots should be placed on same line(s) as invoked members.
         /// </summary>
-        internal static string MiKo_6034_Title {
+        public static string MiKo_6034_Title {
             get {
                 return ResourceManager.GetString("MiKo_6034_Title", resourceCulture);
             }
@@ -15164,7 +15200,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place parenthesis on same line.
         /// </summary>
-        internal static string MiKo_6035_CodeFixTitle {
+        public static string MiKo_6035_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6035_CodeFixTitle", resourceCulture);
             }
@@ -15173,7 +15209,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when the open parenthesis are placed on the same lines as the invoked methods. This makes the code easier to follow and understand..
         /// </summary>
-        internal static string MiKo_6035_Description {
+        public static string MiKo_6035_Description {
             get {
                 return ResourceManager.GetString("MiKo_6035_Description", resourceCulture);
             }
@@ -15182,7 +15218,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place open parenthesis on same line as invocation.
         /// </summary>
-        internal static string MiKo_6035_MessageFormat {
+        public static string MiKo_6035_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6035_MessageFormat", resourceCulture);
             }
@@ -15191,7 +15227,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Open parenthesis should be placed on same line(s) as invoked methods.
         /// </summary>
-        internal static string MiKo_6035_Title {
+        public static string MiKo_6035_Title {
             get {
                 return ResourceManager.GetString("MiKo_6035_Title", resourceCulture);
             }
@@ -15200,7 +15236,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align block directly below arrow.
         /// </summary>
-        internal static string MiKo_6036_CodeFixTitle {
+        public static string MiKo_6036_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6036_CodeFixTitle", resourceCulture);
             }
@@ -15209,7 +15245,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to To easily distinguish lambda blocks from other code blocks, position them either in line with or directly below the corresponding arrow. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6036_Description {
+        public static string MiKo_6036_Description {
             get {
                 return ResourceManager.GetString("MiKo_6036_Description", resourceCulture);
             }
@@ -15218,7 +15254,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align lambda block directly below arrow.
         /// </summary>
-        internal static string MiKo_6036_MessageFormat {
+        public static string MiKo_6036_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6036_MessageFormat", resourceCulture);
             }
@@ -15227,7 +15263,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Lambda blocks should be placed directly below the corresponding arrow(s).
         /// </summary>
-        internal static string MiKo_6036_Title {
+        public static string MiKo_6036_Title {
             get {
                 return ResourceManager.GetString("MiKo_6036_Title", resourceCulture);
             }
@@ -15236,7 +15272,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place argument on same line as invocation.
         /// </summary>
-        internal static string MiKo_6037_CodeFixTitle {
+        public static string MiKo_6037_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6037_CodeFixTitle", resourceCulture);
             }
@@ -15245,7 +15281,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when single arguments are placed on the same lines as the invoked methods. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6037_Description {
+        public static string MiKo_6037_Description {
             get {
                 return ResourceManager.GetString("MiKo_6037_Description", resourceCulture);
             }
@@ -15254,7 +15290,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place argument on same line as invocation.
         /// </summary>
-        internal static string MiKo_6037_MessageFormat {
+        public static string MiKo_6037_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6037_MessageFormat", resourceCulture);
             }
@@ -15263,7 +15299,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Single arguments should be placed on same line(s) as invoked methods.
         /// </summary>
-        internal static string MiKo_6037_Title {
+        public static string MiKo_6037_Title {
             get {
                 return ResourceManager.GetString("MiKo_6037_Title", resourceCulture);
             }
@@ -15272,7 +15308,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place cast on same line.
         /// </summary>
-        internal static string MiKo_6038_CodeFixTitle {
+        public static string MiKo_6038_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6038_CodeFixTitle", resourceCulture);
             }
@@ -15281,7 +15317,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when casts are placed on the same lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6038_Description {
+        public static string MiKo_6038_Description {
             get {
                 return ResourceManager.GetString("MiKo_6038_Description", resourceCulture);
             }
@@ -15290,7 +15326,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place cast on same line.
         /// </summary>
-        internal static string MiKo_6038_MessageFormat {
+        public static string MiKo_6038_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6038_MessageFormat", resourceCulture);
             }
@@ -15299,7 +15335,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Casts should be placed on same line(s).
         /// </summary>
-        internal static string MiKo_6038_Title {
+        public static string MiKo_6038_Title {
             get {
                 return ResourceManager.GetString("MiKo_6038_Title", resourceCulture);
             }
@@ -15308,7 +15344,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place return value on same line as return keyword.
         /// </summary>
-        internal static string MiKo_6039_CodeFixTitle {
+        public static string MiKo_6039_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6039_CodeFixTitle", resourceCulture);
             }
@@ -15317,7 +15353,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when return keywords and return values are placed on the same lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6039_Description {
+        public static string MiKo_6039_Description {
             get {
                 return ResourceManager.GetString("MiKo_6039_Description", resourceCulture);
             }
@@ -15326,7 +15362,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place return value on same line as return keyword.
         /// </summary>
-        internal static string MiKo_6039_MessageFormat {
+        public static string MiKo_6039_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6039_MessageFormat", resourceCulture);
             }
@@ -15335,7 +15371,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Return values should be placed on same line(s) as return keywords.
         /// </summary>
-        internal static string MiKo_6039_Title {
+        public static string MiKo_6039_Title {
             get {
                 return ResourceManager.GetString("MiKo_6039_Title", resourceCulture);
             }
@@ -15344,7 +15380,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Indent dots.
         /// </summary>
-        internal static string MiKo_6040_CodeFixTitle {
+        public static string MiKo_6040_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6040_CodeFixTitle", resourceCulture);
             }
@@ -15353,7 +15389,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when consecutive invocations spanning multiple lines are vertically aligned by their dots. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6040_Description {
+        public static string MiKo_6040_Description {
             get {
                 return ResourceManager.GetString("MiKo_6040_Description", resourceCulture);
             }
@@ -15362,7 +15398,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Indent dots.
         /// </summary>
-        internal static string MiKo_6040_MessageFormat {
+        public static string MiKo_6040_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6040_MessageFormat", resourceCulture);
             }
@@ -15371,7 +15407,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Consecutive invocations spaning multiple lines should be aligned by their dots.
         /// </summary>
-        internal static string MiKo_6040_Title {
+        public static string MiKo_6040_Title {
             get {
                 return ResourceManager.GetString("MiKo_6040_Title", resourceCulture);
             }
@@ -15380,7 +15416,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place assignment on same line.
         /// </summary>
-        internal static string MiKo_6041_CodeFixTitle {
+        public static string MiKo_6041_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6041_CodeFixTitle", resourceCulture);
             }
@@ -15389,7 +15425,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when assignments are placed on the same lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6041_Description {
+        public static string MiKo_6041_Description {
             get {
                 return ResourceManager.GetString("MiKo_6041_Description", resourceCulture);
             }
@@ -15398,7 +15434,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place assignment on same line.
         /// </summary>
-        internal static string MiKo_6041_MessageFormat {
+        public static string MiKo_6041_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6041_MessageFormat", resourceCulture);
             }
@@ -15407,7 +15443,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assignments should be placed on same line(s).
         /// </summary>
-        internal static string MiKo_6041_Title {
+        public static string MiKo_6041_Title {
             get {
                 return ResourceManager.GetString("MiKo_6041_Title", resourceCulture);
             }
@@ -15416,7 +15452,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place new keyword on same line as type.
         /// </summary>
-        internal static string MiKo_6042_CodeFixTitle {
+        public static string MiKo_6042_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6042_CodeFixTitle", resourceCulture);
             }
@@ -15425,7 +15461,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when object creations are placed on the same lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6042_Description {
+        public static string MiKo_6042_Description {
             get {
                 return ResourceManager.GetString("MiKo_6042_Description", resourceCulture);
             }
@@ -15434,7 +15470,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place new keyword on same line as type.
         /// </summary>
-        internal static string MiKo_6042_MessageFormat {
+        public static string MiKo_6042_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6042_MessageFormat", resourceCulture);
             }
@@ -15443,7 +15479,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to &apos;new&apos; keywords should be placed on same line(s) as the types.
         /// </summary>
-        internal static string MiKo_6042_Title {
+        public static string MiKo_6042_Title {
             get {
                 return ResourceManager.GetString("MiKo_6042_Title", resourceCulture);
             }
@@ -15452,7 +15488,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place lambda on single line.
         /// </summary>
-        internal static string MiKo_6043_CodeFixTitle {
+        public static string MiKo_6043_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6043_CodeFixTitle", resourceCulture);
             }
@@ -15461,7 +15497,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when lambdas with expression bodies are placed on a single line. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6043_Description {
+        public static string MiKo_6043_Description {
             get {
                 return ResourceManager.GetString("MiKo_6043_Description", resourceCulture);
             }
@@ -15470,7 +15506,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place lambda on single line.
         /// </summary>
-        internal static string MiKo_6043_MessageFormat {
+        public static string MiKo_6043_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6043_MessageFormat", resourceCulture);
             }
@@ -15479,7 +15515,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Expression bodies of lambdas should be placed on same line as lambda itself when fitting.
         /// </summary>
-        internal static string MiKo_6043_Title {
+        public static string MiKo_6043_Title {
             get {
                 return ResourceManager.GetString("MiKo_6043_Title", resourceCulture);
             }
@@ -15488,7 +15524,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place operator on same line as right operand.
         /// </summary>
-        internal static string MiKo_6044_CodeFixTitle {
+        public static string MiKo_6044_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6044_CodeFixTitle", resourceCulture);
             }
@@ -15497,7 +15533,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when binary operators like &apos;&amp;&amp;&apos; or &apos;||&apos; are placed on the same lines as their right-hand operands. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6044_Description {
+        public static string MiKo_6044_Description {
             get {
                 return ResourceManager.GetString("MiKo_6044_Description", resourceCulture);
             }
@@ -15506,7 +15542,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place operator on same line as right operand.
         /// </summary>
-        internal static string MiKo_6044_MessageFormat {
+        public static string MiKo_6044_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6044_MessageFormat", resourceCulture);
             }
@@ -15515,7 +15551,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Operators such as &apos;&amp;&amp;&apos; or &apos;||&apos; should be placed on same line(s) as their (right) operands.
         /// </summary>
-        internal static string MiKo_6044_Title {
+        public static string MiKo_6044_Title {
             get {
                 return ResourceManager.GetString("MiKo_6044_Title", resourceCulture);
             }
@@ -15524,7 +15560,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place comparison on same line.
         /// </summary>
-        internal static string MiKo_6045_CodeFixTitle {
+        public static string MiKo_6045_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6045_CodeFixTitle", resourceCulture);
             }
@@ -15533,7 +15569,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when comparison operators such as &apos;==&apos; or &apos;!=&apos; are placed on the same lines as their operands. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6045_Description {
+        public static string MiKo_6045_Description {
             get {
                 return ResourceManager.GetString("MiKo_6045_Description", resourceCulture);
             }
@@ -15542,7 +15578,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place comparison on same line.
         /// </summary>
-        internal static string MiKo_6045_MessageFormat {
+        public static string MiKo_6045_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6045_MessageFormat", resourceCulture);
             }
@@ -15551,7 +15587,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Comparisons using operators such as &apos;==&apos; or &apos;!=&apos; should be placed on same line(s).
         /// </summary>
-        internal static string MiKo_6045_Title {
+        public static string MiKo_6045_Title {
             get {
                 return ResourceManager.GetString("MiKo_6045_Title", resourceCulture);
             }
@@ -15560,7 +15596,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place calculation on same line.
         /// </summary>
-        internal static string MiKo_6046_CodeFixTitle {
+        public static string MiKo_6046_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6046_CodeFixTitle", resourceCulture);
             }
@@ -15569,7 +15605,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when calculations operators such as &apos;+&apos; or &apos;%&apos; are placed on the same lines as their operands. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6046_Description {
+        public static string MiKo_6046_Description {
             get {
                 return ResourceManager.GetString("MiKo_6046_Description", resourceCulture);
             }
@@ -15578,7 +15614,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place calculation on same line.
         /// </summary>
-        internal static string MiKo_6046_MessageFormat {
+        public static string MiKo_6046_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6046_MessageFormat", resourceCulture);
             }
@@ -15587,7 +15623,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Calculations using operators such as &apos;+&apos; or &apos;%&apos; should be placed on same line(s).
         /// </summary>
-        internal static string MiKo_6046_Title {
+        public static string MiKo_6046_Title {
             get {
                 return ResourceManager.GetString("MiKo_6046_Title", resourceCulture);
             }
@@ -15596,7 +15632,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below switch.
         /// </summary>
-        internal static string MiKo_6047_CodeFixTitle {
+        public static string MiKo_6047_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6047_CodeFixTitle", resourceCulture);
             }
@@ -15605,7 +15641,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Switch expressions are similar to switch statements. Therefore, the open brace of the expression should be placed directly below the &apos;switch&apos; keyword. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6047_Description {
+        public static string MiKo_6047_Description {
             get {
                 return ResourceManager.GetString("MiKo_6047_Description", resourceCulture);
             }
@@ -15614,7 +15650,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align open brace directly below switch.
         /// </summary>
-        internal static string MiKo_6047_MessageFormat {
+        public static string MiKo_6047_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6047_MessageFormat", resourceCulture);
             }
@@ -15623,7 +15659,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Braces of switch expressions should be placed directly below the corresponding switch keyword.
         /// </summary>
-        internal static string MiKo_6047_Title {
+        public static string MiKo_6047_Title {
             get {
                 return ResourceManager.GetString("MiKo_6047_Title", resourceCulture);
             }
@@ -15632,7 +15668,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place condition on single line.
         /// </summary>
-        internal static string MiKo_6048_CodeFixTitle {
+        public static string MiKo_6048_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6048_CodeFixTitle", resourceCulture);
             }
@@ -15641,7 +15677,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Logical conditions that span multiple lines are hard to read and understand. To improve readability, they should span a single line only. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6048_Description {
+        public static string MiKo_6048_Description {
             get {
                 return ResourceManager.GetString("MiKo_6048_Description", resourceCulture);
             }
@@ -15650,7 +15686,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place condition on single line.
         /// </summary>
-        internal static string MiKo_6048_MessageFormat {
+        public static string MiKo_6048_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6048_MessageFormat", resourceCulture);
             }
@@ -15659,7 +15695,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Logical conditions should be placed on a single line.
         /// </summary>
-        internal static string MiKo_6048_Title {
+        public static string MiKo_6048_Title {
             get {
                 return ResourceManager.GetString("MiKo_6048_Title", resourceCulture);
             }
@@ -15668,7 +15704,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6049_CodeFixTitle {
+        public static string MiKo_6049_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6049_CodeFixTitle", resourceCulture);
             }
@@ -15677,7 +15713,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround event registrations and un-registrations with blank lines to visually separate them from other code. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6049_Description {
+        public static string MiKo_6049_Description {
             get {
                 return ResourceManager.GetString("MiKo_6049_Description", resourceCulture);
             }
@@ -15686,7 +15722,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround event (un-)registration with a blank line.
         /// </summary>
-        internal static string MiKo_6049_MessageFormat {
+        public static string MiKo_6049_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6049_MessageFormat", resourceCulture);
             }
@@ -15695,7 +15731,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Event (un-)registrations should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6049_Title {
+        public static string MiKo_6049_Title {
             get {
                 return ResourceManager.GetString("MiKo_6049_Title", resourceCulture);
             }
@@ -15704,7 +15740,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align argument outdented below method call.
         /// </summary>
-        internal static string MiKo_6050_CodeFixTitle {
+        public static string MiKo_6050_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6050_CodeFixTitle", resourceCulture);
             }
@@ -15713,7 +15749,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Outdent multi-line arguments below the corresponding method call to easily spot them. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6050_Description {
+        public static string MiKo_6050_Description {
             get {
                 return ResourceManager.GetString("MiKo_6050_Description", resourceCulture);
             }
@@ -15722,7 +15758,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align argument &apos;{0}&apos; outdented below method call.
         /// </summary>
-        internal static string MiKo_6050_MessageFormat {
+        public static string MiKo_6050_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6050_MessageFormat", resourceCulture);
             }
@@ -15731,7 +15767,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Multi-line arguments are positioned outdented at end of method call.
         /// </summary>
-        internal static string MiKo_6050_Title {
+        public static string MiKo_6050_Title {
             get {
                 return ResourceManager.GetString("MiKo_6050_Title", resourceCulture);
             }
@@ -15740,7 +15776,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place colon on same line as constructor call.
         /// </summary>
-        internal static string MiKo_6051_CodeFixTitle {
+        public static string MiKo_6051_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6051_CodeFixTitle", resourceCulture);
             }
@@ -15749,7 +15785,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when colons leading constructor calls are placed on the same lines as the calls themselves. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6051_Description {
+        public static string MiKo_6051_Description {
             get {
                 return ResourceManager.GetString("MiKo_6051_Description", resourceCulture);
             }
@@ -15758,7 +15794,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place colon on same line as constructor call.
         /// </summary>
-        internal static string MiKo_6051_MessageFormat {
+        public static string MiKo_6051_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6051_MessageFormat", resourceCulture);
             }
@@ -15767,7 +15803,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Colon of constructor call shall be placed on same line as constructor call.
         /// </summary>
-        internal static string MiKo_6051_Title {
+        public static string MiKo_6051_Title {
             get {
                 return ResourceManager.GetString("MiKo_6051_Title", resourceCulture);
             }
@@ -15776,7 +15812,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place colon on same line as first base type.
         /// </summary>
-        internal static string MiKo_6052_CodeFixTitle {
+        public static string MiKo_6052_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6052_CodeFixTitle", resourceCulture);
             }
@@ -15785,7 +15821,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when the colons leading the list of base types are on the same line as the first base types. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6052_Description {
+        public static string MiKo_6052_Description {
             get {
                 return ResourceManager.GetString("MiKo_6052_Description", resourceCulture);
             }
@@ -15794,7 +15830,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place colon on same line as first base type.
         /// </summary>
-        internal static string MiKo_6052_MessageFormat {
+        public static string MiKo_6052_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6052_MessageFormat", resourceCulture);
             }
@@ -15803,7 +15839,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Colon of list of base types shall be placed on same line as first base type.
         /// </summary>
-        internal static string MiKo_6052_Title {
+        public static string MiKo_6052_Title {
             get {
                 return ResourceManager.GetString("MiKo_6052_Title", resourceCulture);
             }
@@ -15812,7 +15848,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place argument on single line.
         /// </summary>
-        internal static string MiKo_6053_CodeFixTitle {
+        public static string MiKo_6053_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6053_CodeFixTitle", resourceCulture);
             }
@@ -15821,7 +15857,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when single-line arguments are kept on a single line instead of splitting them over multiple lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6053_Description {
+        public static string MiKo_6053_Description {
             get {
                 return ResourceManager.GetString("MiKo_6053_Description", resourceCulture);
             }
@@ -15830,7 +15866,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place argument on single line.
         /// </summary>
-        internal static string MiKo_6053_MessageFormat {
+        public static string MiKo_6053_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6053_MessageFormat", resourceCulture);
             }
@@ -15839,7 +15875,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Single-line arguments shall be placed on single line.
         /// </summary>
-        internal static string MiKo_6053_Title {
+        public static string MiKo_6053_Title {
             get {
                 return ResourceManager.GetString("MiKo_6053_Title", resourceCulture);
             }
@@ -15848,7 +15884,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place lambda arrow on same line as its parameter(s).
         /// </summary>
-        internal static string MiKo_6054_CodeFixTitle {
+        public static string MiKo_6054_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6054_CodeFixTitle", resourceCulture);
             }
@@ -15857,7 +15893,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when the arrow of lambda expressions is on the same line as the parameters or their expression bodies. Avoid splitting them over multiple lines. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6054_Description {
+        public static string MiKo_6054_Description {
             get {
                 return ResourceManager.GetString("MiKo_6054_Description", resourceCulture);
             }
@@ -15866,7 +15902,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place lambda arrow on same line as its parameter(s).
         /// </summary>
-        internal static string MiKo_6054_MessageFormat {
+        public static string MiKo_6054_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6054_MessageFormat", resourceCulture);
             }
@@ -15875,7 +15911,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Lambda arrows shall be placed on same line as the parameter(s) of the lambda.
         /// </summary>
-        internal static string MiKo_6054_Title {
+        public static string MiKo_6054_Title {
             get {
                 return ResourceManager.GetString("MiKo_6054_Title", resourceCulture);
             }
@@ -15884,7 +15920,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6055_CodeFixTitle {
+        public static string MiKo_6055_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6055_CodeFixTitle", resourceCulture);
             }
@@ -15893,7 +15929,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround assignments with blank lines to visually separate them from invocations. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6055_Description {
+        public static string MiKo_6055_Description {
             get {
                 return ResourceManager.GetString("MiKo_6055_Description", resourceCulture);
             }
@@ -15902,7 +15938,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround assignment with a blank line.
         /// </summary>
-        internal static string MiKo_6055_MessageFormat {
+        public static string MiKo_6055_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6055_MessageFormat", resourceCulture);
             }
@@ -15911,7 +15947,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Assignment statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6055_Title {
+        public static string MiKo_6055_Title {
             get {
                 return ResourceManager.GetString("MiKo_6055_Title", resourceCulture);
             }
@@ -15920,7 +15956,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align collection expression brackets.
         /// </summary>
-        internal static string MiKo_6056_CodeFixTitle {
+        public static string MiKo_6056_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6056_CodeFixTitle", resourceCulture);
             }
@@ -15929,7 +15965,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Collection expressions are similar to collection initializers in terms of readability. Therefore, place their open brackets in the same position as the collection initializer braces. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6056_Description {
+        public static string MiKo_6056_Description {
             get {
                 return ResourceManager.GetString("MiKo_6056_Description", resourceCulture);
             }
@@ -15938,7 +15974,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align collection expression brackets.
         /// </summary>
-        internal static string MiKo_6056_MessageFormat {
+        public static string MiKo_6056_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6056_MessageFormat", resourceCulture);
             }
@@ -15947,7 +15983,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned.
         /// </summary>
-        internal static string MiKo_6056_Title {
+        public static string MiKo_6056_Title {
             get {
                 return ResourceManager.GetString("MiKo_6056_Title", resourceCulture);
             }
@@ -15956,7 +15992,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align type parameter constraint vertically along with others.
         /// </summary>
-        internal static string MiKo_6057_CodeFixTitle {
+        public static string MiKo_6057_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6057_CodeFixTitle", resourceCulture);
             }
@@ -15965,7 +16001,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when type parameter constraint clauses are aligned vertically. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6057_Description {
+        public static string MiKo_6057_Description {
             get {
                 return ResourceManager.GetString("MiKo_6057_Description", resourceCulture);
             }
@@ -15974,7 +16010,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align type parameter constraint vertically along with others.
         /// </summary>
-        internal static string MiKo_6057_MessageFormat {
+        public static string MiKo_6057_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6057_MessageFormat", resourceCulture);
             }
@@ -15983,7 +16019,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type parameter constraint clauses should be aligned vertically.
         /// </summary>
-        internal static string MiKo_6057_Title {
+        public static string MiKo_6057_Title {
             get {
                 return ResourceManager.GetString("MiKo_6057_Title", resourceCulture);
             }
@@ -15992,7 +16028,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align type parameter constraint indented below parameter list.
         /// </summary>
-        internal static string MiKo_6058_CodeFixTitle {
+        public static string MiKo_6058_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6058_CodeFixTitle", resourceCulture);
             }
@@ -16001,7 +16037,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when type parameter constraint clauses are indented below the parameter list. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6058_Description {
+        public static string MiKo_6058_Description {
             get {
                 return ResourceManager.GetString("MiKo_6058_Description", resourceCulture);
             }
@@ -16010,7 +16046,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align type parameter constraint indented below parameter list.
         /// </summary>
-        internal static string MiKo_6058_MessageFormat {
+        public static string MiKo_6058_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6058_MessageFormat", resourceCulture);
             }
@@ -16019,7 +16055,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Type parameter constraint clauses should be indented below parameter list.
         /// </summary>
-        internal static string MiKo_6058_Title {
+        public static string MiKo_6058_Title {
             get {
                 return ResourceManager.GetString("MiKo_6058_Title", resourceCulture);
             }
@@ -16028,7 +16064,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align condition outdented.
         /// </summary>
-        internal static string MiKo_6059_CodeFixTitle {
+        public static string MiKo_6059_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6059_CodeFixTitle", resourceCulture);
             }
@@ -16037,7 +16073,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Outdent multi-line conditions below the corresponding call to make them easier to read. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6059_Description {
+        public static string MiKo_6059_Description {
             get {
                 return ResourceManager.GetString("MiKo_6059_Description", resourceCulture);
             }
@@ -16046,7 +16082,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Align condition outdented.
         /// </summary>
-        internal static string MiKo_6059_MessageFormat {
+        public static string MiKo_6059_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6059_MessageFormat", resourceCulture);
             }
@@ -16055,7 +16091,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Multi-line conditions are positioned outdented below associated calls.
         /// </summary>
-        internal static string MiKo_6059_Title {
+        public static string MiKo_6059_Title {
             get {
                 return ResourceManager.GetString("MiKo_6059_Title", resourceCulture);
             }
@@ -16064,7 +16100,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place switch case label on single line.
         /// </summary>
-        internal static string MiKo_6060_CodeFixTitle {
+        public static string MiKo_6060_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6060_CodeFixTitle", resourceCulture);
             }
@@ -16073,7 +16109,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when switch case labels span a single line. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6060_Description {
+        public static string MiKo_6060_Description {
             get {
                 return ResourceManager.GetString("MiKo_6060_Description", resourceCulture);
             }
@@ -16082,7 +16118,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place switch case label on single line.
         /// </summary>
-        internal static string MiKo_6060_MessageFormat {
+        public static string MiKo_6060_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6060_MessageFormat", resourceCulture);
             }
@@ -16091,7 +16127,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Switch case labels should be placed on same line.
         /// </summary>
-        internal static string MiKo_6060_Title {
+        public static string MiKo_6060_Title {
             get {
                 return ResourceManager.GetString("MiKo_6060_Title", resourceCulture);
             }
@@ -16100,7 +16136,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place switch expression arm on single line.
         /// </summary>
-        internal static string MiKo_6061_CodeFixTitle {
+        public static string MiKo_6061_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6061_CodeFixTitle", resourceCulture);
             }
@@ -16109,7 +16145,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Code readability improves when switch expression arms span a single line. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6061_Description {
+        public static string MiKo_6061_Description {
             get {
                 return ResourceManager.GetString("MiKo_6061_Description", resourceCulture);
             }
@@ -16118,7 +16154,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Place switch expression arm on single line.
         /// </summary>
-        internal static string MiKo_6061_MessageFormat {
+        public static string MiKo_6061_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6061_MessageFormat", resourceCulture);
             }
@@ -16127,7 +16163,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Switch expression arms should be placed on same line.
         /// </summary>
-        internal static string MiKo_6061_Title {
+        public static string MiKo_6061_Title {
             get {
                 return ResourceManager.GetString("MiKo_6061_Title", resourceCulture);
             }
@@ -16136,7 +16172,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6070_CodeFixTitle {
+        public static string MiKo_6070_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6070_CodeFixTitle", resourceCulture);
             }
@@ -16145,7 +16181,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround Console input/output with blank lines to visually separate them from business code. This makes the code clearer and easier to follow..
         /// </summary>
-        internal static string MiKo_6070_Description {
+        public static string MiKo_6070_Description {
             get {
                 return ResourceManager.GetString("MiKo_6070_Description", resourceCulture);
             }
@@ -16154,7 +16190,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround Console statement(s) with blank lines.
         /// </summary>
-        internal static string MiKo_6070_MessageFormat {
+        public static string MiKo_6070_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6070_MessageFormat", resourceCulture);
             }
@@ -16163,7 +16199,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Console statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6070_Title {
+        public static string MiKo_6070_Title {
             get {
                 return ResourceManager.GetString("MiKo_6070_Title", resourceCulture);
             }
@@ -16172,7 +16208,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
-        internal static string MiKo_6071_CodeFixTitle {
+        public static string MiKo_6071_CodeFixTitle {
             get {
                 return ResourceManager.GetString("MiKo_6071_CodeFixTitle", resourceCulture);
             }
@@ -16181,7 +16217,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround local &apos;using&apos; statements with blank lines to visually separate them from other code. This improves readability and makes the code easier to follow..
         /// </summary>
-        internal static string MiKo_6071_Description {
+        public static string MiKo_6071_Description {
             get {
                 return ResourceManager.GetString("MiKo_6071_Description", resourceCulture);
             }
@@ -16190,7 +16226,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Surround local &apos;using&apos; with a blank line.
         /// </summary>
-        internal static string MiKo_6071_MessageFormat {
+        public static string MiKo_6071_MessageFormat {
             get {
                 return ResourceManager.GetString("MiKo_6071_MessageFormat", resourceCulture);
             }
@@ -16199,7 +16235,7 @@ namespace MiKoSolutions.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Local using statements should be surrounded by blank lines.
         /// </summary>
-        internal static string MiKo_6071_Title {
+        public static string MiKo_6071_Title {
             get {
                 return ResourceManager.GetString("MiKo_6071_Title", resourceCulture);
             }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1123,6 +1123,18 @@ Example:
   <data name="MiKo_1078_Title" xml:space="preserve">
     <value>Builder method names should start with 'Build'</value>
   </data>
+  <data name="MiKo_1079_CodeFixTitle" xml:space="preserve">
+    <value>Remove suffix 'Repository'</value>
+  </data>
+  <data name="MiKo_1079_Description" xml:space="preserve">
+    <value>DDD defines repository classes. However, those classes should not be suffixed with 'Repository' as everybody understands different things as a repository.</value>
+  </data>
+  <data name="MiKo_1079_MessageFormat" xml:space="preserve">
+    <value>Remove suffix 'Repository'</value>
+  </data>
+  <data name="MiKo_1079_Title" xml:space="preserve">
+    <value>Repositories should not be suffixed with 'Repository'</value>
+  </data>
   <data name="MiKo_1080_Description" xml:space="preserve">
     <value>It is much easier to read a number inside a name if it is written as number and not its spelling (e.g. 'issue42' in contrast to 'issueFortyTwo').</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_CodeFixProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1079_CodeFixProvider)), Shared]
+    public sealed class MiKo_1079_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1079";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1079_RepositorySuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1079";
+
+        private const string Repository = nameof(Repository);
+
+        public MiKo_1079_RepositorySuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        {
+        }
+
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.Length > Repository.Length;
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name;
+
+            return symbolName.EndsWith(Repository, StringComparison.Ordinal)
+                   ? new[] { Issue(symbol, CreateBetterNameProposal(FindBetterName(symbolName))) }
+                   : Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string name) => Pluralizer.MakePluralName(name.WithoutSuffix(Repository));
+    }
+}

--- a/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
@@ -65,6 +65,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("access", ExpectedResult = "accesses")]
         [TestCase("accesses", ExpectedResult = "accesses")]
         [TestCase("aircraft", ExpectedResult = "aircraft")]
+        [TestCase("Child", ExpectedResult = "Children")]
         [TestCase("Children", ExpectedResult = "Children")]
         [TestCase("Data", ExpectedResult = "Data")]
         [TestCase("Indices", ExpectedResult = "Indices")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzerTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1079_RepositorySuffixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_repository_class() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+    }
+");
+
+        [Test]
+        public void No_issue_is_reported_for_repository_class_that_cannot_be_renamed() => No_issue_is_reported_for(@"
+using System;
+
+public class Repository
+{
+    public void DoSomething()
+    {
+    }
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_named_repository_class() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMeRepository
+{
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [TestCase("UserRepository", "Users")]
+        [TestCase("ChildRepository", "Children")]
+        public void Code_gets_fixed_for_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+
+public class ###
+{
+    public void DoSomething()
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1079_RepositorySuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1079_RepositorySuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1079_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 471 rules that are currently provided by the analyzer.
+The following tables lists all the 472 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -109,6 +109,7 @@ The following tables lists all the 471 rules that are currently provided by the 
 |MiKo_1076|Prism event types should be suffixed with 'Event'|&#x2713;|&#x2713;|
 |MiKo_1077|Enum members should not be suffixed with 'Enum'|&#x2713;|&#x2713;|
 |MiKo_1078|Builder method names should start with 'Build'|&#x2713;|&#x2713;|
+|MiKo_1079|Repositories should not be suffixed with 'Repository'|&#x2713;|&#x2713;|
 |MiKo_1080|Names should contain numbers instead of their spellings|&#x2713;|\-|
 |MiKo_1081|Methods should not be suffixed with a number|&#x2713;|&#x2713;|
 |MiKo_1082|Properties should not be suffixed with a number if their types have number suffixes|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Introduced a new analyzer `MiKo_1079_RepositorySuffixAnalyzer` to enforce naming rules for repository classes in DDD.
- Added a corresponding code fix provider `MiKo_1079_CodeFixProvider` to suggest and apply better class names.
- Updated project configuration files to include the new analyzer and code fix provider.
- Added resources for the new rule, including title, description, and message format.
- Updated the README to document the new rule and increment the rule count.
- Extended the `Pluralizer` logic and tests to correctly handle pluralization of "Child" to "Children".
