### PR TITLE
MiKo_2000 now detects '<,>' as invalid XML and replaces it by '&lt;,&gt;'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Composition;
+using System.Linq;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
@@ -15,6 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                      {
                                                          new Pair("&", "&amp;"),
                                                          new Pair("<", "&lt;"),
+                                                         new Pair(">", "&gt;"),
                                                      };
 
         public override string FixableDiagnosticId => "MiKo_2000";
@@ -22,6 +26,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
         {
             var token = syntax.FindToken(diagnostic);
+
+            if (token.IsKind(SyntaxKind.LessThanToken) && token.Parent is XmlElementStartTagSyntax startTag && startTag.Parent is XmlElementSyntax element)
+            {
+                // as the XML element now has an end tag that does not match the start tag, we have to fix the complete documentation XML
+                return GetUpdatedDocumentationComment(syntax, element);
+            }
+
             var tokenText = token.Text;
 
             var text = tokenText.AsCachedBuilder()
@@ -29,6 +40,41 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                 .ToStringAndRelease();
 
             return syntax.ReplaceToken(token, token.WithText(text));
+        }
+
+        private static DocumentationCommentTriviaSyntax GetUpdatedDocumentationComment(DocumentationCommentTriviaSyntax syntax, XmlElementSyntax element)
+        {
+            // as the XML element now has an end tag that does not match the start tag, we have to fix the complete documentation XML
+            var startTag = element.StartTag;
+
+            var location = Location.Create(syntax.SyntaxTree, TextSpan.FromBounds(syntax.SpanStart, startTag.SpanStart));
+            var someText = location.GetText();
+
+            var startTagFullString = startTag.ToFullString();
+            var contentFullString = element.Content.ToFullString();
+            var endTagFullString = element.EndTag.ToFullString();
+
+            const string XmlCommentExterior = "///";
+
+            var capacity = StringBuilderCache.DefaultCapacity // some buffer as we modify the contents
+                         + XmlCommentExterior.Length
+                         + someText.Length
+                         + startTagFullString.Length
+                         + contentFullString.Length
+                         + endTagFullString.Length;
+
+            var text = StringBuilderCache.Acquire(capacity)
+                                         .Append(startTagFullString)
+                                         .Append(contentFullString)
+                                         .ReplaceAllWithCheck(XmlEntities)
+                                         .Insert(0, someText)
+                                         .Insert(0, XmlCommentExterior)
+                                         .AppendLine(endTagFullString)
+                                         .ToStringAndRelease();
+
+            var newParent = SyntaxFactory.ParseTypeName("###").WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(text));
+
+            return newParent.GetDocumentationCommentTriviaSyntax().FirstOrDefault() ?? syntax;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzer.cs
@@ -26,9 +26,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 if (nodeOrToken.IsNode)
                 {
-                    if (nodeOrToken.AsNode() is XmlEmptyElementSyntax element && element.SlashGreaterThanToken.IsMissing)
+                    switch (nodeOrToken.AsNode())
                     {
-                        yield return Issue(element.LessThanToken);
+                        case XmlEmptyElementSyntax emptyElement when emptyElement.SlashGreaterThanToken.IsMissing:
+                        {
+                            yield return Issue(emptyElement.LessThanToken);
+
+                            break;
+                        }
+
+                        case XmlElementSyntax element:
+                        {
+                            var name = element.StartTag.GetName();
+
+                            if (name.IsNullOrWhiteSpace())
+                            {
+                                yield return Issue(element.StartTag);
+                            }
+
+                            break;
+                        }
                     }
                 }
                 else if (nodeOrToken.IsToken)

--- a/MiKo.Analyzer.Shared/StringBuilderCache.cs
+++ b/MiKo.Analyzer.Shared/StringBuilderCache.cs
@@ -7,8 +7,8 @@ namespace MiKoSolutions.Analyzers
 {
     internal static class StringBuilderCache
     {
+        public const int DefaultCapacity = 16;
         private const int MaxBuilderSize = 1000;
-        private const int DefaultCapacity = 16;
 
         [ThreadStatic]
         private static StringBuilder s_cachedInstance;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzerTests.cs
@@ -198,6 +198,20 @@ public sealed class TestMe
 }
 ");
 
+        [TestCase("KeyValuePair<,>")]
+        [TestCase("KeyValuePair<, >")]
+        [TestCase("KeyValuePair< ,>")]
+        [TestCase("KeyValuePair< , >")]
+        public void An_issue_is_reported_for_malformed_remarks_XML_on_field_(string issue) => An_issue_is_reported_for(@"
+public sealed class TestMe
+{
+    /// <summary>
+    /// Fun-fact: IDictionary provides the Add(" + issue + @") interface
+    /// </summary>
+    private string Malform;
+}
+");
+
         [TestCase("&", "&amp;")]
         [TestCase("& ", "&amp; ")]
         [TestCase(" &", " &amp;")]
@@ -218,6 +232,25 @@ public sealed class TestMe
 ";
 
             VerifyCSharpFix(Template.Replace("###", malformed), Template.Replace("###", corrected));
+        }
+
+        [TestCase("KeyValuePair<,>")]
+        [TestCase("KeyValuePair<, >")]
+        [TestCase("KeyValuePair< ,>")]
+        [TestCase("KeyValuePair< , >")]
+        public void Code_gets_fixed_for_malformed_remarks_XML_on_field_(string issue)
+        {
+            const string Template = @"
+public sealed class TestMe
+{
+    /// <summary>
+    /// Fun-fact: IDictionary provides the Add(###) interface
+    /// </summary>
+    private string Malform;
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", issue), Template.Replace("###", issue.Replace("<", "&lt;").Replace(">", "&gt;")));
         }
 
         protected override string GetDiagnosticId() => MiKo_2000_MalformedDocumentationAnalyzer.Id;


### PR DESCRIPTION
- Fix XML escaping by mapping '>' to '&amp;gt;'
- Add tests for malformed XMLs
