### PR TITLE
Documentation analyzers for summaries refactored

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -172,6 +172,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ReturnTypeDefaultPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\SingleLineCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\SummaryDocumentationAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\SummaryStartDocumentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DependencyPropertyRegisterMaintainabilityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DoNotUseSuppressNullableWarningAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\InvertNegativeIfAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -442,6 +442,23 @@ namespace MiKoSolutions.Analyzers.Rules
             }
         }
 
+        private static void ReportDiagnosticsEnumerable(SyntaxNodeAnalysisContext context, IEnumerable<Diagnostic> issues)
+        {
+            foreach (var issue in issues)
+            {
+                if (context.CancellationToken.IsCancellationRequested)
+                {
+                    // seems that we should cancel and not report further issues
+                    return;
+                }
+
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
+            }
+        }
+
         private static void ReportDiagnostics(SyntaxNodeAnalysisContext context, Diagnostic[] issues)
         {
             var issuesLength = issues.Length;
@@ -474,23 +491,6 @@ namespace MiKoSolutions.Analyzers.Rules
                     {
                         context.ReportDiagnostic(issue);
                     }
-                }
-            }
-        }
-
-        private static void ReportDiagnosticsEnumerable(SyntaxNodeAnalysisContext context, IEnumerable<Diagnostic> issues)
-        {
-            foreach (var issue in issues)
-            {
-                if (context.CancellationToken.IsCancellationRequested)
-                {
-                    // seems that we should cancel and not report further issues
-                    return;
-                }
-
-                if (issue != null)
-                {
-                    context.ReportDiagnostic(issue);
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
@@ -14,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static readonly SyntaxKind[] DocumentationCommentTrivia = { SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.MultiLineDocumentationCommentTrivia };
 
-        protected DocumentationAnalyzer(string diagnosticId, SymbolKind symbolKind) : base(nameof(Documentation), diagnosticId, symbolKind)
+        protected DocumentationAnalyzer(string diagnosticId) : base(nameof(Documentation), diagnosticId, (SymbolKind)(-1))
         {
         }
 
@@ -134,267 +135,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 //// ncrunch: rdi default
         }
 
-        protected virtual bool ShallAnalyze(INamedTypeSymbol symbol) => true;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeNamespace(INamespaceSymbol symbol, Compilation compilation) => throw new NotSupportedException("Namespaces are not supported.");
 
-        protected virtual bool ShallAnalyze(IMethodSymbol symbol) => true;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation) => throw new NotSupportedException("Types are not supported.");
 
-        protected virtual bool ShallAnalyze(IEventSymbol symbol) => true;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeEvent(IEventSymbol symbol, Compilation compilation) => throw new NotSupportedException("Events are not supported.");
 
-        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => true;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeField(IFieldSymbol symbol, Compilation compilation) => throw new NotSupportedException("Fields are not supported.");
 
-        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => true;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeMethod(IMethodSymbol symbol, Compilation compilation) => throw new NotSupportedException("Methods are not supported.");
 
-        protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
-        {
-            if (ShallAnalyze(symbol) is false)
-            {
-                return Array.Empty<Diagnostic>();
-            }
+        protected sealed override IEnumerable<Diagnostic> AnalyzeProperty(IPropertySymbol symbol, Compilation compilation) => throw new NotSupportedException("Properties are not supported.");
 
-            var comments = symbol.GetDocumentationCommentTriviaSyntax();
-            var commentsLength = comments.Length;
+        protected sealed override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol symbol, Compilation compilation) => throw new NotSupportedException("Parameters are not supported.");
 
-            if (commentsLength <= 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
 
-            var commentXml = symbol.GetDocumentationCommentXml();
+        protected virtual bool ShallAnalyze(ISymbol symbol) => true;
 
-            if (commentsLength == 1)
-            {
-                return AnalyzeType(symbol, compilation, commentXml, comments[0]);
-            }
-
-            return AnalyzeTypeWithLoop(symbol, compilation, commentXml, comments);
-        }
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, compilation, commentXml, comment);
-
-        protected sealed override IEnumerable<Diagnostic> AnalyzeMethod(IMethodSymbol symbol, Compilation compilation)
-        {
-            if (ShallAnalyze(symbol) is false)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var comments = symbol.GetDocumentationCommentTriviaSyntax();
-            var commentsLength = comments.Length;
-
-            if (commentsLength <= 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var commentXml = symbol.GetDocumentationCommentXml();
-
-            if (commentsLength == 1)
-            {
-                return AnalyzeMethod(symbol, compilation, commentXml, comments[0]);
-            }
-
-            return AnalyzeMethodWithLoop(symbol, compilation, commentXml, comments);
-        }
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeMethod(IMethodSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, compilation, commentXml, comment);
-
-        protected sealed override IEnumerable<Diagnostic> AnalyzeEvent(IEventSymbol symbol, Compilation compilation)
-        {
-            if (ShallAnalyze(symbol) is false)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var comments = symbol.GetDocumentationCommentTriviaSyntax();
-            var commentsLength = comments.Length;
-
-            if (commentsLength <= 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var commentXml = symbol.GetDocumentationCommentXml();
-
-            if (commentsLength == 1)
-            {
-                return AnalyzeEvent(symbol, compilation, commentXml, comments[0]);
-            }
-
-            return AnalyzeEventWithLoop(symbol, compilation, commentXml, comments);
-        }
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeEvent(IEventSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, compilation, commentXml, comment);
-
-        protected sealed override IEnumerable<Diagnostic> AnalyzeProperty(IPropertySymbol symbol, Compilation compilation)
-        {
-            if (ShallAnalyze(symbol) is false)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var comments = symbol.GetDocumentationCommentTriviaSyntax();
-            var commentsLength = comments.Length;
-
-            if (commentsLength <= 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var commentXml = symbol.GetDocumentationCommentXml();
-
-            if (commentsLength == 1)
-            {
-                return AnalyzeProperty(symbol, compilation, commentXml, comments[0]);
-            }
-
-            return AnalyzePropertyWithLoop(symbol, compilation, commentXml, comments);
-        }
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeProperty(IPropertySymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, compilation, commentXml, comment);
-
-        protected sealed override IEnumerable<Diagnostic> AnalyzeField(IFieldSymbol symbol, Compilation compilation)
-        {
-            if (ShallAnalyze(symbol) is false)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var comments = symbol.GetDocumentationCommentTriviaSyntax();
-            var commentsLength = comments.Length;
-
-            if (commentsLength <= 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var commentXml = symbol.GetDocumentationCommentXml();
-
-            if (commentsLength == 1)
-            {
-                return AnalyzeField(symbol, compilation, commentXml, comments[0]);
-            }
-
-            return AnalyzeFieldWithLoop(symbol, compilation, commentXml, comments);
-        }
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeField(IFieldSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeComment(symbol, compilation, commentXml, comment);
-
-        protected virtual IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => Array.Empty<Diagnostic>();
-
-        protected virtual Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => StartIssue(symbol, node.GetLocation());
-
-        protected virtual Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location);
-
-        protected Diagnostic AnalyzeTextStart(ISymbol symbol, XmlElementSyntax xml)
-        {
-            var tag = xml.StartTag.GetName();
-
-            var descendantNodes = xml.DescendantNodes();
-
-            foreach (var node in descendantNodes)
-            {
-                switch (node)
-                {
-                    case XmlElementStartTagSyntax startTag:
-                    {
-                        var tagName = startTag.GetName();
-
-                        if (tagName == tag || tagName == Constants.XmlTag.Para)
-                        {
-                            continue; // skip over the start tag and name syntax
-                        }
-
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
-                    }
-
-                    case XmlElementEndTagSyntax endTag:
-                    {
-                        var tagName = endTag.GetName();
-
-                        if (tagName == Constants.XmlTag.Para)
-                        {
-                            continue; // skip over the start tag and name syntax
-                        }
-
-                        if (endTag.Parent is XmlElementSyntax element)
-                        {
-                            if (ConsiderEmptyTextAsIssue(symbol))
-                            {
-                                return StartIssue(symbol, element.GetContentsLocation()); // it's an empty text
-                            }
-
-                            continue;
-                        }
-
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
-                    }
-
-                    case XmlNameSyntax _:
-                    case XmlElementSyntax e when e.GetName() == Constants.XmlTag.Para:
-                    case XmlEmptyElementSyntax ee when ee.GetName() == Constants.XmlTag.Para:
-                        continue; // skip over the start tag and name syntax
-
-                    case XmlTextSyntax text:
-                    {
-                        // report the location of the first word(s) via the corresponding text token
-                        var textTokens = text.TextTokens;
-
-                        // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                        var textTokensCount = textTokens.Count;
-
-                        for (var index = 0; index < textTokensCount; index++)
-                        {
-                            var token = textTokens[index];
-
-                            if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
-                            {
-                                continue;
-                            }
-
-                            var valueText = token.ValueText;
-
-                            if (valueText.IsNullOrWhiteSpace())
-                            {
-                                // we found the first but empty /// line, so ignore it
-                                continue;
-                            }
-
-                            if (valueText.Length == 1 && Constants.Comments.Delimiters.Contains(valueText[0]))
-                            {
-                                // this is a dot or something directly after the XML tag, so ignore that
-                                continue;
-                            }
-
-                            // we found some text
-                            if (AnalyzeTextStart(symbol, valueText, out var problematicText, out var comparison))
-                            {
-                                // it's no valid text, so we have an issue
-                                var position = valueText.IndexOf(problematicText, comparison);
-
-                                var start = token.SpanStart + position; // find start position for underlining
-                                var end = start + problematicText.Length; // find end position for underlining
-
-                                var location = CreateLocation(token, start, end);
-
-                                return StartIssue(symbol, location);
-                            }
-
-                            // it's a valid text, so we quit
-                            return null;
-                        }
-
-                        // we found a completely empty /// line, so ignore it
-                        continue;
-                    }
-
-                    default:
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
-                }
-            }
-
-            // nothing to report
-            return null;
-        }
+        protected virtual IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel) => Array.Empty<Diagnostic>();
 
 #pragma warning disable CA1021
         protected virtual bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
@@ -639,121 +398,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return results ?? (IReadOnlyList<Location>)Array.Empty<Location>();
         }
 
-        private IEnumerable<Diagnostic> AnalyzeTypeWithLoop(INamedTypeSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax[] comments)
+        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
         {
-            var commentsLength = comments.Length;
-
-            for (var index = 0; index < commentsLength; index++)
+            if (context.Node is DocumentationCommentTriviaSyntax comment)
             {
-                var issues = AnalyzeType(symbol, compilation, commentXml, comments[index]);
+                var symbol = context.ContainingSymbol;
 
-                if (issues.IsEmptyArray())
+                if (ShallAnalyze(symbol))
                 {
-                    continue;
-                }
+                    var issues = AnalyzeComment(comment, symbol, context.SemanticModel);
 
-                // ReSharper disable once LoopCanBePartlyConvertedToQuery
-                foreach (var issue in issues)
-                {
-                    if (issue != null)
+                    if (issues.Count > 0)
                     {
-                        yield return issue;
-                    }
-                }
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeMethodWithLoop(IMethodSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax[] comments)
-        {
-            var commentsLength = comments.Length;
-
-            for (var index = 0; index < commentsLength; index++)
-            {
-                var issues = AnalyzeMethod(symbol, compilation, commentXml, comments[index]);
-
-                if (issues.IsEmptyArray())
-                {
-                    continue;
-                }
-
-                // ReSharper disable once LoopCanBePartlyConvertedToQuery
-                foreach (var issue in issues)
-                {
-                    if (issue != null)
-                    {
-                        yield return issue;
-                    }
-                }
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeEventWithLoop(IEventSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax[] comments)
-        {
-            var commentsLength = comments.Length;
-
-            for (var index = 0; index < commentsLength; index++)
-            {
-                var issues = AnalyzeEvent(symbol, compilation, commentXml, comments[index]);
-
-                if (issues.IsEmptyArray())
-                {
-                    continue;
-                }
-
-                // ReSharper disable once LoopCanBePartlyConvertedToQuery
-                foreach (var issue in issues)
-                {
-                    if (issue != null)
-                    {
-                        yield return issue;
-                    }
-                }
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzePropertyWithLoop(IPropertySymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax[] comments)
-        {
-            var commentsLength = comments.Length;
-
-            for (var index = 0; index < commentsLength; index++)
-            {
-                var issues = AnalyzeProperty(symbol, compilation, commentXml, comments[index]);
-
-                if (issues.IsEmptyArray())
-                {
-                    continue;
-                }
-
-                // ReSharper disable once LoopCanBePartlyConvertedToQuery
-                foreach (var issue in issues)
-                {
-                    if (issue != null)
-                    {
-                        yield return issue;
-                    }
-                }
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeFieldWithLoop(IFieldSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax[] comments)
-        {
-            var commentsLength = comments.Length;
-
-            for (var index = 0; index < commentsLength; index++)
-            {
-                var issues = AnalyzeField(symbol, compilation, commentXml, comments[index]);
-
-                if (issues.IsEmptyArray())
-                {
-                    continue;
-                }
-
-                // ReSharper disable once LoopCanBePartlyConvertedToQuery
-                foreach (var issue in issues)
-                {
-                    if (issue != null)
-                    {
-                        yield return issue;
+                        ReportDiagnostics(context, issues);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExampleDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExampleDocumentationAnalyzer.cs
@@ -3,36 +3,16 @@ using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class ExampleDocumentationAnalyzer : DocumentationAnalyzer
     {
-        protected ExampleDocumentationAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
+        protected ExampleDocumentationAnalyzer(string diagnosticId) : base(diagnosticId)
         {
         }
 
-        protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
-
-        protected virtual IReadOnlyList<Diagnostic> AnalyzeExample(ISymbol symbol, IReadOnlyList<XmlElementSyntax> examples) => Array.Empty<Diagnostic>();
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                var symbol = context.ContainingSymbol;
-
-                var issues = AnalyzeComment(comment, symbol);
-
-                if (issues.Count > 0)
-                {
-                    ReportDiagnostics(context, issues);
-                }
-            }
-        }
-
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected sealed override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var examples = comment.GetExampleXmls();
 
@@ -40,5 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                    ? Array.Empty<Diagnostic>()
                    : AnalyzeExample(symbol, examples);
         }
+
+        protected virtual IReadOnlyList<Diagnostic> AnalyzeExample(ISymbol symbol, IReadOnlyList<XmlElementSyntax> examples) => Array.Empty<Diagnostic>();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
@@ -1,27 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2001_EventSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2001_EventSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2001";
 
         private const string StartingPhrase = Constants.Comments.EventSummaryStartingPhrase;
 
-        public MiKo_2001_EventSummaryAnalyzer() : base(Id, SymbolKind.Event)
+        public MiKo_2001_EventSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Event;
 
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
+        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
@@ -20,15 +20,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private const StringComparison Comparison = StringComparison.Ordinal;
 
-        public MiKo_2002_EventArgsSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2002_EventArgsSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsEventArgs() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol s && s.IsEventArgs();
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment) => HasEventSummary(summaries)
-                                                                                                                                                                                       ? Array.Empty<Diagnostic>()
-                                                                                                                                                                                       : new[] { Issue(symbol, StartingPhraseConcrete, "\"" + EndingPhraseConcrete) };
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
+        {
+            return HasEventSummary(summaries)
+                   ? Array.Empty<Diagnostic>()
+                   : new[] { Issue(symbol, StartingPhraseConcrete, "\"" + EndingPhraseConcrete) };
+        }
 
         private static bool HasEventSummary(IEnumerable<string> summaries)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2003_EventHandlerSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2003_EventHandlerSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2003";
 
         private const string StartingPhrase = Constants.Comments.EventHandlerSummaryStartingPhrase;
 
-        public MiKo_2003_EventHandlerSummaryAnalyzer() : base(Id, SymbolKind.Method)
+        public MiKo_2003_EventHandlerSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsEventHandler() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsEventHandler();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzer.cs
@@ -12,38 +12,27 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2005";
 
-        public MiKo_2005_EventArgsInDocumentationAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2005_EventArgsInDocumentationAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            switch (symbol.Kind)
             {
-                switch (context.ContainingSymbol?.Kind)
-                {
-                    case SymbolKind.NamedType:
-                    case SymbolKind.Method:
-                    case SymbolKind.Property:
-                    case SymbolKind.Event:
-                    case SymbolKind.Field:
-                    {
-                        var issues = AnalyzeComment(comment);
+                case SymbolKind.NamedType:
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                case SymbolKind.Field:
+                    return true;
 
-                        if (issues.Count > 0)
-                        {
-                            ReportDiagnostics(context, issues);
-                        }
-
-                        break;
-                    }
-                }
+                default:
+                    return false;
             }
         }
 
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer.cs
@@ -9,59 +9,65 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer : DocumentationAnalyzer
     {
         public const string Id = "MiKo_2006";
 
-        public MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer() : base(Id, SymbolKind.Field)
+        public MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol) => symbol.Type.IsRoutedEvent() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.Type.IsRoutedEvent();
 
-        protected override IEnumerable<Diagnostic> AnalyzeField(IFieldSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.EndsWith(Constants.RoutedEventFieldSuffix, StringComparison.OrdinalIgnoreCase))
+            if (symbolName.EndsWith(Constants.RoutedEventFieldSuffix, StringComparison.OrdinalIgnoreCase) is false)
             {
-                var eventName = symbolName.WithoutSuffix(Constants.RoutedEventFieldSuffix);
-                var containingType = symbol.ContainingType;
+                return Array.Empty<Diagnostic>();
+            }
 
-                if (containingType.GetMembersIncludingInherited<IEventSymbol>(eventName).Any())
+            var eventName = symbolName.WithoutSuffix(Constants.RoutedEventFieldSuffix);
+            var containingType = symbol.ContainingType;
+
+            if (containingType.GetMembersIncludingInherited<IEventSymbol>(eventName).None())
+            {
+                // it's an unknown event
+                return Array.Empty<Diagnostic>();
+            }
+
+            var containingTypeFullName = containingType.ToString();
+
+            var issues = new List<Diagnostic>(2);
+
+            // loop over phrases for summaries and values
+            var commentXml = symbol.GetDocumentationCommentXml();
+            var summaries = CommentExtensions.GetSummaries(commentXml);
+
+            if (summaries.Count != 0)
+            {
+                var summaryPhrases = Phrases(Constants.Comments.RoutedEventFieldSummaryPhrase, containingTypeFullName, eventName);
+
+                if (summaries.Any(summary => summaryPhrases.None(_ => summary.StartsWith(_, StringComparison.Ordinal))))
                 {
-                    var containingTypeFullName = containingType.ToString();
-
-                    // loop over phrases for summaries and values
-                    var summaries = CommentExtensions.GetSummaries(commentXml);
-
-                    if (summaries.Count != 0)
-                    {
-                        var summaryPhrases = Phrases(Constants.Comments.RoutedEventFieldSummaryPhrase, containingTypeFullName, eventName);
-
-                        if (summaries.Any(summary => summaryPhrases.None(_ => summary.StartsWith(_, StringComparison.Ordinal))))
-                        {
-                            yield return Issue(symbol, Constants.XmlTag.Summary, summaryPhrases[0]);
-                        }
-                    }
-
-                    var values = CommentExtensions.GetValue(commentXml);
-
-                    if (values.Count != 0)
-                    {
-                        var valuePhrases = Phrases(Constants.Comments.RoutedEventFieldValuePhrase, containingTypeFullName, eventName);
-
-                        if (values.Any(value => valuePhrases.None(_ => value.StartsWith(_, StringComparison.Ordinal))))
-                        {
-                            yield return Issue(symbol, Constants.XmlTag.Value, valuePhrases[0]);
-                        }
-                    }
-                }
-                else
-                {
-                    // it's an unknown event
+                    issues.Add(Issue(symbol, Constants.XmlTag.Summary, summaryPhrases[0]));
                 }
             }
+
+            var values = CommentExtensions.GetValue(commentXml);
+
+            if (values.Count != 0)
+            {
+                var valuePhrases = Phrases(Constants.Comments.RoutedEventFieldValuePhrase, containingTypeFullName, eventName);
+
+                if (values.Any(value => valuePhrases.None(_ => value.StartsWith(_, StringComparison.Ordinal))))
+                {
+                    issues.Add(Issue(symbol, Constants.XmlTag.Value, valuePhrases[0]));
+                }
+            }
+
+            return issues;
         }
 
         private static List<string> Phrases(string[] phrases, string typeName, string eventName)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
@@ -13,13 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2010";
 
-        public MiKo_2010_SealedClassSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2010_SealedClassSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsReferenceType && symbol.DeclaredAccessibility == Accessibility.Public && symbol.IsTestClass() is false && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility == Accessibility.Public && type.IsTestClass() is false;
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             if (symbol.IsSealed && summaries.None(_ => _.EndsWith(Constants.Comments.SealedClassPhrase, StringComparison.Ordinal)))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
@@ -13,13 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2011";
 
-        public MiKo_2011_UnsealedClassSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2011_UnsealedClassSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsReferenceType && symbol.DeclaredAccessibility == Accessibility.Public && symbol.IsTestClass() is false && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility == Accessibility.Public && type.IsTestClass() is false;
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             if (symbol.IsSealed is false && summaries.Any(_ => _.Contains(Constants.Comments.SealedClassPhrase)))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -13,15 +13,28 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2012";
 
-        public MiKo_2012_MeaninglessSummaryAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2012_MeaninglessSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field);
+        protected override bool ShallAnalyze(ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.NamedType:
+                    return symbol is INamedTypeSymbol type && type.IsNamespace is false && type.IsEnum() is false && type.IsException() is false;
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsNamespace is false && symbol.IsEnum() is false && symbol.IsException() is false && base.ShallAnalyze(symbol);
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                case SymbolKind.Field:
+                    return true;
+            }
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+            return false;
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             if (summaries.None())
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2013_EnumSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2013_EnumSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2013";
 
         private const string StartingPhrase = Constants.Comments.EnumStartingPhrase;
 
-        public MiKo_2013_EnumSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2013_EnumSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsEnum() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsEnum();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2016_AsyncMethodDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2016_AsyncMethodDefaultPhraseAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2016";
 
         private const string Phrase = Constants.Comments.AsynchronouslyStartingPhrase;
 
-        public MiKo_2016_AsyncMethodDefaultPhraseAnalyzer() : base(Id, SymbolKind.Method)
+        public MiKo_2016_AsyncMethodDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsAsyncTaskBased() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsAsyncTaskBased();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Phrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
@@ -9,66 +9,82 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer : DocumentationAnalyzer
     {
         public const string Id = "MiKo_2017";
 
-        public MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer() : base(Id, SymbolKind.Field)
+        public MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol) => symbol.Type.IsDependencyProperty() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.Type.IsDependencyProperty();
 
-        protected override IEnumerable<Diagnostic> AnalyzeField(IFieldSymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.EndsWith(Constants.DependencyProperty.FieldSuffix, StringComparison.OrdinalIgnoreCase))
+            if (symbolName.EndsWith(Constants.DependencyProperty.FieldSuffix, StringComparison.OrdinalIgnoreCase) is false)
             {
-                var propertyName = symbolName.WithoutSuffix(Constants.DependencyProperty.FieldSuffix);
+                return Array.Empty<Diagnostic>();
+            }
 
-                var containingType = symbol.ContainingType;
+            var propertyName = symbolName.WithoutSuffix(Constants.DependencyProperty.FieldSuffix);
 
-                if (containingType.GetMembersIncludingInherited<IPropertySymbol>(propertyName).Any())
+            var containingType = symbol.ContainingType;
+
+            if (containingType.GetMembersIncludingInherited<IPropertySymbol>(propertyName).None())
+            {
+                // it's an unknown dependency property
+                return Array.Empty<Diagnostic>();
+            }
+
+            List<Diagnostic> issues = null;
+
+            var commentXml = symbol.GetDocumentationCommentXml();
+            var containingTypeFullName = containingType.ToString();
+
+            // loop over phrases for summaries and values
+            var summaries = CommentExtensions.GetSummaries(commentXml);
+
+            if (summaries.Count != 0)
+            {
+                var summaryPhrases = Phrases(Constants.Comments.DependencyPropertyFieldSummaryPhrase, containingTypeFullName, propertyName);
+
+                foreach (var summary in summaries)
                 {
-                    var containingTypeFullName = containingType.ToString();
-
-                    // loop over phrases for summaries and values
-                    var summaries = CommentExtensions.GetSummaries(commentXml);
-
-                    if (summaries.Count != 0)
+                    if (summaryPhrases.None(_ => summary.StartsWith(_, StringComparison.Ordinal)))
                     {
-                        var summaryPhrases = Phrases(Constants.Comments.DependencyPropertyFieldSummaryPhrase, containingTypeFullName, propertyName);
-
-                        foreach (var summary in summaries)
+                        if (issues is null)
                         {
-                            if (summaryPhrases.None(_ => summary.StartsWith(_, StringComparison.Ordinal)))
-                            {
-                                yield return Issue(symbol, Constants.XmlTag.Summary, summaryPhrases[0]);
-                            }
+                            issues = new List<Diagnostic>(1);
                         }
+
+                        issues.Add(Issue(symbol, Constants.XmlTag.Summary, summaryPhrases[0]));
                     }
-
-                    var values = CommentExtensions.GetValue(commentXml);
-
-                    if (values.Count != 0)
-                    {
-                        var valuePhrases = Phrases(Constants.Comments.DependencyPropertyFieldValuePhrase, containingTypeFullName, propertyName);
-
-                        foreach (var value in values)
-                        {
-                            if (valuePhrases.None(_ => value.StartsWith(_, StringComparison.Ordinal)))
-                            {
-                                yield return Issue(symbol, Constants.XmlTag.Value, valuePhrases[0]);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // it's an unknown dependency property
                 }
             }
+
+            var values = CommentExtensions.GetValue(commentXml);
+
+            if (values.Count != 0)
+            {
+                var valuePhrases = Phrases(Constants.Comments.DependencyPropertyFieldValuePhrase, containingTypeFullName, propertyName);
+
+                foreach (var value in values)
+                {
+                    if (valuePhrases.None(_ => value.StartsWith(_, StringComparison.Ordinal)))
+                    {
+                        if (issues is null)
+                        {
+                            issues = new List<Diagnostic>(1);
+                        }
+
+                        issues.Add(Issue(symbol, Constants.XmlTag.Value, valuePhrases[0]));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
 
         private static List<string> Phrases(string[] phrases, string typeName, string propertyName)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using MiKoSolutions.Analyzers.Linguistics;
@@ -12,20 +10,28 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
 
-    public sealed class MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2019";
 
-        public MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property);
+        protected override bool ShallAnalyze(ISymbol symbol)
+        {
+            switch (symbol)
+            {
+                case INamedTypeSymbol type:
+                    return type.IsNamespace is false && type.IsEnum() is false && type.IsException() is false;
+                case IMethodSymbol _:
+                case IPropertySymbol _:
+                    return true;
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsNamespace is false && symbol.IsEnum() is false && symbol.IsException() is false && base.ShallAnalyze(symbol);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
+                default:
+                    return false;
+            }
+        }
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                    .SelectMany(_ => SentenceEndings, string.Concat)
                                                    .ToArray();
 
-        public MiKo_2026_StillUsedParamPhraseAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2026_StillUsedParamPhraseAnalyzer() : base(Id)
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsSerializationConstructor() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsSerializationConstructor();
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.IsSerializationInfoParameter() || parameter.IsStreamingContextParameter();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_InheritdocUsesWrongCrefAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_InheritdocUsesWrongCrefAnalyzer.cs
@@ -12,39 +12,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2029";
 
-        public MiKo_2029_InheritdocUsesWrongCrefAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2029_InheritdocUsesWrongCrefAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            switch (symbol.Kind)
             {
-                var symbol = context.ContainingSymbol;
+                case SymbolKind.NamedType:
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                    return true;
 
-                switch (symbol?.Kind)
-                {
-                    case SymbolKind.NamedType:
-                    case SymbolKind.Method:
-                    case SymbolKind.Property:
-                    case SymbolKind.Event:
-                    {
-                        var issues = AnalyzeComment(comment, symbol, context.SemanticModel);
-
-                        if (issues.Count > 0)
-                        {
-                            ReportDiagnostics(context, issues);
-                        }
-
-                        break;
-                    }
-                }
+                default:
+                    return false;
             }
         }
 
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzer.cs
@@ -13,13 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2037";
 
-        public MiKo_2037_CommandPropertySummaryAnalyzer() : base(Id, SymbolKind.Property)
+        public MiKo_2037_CommandPropertySummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IPropertySymbol symbol) => symbol.Type.IsCommand() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IPropertySymbol property && property.Type.IsCommand();
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             var phrases = GetStartingPhrase((IPropertySymbol)symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2038_CommandTypeSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2038_CommandTypeSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2038";
 
         private const string StartingPhrase = Constants.Comments.CommandSummaryStartingPhrase;
 
-        public MiKo_2038_CommandTypeSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2038_CommandTypeSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.IsCommand() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsCommand();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.cs
@@ -13,13 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2039";
 
-        public MiKo_2039_ExtensionMethodsClassSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2039_ExtensionMethodsClassSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.ContainsExtensionMethods() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.ContainsExtensionMethods();
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             var phrases = Constants.Comments.ExtensionMethodClassStartingPhrase;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
 //// ncrunch: rdi off
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var results = new List<Diagnostic>(1);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_BrParaAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_BrParaAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 
@@ -25,34 +25,40 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 if (node is XmlElementStartTagSyntax || node is XmlEmptyElementSyntax)
                 {
-                    var tag = node.GetXmlTagName().ToLowerCase();
+                    var issue = FindIssue(node);
 
-                    switch (tag)
+                    if (issue is null)
                     {
-                        case "br":
-                            if (results is null)
-                            {
-                                results = new List<Diagnostic>();
-                            }
-
-                            results.Add(Issue(node, "<br/>"));
-
-                            break;
-
-                        case "p":
-                            if (results is null)
-                            {
-                                results = new List<Diagnostic>();
-                            }
-
-                            results.Add(Issue(node, "<p>...</p>"));
-
-                            break;
+                        continue;
                     }
+
+                    if (results is null)
+                    {
+                        results = new List<Diagnostic>(1);
+                    }
+
+                    results.Add(issue);
                 }
             }
 
             return (IReadOnlyList<Diagnostic>)results ?? Array.Empty<Diagnostic>();
+        }
+
+        private Diagnostic FindIssue(SyntaxNode node)
+        {
+            var tag = node.GetXmlTagName().ToLowerCase();
+
+            switch (tag)
+            {
+                case "br":
+                    return Issue(node, "<br/>");
+
+                case "p":
+                    return Issue(node, "<p>...</p>");
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2043_DelegateSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2043_DelegateSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2043";
 
         private const string StartingPhrase = Constants.Comments.DelegateSummaryStartingPhrase;
 
-        public MiKo_2043_DelegateSummaryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2043_DelegateSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Delegate && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.TypeKind == TypeKind.Delegate;
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzer.cs
@@ -19,36 +19,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                Constants.XmlTag.SeeAlso,
                                                            };
 
-        public MiKo_2044_InvalidSeeParameterInXmlAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2044_InvalidSeeParameterInXmlAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Parameters.Length > 0;
 
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            if (symbol is IMethodSymbol method)
             {
-                if (context.ContainingSymbol is IMethodSymbol method)
-                {
-                    var issues = AnalyzeComment(comment, method);
-
-                    if (issues.Count > 0)
-                    {
-                        ReportDiagnostics(context, issues);
-                    }
-                }
+                return AnalyzeComment(comment, method);
             }
+
+            return Array.Empty<Diagnostic>();
         }
 
         private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, IMethodSymbol method)
         {
             var names = method.Parameters.ToHashSet(_ => _.Name);
-
-            if (names.Count == 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
 
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer.cs
@@ -19,37 +19,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                Constants.XmlTag.SeeAlso,
                                                            };
 
-        public MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                var symbol = context.ContainingSymbol;
-
-                switch (symbol?.Kind)
-                {
-                    case SymbolKind.NamedType:
-                    case SymbolKind.Method:
-                    {
-                        var issues = AnalyzeComment(comment, symbol);
-
-                        if (issues.Count > 0)
-                        {
-                            ReportDiagnostics(context, issues);
-                        }
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             switch (symbol)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
@@ -1,30 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2047";
 
         private static readonly string StartingPhrases = Constants.Comments.AttributeSummaryStartingPhrase.OrderBy(_ => _).HumanizedConcatenated();
 
-        public MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.InheritsFrom<Attribute>() && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.InheritsFrom<Attribute>();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrases);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
@@ -37,6 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
 
             problematicText = valueText.FirstWord();
+
             return true;
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
@@ -1,29 +1,24 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2048";
 
         private const string StartingPhrase = Constants.Comments.ValueConverterSummaryStartingPhrase;
 
-        public MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => (symbol.IsValueConverter() || symbol.IsMultiValueConverter()) && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && (type.IsValueConverter() || type.IsMultiValueConverter());
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Issue(location, replacement, properties);
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var issues = AnalyzeCommentXml(comment);
             var count = issues.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_DuplicateExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_DuplicateExceptionAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
@@ -13,33 +13,35 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2060";
 
-        public MiKo_2060_FactoryAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2060_FactoryAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.MethodKind == MethodKind.Ordinary
-                                                                   && symbol.IsPubliclyVisible()
-                                                                   && symbol.ReturnsVoid is false
-                                                                   && symbol.ReturnType.SpecialType != SpecialType.System_Boolean
-                                                                   && base.ShallAnalyze(symbol);
-
-        // overridden because we want to inspect the methods of the type as well
-        protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (symbol.IsFactory())
+            switch (symbol)
             {
-                return AnalyzeAll(symbol, compilation);
-            }
+                case INamedTypeSymbol type:
+                    return type.IsFactory();
 
-            return Array.Empty<Diagnostic>();
+                case IMethodSymbol method:
+                    return method.ContainingType.IsFactory()
+                        && method.MethodKind == MethodKind.Ordinary
+                        && method.IsPubliclyVisible()
+                        && method.ReturnsVoid is false
+                        && method.ReturnType.SpecialType != SpecialType.System_Boolean;
+
+                default:
+                    return false;
+            }
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             switch (symbol)
             {
                 case INamedTypeSymbol type: return AnalyzeStartingPhrase(type, summaries, comment, Constants.Comments.FactorySummaryPhrase);
-                case IMethodSymbol method: return AnalyzeStartingPhrase(symbol, summaries, comment, GetPhrases(method).ToArray());
+                case IMethodSymbol method: return AnalyzeStartingPhrase(method, summaries, comment, GetPhrases(method).ToArray());
                 default: return Array.Empty<Diagnostic>();
             }
         }
@@ -76,40 +78,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             // fitting comment
             return Array.Empty<Diagnostic>();
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeAll(INamedTypeSymbol symbol, Compilation compilation)
-        {
-            var typeIssues = base.AnalyzeType(symbol, compilation);
-
-            if (typeIssues.IsEmptyArray() is false)
-            {
-                foreach (var typeIssue in typeIssues)
-                {
-                    yield return typeIssue;
-                }
-            }
-
-            var methods = symbol.GetNamedMethods();
-            var methodsCount = methods.Count;
-
-            if (methodsCount > 0)
-            {
-                for (var index = 0; index < methodsCount; index++)
-                {
-                    var methodIssues = AnalyzeMethod(methods[index], compilation);
-
-                    if (methodIssues.IsEmptyArray())
-                    {
-                        continue;
-                    }
-
-                    foreach (var methodIssue in methodIssues)
-                    {
-                        yield return methodIssue;
-                    }
-                }
-            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
@@ -1,45 +1,50 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2070_ReturnsSummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2070_ReturnsSummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2070";
 
-        public MiKo_2070_ReturnsSummaryAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2070_ReturnsSummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.Method, SymbolKind.Property);
-
-        protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
-
-        protected override bool ShallAnalyze(IMethodSymbol symbol)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            switch (symbol.Name)
+            switch (symbol)
             {
-                case nameof(ToString):
-                case nameof(IEnumerable.GetEnumerator):
-                    return false;
+                case IPropertySymbol _:
+                    return true;
+
+                case IMethodSymbol method:
+                {
+                    switch (method.Name)
+                    {
+                        case nameof(ToString):
+                        case nameof(IEnumerable.GetEnumerator):
+                            return false;
+
+                        default:
+                            return base.ShallAnalyze(method);
+                    }
+                }
 
                 default:
-                    return base.ShallAnalyze(symbol);
+                    return false;
             }
         }
+
+        protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
 
         protected override Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, GetProposal(symbol));
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
@@ -52,6 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (firstWord.EqualsAny(Constants.Comments.ReturnWords))
             {
                 problematicText = valueText.FirstWord();
+
                 return true;
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
@@ -1,30 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2072_TrySummaryAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2072_TrySummaryAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2072";
 
-        public MiKo_2072_TrySummaryAnalyzer() : base(Id, SymbolKind.Method)
+        public MiKo_2072_TrySummaryAnalyzer() : base(Id)
         {
         }
+
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Method;
 
         protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
 
         protected override Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.Comments.TryStartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2073";
 
@@ -18,16 +16,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string StartingPhraseSecondWord = StartingPhrase.SecondWord();
 
-        public MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer() : base(Id, SymbolKind.Method)
+        public MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase) && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase);
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2074_ContainsParameterDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase) && symbol.Parameters.Length > 0 && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Parameters.Length > 0 && method.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase);
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.ContainingSymbol is IMethodSymbol method && method.Parameters.IndexOf(parameter) == 0;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2076_OptionalParameterDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.Parameters.Any(_ => _.HasExplicitDefaultValue) && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Parameters.Any(_ => _.HasExplicitDefaultValue);
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.HasExplicitDefaultValue;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer.cs
@@ -12,37 +12,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2078";
 
-        public MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2078_CodeShouldNotUseXmlTagsAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
+            switch (symbol.Kind)
             {
-                switch (context.ContainingSymbol?.Kind)
-                {
-                    case SymbolKind.NamedType:
-                    case SymbolKind.Method:
-                    case SymbolKind.Property:
-                    case SymbolKind.Event:
-                    {
-                        var issues = AnalyzeComment(comment);
+                case SymbolKind.NamedType:
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                    return true;
 
-                        if (issues.Length > 0)
-                        {
-                            ReportDiagnostics(context, issues);
-                        }
-
-                        break;
-                    }
-                }
+                default:
+                    return false;
             }
         }
 
-        private Diagnostic[] AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var codeTags = comment.GetXmlSyntax(Constants.XmlTag.Code);
             var codeTagsCount = codeTags.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2080_FieldSummaryDefaultPhraseAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2080_FieldSummaryDefaultPhraseAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2080";
 
@@ -19,28 +17,33 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private const StringComparison Comparison = StringComparison.OrdinalIgnoreCase;
 
-        public MiKo_2080_FieldSummaryDefaultPhraseAnalyzer() : base(Id, SymbolKind.Field)
+        public MiKo_2080_FieldSummaryDefaultPhraseAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (symbol.ContainingType.IsEnum())
+            if (symbol is IFieldSymbol field)
             {
-                return false;
+                if (field.ContainingType.IsEnum())
+                {
+                    return false;
+                }
+
+                if (field.Type.IsDependencyProperty())
+                {
+                    return false; // validated by rule MiKo_2017
+                }
+
+                if (field.Type.IsRoutedEvent())
+                {
+                    return false; // validated by rule MiKo_2006
+                }
+
+                return true;
             }
 
-            if (symbol.Type.IsDependencyProperty())
-            {
-                return false; // validated by rule MiKo_2017
-            }
-
-            if (symbol.Type.IsRoutedEvent())
-            {
-                return false; // validated by rule MiKo_2006
-            }
-
-            return base.ShallAnalyze(symbol);
+            return false;
         }
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location)
@@ -49,9 +52,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             return Issue(symbol.Name, location, proposal, CreateStartingPhraseProposal(proposal));
         }
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
@@ -15,26 +15,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private const StringComparison Comparison = StringComparison.Ordinal;
 
-        public MiKo_2081_ReadOnlyFieldAnalyzer() : base(Id, SymbolKind.Field)
+        public MiKo_2081_ReadOnlyFieldAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            if (symbol.IsReadOnly)
+            if (symbol is IFieldSymbol field && field.IsReadOnly)
             {
-                switch (symbol.DeclaredAccessibility)
+                switch (field.DeclaredAccessibility)
                 {
                     case Accessibility.Public:
                     case Accessibility.Protected:
-                        return symbol.ContainingType.IsTestClass() is false;
+                        return field.ContainingType.IsTestClass() is false;
                 }
             }
 
             return false;
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
             if (summaries.None(_ => _.EndsWith(Constants.Comments.FieldIsReadOnly, Comparison)))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
@@ -1,40 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_2082_EnumMemberAnalyzer : SummaryDocumentationAnalyzer
+    public sealed class MiKo_2082_EnumMemberAnalyzer : SummaryStartDocumentationAnalyzer
     {
         public const string Id = "MiKo_2082";
 
-        public MiKo_2082_EnumMemberAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_2082_EnumMemberAnalyzer() : base(Id)
         {
         }
+
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.ContainingType.IsEnum();
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(location);
-
-        // overridden because we want to inspect the fields of the type as well
-        protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
-        {
-            if (symbol.IsEnum())
-            {
-                foreach (var field in symbol.GetFields())
-                {
-                    foreach (var issue in AnalyzeField(field, compilation))
-                    {
-                        yield return issue;
-                    }
-                }
-            }
-        }
-
-        // TODO RKN: Move this to SummaryDocumentAnalyzer when finished
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment) => AnalyzeSummariesStart(symbol, compilation, commentXml, comment);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2200_DocumentationStartsCapitalizedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2200_DocumentationStartsCapitalizedAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var issue = AnalyzeText(text, xml.GetName());
 
-                    if (issue == null)
+                    if (issue is null)
                     {
                         continue;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var commentXml = symbol.GetDocumentationCommentXml();
             var element = commentXml.GetCommentElement();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer.cs
@@ -13,31 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2211";
 
-        public MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.ContainingType.IsEnum();
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol) => symbol.ContainingType.IsEnum();
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                if (context.ContainingSymbol is IFieldSymbol symbol && ShallAnalyze(symbol))
-                {
-                    var issues = AnalyzeComment(comment);
-
-                    if (issues.Count > 0)
-                    {
-                        ReportDiagnostics(context, issues);
-                    }
-                }
-            }
-        }
-
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var remarks = comment.GetRemarksXmls();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             if (HasIssue(comment))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_XmlListElementAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_XmlListElementAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -331,7 +331,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Issue(location, replacement, properties);
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var issues = AnalyzeCommentXml(comment);
             var count = issues.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -65,7 +65,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var lines = new HashSet<int>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2225";
 
