### PR TITLE
Enhanced MiKo 3085 codefix

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
@@ -287,6 +287,24 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        internal static AccessorDeclarationSyntax WithSemicolonToken(this AccessorDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.SemicolonToken.AsToken());
+
+        internal static MethodDeclarationSyntax WithSemicolonToken(this MethodDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.SemicolonToken.AsToken());
+
+        internal static PropertyDeclarationSyntax WithSemicolonToken(this PropertyDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.SemicolonToken.AsToken());
+
+        internal static AccessorDeclarationSyntax WithoutSemicolonToken(this AccessorDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.None.AsToken());
+
+        internal static MethodDeclarationSyntax WithoutSemicolonToken(this MethodDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.None.AsToken());
+
+        internal static PropertyDeclarationSyntax WithoutSemicolonToken(this PropertyDeclarationSyntax value) => value.WithSemicolonToken(SyntaxKind.None.AsToken());
+
+        internal static AccessorDeclarationSyntax WithoutExpressionBody(this AccessorDeclarationSyntax value) => value.WithExpressionBody(null).WithoutSemicolonToken();
+
+        internal static MethodDeclarationSyntax WithoutExpressionBody(this MethodDeclarationSyntax value) => value.WithExpressionBody(null).WithoutSemicolonToken();
+
+        internal static PropertyDeclarationSyntax WithoutExpressionBody(this PropertyDeclarationSyntax value) => value.WithExpressionBody(null).WithoutSemicolonToken();
+
         private static bool IsSameGeneric(TypeSyntax t1, TypeSyntax t2)
         {
             if (t1 is GenericNameSyntax g1 && t2 is GenericNameSyntax g2)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 
@@ -30,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 // append a semicolon to the end
                 var initializer = CreateInitializer(document, propertySyntax.Type);
-                var updatedNode = propertySyntax.WithInitializer(initializer).WithSemicolonToken(";".AsToken(SyntaxKind.SemicolonToken));
+                var updatedNode = propertySyntax.WithInitializer(initializer).WithSemicolonToken();
 
                 return root.ReplaceNode(propertySyntax, updatedNode);
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
@@ -64,8 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             statements.Add(SyntaxFactory.ParseStatement("return hash.ToHashCode();"));
 
             return method.WithBody(SyntaxFactory.Block(statements.Select(_ => _.WithIndentation().WithTrailingNewLine())))
-                         .WithExpressionBody(null)
-                         .WithSemicolonToken(default);
+                         .WithoutExpressionBody();
         }
 
         private static MethodDeclarationSyntax GetUpdatedSyntaxWithHashCodeCombine(IEnumerable<SyntaxNode> nodes, MethodDeclarationSyntax method)
@@ -75,7 +74,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             return method.WithBody(null)
                          .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(invocation))
-                         .WithSemicolonToken(SyntaxKind.SemicolonToken.AsToken());
+                         .WithSemicolonToken();
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzerTests.cs
@@ -1249,6 +1249,176 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_conditional_expression_in_return_below_if_statement()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            return (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815)) ? true : false;
+        return flag;
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+        {
+            if (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return flag;
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_expression_in_return_below_else_statement()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            return flag;
+        else
+            return (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815)) ? true : false;
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            return flag;
+        else
+        {
+            if (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_expression_in_throw_below_if_statement()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            throw (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815)) ? new ArgumentException() : new ArgumentNullException();
+        return flag;
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+        {
+            if (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815))
+            {
+                throw new ArgumentException();
+            }
+            else
+            {
+                throw new ArgumentNullException();
+            }
+        }
+
+        return flag;
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_expression_in_throw_below_else_statement()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            return flag;
+        else
+            throw (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815)) ? new ArgumentException() : new ArgumentNullException();
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(bool flag, object o)
+    {
+        if (flag)
+            return flag;
+        else
+        {
+            if (o != null && (o.GetHashCode() == 42 || o.GetHashCode() == 0815))
+            {
+                throw new ArgumentException();
+            }
+            else
+            {
+                throw new ArgumentNullException();
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         // TODO RKN: Conditional as parameter for array access
         // TODO RKN: Conditional as parameter for list access
         // TODO RKN: Conditional inside conditional

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzerTests.cs
@@ -182,6 +182,29 @@ public class TestMeWithAVeryLongName
 }");
 
         [Test]
+        public void No_issue_is_reported_for_conditional_inside_exclusive_OR_such_as_used_in_GetHashCode() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    string Id { get; set; }
+
+    string SerializableDefaultValue { get; set; }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = (Id != null ? Id.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^ (SerializableDefaultValue != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(SerializableDefaultValue) : 0);
+
+            return hashCode;
+        }
+    }
+}");
+
+        [Test]
         public void An_issue_is_reported_for_conditional_expression_with_long_condition_and_short_paths() => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Enhanced handling of conditional expressions in code fixes.
- Added support for fixing conditionals in initializers and expression bodies.
- Improved robustness by ignoring certain conditionals in `GetHashCode`.
- Added comprehensive test cases for various conditional scenarios.
