### PR TITLE
Overall documentation analyzers refactored

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -6118,7 +6118,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;&lt;para/&gt;&apos; instead of &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Use &apos;&lt;para/&gt;&apos; instead of &apos;{0}&apos;.
         /// </summary>
         internal static string MiKo_2042_MessageFormat {
             get {
@@ -7993,7 +7993,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &lt;list&gt; properly: {1}.
+        ///   Looks up a localized string similar to Use &lt;list&gt; properly: {0}.
         /// </summary>
         internal static string MiKo_2217_MessageFormat {
             get {
@@ -8125,7 +8125,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provide a documentation for &lt;{1}/&gt;.
+        ///   Looks up a localized string similar to Provide a documentation for &lt;{0}/&gt;.
         /// </summary>
         internal static string MiKo_2221_MessageFormat {
             get {
@@ -11339,7 +11339,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;unchecked((int)0x{1})&apos; instead for HResult.
+        ///   Looks up a localized string similar to Use &apos;unchecked((int)0x{0})&apos; instead for HResult.
         /// </summary>
         internal static string MiKo_3079_MessageFormat {
             get {
@@ -11512,7 +11512,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place it on right side of &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Place it on right side of &apos;{0}&apos;.
         /// </summary>
         internal static string MiKo_3084_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2185,7 +2185,7 @@ This format clearly describes the purpose of the class and its functionality, ma
     <value>https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/para</value>
   </data>
   <data name="MiKo_2042_MessageFormat" xml:space="preserve">
-    <value>Use '&lt;para/&gt;' instead of '{1}'</value>
+    <value>Use '&lt;para/&gt;' instead of '{0}'</value>
   </data>
   <data name="MiKo_2042_Title" xml:space="preserve">
     <value>Documentation should use '&lt;para/&gt;' XML tags instead of '&lt;br/&gt;' HTML tags</value>
@@ -2828,7 +2828,7 @@ This ensures your list documentation is clear and accurately structured.</value>
     <value>The 'type' attribute contains the unknown type {0}</value>
   </data>
   <data name="MiKo_2217_MessageFormat" xml:space="preserve">
-    <value>Use &lt;list&gt; properly: {1}</value>
+    <value>Use &lt;list&gt; properly: {0}</value>
   </data>
   <data name="MiKo_2217_Title" xml:space="preserve">
     <value>&lt;list&gt; documentation is done properly</value>
@@ -2876,7 +2876,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>An empty documentation is a code smell. It indicates that the developer created the XML documentation tag intentionally but failed to provide any actual content. This suggests a potential oversight or lack of attention to detail. Proper documentation is crucial for code clarity and maintenance.</value>
   </data>
   <data name="MiKo_2221_MessageFormat" xml:space="preserve">
-    <value>Provide a documentation for &lt;{1}/&gt;</value>
+    <value>Provide a documentation for &lt;{0}/&gt;</value>
   </data>
   <data name="MiKo_2221_Title" xml:space="preserve">
     <value>Documentation should not use empty XML tags</value>
@@ -3986,7 +3986,7 @@ This approach ensures stability and clarity, keeping the Enum's behavior consist
     <value>Write HResults in hexadecimal, not as negative integers. It's much easier to recognize and search for '0x80070005' than '-2147024891'. Keeps the code clean and user-friendly.</value>
   </data>
   <data name="MiKo_3079_MessageFormat" xml:space="preserve">
-    <value>Use 'unchecked((int)0x{1})' instead for HResult</value>
+    <value>Use 'unchecked((int)0x{0})' instead for HResult</value>
   </data>
   <data name="MiKo_3079_Title" xml:space="preserve">
     <value>HResults should be written in hexadecimal</value>
@@ -4045,7 +4045,7 @@ This approach enhances clarity and maintainability.</value>
     <value>To increase readability, place constants on the right side of an operator, not the left. This makes the code look more intuitive and easier to understand.</value>
   </data>
   <data name="MiKo_3084_MessageFormat" xml:space="preserve">
-    <value>Place it on right side of '{1}'</value>
+    <value>Place it on right side of '{0}'</value>
   </data>
   <data name="MiKo_3084_Title" xml:space="preserve">
     <value>Do not place constants on the left side for comparisons</value>

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -250,6 +250,8 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected Diagnostic Issue(SyntaxToken token) => Issue(token, Array.Empty<Pair>());
 
+        protected Diagnostic Issue(SyntaxTrivia trivia) => Issue(trivia, Array.Empty<Pair>());
+
         protected Diagnostic Issue(Location location) => Issue(location, Array.Empty<Pair>());
 
         protected Diagnostic Issue<T>(ISymbol symbol, T arg1) => Issue(symbol, arg1, Array.Empty<Pair>());
@@ -280,6 +282,8 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected Diagnostic Issue<T1, T2>(ISymbol symbol, T1 arg1, T2 arg2) => Issue(symbol, arg1, arg2, Array.Empty<Pair>());
 
+        protected Diagnostic Issue<T1, T2>(SyntaxNode node, T1 arg1, T2 arg2) => Issue(node.GetLocation(), arg1, arg2, Array.Empty<Pair>());
+
         protected Diagnostic Issue<T1, T2>(Location location, T1 arg1, T2 arg2) => Issue(location, arg1, arg2, Array.Empty<Pair>());
 
         protected Diagnostic Issue<T1, T2>(string name, ISymbol symbol, T1 arg1, T2 arg2) => Issue(name, symbol, arg1, arg2, Array.Empty<Pair>());
@@ -303,6 +307,8 @@ namespace MiKoSolutions.Analyzers.Rules
         protected Diagnostic Issue(SyntaxNode node, params Pair[] properties) => CreateIssue(node.GetLocation(), properties, node.ToString());
 
         protected Diagnostic Issue(SyntaxToken token, params Pair[] properties) => CreateIssue(token.GetLocation(), properties, token.ValueText);
+
+        protected Diagnostic Issue(SyntaxTrivia trivia, params Pair[] properties) => CreateIssue(trivia.GetLocation(), properties);
 
         protected Diagnostic Issue(Location location, params Pair[] properties) => CreateIssue(location, properties, location.GetText());
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -132,15 +132,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 //// ncrunch: rdi default
         }
 
-        protected virtual bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.HasDocumentationCommentTriviaSyntax();
+        protected virtual bool ShallAnalyze(INamedTypeSymbol symbol) => true;
 
-        protected virtual bool ShallAnalyze(IMethodSymbol symbol) => symbol.HasDocumentationCommentTriviaSyntax();
+        protected virtual bool ShallAnalyze(IMethodSymbol symbol) => true;
 
-        protected virtual bool ShallAnalyze(IEventSymbol symbol) => symbol.HasDocumentationCommentTriviaSyntax();
+        protected virtual bool ShallAnalyze(IEventSymbol symbol) => true;
 
-        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => symbol.HasDocumentationCommentTriviaSyntax();
+        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => true;
 
-        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => symbol.HasDocumentationCommentTriviaSyntax();
+        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => true;
 
         protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationAnalyzer.cs
@@ -44,7 +44,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return exceptionXmls.Where(_ => _.IsExceptionComment(m_exceptionType));
         }
 
-        protected Diagnostic ExceptionIssue(XmlElementSyntax exceptionComment, string proposal) => Issue(string.Empty, exceptionComment.GetContentsLocation(), ExceptionPhrase, proposal, CreatePhraseProposal(proposal));
+        protected Diagnostic ExceptionIssue(XmlElementSyntax exceptionComment, string proposal) => Issue(exceptionComment.GetContentsLocation(), ExceptionPhrase, proposal, CreatePhraseProposal(proposal));
 
         private IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, IEnumerable<XmlElementSyntax> comments)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzer.cs
@@ -20,8 +20,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var nodeOrToken in comment.AllDescendantNodesAndTokens())
             {
                 if (nodeOrToken.IsNode)
@@ -30,7 +32,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         case XmlEmptyElementSyntax emptyElement when emptyElement.SlashGreaterThanToken.IsMissing:
                         {
-                            yield return Issue(emptyElement.LessThanToken);
+                            if (results is null)
+                            {
+                                results = new List<Diagnostic>(1);
+                            }
+
+                            results.Add(Issue(emptyElement.LessThanToken));
 
                             break;
                         }
@@ -41,7 +48,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                             if (name.IsNullOrWhiteSpace())
                             {
-                                yield return Issue(element.StartTag);
+                                if (results is null)
+                                {
+                                    results = new List<Diagnostic>(1);
+                                }
+
+                                results.Add(Issue(element.StartTag));
                             }
 
                             break;
@@ -58,11 +70,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         if (text.Contains('&'))
                         {
-                            yield return Issue(token);
+                            if (results is null)
+                            {
+                                results = new List<Diagnostic>(1);
+                            }
+
+                            results.Add(Issue(token));
                         }
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -28,14 +28,57 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
-        {
-            return comment is null
-                   ? Array.Empty<Diagnostic>()
-                   : AnalyzeComment(symbol.Name, comment);
-        }
-
 //// ncrunch: rdi off
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        {
+            var results = new List<Diagnostic>(1);
+
+            foreach (var descendant in comment.DescendantNodes(DescendIntoChildren))
+            {
+                switch (descendant)
+                {
+                    case XmlElementSyntax e when e.IsWrongBooleanTag() || e.IsWrongNullTag():
+                    {
+                        var wrongText = e.Content.ToString();
+                        var proposal = Proposal(wrongText);
+
+                        results.Add(Issue(e, wrongText, proposal));
+
+                        break;
+                    }
+
+                    case XmlEmptyElementSyntax ee when ee.IsSee(WrongAttributes) || ee.IsSeeAlso(WrongAttributes):
+                    {
+                        var wrongText = GetWrongText(ee.Attributes);
+                        var proposal = Proposal(wrongText);
+
+                        results.Add(Issue(ee, wrongText, proposal));
+
+                        break;
+                    }
+
+                    case XmlElementSyntax e when e.IsSee(WrongAttributes) || e.IsSeeAlso(WrongAttributes):
+                    {
+                        var wrongText = GetWrongText(e.StartTag.Attributes);
+                        var proposal = Proposal(wrongText);
+
+                        results.Add(Issue(e, wrongText, proposal));
+
+                        break;
+                    }
+
+                    case XmlTextSyntax textNode:
+                    {
+                        results.AddRange(AnalyzeTextTokens(textNode));
+
+                        break;
+                    }
+                }
+            }
+
+            return results;
+        }
 
         private static Pair[] CreateStartParts()
         {
@@ -144,58 +187,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private IEnumerable<Diagnostic> AnalyzeComment(string symbolName, DocumentationCommentTriviaSyntax comment)
-        {
-            var descendantNodes = comment.DescendantNodes(DescendIntoChildren);
-
-            foreach (var descendant in descendantNodes)
-            {
-                switch (descendant)
-                {
-                    case XmlElementSyntax e when e.IsWrongBooleanTag() || e.IsWrongNullTag():
-                    {
-                        var wrongText = e.Content.ToString();
-                        var proposal = Proposal(wrongText);
-
-                        yield return Issue(symbolName, e, wrongText, proposal);
-
-                        break;
-                    }
-
-                    case XmlEmptyElementSyntax ee when ee.IsSee(WrongAttributes) || ee.IsSeeAlso(WrongAttributes):
-                    {
-                        var wrongText = GetWrongText(ee.Attributes);
-                        var proposal = Proposal(wrongText);
-
-                        yield return Issue(symbolName, ee, wrongText, proposal);
-
-                        break;
-                    }
-
-                    case XmlElementSyntax e when e.IsSee(WrongAttributes) || e.IsSeeAlso(WrongAttributes):
-                    {
-                        var wrongText = GetWrongText(e.StartTag.Attributes);
-                        var proposal = Proposal(wrongText);
-
-                        yield return Issue(symbolName, e, wrongText, proposal);
-
-                        break;
-                    }
-
-                    case XmlTextSyntax textNode:
-                    {
-                        foreach (var issue in AnalyzeTextTokens(symbolName, textNode))
-                        {
-                            yield return issue;
-                        }
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeTextTokens(string symbolName, XmlTextSyntax textNode)
+        private IEnumerable<Diagnostic> AnalyzeTextTokens(XmlTextSyntax textNode)
         {
             var alreadyFoundLocations = new HashSet<Location>();
 
@@ -249,7 +241,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                             if (alreadyFoundLocations.Add(location))
                             {
-                                yield return Issue(symbolName, location, wrongText, proposal);
+                                yield return Issue(location, wrongText, proposal);
                             }
                         }
                     }
@@ -268,7 +260,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (location != null && alreadyFoundLocations.Add(location))
                     {
-                        yield return Issue(symbolName, location, wrongText, proposal);
+                        yield return Issue(location, wrongText, proposal);
                     }
                 }
 
@@ -285,7 +277,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (location != null && alreadyFoundLocations.Add(location))
                     {
-                        yield return Issue(symbolName, location, wrongText, proposal);
+                        yield return Issue(location, wrongText, proposal);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_BrParaAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_BrParaAnalyzer.cs
@@ -17,8 +17,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var node in comment.DescendantNodes(_ => CodeTags.Contains(_.GetXmlTagName()) is false, true))
             {
                 if (node is XmlElementStartTagSyntax || node is XmlEmptyElementSyntax)
@@ -28,17 +30,29 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     switch (tag)
                     {
                         case "br":
-                            yield return Issue(symbol.Name, node, "<br/>");
+                            if (results is null)
+                            {
+                                results = new List<Diagnostic>();
+                            }
+
+                            results.Add(Issue(node, "<br/>"));
 
                             break;
 
                         case "p":
-                            yield return Issue(symbol.Name, node, "<p>...</p>");
+                            if (results is null)
+                            {
+                                results = new List<Diagnostic>();
+                            }
+
+                            results.Add(Issue(node, "<p>...</p>"));
 
                             break;
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Issue(location, replacement, properties);
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var issues = AnalyzeCommentXml(comment);
             var count = issues.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
@@ -18,22 +18,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.ActionTerms, StringComparison.Ordinal) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -44,12 +46,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(locations[index], Constants.Comments.CallbackTerm);
+                        results.Add(Issue(locations[index], Constants.Comments.CallbackTerm));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2200_DocumentationStartsCapitalizedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2200_DocumentationStartsCapitalizedAnalyzer.cs
@@ -33,15 +33,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var xml in comment.GetXmlSyntax(XmlTags))
             {
                 if (xml.Content.FirstOrDefault() is XmlTextSyntax text)
                 {
-                    yield return AnalyzeText(text, xml.GetName());
+                    var issue = AnalyzeText(text, xml.GetName());
+
+                    if (issue == null)
+                    {
+                        continue;
+                    }
+
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(1);
+                    }
+
+                    results.Add(issue);
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
 
         private Diagnostic AnalyzeText(XmlTextSyntax syntax, string xmlTag)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
@@ -17,24 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, comment);
-
-        private IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
             if (trimmed.ContainsAny(Constants.Comments.IdTerms, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -45,12 +45,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
@@ -17,24 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, comment);
-
-        private IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
             if (trimmed.ContainsAny(Constants.Comments.Guids, StringComparison.Ordinal) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -45,12 +45,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
@@ -18,22 +18,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Triggers, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -42,12 +44,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
@@ -16,22 +16,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.FlagTermsWithDelimiters, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -42,12 +44,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
@@ -21,22 +21,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Phrases, StringComparison.Ordinal) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -54,12 +56,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
@@ -23,14 +23,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             const string Dots = "..";
@@ -39,8 +39,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (text.Contains(Dots, StringComparison.Ordinal) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -49,12 +51,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
@@ -16,22 +16,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.InfoTerms, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -42,12 +44,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
@@ -16,22 +16,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.NotContractionPhrase, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -40,12 +42,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
@@ -18,8 +18,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var tokens in comment.DescendantNodes<XmlTextSyntax>().Select(_ => _.TextTokens))
             {
                 var count = tokens.Count - 1;
@@ -36,12 +38,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                             if (nextToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                             {
-                                yield return Issue(symbol.Name, nextToken);
+                                if (results is null)
+                                {
+                                    results = new List<Diagnostic>(1);
+                                }
+
+                                results.Add(Issue(nextToken));
                             }
                         }
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             if (HasIssue(comment))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -15,23 +16,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
-            foreach (var element in FindProblematicElements(comment))
-            {
-                yield return Issue(element);
-            }
-        }
+            List<Diagnostic> results = null;
 
-        private static IEnumerable<SyntaxNode> FindProblematicElements(SyntaxNode comment)
-        {
+            // ReSharper disable once LoopCanBePartlyConvertedToQuery
             foreach (var element in comment.DescendantNodes())
             {
                 if (element.Parent is XmlElementSyntax && element.IsXmlTag(Constants.XmlTag.Param))
                 {
-                    yield return element;
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(1);
+                    }
+
+                    results.Add(Issue(element));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -331,7 +331,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Issue(location, replacement, properties);
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var issues = AnalyzeCommentXml(comment);
             var count = issues.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
@@ -26,8 +26,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var token in comment.DescendantNodes<XmlTextSyntax>(_ => _.AncestorsWithinDocumentation<XmlElementSyntax>().None(__ => AllowedTags.Contains(__.GetName())))
                                          .SelectMany(_ => _.TextTokens.OfKind(SyntaxKind.XmlTextLiteralToken)))
             {
@@ -46,10 +48,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             continue;
                         }
 
-                        yield return Issue(location);
+                        if (results is null)
+                        {
+                            results = new List<Diagnostic>(1);
+                        }
+
+                        results.Add(Issue(location));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
@@ -18,22 +18,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.FindTerms, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -44,12 +46,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index], Constants.Comments.ToSeekTerm);
+                        results.Add(Issue(locations[index], Constants.Comments.ToSeekTerm));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -29,8 +30,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var xml in comment.GetEmptyXmlSyntax(Tags))
             {
                 var tagName = xml.GetName();
@@ -41,8 +44,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     continue;
                 }
 
-                yield return Issue(symbol.Name, xml, tagName);
+                if (results is null)
+                {
+                    results = new List<Diagnostic>(1);
+                }
+
+                results.Add(Issue(xml, tagName));
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
@@ -17,24 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, comment);
-
-        private IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
             if (trimmed.ContainsAny(Constants.Comments.IdentTerms, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -45,12 +45,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -46,7 +46,57 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(comment);
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        {
+            var lines = new HashSet<int>();
+
+            var emptyElements = new List<XmlEmptyElementSyntax>();
+            var elements = new List<XmlElementSyntax>();
+
+            foreach (var node in comment.DescendantNodes<XmlNodeSyntax>())
+            {
+                switch (node)
+                {
+                    case XmlEmptyElementSyntax emptyElement:
+                        emptyElements.Add(emptyElement);
+
+                        break;
+
+                    case XmlElementSyntax element:
+                        elements.Add(element);
+
+                        break;
+                }
+            }
+
+            // first loop over the elements to collect all lines that are also required to check for the empty elements, then loop over the empty ones
+            List<Diagnostic> results = null;
+
+            foreach (var element in elements)
+            {
+                foreach (var issue in AnalyzeXmlElement(element, lines))
+                {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(1);
+                    }
+
+                    results.Add(issue);
+                }
+            }
+
+            foreach (var issue in emptyElements.Select(_ => AnalyzeEmptyXmlElement(_, lines)))
+            {
+                if (results is null)
+                {
+                    results = new List<Diagnostic>(1);
+                }
+
+                results.Add(issue);
+            }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
+        }
 
         private static bool IsOnSameLine(XmlTextSyntax text, params int[] lines)
         {
@@ -115,35 +165,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
 
             return onSameLineAsTextAfter ? AddSpacesAfter : Array.Empty<Pair>();
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment)
-        {
-            var lines = new HashSet<int>();
-
-            var emptyElements = new List<XmlEmptyElementSyntax>();
-            var elements = new List<XmlElementSyntax>();
-
-            foreach (var node in comment.DescendantNodes<XmlNodeSyntax>())
-            {
-                switch (node)
-                {
-                    case XmlEmptyElementSyntax emptyElement:
-                        emptyElements.Add(emptyElement);
-
-                        break;
-
-                    case XmlElementSyntax element:
-                        elements.Add(element);
-
-                        break;
-                }
-            }
-
-            // first loop over the elements to collect all lines that are also required to check for the empty elements, then loop over the empty ones
-            return Array.Empty<Diagnostic>()
-                        .Concat(elements.SelectMany(_ => AnalyzeXmlElement(_, lines)))
-                        .Concat(emptyElements.Select(_ => AnalyzeEmptyXmlElement(_, lines)));
         }
 
         private IEnumerable<Diagnostic> AnalyzeXmlElement(XmlElementSyntax element, HashSet<int> lines)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
@@ -21,22 +21,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
             if (trimmed.ContainsAny(Phrases, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -58,12 +60,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
@@ -21,22 +21,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
             if (trimmed.ContainsAny(Phrases, StringComparison.Ordinal) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -52,12 +54,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var summaryXmls = comment.GetSummaryXmls();
             var remarksXmls = comment.GetRemarksXmls();
@@ -31,7 +31,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             return Array.Empty<Diagnostic>()
                         .Concat(AnalyzeXml(summaryXmls))
-                        .Concat(AnalyzeXml(remarksXmls));
+                        .Concat(AnalyzeXml(remarksXmls))
+                        .ToList();
         }
 
         private static bool SentenceHasIssue(XmlElementSyntax xml)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,8 +19,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
+            List<Diagnostic> results = null;
+
             foreach (var token in comment.DescendantTokens(SyntaxKind.XmlTextLiteralToken))
             {
                 if (token.Parent.IsKind(SyntaxKind.XmlCDataSection))
@@ -33,12 +36,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(locations[index]);
+                        results.Add(Issue(locations[index]));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
@@ -16,22 +16,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
             if (textTokensCount == 0)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
             if (text.ContainsAny(Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase) is false)
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
+
+            List<Diagnostic> results = null;
 
             for (var i = 0; i < textTokensCount; i++)
             {
@@ -40,12 +42,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (locationsCount > 0)
                 {
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(locationsCount);
+                    }
+
                     for (var index = 0; index < locationsCount; index++)
                     {
-                        yield return Issue(symbol.Name, locations[index], Constants.Comments.ToTerm);
+                        results.Add(Issue(locations[index], Constants.Comments.ToTerm));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (CommentContainsSeparator(comment.AsSpan()))
                     {
-                        yield return Issue(string.Empty, trivia);
+                        yield return Issue(trivia);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3030_MethodsFollowLawOfDemeterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3030_MethodsFollowLawOfDemeterAnalyzer.cs
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                   ? maes.Name
                                   : node;
 
-            ReportDiagnostics(context, Issue(string.Empty, problematicNode));
+            ReportDiagnostics(context, Issue(problematicNode));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3079_DoNotUseIntegerForHResultAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3079_DoNotUseIntegerForHResultAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var hexValue = ((-1) * result).ToString("X");
 
-                    ReportDiagnostics(context, Issue(string.Empty, parent, hexValue));
+                    ReportDiagnostics(context, Issue(parent, hexValue));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3084_YodaExpressionAnalyzer.cs
@@ -49,15 +49,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (IsResponsibleNode(left) || left.IsConst(context))
             {
-                ReportIssue(context, node.OperatorToken, left);
+                ReportDiagnostics(context, Issue(left, node.OperatorToken.ValueText));
             }
-        }
-
-        private void ReportIssue(SyntaxNodeAnalysisContext context, SyntaxToken token, SyntaxNode node)
-        {
-            var issue = Issue(string.Empty, node, token.ValueText);
-
-            ReportDiagnostics(context, issue);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzer.cs
@@ -162,7 +162,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             if (AnalyzeLength(node, context.SemanticModel))
             {
-                ReportDiagnostics(context, Issue(string.Empty, node));
+                ReportDiagnostics(context, Issue(node));
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3086_DoNotNestConditionalExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3086_DoNotNestConditionalExpressionAnalyzer.cs
@@ -32,19 +32,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     case SyntaxKind.ConditionalExpression:
                     case SyntaxKind.CoalesceExpression:
                     {
-                        ReportIssue(context, descendant);
+                        ReportDiagnostics(context, Issue(descendant));
 
                         break;
                     }
                 }
             }
-        }
-
-        private void ReportIssue(SyntaxNodeAnalysisContext context, SyntaxNode node)
-        {
-            var issue = Issue(string.Empty, node);
-
-            ReportDiagnostics(context, issue);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3401_NamespaceDepthAnalyzer.cs
@@ -37,9 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (depth > MaxDepth)
             {
-                var issue = Issue(string.Empty, node.Name, depth, MaxDepth);
-
-                ReportDiagnostics(context, issue);
+                ReportDiagnostics(context, Issue(node.Name, depth, MaxDepth));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForExpressionAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected abstract void AnalyzeExpression(SyntaxNodeAnalysisContext context);
 
-        protected void ReportIssue(SyntaxNodeAnalysisContext context, SyntaxToken token) => ReportDiagnostics(context, Issue(string.Empty, token));
+        protected void ReportIssue(SyntaxNodeAnalysisContext context, SyntaxToken token) => ReportDiagnostics(context, Issue(token));
 
         private void AnalyzeExpressionLanguageAware(SyntaxNodeAnalysisContext context)
         {

--- a/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -58,6 +58,7 @@ namespace TestHelper
                                          var message = result.GetMessage(null);
 
                                          Assert.That(message, Does.Not.Contain("tring[]"), "Wrong parameter provided, string array is not converted.");
+                                         Assert.That(message, Does.Not.Contain(" -> "), "Wrong parameter provided, Pair.");
 
                                          foreach (var placeholder in Placeholders)
                                          {


### PR DESCRIPTION
- Change analyzers to return `IReadOnlyList` diagnostics
- Update resource format strings with corrected indexes
- Refactor methods to use list accumulation instead of yield
- Simplify issue reporting calls and overloads