-        public MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer() : base(Id)
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var summaryXmls = comment.GetSummaryXmls();
             var remarksXmls = comment.GetRemarksXmls();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             List<Diagnostic> results = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
@@ -13,31 +13,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2231";
 
-        public MiKo_2231_InheritdocGetHashCodeAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2231_InheritdocGetHashCodeAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsOverride && method.Parameters.IsEmpty && method.ReturnType.SpecialType == SpecialType.System_Int32 && method.Name == nameof(GetHashCode);
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsOverride && symbol.Parameters.IsEmpty && symbol.ReturnType.SpecialType == SpecialType.System_Int32 && symbol.Name == nameof(GetHashCode);
-
-        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                if (context.ContainingSymbol is IMethodSymbol symbol && ShallAnalyze(symbol))
-                {
-                    var issues = AnalyzeComment(comment);
-
-                    if (issues.Length > 0)
-                    {
-                        ReportDiagnostics(context, issues);
-                    }
-                }
-            }
-        }
-
-        private Diagnostic[] AnalyzeComment(DocumentationCommentTriviaSyntax comment)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var tagNames = comment.Content.ToHashSet(_ => _.GetXmlTagName());
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
@@ -12,30 +12,40 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2232";
 
-        public MiKo_2232_EmptySummaryAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2232_EmptySummaryAnalyzer() : base(Id)
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => InitializeCore(context, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field);
-
-        protected override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            var summaryXmls = comment.GetSummaryXmls();
+            switch (symbol.Kind)
+            {
+                case SymbolKind.NamedType:
+                case SymbolKind.Method:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                case SymbolKind.Field:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
+        {
             var count = summaryXmls.Count;
 
-            if (count > 0)
+            for (var index = 0; index < count; index++)
             {
-                for (var index = 0; index < count; index++)
-                {
-                    var summary = summaryXmls[index];
-                    var content = summary.Content;
+                var summary = summaryXmls[index];
+                var content = summary.Content;
 
-                    switch (content.Count)
-                    {
-                        case 0:
-                        case 1 when content[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
-                            return new[] { Issue(summary) };
-                    }
+                switch (content.Count)
+                {
+                    case 0:
+                    case 1 when content[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
+                        return new[] { Issue(summary) };
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly SyntaxKind[] XmlTags = { SyntaxKind.XmlEmptyElement, SyntaxKind.XmlElementStartTag, SyntaxKind.XmlElementEndTag };
 
-        public MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer() : base(Id)
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] Separators = { "----", "****", "====", "####" };
 
-        public MiKo_2311_CommentIsSeparatorAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_2311_CommentIsSeparatorAnalyzer() : base(Id)
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
@@ -8,42 +8,69 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
-    public abstract class OperatorAnalyzer : SummaryDocumentationAnalyzer
+    public abstract class OperatorAnalyzer : DocumentationAnalyzer
     {
         private readonly string m_methodName;
 
-        protected OperatorAnalyzer(string diagnosticId, string methodName) : base(diagnosticId, SymbolKind.Method) => m_methodName = methodName;
+        protected OperatorAnalyzer(string diagnosticId, string methodName) : base(diagnosticId) => m_methodName = methodName;
 
         protected abstract string[] GetSummaryPhrases(ISymbol symbol);
 
         protected abstract string[] GetReturnsPhrases(ISymbol symbol);
 
-        protected sealed override bool ShallAnalyze(IMethodSymbol symbol)
+        protected override bool ShallAnalyze(ISymbol symbol)
         {
-            switch (symbol.MethodKind)
+            if (symbol is IMethodSymbol method)
             {
-                case MethodKind.UserDefinedOperator:
-                case MethodKind.Conversion: // that's an unary operator, such as an implicit conversion call
-                    return symbol.Name == m_methodName && base.ShallAnalyze(symbol);
+                switch (method.MethodKind)
+                {
+                    case MethodKind.UserDefinedOperator:
+                    case MethodKind.Conversion: // that's a unary operator, such as an implicit conversion call
+                        return method.Name == m_methodName;
 
-                default:
-                    return false;
+                    default:
+                        return false;
+                }
             }
+
+            return false;
         }
 
-        protected sealed override IEnumerable<Diagnostic> AnalyzeComment(ISymbol symbol, Compilation compilation, string commentXml, DocumentationCommentTriviaSyntax comment)
+        protected sealed override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var method = (IMethodSymbol)symbol;
+            var commentXml = symbol.GetDocumentationCommentXml();
 
-            var violationsInSummaries = AnalyzeSummaries(method, compilation, commentXml, comment);
-            var violationsInParameters = AnalyzeParameters(method.Parameters, commentXml, comment);
+            var violationsInSummaries = AnalyzeSummaries(comment, method, commentXml);
             var violationsInReturns = AnalyzeReturns(method, commentXml, comment);
+            var violationsInParameters = AnalyzeParameters(method.Parameters, commentXml, comment);
 
-            return violationsInSummaries.Concat(violationsInParameters).Concat(violationsInReturns);
+            var issueCount = violationsInSummaries.Length + violationsInReturns.Length + violationsInParameters.Length;
+
+            if (issueCount == 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var results = new List<Diagnostic>(issueCount);
+            results.AddRange(violationsInSummaries);
+            results.AddRange(violationsInReturns);
+            results.AddRange(violationsInParameters);
+
+            return results;
         }
 
-        protected sealed override IEnumerable<Diagnostic> AnalyzeSummary(ISymbol symbol, Compilation compilation, IEnumerable<string> summaries, DocumentationCommentTriviaSyntax comment)
+        private Diagnostic[] AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, string commentXml)
         {
+            var summaryXmls = comment.GetSummaryXmls();
+
+            if (summaryXmls.Count == 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var summaries = CommentExtensions.GetSummaries(commentXml);
+
             var phrases = GetSummaryPhrases(symbol);
 
             if (summaries.None(_ => _.AsSpan().Trim().EqualsAny(phrases)))
@@ -67,13 +94,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        private IEnumerable<Diagnostic> AnalyzeParameters(ImmutableArray<IParameterSymbol> parameters, string commentXml, DocumentationCommentTriviaSyntax comment)
+        private Diagnostic[] AnalyzeParameters(ImmutableArray<IParameterSymbol> parameters, string commentXml, DocumentationCommentTriviaSyntax comment)
         {
-            if (parameters.Length == 2)
+            if (parameters.Length != 2)
             {
-                yield return AnalyzeParameter(commentXml, parameters[0], "The first value to compare.");
-                yield return AnalyzeParameter(commentXml, parameters[1], "The second value to compare.");
+                return Array.Empty<Diagnostic>();
             }
+
+            var issue1 = AnalyzeParameter(commentXml, parameters[0], "The first value to compare.");
+            var issue2 = AnalyzeParameter(commentXml, parameters[1], "The second value to compare.");
+
+            if (issue1 is null)
+            {
+                return issue2 is null ? Array.Empty<Diagnostic>() : new[] { issue2 };
+            }
+
+            return issue2 is null ? new[] { issue1 } : new[] { issue1, issue2 };
         }
 
         private Diagnostic AnalyzeParameter(string commentXml, IParameterSymbol parameter, string phrase)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 using MiKoSolutions.Analyzers.Linguistics;
 
@@ -11,36 +9,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class OverallDocumentationAnalyzer : DocumentationAnalyzer
     {
-        protected OverallDocumentationAnalyzer(string id) : base(id, (SymbolKind)(-1))
+        protected OverallDocumentationAnalyzer(string id) : base(id)
         {
         }
 
-        protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.IsPrimaryConstructor() is false;
 
         protected virtual Diagnostic Issue(Location location, string replacement) => base.Issue(location, replacement);
-
-        protected void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                var symbol = context.ContainingSymbol;
-
-                if (symbol.IsPrimaryConstructor())
-                {
-                    // records are analyzed for their type as well, so we do not need to report twice
-                    return;
-                }
-
-                var issues = AnalyzeComment(comment, symbol);
-
-                if (issues.Count > 0)
-                {
-                    ReportDiagnostics(context, issues);
-                }
-            }
-        }
-
-        protected abstract IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol);
 
         protected IReadOnlyList<Diagnostic> AnalyzeForSpecialPhrase(SyntaxToken token, string startingPhrase, Func<string, string> replacementCallback)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -4,7 +4,6 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 using static MiKoSolutions.Analyzers.Constants;
 
@@ -12,28 +11,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class ReturnsValueDocumentationAnalyzer : DocumentationAnalyzer
     {
-        protected ReturnsValueDocumentationAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
+        protected ReturnsValueDocumentationAnalyzer(string diagnosticId) : base(diagnosticId)
         {
         }
 
-        protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, DocumentationCommentTrivia);
+        protected virtual bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnsVoid is false;
 
-        protected void AnalyzeComment(SyntaxNodeAnalysisContext context)
-        {
-            if (context.Node is DocumentationCommentTriviaSyntax comment)
-            {
-                var issues = AnalyzeComment(comment, context.ContainingSymbol);
-
-                if (issues.Count > 0)
-                {
-                    ReportDiagnostics(context, issues);
-                }
-            }
-        }
-
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnsVoid is false;
-
-        protected override bool ShallAnalyze(IPropertySymbol symbol) => symbol.GetReturnType() != null;
+        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => symbol.GetReturnType() != null;
 
         protected virtual bool ShallAnalyzeReturnType(ITypeSymbol returnType) => true;
 
@@ -75,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected virtual Diagnostic[] AnalyzeReturnType(ISymbol owningSymbol, ITypeSymbol returnType, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag) => Array.Empty<Diagnostic>();
 
-        private IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol)
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             switch (symbol)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class SingleLineCommentAnalyzer : DocumentationAnalyzer
     {
-        protected SingleLineCommentAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1)) => IgnoreMultipleLines = true;
+        protected SingleLineCommentAnalyzer(string diagnosticId) : base(diagnosticId) => IgnoreMultipleLines = true;
 
         protected bool IgnoreMultipleLines { get; set; }
 
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected virtual IEnumerable<Diagnostic> CollectIssues(string name, SyntaxTrivia trivia) => new[] { Issue(name, trivia) };
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => true;
+        protected virtual bool ShallAnalyze(IMethodSymbol symbol) => true;
 
         protected virtual bool ShallAnalyze(SyntaxTrivia trivia) => trivia.IsSingleLineComment();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    public abstract class SummaryStartDocumentationAnalyzer : SummaryDocumentationAnalyzer
+    {
+        protected SummaryStartDocumentationAnalyzer(string diagnosticId) : base(diagnosticId)
+        {
+        }
+
+        protected virtual Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => StartIssue(symbol, node.GetLocation());
+
+        protected virtual Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location);
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
+        {
+            var count = summaryXmls.Count;
+
+            List<Diagnostic> issues = null;
+
+            for (var index = 0; index < count; index++)
+            {
+                var issue = AnalyzeTextStart(symbol, summaryXmls[index]);
+
+                if (issue is null)
+                {
+                    continue;
+                }
+
+                if (issues is null)
+                {
+                    issues = new List<Diagnostic>(1);
+                }
+
+                issues.Add(issue);
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+
+        protected Diagnostic AnalyzeTextStart(ISymbol symbol, XmlElementSyntax xml)
+        {
+            var tag = xml.StartTag.GetName();
+
+            var descendantNodes = xml.DescendantNodes();
+
+            foreach (var node in descendantNodes)
+            {
+                switch (node)
+                {
+                    case XmlElementStartTagSyntax startTag:
+                    {
+                        var tagName = startTag.GetName();
+
+                        if (tagName == tag || tagName == Constants.XmlTag.Para)
+                        {
+                            continue; // skip over the start tag and name syntax
+                        }
+
+                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                    }
+
+                    case XmlElementEndTagSyntax endTag:
+                    {
+                        var tagName = endTag.GetName();
+
+                        if (tagName == Constants.XmlTag.Para)
+                        {
+                            continue; // skip over the start tag and name syntax
+                        }
+
+                        if (endTag.Parent is XmlElementSyntax element)
+                        {
+                            if (ConsiderEmptyTextAsIssue(symbol))
+                            {
+                                return StartIssue(symbol, element.GetContentsLocation()); // it's an empty text
+                            }
+
+                            continue;
+                        }
+
+                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                    }
+
+                    case XmlNameSyntax _:
+                    case XmlElementSyntax e when e.GetName() == Constants.XmlTag.Para:
+                    case XmlEmptyElementSyntax ee when ee.GetName() == Constants.XmlTag.Para:
+                        continue; // skip over the start tag and name syntax
+
+                    case XmlTextSyntax text:
+                    {
+                        // report the location of the first word(s) via the corresponding text token
+                        var textTokens = text.TextTokens;
+
+                        // keep in local variable to avoid multiple requests (see Roslyn implementation)
+                        var textTokensCount = textTokens.Count;
+
+                        for (var index = 0; index < textTokensCount; index++)
+                        {
+                            var token = textTokens[index];
+
+                            if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                            {
+                                continue;
+                            }
+
+                            var valueText = token.ValueText;
+
+                            if (valueText.IsNullOrWhiteSpace())
+                            {
+                                // we found the first but empty /// line, so ignore it
+                                continue;
+                            }
+
+                            if (valueText.Length == 1 && Constants.Comments.Delimiters.Contains(valueText[0]))
+                            {
+                                // this is a dot or something directly after the XML tag, so ignore that
+                                continue;
+                            }
+
+                            // we found some text
+                            if (AnalyzeTextStart(symbol, valueText, out var problematicText, out var comparison))
+                            {
+                                // it's no valid text, so we have an issue
+                                var position = valueText.IndexOf(problematicText, comparison);
+
+                                var start = token.SpanStart + position; // find start position for underlining
+                                var end = start + problematicText.Length; // find end position for underlining
+
+                                var location = CreateLocation(token, start, end);
+
+                                return StartIssue(symbol, location);
+                            }
+
+                            // it's a valid text, so we quit
+                            return null;
+                        }
+
+                        // we found a completely empty /// line, so ignore it
+                        continue;
+                    }
+
+                    default:
+                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                }
+            }
+
+            // nothing to report
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Remove explicit SymbolKind parameters in analyzer constructors.

- Standardize ShallAnalyze and AnalyzeComment method signatures.

- Refactor documentation analyzer classes for consistency.

- Update diagnostic reporting and utility methods across rules.

