### PR TITLE
MiKo_1115 is now aware of numbers in method names

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -53,6 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                       "Everything",
                                                                       Rejected,
                                                                       Consumed,
+                                                                      "Once",
                                                                   };
 
         private static readonly string[] SpecialFirstPhrases =
@@ -105,7 +106,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             foreach (var part in parts)
             {
-                if (part[0].IsUpperCase() is false)
+                if (part[0].IsUpperCase() is false && part[0].IsNumber() is false)
                 {
                     return false;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -101,7 +101,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static bool HasIssue(string methodName)
         {
-            var parts = methodName.Split(Constants.Underscores, StringSplitOptions.RemoveEmptyEntries);
+            var parts = GetParts(methodName);
             var first = true;
 
             foreach (var part in parts)
@@ -141,9 +141,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return NamesFinder.FindBetterTestName(nameToImprove, symbol);
         }
 
+        private static string[] GetParts(string methodName) => methodName.Split(Constants.Underscores, StringSplitOptions.RemoveEmptyEntries);
+
         private static bool TryGetInOrder(string name, out string result)
         {
-            var parts = name.Split(Constants.Underscores, StringSplitOptions.RemoveEmptyEntries);
+            var parts = GetParts(name);
 
             switch (parts.Length)
             {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -168,6 +168,8 @@ public class TestMe
         [TestCase("MethodName_ThrowsArgumentException_if_SomeConditionIsMet", "Method_name_throws_ArgumentException_if_some_condition_is_met")]
         [TestCase("MethodName_NoLongerThrowsNullReferenceException_if_SomeConditionIsMet", "Method_name_throws_no_NullReferenceException_if_some_condition_is_met")]
         [TestCase("MethodName_NotThrowsNullReferenceException_if_SomeConditionIsMet", "Method_name_throws_no_NullReferenceException_if_some_condition_is_met")]
+        [TestCase("Send_2Args_ContentParameterIsNull_ThrowsArgumentNullException", "Send_throws_ArgumentNullException_if_content_parameter_is_null_and_2_args")]
+        [TestCase("Send_2Args_ValidMessageContent_MessageIsSentOnce", "Send_message_is_sent_once_if_valid_message_content_and_2_args")] // TODO RKN: we should better rename it to 'Send_sends_message_with_valid_content_once_and_2_args'
         public void Code_gets_fixed_for_3_slashes_in_(string originalName, string fixedName) => VerifyCSharpFix(
                                                                                                             "class TestMe { [Test] public void " + originalName + "() { } }",
                                                                                                             "class TestMe { [Test] public void " + fixedName + "() { } }");


### PR DESCRIPTION
- Update condition to allow numeric starting characters.
- Introduce `GetParts` method for splitting method names.
- Recognize "Once" as a valid keyword.
- Add test cases for methods with numbers.
