### PR TITLE
MiKo_3503 now initializes variables when moving the local declarations into the try/catch blocks

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1843,6 +1843,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsCode(this XmlElementSyntax value) => value.GetName() == Constants.XmlTag.Code;
 
+        internal static bool IsAssignmentOf(this StatementSyntax value, string identifierName) => value is ExpressionStatementSyntax e
+                                                                                               && e.Expression is AssignmentExpressionSyntax a
+                                                                                               && a.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                                                                                               && a.Left is IdentifierNameSyntax i
+                                                                                               && i.GetName() == identifierName;
+
         internal static bool IsCommand(this TypeSyntax value, SemanticModel semanticModel)
         {
             if (value is PredefinedTypeSyntax)

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13496,7 +13496,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not assign variables in try/catch blocks and return them as soon as the try/catch block is left. Instead, return them from within the try block..
+        ///   Looks up a localized string similar to Avoid defining variables outside of try/catch blocks, assigning them within the try/catch block, and then returning them immediately after leaving the block. Instead, return the variables directly from within the try/catch block. This makes the code easier to read and understand..
         /// </summary>
         internal static string MiKo_3503_Description {
             get {
@@ -13505,7 +13505,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return variable inside try/catch block.
+        ///   Looks up a localized string similar to Place return inside the try/catch block.
         /// </summary>
         internal static string MiKo_3503_MessageFormat {
             get {
@@ -13514,7 +13514,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not assign variables in try catch blocks and return them directly outside the block.
+        ///   Looks up a localized string similar to Do not assign variables in try-catch blocks and return them directly outside the block.
         /// </summary>
         internal static string MiKo_3503_Title {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4721,13 +4721,13 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Return variable inside try/catch block</value>
   </data>
   <data name="MiKo_3503_Description" xml:space="preserve">
-    <value>Do not assign variables in try/catch blocks and return them as soon as the try/catch block is left. Instead, return them from within the try block.</value>
+    <value>Avoid defining variables outside of try/catch blocks, assigning them within the try/catch block, and then returning them immediately after leaving the block. Instead, return the variables directly from within the try/catch block. This makes the code easier to read and understand.</value>
   </data>
   <data name="MiKo_3503_MessageFormat" xml:space="preserve">
-    <value>Return variable inside try/catch block</value>
+    <value>Place return inside the try/catch block</value>
   </data>
   <data name="MiKo_3503_Title" xml:space="preserve">
-    <value>Do not assign variables in try catch blocks and return them directly outside the block</value>
+    <value>Do not assign variables in try-catch blocks and return them directly outside the block</value>
   </data>
   <data name="MiKo_4001_CodeFixTitle" xml:space="preserve">
     <value>Place and order method side-by-side with overloads</value>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3503_DoNotReturnVariableImmediatelyAfterTryCatchBlockAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3503_DoNotReturnVariableImmediatelyAfterTryCatchBlockAnalyzer.cs
@@ -22,12 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             if (context.Node is TryStatementSyntax node)
             {
-                var issue = Analyze(node);
-
-                if (issue != null)
-                {
-                    context.ReportDiagnostic(issue);
-                }
+                ReportDiagnostics(context, Analyze(node));
             }
         }
 
@@ -48,12 +43,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         {
                             for (var index = 0; index < statementsCount; index++)
                             {
-                                if (statements[index] is ExpressionStatementSyntax e && e.Expression is AssignmentExpressionSyntax assignment && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+                                if (statements[index].IsAssignmentOf(identifierName))
                                 {
-                                    if (assignment.Left is IdentifierNameSyntax left && left.GetName() == identifierName)
-                                    {
-                                        return Issue(identifier);
-                                    }
+                                    return Issue(identifierName, identifier);
                                 }
                             }
                         }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3503_DoNotReturnVariableImmediatelyAfterTryCatchBlockAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3503_DoNotReturnVariableImmediatelyAfterTryCatchBlockAnalyzerTests.cs
@@ -254,7 +254,7 @@ public class TestMe
         }
         catch
         {
-            string result;
+            string result = default(string);
 
             return result;
         }

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ The following tables lists all the 477 rules that are currently provided by the 
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|
 |MiKo_3501|Do not suppress nullable warnings on Null-conditional operators|&#x2713;|&#x2713;|
 |MiKo_3502|Do not suppress nullable warnings on Linq calls|&#x2713;|&#x2713;|
-|MiKo_3503|Do not assign variables in try catch blocks and return them directly outside the block|&#x2713;|&#x2713;|
+|MiKo_3503|Do not assign variables in try-catch blocks and return them directly outside the block|&#x2713;|&#x2713;|
 
 ### Ordering
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Added new helper method `IsAssignmentOf` for assignment checks.
- Refactored code fix provider using switch-case and `UpdateBlock` method.
- Updated analyzer and tests to utilize new method.
- Revised resource strings and documentation for clarity.

