### PR TITLE
Fixed MiKo_1064 so that it now accepts short names without capital letters

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -1756,7 +1756,7 @@ namespace MiKoSolutions.Analyzers
             if (symbolName.Equals(typeName, StringComparison.OrdinalIgnoreCase))
             {
                 // there must be at least a minimum of upper case letters (except the first character)
-                if (typeName.HasUpperCaseLettersAbove(minimumUpperCaseLetters))
+                if (symbolName.HasUpperCaseLettersAbove(minimumUpperCaseLetters))
                 {
                     return true;
                 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzerTests.cs
@@ -38,6 +38,58 @@ public class Side
 ");
 
         [Test]
+        public void No_issue_is_reported_for_ctor_parameter_named_after_interface_type_and_only_lowercase_letters() => No_issue_is_reported_for(@"
+public interface IProducer
+{
+}
+
+public class TestMe
+{
+    public TestMe(IProducer producer)
+    { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ctor_parameter_named_after_generic_interface_type_and_only_lowercase_letters() => No_issue_is_reported_for(@"
+public interface ILogger<T>
+{
+}
+
+public class TestMe
+{
+    public TestMe(ILogger<string> logger)
+    { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_parameter_named_after_interface_type_and_only_lowercase_letters() => No_issue_is_reported_for(@"
+public interface IProducer
+{
+}
+
+public class TestMe
+{
+    public void DoSomething(IProducer producer)
+    { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_parameter_named_after_generic_interface_type_and_only_lowercase_letters() => No_issue_is_reported_for(@"
+public interface ILogger<T>
+{
+}
+
+public class TestMe
+{
+    public void DoSomething(ILogger<string> logger)
+    { }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_parameter_named_after_property_and_used_in_ctor() => No_issue_is_reported_for(@"
 public enum Side
 {


### PR DESCRIPTION
- Correct uppercase check using symbol name.
- Add tests for interface-based parameter naming.
