### PR TITLE
Added rules MiKo_2234 and MiKo_2312 that report 'which is to' to shorten to 'to'

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -295,6 +295,7 @@ namespace MiKoSolutions.Analyzers
             internal const string SpecialOrPhrase = "-or-";
             internal const string StringReturnTypeStartingPhraseTemplate = "A {0} {1} ";
             internal const string ThatContainsTerm = "that contains";
+            internal const string ToTerm = " to ";
             internal const string ToSeekTerm = "to seek";
             internal const string TryStartingPhrase = "Attempts to";
             internal const string ValueConverterSummaryStartingPhrase = "Represents a converter that converts ";
@@ -993,6 +994,18 @@ namespace MiKoSolutions.Analyzers
                                                                                  "Specifies",
                                                                                  "Enum",
                                                                              };
+
+            internal static readonly string[] WhichIsToTerms =
+                                                               {
+                                                                   ", that is to have to ",
+                                                                   ", that is to ",
+                                                                   " that is to have to ",
+                                                                   " that is to ",
+                                                                   ", which is to have to ",
+                                                                   ", which is to ",
+                                                                   " which is to have to ",
+                                                                   " which is to ",
+                                                               };
         }
 
         internal static class XmlTag

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -132,6 +132,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2231_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2308_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2309_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2311_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2312_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OverallDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ParameterDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ReturnTypeDocumentationCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -150,6 +150,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2231_InheritdocGetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_EmptySummaryAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_DocumentationShouldUseToAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2309_CommentContainsNtContractionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2310_CommentContainsIntentionallyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2311_CommentIsSeparatorAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2312_CommentShouldUseToAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MultiLineCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OperatorAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OverallDocumentationAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8514,6 +8514,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace with &apos;to&apos;.
+        /// </summary>
+        internal static string MiKo_2234_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2234_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Phrases like &quot;that is to&quot; or &quot;which is to&quot; are wordy and can just be replaced with &quot;to&quot;. This makes documentation clearer and more concise for developers..
+        /// </summary>
+        internal static string MiKo_2234_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2234_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;to&apos; instead.
+        /// </summary>
+        internal static string MiKo_2234_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2234_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos;.
+        /// </summary>
+        internal static string MiKo_2234_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2234_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>
@@ -8905,6 +8941,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_2311_Title {
             get {
                 return ResourceManager.GetString("MiKo_2311_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace with &apos;to&apos;.
+        /// </summary>
+        internal static string MiKo_2312_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2312_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Phrases like &quot;that is to&quot; or &quot;which is to&quot; are wordy and can just be replaced with &quot;to&quot;. This makes comments clearer and more concise for developers..
+        /// </summary>
+        internal static string MiKo_2312_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2312_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;to&apos; instead.
+        /// </summary>
+        internal static string MiKo_2312_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2312_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Comments should use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos;.
+        /// </summary>
+        internal static string MiKo_2312_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2312_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3006,6 +3006,18 @@ However, these suppressions should remain inline comments and must not be part o
   <data name="MiKo_2233_Title" xml:space="preserve">
     <value>XML tags should be placed on single line</value>
   </data>
+  <data name="MiKo_2234_CodeFixTitle" xml:space="preserve">
+    <value>Replace with 'to'</value>
+  </data>
+  <data name="MiKo_2234_Description" xml:space="preserve">
+    <value>Phrases like "that is to" or "which is to" are wordy and can just be replaced with "to". This makes documentation clearer and more concise for developers.</value>
+  </data>
+  <data name="MiKo_2234_MessageFormat" xml:space="preserve">
+    <value>Use 'to' instead</value>
+  </data>
+  <data name="MiKo_2234_Title" xml:space="preserve">
+    <value>Documentation should use 'to' instead of 'that is to' or 'which is to'</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>
@@ -3142,6 +3154,18 @@ Instead, comments should enhance understanding, giving context and reasoning for
   </data>
   <data name="MiKo_2311_Title" xml:space="preserve">
     <value>Do not use separator comments</value>
+  </data>
+  <data name="MiKo_2312_CodeFixTitle" xml:space="preserve">
+    <value>Replace with 'to'</value>
+  </data>
+  <data name="MiKo_2312_Description" xml:space="preserve">
+    <value>Phrases like "that is to" or "which is to" are wordy and can just be replaced with "to". This makes comments clearer and more concise for developers.</value>
+  </data>
+  <data name="MiKo_2312_MessageFormat" xml:space="preserve">
+    <value>Use 'to' instead</value>
+  </data>
+  <data name="MiKo_2312_Title" xml:space="preserve">
+    <value>Comments should use 'to' instead of 'that is to' or 'which is to'</value>
   </data>
   <data name="MiKo_3000_Description" xml:space="preserve">
     <value>If #region directives are used, avoid any empty #region. They just clutter the code without adding any value. When regions are truly needed, keep them meaningful and populated to ensure the code remains clean and efficient. This approach maintains clarity and organization in the codebase.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2234_CodeFixProvider)), Shared]
+    public sealed class MiKo_2234_CodeFixProvider : OverallDocumentationCodeFixProvider
+    {
+        private static readonly Pair[] ReplacementMap = CreateReplacementMap();
+
+        public override string FixableDiagnosticId => "MiKo_2234";
+
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        {
+            return Comment(syntax, Constants.Comments.WhichIsToTerms, ReplacementMap);
+        }
+
+//// ncrunch: rdi off
+
+        private static Pair[] CreateReplacementMap()
+        {
+            var terms = Constants.Comments.WhichIsToTerms;
+            var termsLength = terms.Length;
+
+            var result = new Pair[termsLength];
+
+            for (var index = 0; index < termsLength; index++)
+            {
+                result[index] = new Pair(terms[index], Constants.Comments.ToTerm);
+            }
+
+            return result;
+        }
+
+//// ncrunch: rdi default
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2234_DocumentationShouldUseToAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2234";
+
+        public MiKo_2234_DocumentationShouldUseToAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        {
+            var textTokens = comment.GetXmlTextTokens();
+            var textTokensCount = textTokens.Count;
+
+            if (textTokensCount == 0)
+            {
+                yield break;
+            }
+
+            var text = textTokens.GetTextTrimmedWithParaTags();
+
+            if (text.ContainsAny(Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase) is false)
+            {
+                yield break;
+            }
+
+            for (var i = 0; i < textTokensCount; i++)
+            {
+                var locations = GetAllLocations(textTokens[i], Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase);
+                var locationsCount = locations.Count;
+
+                if (locationsCount > 0)
+                {
+                    for (var index = 0; index < locationsCount; index++)
+                    {
+                        yield return Issue(symbol.Name, locations[index], Constants.Comments.ToTerm);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CodeFixProvider.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Composition;
+using System.Text;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2312_CodeFixProvider)), Shared]
+    public sealed class MiKo_2312_CodeFixProvider : CommentCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2312";
+
+        protected override SyntaxTrivia ComputeReplacementTrivia(SyntaxTrivia original, SyntaxTrivia rewritten)
+        {
+            var comment = original.ToString();
+
+            if (DocumentationComment.ContainsPhrases(Constants.Comments.WhichIsToTerms, comment.AsSpan().TrimStart()))
+            {
+                var text = comment.AsCachedBuilder().ReplaceAllWithCheck(Constants.Comments.WhichIsToTerms, Constants.Comments.ToTerm).ToStringAndRelease();
+
+                return SyntaxFactory.Comment(text);
+            }
+
+            return original;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2312_CommentShouldUseToAnalyzer : MultiLineCommentAnalyzer
+    {
+        public const string Id = "MiKo_2312";
+
+        public MiKo_2312_CommentShouldUseToAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool CommentHasIssue(ReadOnlySpan<char> comment, SemanticModel semanticModel) => DocumentationComment.ContainsPhrases(Constants.Comments.WhichIsToTerms, comment);
+
+        protected override IEnumerable<Diagnostic> CollectIssues(string name, SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase).Select(_ => Issue(name, _, Constants.Comments.ToTerm));
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzerTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2234_DocumentationShouldUseToAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] WrongTerms = Constants.Comments.WhichIsToTerms;
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}");
+
+        [TestCase("Some summary.")]
+        [TestCase("Some parent.")]
+        public void No_issue_is_reported_for_correct_comment_(string text) => No_issue_is_reported_for(@"
+/// <summary>
+/// " + text + @"
+/// </summary>
+public class TestMe
+{
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_contraction_in_documentation_([ValueSource(nameof(WrongTerms))] string phrase) => An_issue_is_reported_for(@"
+/// <summary>
+/// Something" + phrase + @"do.
+/// </summary>
+public class TestMe
+{
+}");
+
+        [Test]
+        public void Code_gets_fixed_([ValueSource(nameof(WrongTerms))] string phrase)
+        {
+            var originalCode = @"
+/// <summary>
+/// Something" + phrase + @"do.
+/// </summary>
+public class TestMe
+{
+}";
+
+            const string FixedCode = @"
+/// <summary>
+/// Something to do.
+/// </summary>
+public class TestMe
+{
+}";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2234_DocumentationShouldUseToAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2234_DocumentationShouldUseToAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2234_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzerTests.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2312_CommentShouldUseToAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] WrongTerms = Constants.Comments.WhichIsToTerms;
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // some comment
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_wrong_documentation_([ValueSource(nameof(WrongTerms))] string term) => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // Something" + term + @"do
+    }
+}");
+
+        [Test]
+        public void Code_gets_fixed_for_single_line_([ValueSource(nameof(WrongTerms))] string term)
+        {
+            var originalCode = @"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // Something" + term + @"do
+        DoSomething();
+    }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // Something to do
+        DoSomething();
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2312_CommentShouldUseToAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2312_CommentShouldUseToAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2312_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 478 rules that are currently provided by the analyzer.
+The following tables lists all the 480 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -272,6 +272,7 @@ The following tables lists all the 478 rules that are currently provided by the 
 |MiKo_2231|Documentation of overridden 'GetHashCode()' methods shall use '&lt;inheritdoc /&gt;' marker|&#x2713;|&#x2713;|
 |MiKo_2232|&lt;summary&gt; documentation should not be empty|&#x2713;|&#x2713;|
 |MiKo_2233|XML tags should be placed on single line|&#x2713;|&#x2713;|
+|MiKo_2224|Documentation should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|
@@ -284,6 +285,7 @@ The following tables lists all the 478 rules that are currently provided by the 
 |MiKo_2309|Comments should not use the contraction "n't"|&#x2713;|&#x2713;|
 |MiKo_2310|Comments should explain the 'Why' and not the 'That'|&#x2713;|\-|
 |MiKo_2311|Do not use separator comments|&#x2713;|&#x2713;|
+|MiKo_2312|Comments should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
 
 ### Maintainability
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Implemented new analyzers and code fixes (MiKo_2234, MiKo_2312).
- Added constants for phrase replacement in documentation.
- Added comprehensive tests for the new rules.
- Updated resources, project files and README with rule details.

