### PR TITLE
Refactored return value documentation analyzers to directly use DocumentationCommentTriviaSyntax

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -45,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return true;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        protected override Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             return AnalyzeStartingPhrase(owningSymbol, comment, commentXml, xmlTag, Constants.Comments.ReturnTypeStartingPhrase);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -19,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeReturnType(ITypeSymbol returnType) => returnType.IsTask();
 
-        protected override IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        protected override Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             switch (owningSymbol?.Name)
             {
@@ -59,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return true;
         }
 
-        private IEnumerable<Diagnostic> AnalyzeDefaultReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        private Diagnostic[] AnalyzeDefaultReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             if (returnType.TryGetGenericArgumentType(out var argumentType))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -16,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        protected override Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             var startingPhrases = GetStartingPhrases(owningSymbol, returnType);
             var endingPhrases = GetEndingPhrases(returnType);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -17,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Property);
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => false;
 
         protected override bool ShallAnalyze(IPropertySymbol symbol)
         {
@@ -36,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return false;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        protected override Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             if (commentXml.EndsWith(Constants.Comments.NoDefaultPhrase, StringComparison.Ordinal))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -27,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return false;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
+        protected override Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag)
         {
             var startingPhrases = GetStartingPhrases(owningSymbol, returnType);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -16,75 +16,138 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Method, SymbolKind.Property);
+        protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnsVoid is false && base.ShallAnalyze(symbol);
-
-        protected override bool ShallAnalyze(IPropertySymbol symbol) => symbol.GetReturnType() != null && base.ShallAnalyze(symbol);
-
-        protected sealed override IEnumerable<Diagnostic> AnalyzeMethod(IMethodSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected void AnalyzeComment(SyntaxNodeAnalysisContext context)
         {
-            return AnalyzeReturnType(symbol, symbol.ReturnType, comment, commentXml);
+            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            {
+                var issues = AnalyzeComment(comment, context.ContainingSymbol);
+
+                if (issues.Count > 0)
+                {
+                    ReportDiagnostics(context, issues);
+                }
+            }
         }
 
-        protected sealed override IEnumerable<Diagnostic> AnalyzeProperty(IPropertySymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
-        {
-            return AnalyzeReturnType(symbol, symbol.GetReturnType(), comment, commentXml);
-        }
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnsVoid is false;
+
+        protected override bool ShallAnalyze(IPropertySymbol symbol) => symbol.GetReturnType() != null;
 
         protected virtual bool ShallAnalyzeReturnType(ITypeSymbol returnType) => true;
 
-        protected IEnumerable<Diagnostic> AnalyzeStartingPhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, string[] phrase)
+        protected Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, string[] phrase)
         {
             if (commentXml.StartsWithAny(phrase, StringComparison.Ordinal) is false)
             {
-                foreach (var node in comment.GetXmlSyntax(xmlTag))
+                var nodes = comment.GetXmlSyntax(xmlTag);
+
+                if (nodes.Count > 0)
                 {
-                    yield return Issue(symbol.Name, node.GetContentsLocation(), xmlTag, phrase[0]);
+                    var symbolName = symbol.Name;
+                    var text = phrase[0];
+
+                    return nodes.Select(_ => Issue(symbolName, _.GetContentsLocation(), xmlTag, text)).ToArray();
                 }
             }
+
+            return Array.Empty<Diagnostic>();
         }
 
-        protected IEnumerable<Diagnostic> AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, params string[] phrase)
+        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, params string[] phrase)
         {
             if (phrase.None(_ => _.Equals(commentXml, StringComparison.Ordinal)))
             {
-                foreach (var node in comment.GetXmlSyntax(xmlTag))
+                var nodes = comment.GetXmlSyntax(xmlTag);
+
+                if (nodes.Count > 0)
                 {
-                    yield return Issue(symbol.Name, node.GetContentsLocation(), xmlTag, phrase[0]);
+                    var symbolName = symbol.Name;
+                    var text = phrase[0];
+
+                    return nodes.Select(_ => Issue(symbolName, _.GetContentsLocation(), xmlTag, text)).ToArray();
                 }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        protected virtual Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag) => Array.Empty<Diagnostic>();
+
+        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        {
+            switch (symbol)
+            {
+                case IMethodSymbol method when ShallAnalyze(method):
+                    return AnalyzeComment(comment, method);
+                case IPropertySymbol property when ShallAnalyze(property):
+                    return AnalyzeComment(comment, property);
+                default:
+                    return Array.Empty<Diagnostic>();
             }
         }
 
-        protected virtual IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag) => Array.Empty<Diagnostic>();
+        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, IMethodSymbol symbol)
+        {
+            return AnalyzeReturnType(symbol, symbol.ReturnType, comment);
+        }
 
-        private IEnumerable<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml)
+        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, IPropertySymbol symbol)
+        {
+            return AnalyzeReturnType(symbol, symbol.GetReturnType(), comment);
+        }
+
+        private IReadOnlyList<Diagnostic> AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment)
         {
             if (ShallAnalyzeReturnType(returnType))
             {
-                var foundIssues = false;
+                var commentXml = owningSymbol.GetDocumentationCommentXml();
+
+                List<Diagnostic> issues = null;
 
                 foreach (var returnComment in CommentExtensions.GetComments(commentXml, XmlTag.Returns).WhereNotNull())
                 {
-                    foreach (var finding in AnalyzeReturnType(owningSymbol, returnType, comment, returnComment, XmlTag.Returns))
-                    {
-                        foundIssues = true;
+                    var findings = AnalyzeReturnType(owningSymbol, returnType, comment, returnComment, XmlTag.Returns);
+                    var findingsLength = findings.Length;
 
-                        yield return finding;
+                    if (findingsLength > 0)
+                    {
+                        if (issues is null)
+                        {
+                            issues = new List<Diagnostic>(findingsLength);
+                        }
+
+                        issues.AddRange(findings);
                     }
                 }
 
-                if (foundIssues is false)
+                if (issues is null)
                 {
                     foreach (var valueComment in CommentExtensions.GetComments(commentXml, XmlTag.Value).WhereNotNull())
                     {
-                        foreach (var finding in AnalyzeReturnType(owningSymbol, returnType, comment, valueComment, XmlTag.Value))
+                        var findings = AnalyzeReturnType(owningSymbol, returnType, comment, valueComment, XmlTag.Value);
+                        var findingsLength = findings.Length;
+
+                        if (findingsLength > 0)
                         {
-                            yield return finding;
+                            if (issues is null)
+                            {
+                                issues = new List<Diagnostic>(findingsLength);
+                            }
+
+                            issues.AddRange(findings);
                         }
                     }
                 }
+
+                if (issues != null)
+                {
+                    return issues;
+                }
             }
+
+            return Array.Empty<Diagnostic>();
         }
     }
 }


### PR DESCRIPTION
- Refactored analyzer initialization to use syntax node actions.
- Changed return types from `IEnumerable` to `Diagnostic[]`.
- Simplified comment analysis and diagnostic accumulation.
- Removed unnecessary using directives.
