### PR TITLE
MiKo_3105 is now aware of 'Assert.ThatAsync'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzer.cs
@@ -15,6 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static readonly HashSet<string> AllowedAssertionMethods = new HashSet<string>
                                                                               {
+                                                                                  "ThatAsync",
                                                                                   "That",
                                                                                   "Fail",
                                                                                   "Pass",

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -135,9 +135,31 @@ namespace Bla
 {
     public class TestMe
     {
+        [Test]
         public void DoSomething()
         {
             Assert.Multiple(() => { });
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_a_AssertThatAsync() => No_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Test]
+        public async Task DoSomethingAsync()
+        {
+            var result = true;
+
+            await Assert.ThatAsync(() => Task.FromResult(result), Is.EqualTo(true));
         }
     }
 }


### PR DESCRIPTION
- Added support for `Assert.ThatAsync` in `MiKo_3105_TestMethodsUseAssertThatAnalyzer`.
- Updated test cases to validate `Assert.ThatAsync` usage.
