### PR TITLE
MiKo_3401 is now aware of nested "combined" namespaces

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzer.cs
@@ -24,14 +24,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static int GetNamespaceDepth(NamespaceDeclarationSyntax declaration)
         {
-            var parentNamespaces = declaration.Ancestors<NamespaceDeclarationSyntax>().ToList();
+            var parentNamespacesCount = declaration.Ancestors<NamespaceDeclarationSyntax>().Sum(CountNamespaces);
 
-            if (parentNamespaces.Count != 0)
-            {
-                return parentNamespaces.Sum(CountNamespaces) + 1;
-            }
-
-            return CountNamespaces(declaration);
+            return parentNamespacesCount + CountNamespaces(declaration);
         }
 
         private void AnalyzeNamespace(SyntaxNodeAnalysisContext context)

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzerTests.cs
@@ -34,16 +34,44 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                  ];
 
         [Test]
-        public void No_issue_is_reported_for_namespace_within_depth_([ValueSource(nameof(AllowedNamespaceNames))]string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_within_depth_([ValueSource(nameof(AllowedNamespaceNames))] string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_namespace_that_exceeds_depth_([ValueSource(nameof(TooDeepNamespaceNames))]string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_that_exceeds_depth_([ValueSource(nameof(TooDeepNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @"
 {
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_namespace_that_just_exceeds_depth() => An_issue_is_reported_for(@"
+namespace A
+{
+    namespace B
+    {
+        namespace C
+        {
+            namespace D
+            {
+                namespace E
+                {
+                    namespace F
+                    {
+                        namespace G
+                        {
+                            namespace H
+                            {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 ");
 
@@ -75,6 +103,16 @@ namespace A
                 }
             }
         }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_combined_namespace_that_exceeds_depth() => An_issue_is_reported_for(@"
+namespace A.B.C.D
+{
+    namespace E.F.G.H
+    {
     }
 }
 ");


### PR DESCRIPTION
- Fixed namespace depth calculation to handle nested combined namespaces.
- Updated logic in `GetNamespaceDepth` for accurate depth computation.
- Added new test cases for nested and combined namespaces exceeding depth.
- Improved test formatting and consistency in namespace depth analyzer tests.
