### PR TITLE
Code cleaned up

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -36,11 +36,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(DocumentationCommentTriviaSyntax comment, ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, string commentXml, IReadOnlyCollection<string> summaries)
         {
-            if (summaries.None())
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
             var symbolNames = GetSelfSymbolNames(symbol);
             var phrases = GetPhrases(symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
@@ -40,8 +40,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             switch (symbol)
             {
-                case INamedTypeSymbol type: return AnalyzeStartingPhrase(type, summaries, comment, Constants.Comments.FactorySummaryPhrase);
-                case IMethodSymbol method: return AnalyzeStartingPhrase(method, summaries, comment, GetPhrases(method).ToArray());
+                case INamedTypeSymbol type: return AnalyzeStartingPhrase(type, summaryXmls, summaries, Constants.Comments.FactorySummaryPhrase);
+                case IMethodSymbol method: return AnalyzeStartingPhrase(method, summaryXmls, summaries, GetPhrases(method).ToArray());
                 default: return Array.Empty<Diagnostic>();
             }
         }
@@ -67,13 +67,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                    : startingPhrases.Select(_ => _.FormatWith(argumentType));
         }
 
-        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, IEnumerable<string> comments, DocumentationCommentTriviaSyntax comment, params string[] phrases)
+        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, IEnumerable<string> summaries, params string[] phrases)
         {
-            if (comments.None(_ => phrases.Exists(__ => _.StartsWith(__, StringComparison.Ordinal))))
+            if (summaries.None(_ => phrases.Exists(__ => _.StartsWith(__, StringComparison.Ordinal))))
             {
-                var summaries = comment.GetSummaryXmls();
-
-                return new[] { Issue(symbol.Name, summaries[0].GetContentsLocation(), phrases[0]) };
+                return new[] { Issue(symbol.Name, summaryXmls[0].GetContentsLocation(), phrases[0]) };
             }
 
             // fitting comment

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var symbolName = symbol.Name;
             var obviousComments = GetObviousComments(symbolName);
 
-            var count = summaries.Count;
+            var count = summaryXmls.Count;
 
             List<Diagnostic> issues = null;
 


### PR DESCRIPTION
- Remove unnecessary empty summaries check in `MeaninglessSummaryAnalyzer`.
- Refactor `AnalyzeSummaries` to use `summaryXmls` instead of `comment`.
- Update `AnalyzeStartingPhrase` signature and parameter order.
