### PR TITLE
Improved performance, renamed 'Filter' methods

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -584,6 +584,11 @@ namespace System
 
             if (difference < 0)
             {
+                if (comparison == StringComparison.Ordinal)
+                {
+                    return value.AsSpan().IndexOf(finding.AsSpan()) >= 0;
+                }
+
                 return value.IndexOf(finding, comparison) >= 0;
             }
 

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -430,7 +430,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                         return word;
                     }
 
-                    if (word.EndsWith("thing", StringComparison.CurrentCultureIgnoreCase))
+                    if (word.EndsWith("thing", StringComparison.OrdinalIgnoreCase))
                     {
                         return word;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
@@ -92,7 +92,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IgnoreBasedOnParent(LiteralExpressionSyntax node)
         {
-            var parent = FilterUnimportantParents(node);
+            var parent = SkipUnimportantParents(node);
             var kind = parent?.Kind();
 
             switch (kind)
@@ -150,9 +150,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static SyntaxNode FilterUnimportantParents(LiteralExpressionSyntax node)
+        private static SyntaxNode SkipUnimportantParents(LiteralExpressionSyntax node)
         {
-            var parent = FilterUnimportantUnaryParents(node.Parent);
+            var parent = SkipUnimportantUnaryParents(node.Parent);
 
             if (parent != null && parent.IsKind(SyntaxKind.ParenthesizedExpression))
             {
@@ -162,7 +162,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return parent;
         }
 
-        private static SyntaxNode FilterUnimportantUnaryParents(SyntaxNode parent)
+        private static SyntaxNode SkipUnimportantUnaryParents(SyntaxNode parent)
         {
             switch (parent?.Kind())
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        private static void FilterIdenticalParameters(List<IParameterSymbol> referenceParameters, List<IParameterSymbol> otherParameters)
+        private static void RemoveIdenticalParameters(List<IParameterSymbol> referenceParameters, List<IParameterSymbol> otherParameters)
         {
             var otherIndex = 0;
             var referenceIndex = 0;
@@ -84,13 +84,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     referenceParameters.Reverse();
                     otherParameters.Reverse();
 
-                    FilterIdenticalParameters(referenceParameters, otherParameters);
+                    RemoveIdenticalParameters(referenceParameters, otherParameters);
 
                     referenceParameters.Reverse();
                     otherParameters.Reverse();
                 }
 
-                FilterIdenticalParameters(referenceParameters, otherParameters);
+                RemoveIdenticalParameters(referenceParameters, otherParameters);
 
                 var referenceIndex = 0;
                 var otherIndex = 0;


### PR DESCRIPTION
- Improved performance in `StringExtensions.Contains` using `Span` for ordinal comparison.

- Updated `CreateInfiniteVerb` to use `OrdinalIgnoreCase` for string comparison.

- Renamed methods for better clarity and consistency:
  - `FilterIdenticalParameters` to `RemoveIdenticalParameters`.
  - `FilterUnimportantParents` to `SkipUnimportantParents`.
  - `FilterUnimportantUnaryParents` to `SkipUnimportantUnaryParents`.

- Enhanced maintainability by aligning naming and logic in analyzers.

