### PR TITLE
Refactored 'AnalyzeTestStart' methods

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
@@ -25,15 +25,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
             var text = valueText.AsSpan().TrimStart();
 
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (text.StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = text.FirstWord().ToString();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
@@ -27,15 +27,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
@@ -27,15 +27,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
             var text = valueText.AsSpan().TrimStart();
 
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (text.StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = text.FirstWord().ToString();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
@@ -27,15 +27,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWith(Phrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWith(Phrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
@@ -27,15 +27,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
@@ -27,15 +27,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = null;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
@@ -28,15 +28,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWithAny(Constants.Comments.AttributeSummaryStartingPhrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWithAny(Constants.Comments.AttributeSummaryStartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
-
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
@@ -27,15 +27,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            var text = valueText.AsSpan().TrimStart();
-
-            var startsWith = text.StartsWith(StartingPhrase, comparison);
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            {
+                return false;
+            }
 
             problematicText = valueText.FirstWord();
 
-            return startsWith is false;
+            return true;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
@@ -43,14 +43,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.OrdinalIgnoreCase;
 
             var firstWord = valueText.Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
                                      .FirstWord();
 
-            problematicText = valueText.FirstWord();
+            if (firstWord.EqualsAny(Constants.Comments.ReturnWords))
+            {
+                problematicText = valueText.FirstWord();
+                return true;
+            }
 
-            return firstWord.EqualsAny(Constants.Comments.ReturnWords);
+            return false;
         }
 
         private static string GetProposal(ISymbol symbol)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
@@ -44,7 +44,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (secondWord.Equals(StartingPhraseSecondWord, comparison))
                 {
                     // no issue
-                    problematicText = null;
+                    problematicText = string.Empty;
 
                     return false;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
@@ -65,7 +65,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (comment.StartsWith(phrase, Comparison))
             {
                 // no issue
-                problematicText = null;
+                problematicText = string.Empty;
 
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
@@ -38,15 +38,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
+            problematicText = string.Empty;
             comparison = StringComparison.OrdinalIgnoreCase;
 
             var text = valueText.AsSpan().TrimStart();
 
-            var startsWith = text.StartsWithAny(Constants.Comments.EnumMemberWrongStartingWords, comparison);
+            if (text.StartsWithAny(Constants.Comments.EnumMemberWrongStartingWords, comparison))
+            {
+                problematicText = text.FirstWord().ToString();
 
-            problematicText = text.FirstWord().ToString();
+                return true;
+            }
 
-            return startsWith;
+            return false;
         }
     }
 }


### PR DESCRIPTION
- Refactored `AnalyzeTextStart` logic by standardizing `problematicText` assignments and simplifying return conditions.
- Ensured consistent string handling.
