### PR TITLE
MiKo_2215 now calls 'WithoutXmlCommentExterior' once

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3406,14 +3406,12 @@ namespace MiKoSolutions.Analyzers
         {
             var builder = StringBuilderCache.Acquire();
 
-            var trimmed = builder.WithoutXmlCommentExterior(value).Trim();
+            var trimmed = builder.Append(value).WithoutXmlCommentExterior().Trim();
 
             StringBuilderCache.Release(builder);
 
             return trimmed;
         }
-
-        internal static StringBuilder WithoutXmlCommentExterior(this StringBuilder value, SyntaxNode node) => value.Append(node).WithoutXmlCommentExterior();
 
         internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this XmlElementSyntax value, params string[] startTexts) => value.Content.WithoutStartText(startTexts);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
@@ -57,10 +57,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var syntax in node.DescendantNodes(_ => _.IsCode() is false, true).OfType<XmlTextSyntax>())
                 {
-                    builder.Append(' ').WithoutXmlCommentExterior(syntax).Append(' ');
+                    builder.Append(' ').Append(syntax).Append(' ');
                 }
 
-                var specificComment = builder.Trim();
+                var specificComment = builder.WithoutXmlCommentExterior().Trim();
 
                 StringBuilderCache.Release(builder);
 


### PR DESCRIPTION
- Adjusted logic in `MiKo_2215_SentencesShallBeShortAnalyzer.cs` for better clarity.
- Refactored `WithoutXmlCommentExterior` method for improved efficiency.
- Simplified method chaining in `SyntaxNodeExtensions.cs`.
- Removed redundant method overload in `SyntaxNodeExtensions.cs`.


