### PR TITLE
Added null check to avoid NullReferenceException

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
@@ -23,6 +23,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var symbol = await syntax.GetSymbolAsync(document, cancellationToken).ConfigureAwait(false);
 
+            if (symbol is null)
+            {
+                // cannot change anything
+                return originalSolution;
+            }
+
             var newName = GetNewName(diagnostic, symbol);
 
             if (newName.IsNullOrWhiteSpace() || newName.Equals(symbol.Name, StringComparison.Ordinal))


### PR DESCRIPTION
- Added a `null` check to prevent a `NullReferenceException` if `symbol` is `null`, and returning now the original solution in such case.
