### PR TITLE
Added new rule MiKo_1501 that reports 'Filter' in names

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -455,6 +455,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1407_TestNamespaceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1501_FilterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4633,6 +4633,33 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When naming something &apos;Filter&apos;, it is not clear whether the criteria to filter on gets included or excluded in the result. So instead, it should be named something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`. That makes it clear about what gets filtered..
+        /// </summary>
+        internal static string MiKo_1501_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1501_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;Filter&apos; to something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`.
+        /// </summary>
+        internal static string MiKo_1501_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1501_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use &apos;Filter&apos; in names.
+        /// </summary>
+        internal static string MiKo_1501_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1501_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1683,6 +1683,15 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
   <data name="MiKo_1409_Title" xml:space="preserve">
     <value>Do not prefix or suffix namespaces with underscores</value>
   </data>
+  <data name="MiKo_1501_Description" xml:space="preserve">
+    <value>When naming something 'Filter', it is not clear whether the criteria to filter on gets included or excluded in the result. So instead, it should be named something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`. That makes it clear about what gets filtered.</value>
+  </data>
+  <data name="MiKo_1501_MessageFormat" xml:space="preserve">
+    <value>Rename 'Filter' to something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`</value>
+  </data>
+  <data name="MiKo_1501_Title" xml:space="preserve">
+    <value>Do not use 'Filter' in names</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1501_FilterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1501_FilterAnalyzer.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1501_FilterAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1501";
+
+        public MiKo_1501_FilterAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Method, SymbolKind.Property, SymbolKind.Field);
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod() is false;
+
+        protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => symbol.IsTestMethod() is false; // do not consider local functions inside tests
+
+        protected override bool ShallAnalyzeLocalFunction(IMethodSymbol symbol) => true;
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IEventSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        private Diagnostic[] AnalyzeName(ISymbol symbol)
+        {
+            var hasFilter = symbol.Name.Contains("Filter", StringComparison.OrdinalIgnoreCase);
+
+            return hasFilter
+                   ? new[] { Issue(symbol) }
+                   : Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1501_FilterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1501_FilterAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Method, SymbolKind.Property, SymbolKind.Field);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field);
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod() is false;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1501_FilterAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = ["m_", "s_", "t_", "_", string.Empty,];
+        private static readonly string[] FilterNames = ["Filter", "filter"];
+
+        [Test]
+        public void No_issue_is_reported_for_method_without_Filter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public void DoSomething(int i) { }
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_event_without_Filter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public event EventHandler DoSomething;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_property_without_Filter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public int Something { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_field_without_Filter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int Something;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public void " + name + @"Something(int i) { }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_event_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public event EventHandler " + name + @"Something;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_property_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public int " + name + @"Something { get; set;}
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix, [ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      private int " + fieldPrefix + name + @"Something(int i) { }
+  }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1501_FilterAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1501_FilterAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 474 rules that are currently provided by the analyzer.
+The following tables lists all the 475 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -159,6 +159,7 @@ The following tables lists all the 474 rules that are currently provided by the 
 |MiKo_1407|Test namespaces should not contain 'Test'|&#x2713;|\-|
 |MiKo_1408|Extension methods should be placed in same namespace as the extended types|&#x2713;|\-|
 |MiKo_1409|Do not prefix or suffix namespaces with underscores|&#x2713;|\-|
+|MiKo_1501|Do not use 'Filter' in names|&#x2713;|\-|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Introduced a new naming rule `MiKo_1501` to discourage the use of 'Filter' in names.
- Added analyzer logic to detect and report usage of 'Filter' in method, property, field, and event names.
- Implemented unit tests to validate the new rule for various scenarios.
- Updated resources and documentation to include the new rule details.

(resolves #1190)
