### PR TITLE
Refactored example documentation analyzers to directly use DocumentationCommentTriviaSyntax

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -7272,7 +7272,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start &lt;example&gt; with: &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Start &lt;example&gt; with: &apos;{0}&apos;.
         /// </summary>
         internal static string MiKo_2100_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2577,7 +2577,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>To make example documentation more user-friendly, it should begin with a brief phrase that explains what the example demonstrates. This provides clarity and helps developers quickly understand the purpose of the example.</value>
   </data>
   <data name="MiKo_2100_MessageFormat" xml:space="preserve">
-    <value>Start &lt;example&gt; with: '{1}'</value>
+    <value>Start &lt;example&gt; with: '{0}'</value>
   </data>
   <data name="MiKo_2100_Title" xml:space="preserve">
     <value>&lt;example&gt; documentation should start with descriptive default phrase</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -12,6 +12,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         protected static readonly string[] CodeTags = { Constants.XmlTag.Code, Constants.XmlTag.C };
 
+        protected static readonly SyntaxKind[] DocumentationCommentTrivia = { SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.MultiLineDocumentationCommentTrivia };
+
         protected DocumentationAnalyzer(string diagnosticId, SymbolKind symbolKind) : base(nameof(Documentation), diagnosticId, symbolKind)
         {
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzer.cs
@@ -13,15 +13,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2100";
 
+        private const string Phrase = Constants.Comments.ExampleDefaultPhrase;
+
         public MiKo_2100_ExampleDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeExample(ISymbol owningSymbol, IEnumerable<XmlElementSyntax> examples) => AnalyzeStartingPhrase(owningSymbol, examples);
-
-        private IEnumerable<Diagnostic> AnalyzeStartingPhrase(ISymbol symbol, IEnumerable<XmlElementSyntax> examples)
+        protected override IReadOnlyList<Diagnostic> AnalyzeExample(ISymbol symbol, IReadOnlyList<XmlElementSyntax> examples)
         {
-            const string Phrase = Constants.Comments.ExampleDefaultPhrase;
+            List<Diagnostic> results = null;
 
             foreach (var example in examples)
             {
@@ -29,9 +29,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (tokens.None(_ => _.ValueText.AsSpan().TrimStart().StartsWith(Phrase, StringComparison.Ordinal)))
                 {
-                    yield return Issue(symbol.Name, example.StartTag, Phrase);
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(1);
+                    }
+
+                    results.Add(Issue(example.StartTag, Phrase));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_ExampleUsesCodeTagAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_ExampleUsesCodeTagAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -15,25 +16,30 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeExample(ISymbol owningSymbol, IEnumerable<XmlElementSyntax> examples) => AnalyzeStartingPhrase(owningSymbol, examples);
-
-        private IEnumerable<Diagnostic> AnalyzeStartingPhrase(ISymbol symbol, IEnumerable<XmlElementSyntax> examples)
+        protected override IReadOnlyList<Diagnostic> AnalyzeExample(ISymbol symbol, IReadOnlyList<XmlElementSyntax> examples)
         {
+            List<Diagnostic> results = null;
+
             foreach (var example in examples)
             {
                 var tokens = example.GetXmlTextTokens();
 
                 foreach (var token in tokens)
                 {
-                    var index = token.ValueText.IndexOf('=');
-
-                    if (index >= 0)
+                    if (token.ValueText.IndexOf('=') >= 0)
                     {
+                        if (results is null)
+                        {
+                            results = new List<Diagnostic>(1);
+                        }
+
                         // we have an issue
-                        yield return Issue(symbol.Name, example);
+                        results.Add(Issue(example));
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -12,8 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class OverallDocumentationAnalyzer : DocumentationAnalyzer
     {
-        private static readonly SyntaxKind[] DocumentationCommentTrivia = { SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.MultiLineDocumentationCommentTrivia };
-
         protected OverallDocumentationAnalyzer(string id) : base(id, (SymbolKind)(-1))
         {
         }


### PR DESCRIPTION
- Refactored analyzers to use `DocumentationCommentTriviaSyntax` directly
- Changed diagnostic methods to return `IReadOnlyList`
- Updated resource strings for consistent formatting
- Removed redundant syntax constant in `OverallDocumentationAnalyzer`

