### PR TITLE
Added new rule MiKo_1502 that reports 'Process' in names

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -456,6 +456,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1501_FilterAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1502_ProcessAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4660,6 +4660,37 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When naming something &apos;Process&apos;, it is not clear what is processed, why it is processed and what the result after processing is.
+        ///It is better to when the name contains the purpose behind it.
+        ///
+        ///Example:
+        ///&quot;ProcessMessages&quot; could be renamed to &quot;DeleteObsoleteMessages&quot; or similar if the purpose of processing messages is to detect and delete obsolete ones..
+        /// </summary>
+        internal static string MiKo_1502_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1502_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename so that &apos;Process&apos; is not used.
+        /// </summary>
+        internal static string MiKo_1502_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1502_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use &apos;Process&apos; in names.
+        /// </summary>
+        internal static string MiKo_1502_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1502_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1692,6 +1692,19 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
   <data name="MiKo_1501_Title" xml:space="preserve">
     <value>Do not use 'Filter' in names</value>
   </data>
+  <data name="MiKo_1502_Description" xml:space="preserve">
+    <value>When naming something 'Process', it is not clear what is processed, why it is processed and what the result after processing is.
+It is better to when the name contains the purpose behind it.
+
+Example:
+"ProcessMessages" could be renamed to "DeleteObsoleteMessages" or similar if the purpose of processing messages is to detect and delete obsolete ones.</value>
+  </data>
+  <data name="MiKo_1502_MessageFormat" xml:space="preserve">
+    <value>Rename so that 'Process' is not used</value>
+  </data>
+  <data name="MiKo_1502_Title" xml:space="preserve">
+    <value>Do not use 'Process' in names</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1502_ProcessAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1502_ProcessAnalyzer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1502_ProcessAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1502";
+
+        public MiKo_1502_ProcessAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field);
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod() is false;
+
+        protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => symbol.IsTestMethod() is false; // do not consider local functions inside tests
+
+        protected override bool ShallAnalyzeLocalFunction(IMethodSymbol symbol) => true;
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IEventSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        private Diagnostic[] AnalyzeName(ISymbol symbol)
+        {
+            var hasIssue = symbol.Name.Contains("Process", StringComparison.OrdinalIgnoreCase);
+
+            return hasIssue
+                   ? new[] { Issue(symbol) }
+                   : Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 
 using TestHelper;
 
+//// ncrunch: rdi off
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [TestFixture]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1502_ProcessAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1502_ProcessAnalyzerTests.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1502_ProcessAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = ["m_", "s_", "t_", "_", string.Empty,];
+        private static readonly string[] Names = ["Process", "process", "Processor", "processor"];
+
+        [Test]
+        public void No_issue_is_reported_for_type_without_Process_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_without_Process_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public void DoSomething(int i) { }
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_event_without_Process_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public event EventHandler DoSomething;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_property_without_Process_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      public int Something { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_field_without_Process_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int Something;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class Test" + name + @"Me
+  {
+      public void DoSomething(int i) { }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public void " + name + @"Something(int i) { }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_event_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public event EventHandler " + name + @"Something;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_property_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      public int " + name + @"Something { get; set;}
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix, [ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public static class TestMe
+  {
+      private int " + fieldPrefix + name + @"Something(int i) { }
+  }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1502_ProcessAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1502_ProcessAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 475 rules that are currently provided by the analyzer.
+The following tables lists all the 476 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -160,6 +160,7 @@ The following tables lists all the 475 rules that are currently provided by the 
 |MiKo_1408|Extension methods should be placed in same namespace as the extended types|&#x2713;|\-|
 |MiKo_1409|Do not prefix or suffix namespaces with underscores|&#x2713;|\-|
 |MiKo_1501|Do not use 'Filter' in names|&#x2713;|\-|
+|MiKo_1502|Do not use 'Process' in names|&#x2713;|\-|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Added a new analyzer rule `MiKo_1502` to discourage the use of `Process` in names.
- Implemented logic to detect and report names containing `Process`.
- Created comprehensive unit tests for the `MiKo_1502_ProcessAnalyzer`.
- Updated resources and documentation to include the new rule.

(resolves #1192)