### PR TITLE
MiKo_6041 now does not report on collection initializer assignments that span multiple lines

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzerTests.cs
@@ -27,6 +27,27 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_if_multi_line_assignment_of_collection_initializer_is_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Net.Http;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        HttpClient client = new HttpClient
+                                {
+                                    DefaultRequestHeaders =
+                                                            {
+                                                                { ""some text A"", ""some Value 1"" },
+                                                                { ""some text B"", ""some Value 2"" },
+                                                            }
+                                };
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_if_multi_line_assignment_to_array_is_on_other_line() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Added logic to ignore multi-line collection initializers in analysis.
- Refactored `ReportIssue` method to utilize `IgnoreIssue`.
- Introduced new test cases for multi-line collection initializers.
