### PR TITLE
Refactored exception documentation analyzers to directly use DocumentationCommentTriviaSyntax

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
@@ -122,7 +122,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static IEnumerable<string> GetExceptionComments(string commentXml) => Cleaned(GetExceptionCommentElements(commentXml)).WhereNotNull();
 
-        internal static IEnumerable<string> GetExceptionsOfExceptionComments(string commentXml)
+        internal static IEnumerable<string> GetExceptionsOfExceptionComments(this string commentXml)
         {
             return GetExceptionCommentElements(commentXml).Select(_ => _.Attribute(Constants.XmlTag.Attribute.Cref)?.Value).WhereNotNull();
         }

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -6539,6 +6539,7 @@ namespace MiKoSolutions.Analyzers {
         
         /// <summary>
         ///   Looks up a localized string similar to {1} should be something like:
+        ///
         ///{2}.
         /// </summary>
         internal static string MiKo_2054_MessageFormat {
@@ -6577,6 +6578,7 @@ namespace MiKoSolutions.Analyzers {
         
         /// <summary>
         ///   Looks up a localized string similar to {1} should be something like:
+        ///
         ///{2}.
         /// </summary>
         internal static string MiKo_2055_MessageFormat {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2330,6 +2330,7 @@ This approach ensures clarity and consistency, helping developers understand the
   </data>
   <data name="MiKo_2054_MessageFormat" xml:space="preserve">
     <value>{1} should be something like:
+
 {2}</value>
   </data>
   <data name="MiKo_2054_Title" xml:space="preserve">
@@ -2344,6 +2345,7 @@ This approach ensures clarity and consistency, helping developers understand und
   </data>
   <data name="MiKo_2055_MessageFormat" xml:space="preserve">
     <value>{1} should be something like:
+
 {2}</value>
   </data>
   <data name="MiKo_2055_Title" xml:space="preserve">

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ArgumentExceptionPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ArgumentExceptionPhraseAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             m_exceptionPhrases = phrases;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
         {
             switch (symbol)
             {
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        protected virtual IEnumerable<Diagnostic> AnalyzeException(ISymbol owningSymbol, IReadOnlyCollection<IParameterSymbol> parameters, XmlElementSyntax exceptionComment)
+        protected virtual IReadOnlyList<Diagnostic> AnalyzeException(ISymbol owningSymbol, IReadOnlyCollection<IParameterSymbol> parameters, XmlElementSyntax exceptionComment)
         {
             // get rid of the para tags as we are not interested into them
             var comment = exceptionComment.GetTextTrimmed();
@@ -80,7 +80,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected virtual IReadOnlyCollection<IParameterSymbol> GetMatchingParameters(ImmutableArray<IParameterSymbol> parameterSymbols) => parameterSymbols;
 
-        private IEnumerable<Diagnostic> AnalyzeException(ISymbol owningSymbol, IMethodSymbol methodSymbol, XmlElementSyntax exceptionComment)
+        private IReadOnlyList<Diagnostic> AnalyzeException(ISymbol owningSymbol, IMethodSymbol methodSymbol, XmlElementSyntax exceptionComment)
         {
             if (methodSymbol is null)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2051_ExceptionTagDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2051_ExceptionTagDefaultPhraseAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override IEnumerable<XmlElementSyntax> GetExceptionComments(DocumentationCommentTriviaSyntax documentation) => documentation.GetExceptionXmls();
 
-        protected override IEnumerable<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
         {
             // get rid of the para tags as we are not interested into them
             var comment = exceptionComment.GetTextTrimmed();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2053_ArgumentNullExceptionWrongParameterInPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2053_ArgumentNullExceptionWrongParameterInPhraseAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override IReadOnlyCollection<IParameterSymbol> GetMatchingParameters(ImmutableArray<IParameterSymbol> parameterSymbols) => parameterSymbols.Where(_ => _.Type.IsValueType && _.Type.IsNullable() is false).ToList();
 
-        protected override IEnumerable<Diagnostic> AnalyzeException(ISymbol owningSymbol, IReadOnlyCollection<IParameterSymbol> parameters, XmlElementSyntax exceptionComment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeException(ISymbol owningSymbol, IReadOnlyCollection<IParameterSymbol> parameters, XmlElementSyntax exceptionComment)
         {
             List<Diagnostic> issues = null;
 
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            return issues ?? (IEnumerable<Diagnostic>)Array.Empty<Diagnostic>();
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_ObjectDisposedExceptionPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_ObjectDisposedExceptionPhraseAnalyzer.cs
@@ -19,14 +19,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
         {
             // get rid of the para tags as we are not interested into them
             var comment = exceptionComment.GetTextTrimmed();
 
             if (comment.EndsWith(Constants.Comments.ObjectDisposedExceptionEndingPhrase, Comparison))
             {
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var hasCloseMethod = HasCloseMethod(symbol);
@@ -34,14 +34,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (hasCloseMethod && comment.EndsWith(Constants.Comments.ObjectDisposedExceptionAlternatingEndingPhrase, Comparison))
             {
                 // allowed alternative for Closed methods
-                yield break;
+                return Array.Empty<Diagnostic>();
             }
 
             var endingPhrase = hasCloseMethod
                                ? Constants.Comments.ObjectDisposedExceptionAlternatingEndingPhrase
                                : Constants.Comments.ObjectDisposedExceptionEndingPhrase;
 
-            yield return ExceptionIssue(exceptionComment, endingPhrase);
+            return new[] { ExceptionIssue(exceptionComment, endingPhrase) };
         }
 
         private static bool HasCloseMethod(ISymbol symbol) => symbol.FindContainingType().GetMembersIncludingInherited<IMethodSymbol>("Close").Any();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2057_ObjectDisposedExceptionWrongPlacedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2057_ObjectDisposedExceptionWrongPlacedAnalyzer.cs
@@ -16,12 +16,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeException(ISymbol symbol, XmlElementSyntax exceptionComment)
         {
-            if (symbol.FindContainingType().IsDisposable() is false)
-            {
-                yield return ExceptionIssue(exceptionComment, string.Empty);
-            }
+            return symbol.FindContainingType().IsDisposable()
+                   ? Array.Empty<Diagnostic>()
+                   : new[] { ExceptionIssue(exceptionComment, string.Empty) };
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_DuplicateExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_DuplicateExceptionAnalyzer.cs
@@ -17,15 +17,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
         {
-            var groups = CommentExtensions.GetExceptionsOfExceptionComments(commentXml)
-                                          .GroupBy(_ => _); // TODO: what about namespaces
+            List<Diagnostic> results = null;
 
-            foreach (var g in groups.Where(_ => _.MoreThan(1)))
+            var groups = symbol.GetDocumentationCommentXml()
+                               .GetExceptionsOfExceptionComments()
+                               .GroupBy(_ => _) // TODO: what about namespaces
+                               .Where(_ => _.MoreThan(1));
+
+            foreach (var g in groups)
             {
-                yield return Issue(symbol, g.Key);
+                if (results is null)
+                {
+                    results = new List<Diagnostic>(1);
+                }
+
+                results.Add(Issue(symbol, g.Key));
             }
+
+            return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -19,6 +19,27 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected virtual Diagnostic Issue(Location location, string replacement) => base.Issue(location, replacement);
 
+        protected void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            {
+                var symbol = context.ContainingSymbol;
+
+                if (symbol is IMethodSymbol method && method.IsPrimaryConstructor())
+                {
+                    // records are analyzed for their type as well, so we do not need to report twice
+                    return;
+                }
+
+                var issues = AnalyzeComment(comment, symbol);
+
+                if (issues.Count > 0)
+                {
+                    ReportDiagnostics(context, issues);
+                }
+            }
+        }
+
         protected abstract IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol);
 
         protected IReadOnlyList<Diagnostic> AnalyzeForSpecialPhrase(SyntaxToken token, string startingPhrase, Func<string, string> replacementCallback)
@@ -78,27 +99,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
 
                 return issues;
-            }
-        }
-
-        protected void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                var symbol = context.ContainingSymbol;
-
-                if (symbol is IMethodSymbol method && method.IsPrimaryConstructor())
-                {
-                    // records are analyzed for their type as well, so we do not need to report twice
-                    return;
-                }
-
-                var issues = AnalyzeComment(comment, symbol);
-
-                if (issues.Count > 0)
-                {
-                    ReportDiagnostics(context, issues);
-                }
             }
         }
     }


### PR DESCRIPTION
- Changed `GetExceptionsOfExceptionComments` to extension method.
- Updated analyzer methods to return `IReadOnlyList` for diagnostics.
- Revised syntax node registration for documentation comments.
- Adjusted XML formatting in resource files.

