### PR TITLE
MiKo_1063 is now aware of abbreviations for Portugese and Latvian

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -305,6 +305,14 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                             "text",
                                                             "Text",
                                                             "MEF",
+
+                                                            // languages
+                                                            "lvLV",
+                                                            "LvLV",
+                                                            "ptBR",
+                                                            "PtBR",
+                                                            "ptPT",
+                                                            "PtPT",
                                                         };
 
         private static readonly string[] AllowedNames =

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -301,11 +301,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "signCertificate",
                                                             "text",
                                                             "tires",
+
+                                                            // languages
+                                                            "ptPT", // Portugal
+                                                            "ptBR", // Brazil
+                                                            "lvLV", // Latvia
                                                         ];
 
         private static readonly string[] AllowedWords = [.. AllowedTerms, "obj", "href", "cref"];
 
-        private static readonly string[] WrongWords = BadPrefixes.Except(AllowedWords).ToArray();
+        private static readonly string[] WrongWords = [.. BadPrefixes.Except(AllowedWords)];
 
         [Test]
         public void No_issue_is_reported_for_properly_named_code() => No_issue_is_reported_for(@"


### PR DESCRIPTION
- Add language abbreviations for LV, PT codes in detector
- Update tests to recognize new language abbreviation codes
