### PR TITLE
Added new rule MiKo_3226 that converts readonly fields into consts

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -208,6 +208,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3226_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -310,6 +310,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_LogicalConditionsAreTheSameAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13316,6 +13316,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert field to const.
+        /// </summary>
+        internal static string MiKo_3226_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3226_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields const&apos;. This ensures their values remain constant and clearly communicates their intended use..
+        /// </summary>
+        internal static string MiKo_3226_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3226_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Convert field to const.
+        /// </summary>
+        internal static string MiKo_3226_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3226_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read-only fields with initializers should be const.
+        /// </summary>
+        internal static string MiKo_3226_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3226_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13325,7 +13325,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields const&apos;. This ensures their values remain constant and clearly communicates their intended use..
+        ///   Looks up a localized string similar to Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields &apos;const&apos;. This ensures their values remain constant and clearly communicates their intended use..
         /// </summary>
         internal static string MiKo_3226_Description {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4660,6 +4660,18 @@ Instead, use non-generic types as type arguments. This approach makes the code's
   <data name="MiKo_3225_Title" xml:space="preserve">
     <value>Redundant comparisons can be simplified</value>
   </data>
+  <data name="MiKo_3226_CodeFixTitle" xml:space="preserve">
+    <value>Convert field to const</value>
+  </data>
+  <data name="MiKo_3226_Description" xml:space="preserve">
+    <value>Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields const'. This ensures their values remain constant and clearly communicates their intended use.</value>
+  </data>
+  <data name="MiKo_3226_MessageFormat" xml:space="preserve">
+    <value>Convert field to const</value>
+  </data>
+  <data name="MiKo_3226_Title" xml:space="preserve">
+    <value>Read-only fields with initializers should be const</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4664,7 +4664,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Convert field to const</value>
   </data>
   <data name="MiKo_3226_Description" xml:space="preserve">
-    <value>Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields const'. This ensures their values remain constant and clearly communicates their intended use.</value>
+    <value>Read-only fields with pre-assigned values are likely meant to be constant values. Therefore, make these fields 'const'. This ensures their values remain constant and clearly communicates their intended use.</value>
   </data>
   <data name="MiKo_3226_MessageFormat" xml:space="preserve">
     <value>Convert field to const</value>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3226";
+
+        public MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeField, SyntaxKind.FieldDeclaration);
+
+        private void AnalyzeField(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is FieldDeclarationSyntax declaration && declaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
+            {
+                foreach (var variable in declaration.Declaration.Variables)
+                {
+                    if (variable.Initializer?.Value is LiteralExpressionSyntax)
+                    {
+                        ReportDiagnostics(context, Issue(declaration));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private void AnalyzeField(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is FieldDeclarationSyntax declaration && declaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
+            if (context.Node is FieldDeclarationSyntax declaration && declaration.IsReadOnly())
             {
                 foreach (var variable in declaration.Declaration.Variables)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_CodeFixProvider.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3226_CodeFixProvider)), Shared]
+    public sealed class MiKo_3226_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3226";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<FieldDeclarationSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is FieldDeclarationSyntax field)
+            {
+                var modifiers = field.Modifiers;
+                var readonlyModifier = modifiers.First(SyntaxKind.ReadOnlyKeyword);
+                var updatedModifiers = modifiers.Replace(readonlyModifier, SyntaxKind.ConstKeyword.AsToken());
+
+                var staticModifier = updatedModifiers.First(SyntaxKind.StaticKeyword);
+
+                return field.WithModifiers(staticModifier.IsDefaultValue() ? updatedModifiers : updatedModifiers.Remove(staticModifier));
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzerTests.cs
@@ -1,0 +1,187 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_type() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_unassigned_static_field() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private static int m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_unassigned_static_readonly_field() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private static readonly int m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_assigned_non_static_field() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private int m_field = 42;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_const_field() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private const int FIELD = 42;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_assigned_static_readonly_field_of_reference_type() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private static readonly object m_field = new object();
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_assigned_non_static_readonly_field_of_reference_type() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private readonly object m_field = new object();
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assigned_static_readonly_field_with_number_literal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private static readonly int m_field = 42;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assigned_non_static_readonly_field_with_number_literal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private readonly int m_field = 42;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assigned_static_readonly_field_with_string_literal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private static readonly string m_field = ""42"";
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_assigned_non_static_readonly_field_with_string_literal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private readonly string m_field = ""42"";
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_assigned_static_readonly_field_with_number_literal()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private static readonly int m_field = 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const int m_field = 42;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assigned_non_static_readonly_field_with_number_literal()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private readonly int m_field = 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const int m_field = 42;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assigned_static_readonly_field_with_string_literal()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private static readonly string m_field = ""42"";
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const string m_field = ""42"";
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assigned_non_static_readonly_field_with_string_literal()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private readonly string m_field = ""42"";
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const string m_field = ""42"";
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3226_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 477 rules that are currently provided by the analyzer.
+The following tables lists all the 478 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -422,6 +422,7 @@ The following tables lists all the 477 rules that are currently provided by the 
 |MiKo_3223|Reference comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3224|Value comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3225|Redundant comparisons can be simplified|&#x2713;|&#x2713;|
+|MiKo_3226|Read-only fields with initializers should be const|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduced analyzer detecting readonly fields with literal initializers.
- Added code fix provider converting readonly to const.
- Updated resources, project files, and README for new rule.
- Added comprehensive tests for analyzer and code fix.

(resolves #1216)