### PR TITLE
MiKo_1044 is now aware of abbreviation 'Cmd' at the end and adds 'Command' suffix properly

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            return new[] { Issue(symbol, Suffix, CreateBetterNameProposal(symbolName + Suffix)) };
+            return new[] { Issue(symbol, Suffix, CreateBetterNameProposal(symbolName.WithoutSuffix("Cmd") + Suffix)) };
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1044_CommandSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1044_CommandSuffixAnalyzerTests.cs
@@ -198,6 +198,32 @@ public class TestMe
 ");
 
         [Test]
+        public void Code_gets_fixed_for_field_and_suffix_Cmd()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Windows.Input;
+
+public class TestMe
+{
+    private ICommand m_fieldCmd;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Windows.Input;
+
+public class TestMe
+{
+    private ICommand m_fieldCommand;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_field()
         {
             const string OriginalCode = @"


### PR DESCRIPTION
- Enhanced `MiKo_1044_CommandSuffixAnalyzer` to handle 'Cmd' abbreviation.
- Added a test to verify 'Cmd' suffix renaming to 'Command'.
