### PR TITLE
MiKo_6050 codefix is now aware of middle arguments and adds a line-break if necessary

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -89,6 +89,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool HasTrailingComment(this SyntaxToken value) => value.TrailingTrivia.Any(_ => _.IsComment());
 
+        internal static bool HasTrailingEndOfLine(this SyntaxToken value) => value.TrailingTrivia.Any(_ => _.IsEndOfLine());
+
         internal static bool IsDefaultValue(this SyntaxToken value) => value.IsKind(SyntaxKind.None);
 
         internal static bool IsAnyKind(this SyntaxToken value, ISet<SyntaxKind> kinds) => kinds.Contains(value.Kind());

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_CodeFixProvider.cs
@@ -30,5 +30,26 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             return syntax;
         }
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (syntax is ArgumentSyntax argument && argument.Parent is ArgumentListSyntax list)
+            {
+                var arguments = list.Arguments;
+                var index = arguments.IndexOf(argument);
+
+                if (index > 0)
+                {
+                    var separator = arguments.GetSeparators().ElementAtOrDefault(index - 1);
+
+                    if (separator.HasTrailingEndOfLine() is false)
+                    {
+                        return root.ReplaceNode(list, list.ReplaceToken(separator, separator.WithTrailingNewLine()));
+                    }
+                }
+            }
+
+            return root;
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzerTests.cs
@@ -465,6 +465,55 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_method_with_arguments_that_contains_initializer_and_second_argument_that_is_on_same_line_as_end_of_first_argument()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        DoSomethingCore(new Dictionary<int, int>
+                            {
+                                { 1, 2 },
+                                { 3, 4 },
+                            }, 42);
+    }
+
+    private void DoSomethingCore(Dictionary<int, int> dictionary, int i)
+    {
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        DoSomethingCore(new Dictionary<int, int>
+                            {
+                                { 1, 2 },
+                                { 3, 4 },
+                            },
+                        42);
+    }
+
+    private void DoSomethingCore(Dictionary<int, int> dictionary, int i)
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer();


### PR DESCRIPTION
- Added a method to check for trailing end-of-line in syntax tokens.
- Enhanced code fix provider to ensure proper line breaks in argument lists.
- Introduced a new test case for multiline arguments with specific formatting.

