### PR TITLE
Return values changed to arrays for peformance reasons

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         var issues = AnalyzeComment(comment);
 
-                        if (issues.Count > 0)
+                        if (issues.Length > 0)
                         {
                             ReportDiagnostics(context, issues);
                         }
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        private Diagnostic[] AnalyzeComment(DocumentationCommentTriviaSyntax comment)
         {
             var codeTags = comment.GetXmlSyntax(Constants.XmlTag.Code);
             var codeTagsCount = codeTags.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var issues = AnalyzeComment(comment);
 
-                    if (issues.Count > 0)
+                    if (issues.Length > 0)
                     {
                         ReportDiagnostics(context, issues);
                     }
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        private Diagnostic[] AnalyzeComment(DocumentationCommentTriviaSyntax comment)
         {
             var tagNames = comment.Content.ToHashSet(_ => _.GetXmlTagName());
 


### PR DESCRIPTION
- Changed diagnostic methods to return arrays for performance.
- Replaced Count property checks with Length checks.
- Refactored XML documentation analyzers for consistency.
