### PR TITLE
Refactored parameter documentation analyzers to directly use DocumentationCommentTriviaSyntax

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -38,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return parameterType.IsBoolean() is false;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             return AnalyzePlainTextStartingPhrase(parameter, parameterComment, Constants.Comments.ParameterStartingPhrase, StringComparison.OrdinalIgnoreCase);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -15,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind == RefKind.Out;
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             var phrases = GetStartingPhrase(parameter);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -24,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                      && parameter.RefKind != RefKind.Out
                                                                                      && parameter.GetEnclosingMethod().Name != nameof(IDisposable.Dispose);
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             if (CommentHasIssue(comment))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsEnum();
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             var phrases = parameter.HasFlags()
                           ? Constants.Comments.EnumFlagsParameterStartingPhrase

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -17,6 +15,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsCancellationToken();
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment) => AnalyzePlainTextStartingPhrase(parameter, parameterComment, Constants.Comments.CancellationTokenParameterPhrase);
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment) => AnalyzePlainTextStartingPhrase(parameter, parameterComment, Constants.Comments.CancellationTokenParameterPhrase);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,31 +19,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.IsSerializationInfoParameter() || parameter.IsStreamingContextParameter();
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             if (parameter.IsSerializationInfoParameter())
             {
-                return AnalyzeParameterComment(Constants.Comments.CtorSerializationInfoParamPhrase);
+                return AnalyzeParameterComment(parameter.Name, parameterComment, comment, Constants.Comments.CtorSerializationInfoParamPhrase);
             }
 
             if (parameter.IsStreamingContextParameter())
             {
-                return AnalyzeParameterComment(Constants.Comments.CtorStreamingContextParamPhrase);
+                return AnalyzeParameterComment(parameter.Name, parameterComment, comment, Constants.Comments.CtorStreamingContextParamPhrase);
             }
 
             return Array.Empty<Diagnostic>();
+        }
 
-            IEnumerable<Diagnostic> AnalyzeParameterComment(string[] phrases)
+        private Diagnostic[] AnalyzeParameterComment(string parameterName, XmlElementSyntax parameterComment, string comment, string[] phrases)
+        {
+            if (comment.EqualsAny(phrases))
             {
-                if (comment.EqualsAny(phrases) is false)
-                {
-                    var phrase = phrases[0];
-
-                    return new[] { Issue(parameter.Name, parameterComment.GetContentsLocation(), phrase, CreatePhraseProposal(phrase)) };
-                }
-
                 return Array.Empty<Diagnostic>();
             }
+
+            var phrase = phrases[0];
+
+            return new[] { Issue(parameterName, parameterComment.GetContentsLocation(), phrase, CreatePhraseProposal(phrase)) };
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -16,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             var phrases = GetPhrases(parameter.Name);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -17,11 +15,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2074_ContainsParameterDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase) && symbol.Parameters.Any() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase) && symbol.Parameters.Length > 0 && base.ShallAnalyze(symbol);
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.ContainingSymbol is IMethodSymbol method && method.Parameters.IndexOf(parameter) == 0;
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             if (parameterComment.GetTextTrimmed().EndsWithAny(Phrases, StringComparison.Ordinal))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -29,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.HasExplicitDefaultValue;
 
-        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
             if (parameterComment.GetTextTrimmed().ContainsAny(Phrases, StringComparison.OrdinalIgnoreCase))
             {
@@ -137,7 +136,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 case TypeKind.Struct:
                 {
                     var defaultStructValue = parameterType.GetProperties().FirstOrDefault(_ => _.IsStatic)?.Name
-                                             ?? parameterType.GetFields().FirstOrDefault(_ => _.IsStatic)?.Name;
+                                          ?? parameterType.GetFields().FirstOrDefault(_ => _.IsStatic)?.Name;
 
                     var defaultValue = defaultStructValue != null
                                        ? parameterType.Name + "." + defaultStructValue


### PR DESCRIPTION
- Improved parameter comment analysis logic.
- Updated base analyzer initialization with SyntaxNodeAction.
- Refactored analyzer methods to return Diagnostic[].
- Removed unnecessary using directives.


