### PR TITLE
MiKo_3085 now has a codefix provider

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -179,6 +179,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3082_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3083_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3084_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3085_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3088_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3089_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3099_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -11458,6 +11458,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to &apos;if ... else ...&apos;.
+        /// </summary>
+        internal static string MiKo_3085_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3085_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Long conditional statements are hard to read and maintain. Keep them short for easy understanding at a glance, or refactor into if-else statements for clarity. This approach keeps your code clean and maintainable..
         /// </summary>
         internal static string MiKo_3085_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4026,6 +4026,9 @@ This approach enhances clarity and maintainability.</value>
   <data name="MiKo_3084_Title" xml:space="preserve">
     <value>Do not place constants on the left side for comparisons</value>
   </data>
+  <data name="MiKo_3085_CodeFixTitle" xml:space="preserve">
+    <value>Convert to 'if ... else ...'</value>
+  </data>
   <data name="MiKo_3085_Description" xml:space="preserve">
     <value>Long conditional statements are hard to read and maintain. Keep them short for easy understanding at a glance, or refactor into if-else statements for clarity. This approach keeps your code clean and maintainable.</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3085_CodeFixProvider)), Shared]
+    public sealed class MiKo_3085_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        private static readonly Dictionary<SpecialType, SyntaxKind> TypeMapping = new Dictionary<SpecialType, SyntaxKind>
+                                                                                      {
+                                                                                          { SpecialType.System_Object, SyntaxKind.ObjectKeyword },
+                                                                                          { SpecialType.System_Boolean, SyntaxKind.BoolKeyword },
+                                                                                          { SpecialType.System_Char, SyntaxKind.CharKeyword },
+                                                                                          { SpecialType.System_SByte, SyntaxKind.SByteKeyword },
+                                                                                          { SpecialType.System_Byte, SyntaxKind.ByteKeyword },
+                                                                                          { SpecialType.System_Int16, SyntaxKind.ShortKeyword },
+                                                                                          { SpecialType.System_UInt16, SyntaxKind.UShortKeyword },
+                                                                                          { SpecialType.System_Int32, SyntaxKind.IntKeyword },
+                                                                                          { SpecialType.System_UInt32, SyntaxKind.UIntKeyword },
+                                                                                          { SpecialType.System_Int64, SyntaxKind.LongKeyword },
+                                                                                          { SpecialType.System_UInt64, SyntaxKind.ULongKeyword },
+                                                                                          { SpecialType.System_Decimal, SyntaxKind.DecimalKeyword },
+                                                                                          { SpecialType.System_Single, SyntaxKind.FloatKeyword },
+                                                                                          { SpecialType.System_Double, SyntaxKind.DoubleKeyword },
+                                                                                          { SpecialType.System_String, SyntaxKind.StringKeyword },
+                                                                                      };
+
+        public override string FixableDiagnosticId => "MiKo_3085";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ConditionalExpressionSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => syntax;
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            // detect if we are an arrow
+            if (syntax is ConditionalExpressionSyntax conditional)
+            {
+                switch (conditional.Parent)
+                {
+                    case ArrowExpressionClauseSyntax clause: return UpdateArrowExpressionClause(root, conditional, clause);
+                    case AssignmentExpressionSyntax assignment: return UpdateAssignment(root, conditional, assignment);
+                    case EqualsValueClauseSyntax clause: return UpdateEqualsValueClause(document, root, conditional, clause);
+                    case ReturnStatementSyntax statement: return UpdateReturn(root, conditional, statement);
+                    case ThrowStatementSyntax statement: return UpdateThrow(root, conditional, statement);
+                }
+            }
+
+            return root;
+        }
+
+        private static SyntaxNode UpdateArrowExpressionClause(SyntaxNode root, ConditionalExpressionSyntax conditional, ArrowExpressionClauseSyntax arrowClause)
+        {
+            var ifStatement = ConvertToIfStatement(conditional, SyntaxFactory.ReturnStatement);
+
+            switch (arrowClause.Parent)
+            {
+                case MethodDeclarationSyntax method:
+                {
+                    var updatedMethod = method.WithBody(SyntaxFactory.Block(ifStatement))
+                                              .WithExpressionBody(null)
+                                              .WithSemicolonToken(default);
+
+                    return root.ReplaceNode(method, updatedMethod);
+                }
+
+                case PropertyDeclarationSyntax property:
+                {
+                    var getter = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, SyntaxFactory.Block(ifStatement));
+                    var updatedProperty = property.WithAccessorList(SyntaxFactory.AccessorList(getter.ToSyntaxList()))
+                                                  .WithExpressionBody(null)
+                                                  .WithSemicolonToken(default);
+
+                    return root.ReplaceNode(property, updatedProperty);
+                }
+
+                case AccessorDeclarationSyntax accessor:
+                {
+                    var updatedAccessor = accessor.WithBody(SyntaxFactory.Block(ifStatement))
+                                                  .WithExpressionBody(null)
+                                                  .WithSemicolonToken(default);
+
+                    return root.ReplaceNode(accessor, updatedAccessor);
+                }
+
+                default:
+                    return root;
+            }
+        }
+
+        private static SyntaxNode UpdateAssignment(SyntaxNode root, ConditionalExpressionSyntax conditional, AssignmentExpressionSyntax assignment)
+        {
+            if (assignment.Parent is ArrowExpressionClauseSyntax clause && clause.Parent is AccessorDeclarationSyntax accessor)
+            {
+                var ifStatement = ConvertToIfStatement(conditional, trueCase => AssignmentStatement(assignment, trueCase), falseCase => AssignmentStatement(assignment, falseCase));
+
+                var updatedAccessor = accessor.WithBody(SyntaxFactory.Block(ifStatement))
+                                              .WithExpressionBody(null)
+                                              .WithSemicolonToken(default);
+
+                return root.ReplaceNode(accessor, updatedAccessor);
+            }
+
+            return root;
+        }
+
+        private static SyntaxNode UpdateEqualsValueClause(Document document, SyntaxNode root, ConditionalExpressionSyntax conditional, EqualsValueClauseSyntax clause)
+        {
+            if (clause.Parent is VariableDeclaratorSyntax declarator && declarator.Parent is VariableDeclarationSyntax declaration && declaration.Parent is LocalDeclarationStatementSyntax localDeclaration)
+            {
+                var typeSyntax = GetTypeSyntax(declaration, document);
+
+                var updatedDeclarator = SyntaxFactory.VariableDeclarator(declarator.Identifier);
+                var updatedDeclaration = SyntaxFactory.VariableDeclaration(typeSyntax, updatedDeclarator.ToSeparatedSyntaxList());
+                var updatedLocalDeclaration = SyntaxFactory.LocalDeclarationStatement(updatedDeclaration);
+
+                var ifStatement = ConvertToIfStatement(conditional, trueCase => AssignmentStatement(declarator, trueCase), falseCase => AssignmentStatement(declarator, falseCase));
+
+                return root.ReplaceNode(localDeclaration, new SyntaxNode[] { updatedLocalDeclaration, ifStatement });
+            }
+
+            return root;
+        }
+
+        private static ExpressionStatementSyntax AssignmentStatement(AssignmentExpressionSyntax assignment, ExpressionSyntax expression)
+        {
+            return SyntaxFactory.ExpressionStatement(assignment.WithRight(expression));
+        }
+
+        private static ExpressionStatementSyntax AssignmentStatement(VariableDeclaratorSyntax declarator, ExpressionSyntax expression)
+        {
+            return SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(declarator.Identifier), expression));
+        }
+
+        private static SyntaxNode UpdateReturn(SyntaxNode root, ConditionalExpressionSyntax conditional, ReturnStatementSyntax returnStatement)
+        {
+            var ifStatement = ConvertToIfStatement(conditional, SyntaxFactory.ReturnStatement);
+
+            return root.ReplaceNode(returnStatement, ifStatement);
+        }
+
+        private static SyntaxNode UpdateThrow(SyntaxNode root, ConditionalExpressionSyntax conditional, ThrowStatementSyntax throwStatement)
+        {
+            var ifStatement = ConvertToIfStatement(conditional, SyntaxFactory.ThrowStatement);
+
+            return root.ReplaceNode(throwStatement, ifStatement);
+        }
+
+        private static IfStatementSyntax ConvertToIfStatement(ConditionalExpressionSyntax conditional, Func<ExpressionSyntax, StatementSyntax> statementCallback)
+        {
+            return ConvertToIfStatement(conditional, statementCallback, statementCallback);
+        }
+
+        private static IfStatementSyntax ConvertToIfStatement(ConditionalExpressionSyntax conditional, Func<ExpressionSyntax, StatementSyntax> trueStatementCallback, Func<ExpressionSyntax, StatementSyntax> falseStatementCallback)
+        {
+            var condition = conditional.Condition.WithoutParenthesis().WithoutTrivia();
+            var ifBlock = SyntaxFactory.Block(trueStatementCallback(conditional.WhenTrue));
+            var elseBlock = SyntaxFactory.Block(falseStatementCallback(conditional.WhenFalse));
+
+            return SyntaxFactory.IfStatement(condition, ifBlock, SyntaxFactory.ElseClause(elseBlock));
+        }
+
+        private static TypeSyntax GetTypeSyntax(VariableDeclarationSyntax declaration, Document document)
+        {
+            var declarationType = declaration.Type;
+
+            if (declarationType is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == "var")
+            {
+                var type = declarationType.GetTypeSymbol(GetSemanticModel(document));
+
+                return TypeMapping.TryGetValue(type.SpecialType, out var kind)
+                       ? SyntaxFactory.PredefinedType(SyntaxFactory.Token(kind))
+                       : SyntaxFactory.ParseTypeName(type.Name);
+            }
+
+            return declarationType;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The following tables lists all the 476 rules that are currently provided by the 
 |MiKo_3082|Prefer pattern matching over a logical comparison with 'true' or 'false'|&#x2713;|&#x2713;|
 |MiKo_3083|Prefer pattern matching for null checks|&#x2713;|&#x2713;|
 |MiKo_3084|Do not place constants on the left side for comparisons|&#x2713;|&#x2713;|
-|MiKo_3085|Conditional statements should be short|&#x2713;|\-|
+|MiKo_3085|Conditional statements should be short|&#x2713;|&#x2713;|
 |MiKo_3086|Do not nest conditional statements|&#x2713;|\-|
 |MiKo_3087|Do not use negative complex conditions|&#x2713;|\-|
 |MiKo_3088|Prefer pattern matching for not-null checks|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Introduced a new code fix provider `MiKo_3085_CodeFixProvider` for converting long conditional expressions into `if/else` statements.
- Added extensive unit tests to validate the functionality of the new code fix provider.
- Updated resources and documentation to include the new rule and its description.
- Modified project files to include the new code fix provider.

(resolves #397)