### PR TITLE
MiKo_2223 is now aware of 'e.g.'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -159,11 +159,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (trimmed[0].IsNumber())
             {
-                if (trimmed.Any(_ => _ == '.') && trimmed[1].IsLetter())
-                {
-                    return true;
-                }
+                return trimmed.Any(_ => _ == '.') && trimmed[1].IsLetter();
+            }
 
+            if (trimmed.Length == 3 && trimmed.Equals("e.g", StringComparison.OrdinalIgnoreCase))
+            {
                 return false;
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -405,6 +405,21 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_comment_with_e_g() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something, e.g. that is very important, on stuff.
+    /// </summary>
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Add explicit check for "e.g" string in compound word verification.
- Implement new unit test to validate "e.g" handling in documentation.
- Refactor numeric prefix condition for clarity.

