### PR TITLE
Added new rule MiKo_4105 that reports if 'objectUnderTest' fields are not the first fields

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -315,6 +315,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4102_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4103_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4104_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4105_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\Orderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\OrderingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5001_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -471,6 +471,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4102_TestTearDownMethodOrderingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4103_TestOneTimeSetUpMethodOrderingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4104_TestOneTimeTearDownMethodOrderingAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\Orderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\OrderingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\TestMethodsOrderingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13822,6 +13822,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place field before all other fields.
+        /// </summary>
+        internal static string MiKo_4105_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_4105_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field that contains the object under test is an essential part of a test class. To make them easy to find, place these fields first..
+        /// </summary>
+        internal static string MiKo_4105_Description {
+            get {
+                return ResourceManager.GetString("MiKo_4105_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place object under test field before all other fields.
+        /// </summary>
+        internal static string MiKo_4105_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_4105_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Object under test fields should be ordered before all other fields.
+        /// </summary>
+        internal static string MiKo_4105_Title {
+            get {
+                return ResourceManager.GetString("MiKo_4105_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Place inside &apos;if&apos;.
         /// </summary>
         internal static string MiKo_5001_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4830,6 +4830,18 @@ This organization ensures clarity and makes the code easier to find, understand 
   <data name="MiKo_4104_Title" xml:space="preserve">
     <value>One-Time test cleanup methods should be ordered directly after One-Time test initialization methods</value>
   </data>
+  <data name="MiKo_4105_CodeFixTitle" xml:space="preserve">
+    <value>Place field before all other fields</value>
+  </data>
+  <data name="MiKo_4105_Description" xml:space="preserve">
+    <value>The field that contains the object under test is an essential part of a test class. To make them easy to find, place these fields first.</value>
+  </data>
+  <data name="MiKo_4105_MessageFormat" xml:space="preserve">
+    <value>Place object under test field before all other fields</value>
+  </data>
+  <data name="MiKo_4105_Title" xml:space="preserve">
+    <value>Object under test fields should be ordered before all other fields</value>
+  </data>
   <data name="MiKo_5001_CodeFixTitle" xml:space="preserve">
     <value>Place inside 'if'</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs
@@ -20,11 +20,19 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
         {
             var ctors = GetMethodsOrderedByLocation(symbol, MethodKind.Constructor);
             var methods = GetMethodsOrderedByLocation(symbol);
-            var methodsAndCtors = ctors.Concat(methods).ToList();
 
-            return methodsAndCtors.Count != 0
-                   ? AnalyzeMethods(methodsAndCtors)
-                   : Array.Empty<Diagnostic>();
+            var count = ctors.Count + methods.Count;
+
+            if (count <= 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var methodsAndCtors = new List<IMethodSymbol>(count);
+            methodsAndCtors.AddRange(ctors);
+            methodsAndCtors.AddRange(methods);
+
+            return AnalyzeMethods(methodsAndCtors);
         }
 
         private IEnumerable<Diagnostic> AnalyzeMethods(IEnumerable<IMethodSymbol> methods)

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs
@@ -23,15 +23,23 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             if (symbol.IsRecord)
             {
                 // filter primary ctors (as we cannot re-align those)
-                ctors = ctors.Where(_ => _.IsPrimaryConstructor() is false);
+                ctors = ctors.Where(_ => _.IsPrimaryConstructor() is false).ToList();
             }
 
             var methods = GetMethodsOrderedByLocation(symbol);
-            var methodsAndCtors = ctors.Concat(methods).ToList();
 
-            return methodsAndCtors.Count != 0
-                   ? AnalyzeMethodsGroupedByAccessibility(methodsAndCtors)
-                   : Array.Empty<Diagnostic>();
+            var count = ctors.Count + methods.Count;
+
+            if (count <= 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var methodsAndCtors = new List<IMethodSymbol>(count);
+            methodsAndCtors.AddRange(ctors);
+            methodsAndCtors.AddRange(methods);
+
+            return AnalyzeMethodsGroupedByAccessibility(methodsAndCtors);
         }
 
         private IEnumerable<Diagnostic> AnalyzeMethodsGroupedByAccessibility(IList<IMethodSymbol> allMethods) => allMethods.GroupBy(_ => _.DeclaredAccessibility)

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs
@@ -32,8 +32,8 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             var ctors = GetMethodsOrderedByLocation(symbol, MethodKind.Constructor).Select(_ => _.GetStartingLine()).ToList();
             var finalizers = GetMethodsOrderedByLocation(symbol, MethodKind.Destructor).Select(_ => _.GetStartingLine()).ToList();
 
-            var ordinaryMethods = GetMethodsOrderedByLocation(symbol).ToList();
-            var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation).ToList();
+            var ordinaryMethods = GetMethodsOrderedByLocation(symbol);
+            var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation);
 
             var ordinaryDisposeMethods = ordinaryMethods.Where(_ => _.DeclaredAccessibility == Accessibility.Public && _.Parameters.None() && _.Name == nameof(IDisposable.Dispose)).ToList();
             var interfaceDisposeMethods = interfaceImplementations.Where(_ => _.Parameters.None() && _.Name == nameof(System) + "." + nameof(IDisposable) + "." + nameof(IDisposable.Dispose)).ToList();

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
         private IEnumerable<Diagnostic> AnalyzeTypeCore(INamedTypeSymbol symbol)
         {
-            var ordinaryMethods = GetMethodsOrderedByLocation(symbol).ToList();
+            var ordinaryMethods = GetMethodsOrderedByLocation(symbol);
 
             foreach (var accessibility in Accessibilities)
             {
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
                 if (accessibility == Accessibility.Public && disposeMethods.Count == 0)
                 {
-                    var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation).ToList();
+                    var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation);
                     disposeMethods = interfaceImplementations.Where(_ => _.Parameters.None() && _.Name == nameof(System) + "." + nameof(IDisposable) + "." + nameof(IDisposable.Dispose)).ToList();
                 }
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4007_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4007_CodeFixProvider.cs
@@ -11,13 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4007";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
-        {
-            var modifiedType = typeSyntax.RemoveNodeAndAdjustOpenCloseBraces(syntax);
-            var method = modifiedType.FirstChild<MethodDeclarationSyntax>();
-
-            // place before all other methods
-            return modifiedType.InsertNodeBefore(method, syntax);
-        }
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax); // place before all other methods
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
@@ -11,15 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4103";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
-        {
-            var method = (MethodDeclarationSyntax)syntax;
-
-            var modifiedType = typeSyntax.RemoveNodeAndAdjustOpenCloseBraces(method);
-
-            var firstMethod = modifiedType.FirstChild<MethodDeclarationSyntax>();
-
-            return modifiedType.InsertNodeBefore(firstMethod, method);
-        }
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_CodeFixProvider.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Ordering
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_4105_CodeFixProvider)), Shared]
+    public sealed class MiKo_4105_CodeFixProvider : OrderingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_4105";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<FieldDeclarationSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<FieldDeclarationSyntax>(syntax, typeSyntax);
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Ordering
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer : OrderingAnalyzer
+    {
+        public const string Id = "MiKo_4105";
+
+        public MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
+        {
+            var field = symbol.GetFields().FirstOrDefault(_ => Constants.Names.TypeUnderTestFieldNames.Contains(_.Name));
+
+            return field is null
+                   ? Array.Empty<Diagnostic>()
+                   : AnalyzeTestType(symbol, field);
+        }
+
+        private Diagnostic[] AnalyzeTestType(INamedTypeSymbol symbol, IFieldSymbol field)
+        {
+            var path = field.Locations.First(_ => _.IsInSource).GetLineSpan().Path;
+
+            var fields = GetFieldsOrderedByLocation(symbol, path);
+            var firstField = fields[0];
+
+            return ReferenceEquals(field, firstField)
+                   ? Array.Empty<Diagnostic>()
+                   : new[] { Issue(field) };
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Ordering/OrderingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/OrderingAnalyzer.cs
@@ -11,10 +11,16 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
         {
         }
 
-        protected static IEnumerable<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, MethodKind kind = MethodKind.Ordinary) => GetMethodsOrderedByLocation(type, type.Locations.First(_ => _.IsInSource).GetLineSpan().Path, kind);
+        protected static IReadOnlyList<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, MethodKind kind = MethodKind.Ordinary) => GetMethodsOrderedByLocation(type, type.Locations.First(_ => _.IsInSource).GetLineSpan().Path, kind);
 
-        protected static IEnumerable<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, string path, MethodKind kind = MethodKind.Ordinary) => type.GetMethods(kind)
-                                                                                                                                                                  .Where(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().Path == path)
-                                                                                                                                                                  .OrderBy(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().StartLinePosition);
+        protected static IReadOnlyList<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, string path, MethodKind kind = MethodKind.Ordinary) => type.GetMethods(kind)
+                                                                                                                                                                    .Where(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().Path == path)
+                                                                                                                                                                    .OrderBy(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().StartLinePosition)
+                                                                                                                                                                    .ToList();
+
+        protected static IReadOnlyList<IFieldSymbol> GetFieldsOrderedByLocation(INamedTypeSymbol type, string path) => type.GetFields()
+                                                                                                                           .Where(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().Path == path)
+                                                                                                                           .OrderBy(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().StartLinePosition)
+                                                                                                                           .ToList();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/OrderingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/OrderingCodeFixProvider.cs
@@ -8,7 +8,16 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 {
     public abstract class OrderingCodeFixProvider : MiKoCodeFixProvider
     {
-        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.First();
+        protected static SyntaxNode PlaceFirst<T>(SyntaxNode syntax, BaseTypeDeclarationSyntax typeSyntax) where T : SyntaxNode
+        {
+            var modifiedType = typeSyntax.RemoveNodeAndAdjustOpenCloseBraces(syntax);
+
+            var firstChild = modifiedType.FirstChild<T>();
+
+            return modifiedType.InsertNodeBefore(firstChild, syntax);
+        }
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.First();
 
         protected sealed override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => syntax;
 

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzerTests.cs
@@ -1,0 +1,309 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Ordering
+{
+    [TestFixture]
+    public sealed class MiKo_4105_ObjectUnderTestFieldOrderingAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_test_class_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+[" + fixture + @"]
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_a_test_class_with_only_a_Test_method_(
+                                                                               [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                               [ValueSource(nameof(Tests))] string test)
+            => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+[" + fixture + @"]
+public class TestMe
+{
+    [" + test + @"]
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_a_test_class_with_the_field_as_the_only_field_(
+                                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                        [ValueSource(nameof(Tests))] string test)
+            => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[" + fixture + @"]
+public class TestMeTests
+{
+    private TestMe _objectUnderTest;
+
+    [" + test + @"]
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_a_test_class_with_the_field_as_very_first_field_(
+                                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                          [ValueSource(nameof(Tests))] string test)
+            => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[" + fixture + @"]
+public class TestMeTests
+{
+    private TestMe _objectUnderTest;
+    private int _someField;
+
+    [" + test + @"]
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_a_test_class_with_the_field_as_non_first_field_(
+                                                                                         [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                         [ValueSource(nameof(Tests))] string test)
+            => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[" + fixture + @"]
+public class TestMeTests
+{
+    private int _someField;
+    private TestMe _objectUnderTest;
+
+    [" + test + @"]
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_field_as_last_field()
+        {
+            const string OriginalCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    private int _someField1;
+    private int _someField2;
+    private TestMe _objectUnderTest;
+
+    [Test]
+    public void DoSomething()
+    {
+    }
+}";
+
+            const string FixedCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    private TestMe _objectUnderTest;
+    private int _someField1;
+    private int _someField2;
+
+    [Test]
+    public void DoSomething()
+    {
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_field_as_middle_field()
+        {
+            const string OriginalCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    private int _someField1;
+    private TestMe _objectUnderTest;
+    private int _someField2;
+
+    [Test]
+    public void DoSomething()
+    {
+    }
+}";
+
+            const string FixedCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    private TestMe _objectUnderTest;
+    private int _someField1;
+    private int _someField2;
+
+    [Test]
+    public void DoSomething()
+    {
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_field_as_last_field_if_all_fields_are_at_end_of_type()
+        {
+            const string OriginalCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething()
+    {
+    }
+
+    private int _someField1;
+    private int _someField2;
+    private TestMe _objectUnderTest;
+}";
+
+            const string FixedCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething()
+    {
+    }
+
+    private TestMe _objectUnderTest;
+    private int _someField1;
+    private int _someField2;
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_field_as_middle_field_if_all_fields_are_at_end_of_type()
+        {
+            const string OriginalCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething()
+    {
+    }
+
+    private int _someField1;
+    private TestMe _objectUnderTest;
+    private int _someField2;
+}";
+
+            const string FixedCode = @"
+using NUnit.Framework;
+
+public class TestMe
+{
+}
+
+[TestFixture]
+public class TestMeTests
+{
+    [Test]
+    public void DoSomething()
+    {
+    }
+
+    private TestMe _objectUnderTest;
+    private int _someField1;
+    private int _someField2;
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_4105_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 473 rules that are currently provided by the analyzer.
+The following tables lists all the 474 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -440,6 +440,7 @@ The following tables lists all the 473 rules that are currently provided by the 
 |MiKo_4102|Test cleanup methods should be ordered after test initialization methods and before test methods|&#x2713;|&#x2713;|
 |MiKo_4103|One-Time test initialization methods should be ordered before all other methods|&#x2713;|&#x2713;|
 |MiKo_4104|One-Time test cleanup methods should be ordered directly after One-Time test initialization methods|&#x2713;|&#x2713;|
+|MiKo_4105|Object under test fields should be ordered before all other fields|&#x2713;|&#x2713;|
 
 ### Performance
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Introduced a new rule `MiKo_4105` to ensure "object under test" fields are the first fields in test classes.
- Added code fix provider for `MiKo_4105` to automatically reorder fields.
- Added comprehensive unit tests for `MiKo_4105` to validate functionality.
- Updated existing analyzers and code fix providers for consistency and performance improvements.

(resolves #1146)