### PR TITLE
MiKo_1059 is now aware of 'imp' as abbreviation for 'implementation'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_ImplClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_ImplClassNameAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1059";
 
-        private static readonly string[] WrongSuffixes = { "Impl", "Implementation", };
+        private static readonly string[] WrongSuffixes = { "Impl", "Implementation", "Imp" };
 
         public MiKo_1059_ImplClassNameAnalyzer() : base(Id, SymbolKind.NamedType)
         {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1059_ImplClassNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1059_ImplClassNameAnalyzerTests.cs
@@ -17,6 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         private static readonly string[] WrongSuffixes =
                                                          [
+                                                             "Imp",
                                                              "Impl",
                                                              "Implementation",
                                                          ];


### PR DESCRIPTION
- Added awareness of `Imp` as an abbreviation for `implementation`.
- Updated `MiKo_1059_ImplClassNameAnalyzer` to include `Imp` in wrong suffixes.
- Enhanced unit tests to validate `Imp` suffix detection.
