### PR TITLE
Added new rules MiKo_1503 - MiKo_1507 that report if something was suffixed with 'Counter'

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1103,6 +1103,8 @@ namespace MiKoSolutions.Analyzers
             internal const string Create = "Create";
             internal const string Factory = "Factory";
 
+            internal const string Counter = "Counter";
+
             internal const string DefaultPropertyParameterName = "value";
 
             internal const string IMultiValueConverter = "IMultiValueConverter";

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -221,6 +221,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UnitTestCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UsePatternMatchingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\MiKoCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\FieldNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1000_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1001_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1002_CodeFixProvider.cs" />
@@ -306,9 +307,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1200_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1201_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1300_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1503_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1504_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1505_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1506_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLocalVariableCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\DisposeOrderingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4001_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4002_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -462,6 +462,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1501_FilterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1502_ProcessAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4691,6 +4691,191 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Counter&apos; with &apos;Count&apos;.
+        /// </summary>
+        internal static string MiKo_1503_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1503_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Methods that return values but are suffixed with &apos;Counter&apos; are most likely not returning counters but counted values instead.
+        ///So they should be suffixed with &apos;Count&apos;..
+        /// </summary>
+        internal static string MiKo_1503_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1503_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1503_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1503_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Methods should not be suffixed with &apos;Counter&apos;.
+        /// </summary>
+        internal static string MiKo_1503_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1503_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Counter&apos; with &apos;Counted&apos;.
+        /// </summary>
+        internal static string MiKo_1504_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1504_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties that return values but are suffixed with &apos;Counter&apos; are most likely not returning counters but counted values instead.
+        ///So they should be named accordingly..
+        /// </summary>
+        internal static string MiKo_1504_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1504_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1504_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1504_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Properties should not be suffixed with &apos;Counter&apos;.
+        /// </summary>
+        internal static string MiKo_1504_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1504_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Counter&apos; with &apos;counted&apos;.
+        /// </summary>
+        internal static string MiKo_1505_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1505_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fields that hold values but are suffixed with &apos;Counter&apos; are most likely not holding counters but counted values instead.
+        ///So they should be named accordingly..
+        /// </summary>
+        internal static string MiKo_1505_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1505_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1505_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1505_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fields should not be suffixed with &apos;Counter&apos;.
+        /// </summary>
+        internal static string MiKo_1505_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1505_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Counter&apos; with &apos;counted&apos;.
+        /// </summary>
+        internal static string MiKo_1506_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1506_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local variables that hold values but are suffixed with &apos;Counter&apos; are most likely not holding counters but counted values instead.
+        ///So they should be named accordingly..
+        /// </summary>
+        internal static string MiKo_1506_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1506_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1506_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1506_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local variables should not be suffixed with &apos;Counter&apos;.
+        /// </summary>
+        internal static string MiKo_1506_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1506_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;Counter&apos; with &apos;counted&apos;.
+        /// </summary>
+        internal static string MiKo_1507_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1507_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters that hold values but are suffixed with &apos;Counter&apos; are most likely not holding counters but counted values instead.
+        ///So they should be named accordingly..
+        /// </summary>
+        internal static string MiKo_1507_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1507_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1507_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1507_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters should not be suffixed with &apos;Counter&apos;.
+        /// </summary>
+        internal static string MiKo_1507_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1507_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1705,6 +1705,71 @@ Example:
   <data name="MiKo_1502_Title" xml:space="preserve">
     <value>Do not use 'Process' in names</value>
   </data>
+  <data name="MiKo_1503_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Counter' with 'Count'</value>
+  </data>
+  <data name="MiKo_1503_Description" xml:space="preserve">
+    <value>Methods that return values but are suffixed with 'Counter' are most likely not returning counters but counted values instead.
+So they should be suffixed with 'Count'.</value>
+  </data>
+  <data name="MiKo_1503_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1503_Title" xml:space="preserve">
+    <value>Methods should not be suffixed with 'Counter'</value>
+  </data>
+  <data name="MiKo_1504_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Counter' with 'Counted'</value>
+  </data>
+  <data name="MiKo_1504_Description" xml:space="preserve">
+    <value>Properties that return values but are suffixed with 'Counter' are most likely not returning counters but counted values instead.
+So they should be named accordingly.</value>
+  </data>
+  <data name="MiKo_1504_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1504_Title" xml:space="preserve">
+    <value>Properties should not be suffixed with 'Counter'</value>
+  </data>
+  <data name="MiKo_1505_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Counter' with 'counted'</value>
+  </data>
+  <data name="MiKo_1505_Description" xml:space="preserve">
+    <value>Fields that hold values but are suffixed with 'Counter' are most likely not holding counters but counted values instead.
+So they should be named accordingly.</value>
+  </data>
+  <data name="MiKo_1505_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1505_Title" xml:space="preserve">
+    <value>Fields should not be suffixed with 'Counter'</value>
+  </data>
+  <data name="MiKo_1506_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Counter' with 'counted'</value>
+  </data>
+  <data name="MiKo_1506_Description" xml:space="preserve">
+    <value>Local variables that hold values but are suffixed with 'Counter' are most likely not holding counters but counted values instead.
+So they should be named accordingly.</value>
+  </data>
+  <data name="MiKo_1506_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1506_Title" xml:space="preserve">
+    <value>Local variables should not be suffixed with 'Counter'</value>
+  </data>
+  <data name="MiKo_1507_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'Counter' with 'counted'</value>
+  </data>
+  <data name="MiKo_1507_Description" xml:space="preserve">
+    <value>Parameters that hold values but are suffixed with 'Counter' are most likely not holding counters but counted values instead.
+So they should be named accordingly.</value>
+  </data>
+  <data name="MiKo_1507_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1507_Title" xml:space="preserve">
+    <value>Parameters should not be suffixed with 'Counter'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/FieldNamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/FieldNamingCodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    public abstract class FieldNamingCodeFixProvider : NamingCodeFixProvider
+    {
+        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1034_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1034_CodeFixProvider)), Shared]
-    public sealed class MiKo_1034_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1034_CodeFixProvider : FieldNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1034";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1035_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1035_CodeFixProvider)), Shared]
-    public sealed class MiKo_1035_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1035_CodeFixProvider : PropertyNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1035";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<PropertyDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1036_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1036_CodeFixProvider)), Shared]
-    public sealed class MiKo_1036_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1036_CodeFixProvider : FieldNamingCodeFixProvider // events are similar to fields (variable declarators)
     {
         public override string FixableDiagnosticId => "MiKo_1036";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault(); // events are variable declarators
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1053_CodeFixProvider)), Shared]
-    public sealed class MiKo_1053_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1053_CodeFixProvider : FieldNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1053";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
@@ -1,23 +1,18 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1055_1056_CodeFixProvider)), Shared]
-    public sealed class MiKo_1055_1056_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1055_1056_CodeFixProvider : FieldNamingCodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("MiKo_1055", "MiKo_1056");
 
         public override string FixableDiagnosticId => "MiKo_1055_1056";
 
         protected override string Title => Resources.MiKo_1055_CodeFixTitle;
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
@@ -1,23 +1,18 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1057_1058_CodeFixProvider)), Shared]
-    public sealed class MiKo_1057_1058_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1057_1058_CodeFixProvider : FieldNamingCodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("MiKo_1057", "MiKo_1058");
 
         public override string FixableDiagnosticId => "MiKo_1057_1058";
 
         protected override string Title => Resources.MiKo_1057_CodeFixTitle;
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -78,24 +78,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return prefixLength > 0
                    ? AnalyzeName(symbolName.Substring(prefixLength), symbol, fieldPrefix)
                    : AnalyzeName(symbolName, symbol);
-
-            string GetFieldPrefix(string fieldName)
-            {
-                var fieldPrefixes = Constants.Markers.FieldPrefixes;
-                var prefixesLength = fieldPrefixes.Length;
-
-                for (var index = 0; index < prefixesLength; index++)
-                {
-                    var prefix = fieldPrefixes[index];
-
-                    if (prefix.Length > 0 && fieldName.StartsWith(prefix, StringComparison.Ordinal))
-                    {
-                        return prefix;
-                    }
-                }
-
-                return string.Empty;
-            }
         }
 
         private Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "")

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1082_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1082_CodeFixProvider)), Shared]
-    public sealed class MiKo_1082_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1082_CodeFixProvider : PropertyNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1082";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<PropertyDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1083_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1083_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1083_CodeFixProvider)), Shared]
-    public sealed class MiKo_1083_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1083_CodeFixProvider : FieldNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1083";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<VariableDeclaratorSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1503_CodeFixProvider)), Shared]
+    public sealed class MiKo_1503_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1503";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
@@ -25,14 +25,26 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+            if (symbolName.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
             {
-                var betterName = symbolName.WithoutSuffix("er");
+                var betterName = FindBetterName(symbolName);
 
                 return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
             }
 
             return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string symbolName)
+        {
+            var nameSpan = symbolName.AsSpan();
+
+            if (nameSpan.Contains("Increment") || nameSpan.Contains("Decrement"))
+            {
+                return symbolName.WithoutSuffix(Constants.Names.Counter);
+            }
+
+            return symbolName.WithoutSuffix("er");
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1503_MethodsWithCounterSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1503";
+
+        public MiKo_1503_MethodsWithCounterSuffixAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct && base.ShallAnalyze(symbol);
+
+        protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct;
+
+        protected override bool ShallAnalyzeLocalFunction(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct;
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name;
+
+            if (symbolName.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = symbolName.WithoutSuffix("er");
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1504_CodeFixProvider)), Shared]
+    public sealed class MiKo_1504_CodeFixProvider : PropertyNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1504";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+using MiKoSolutions.Analyzers.Linguistics;
+
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -21,14 +23,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+            if (symbolName.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
             {
-                var betterName = "Counted" + symbolName.WithoutSuffix("Counter").ToUpperCaseAt(0);
+                var betterName = FindBetterName(symbolName);
 
                 return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
             }
 
             return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string symbolName)
+        {
+            return "Counted" + Pluralizer.MakePluralName(symbolName.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_1504_PropertiesWithCounterSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1504";
+
+        public MiKo_1504_PropertiesWithCounterSuffixAnalyzer() : base(Id, SymbolKind.Property)
+        {
+        }
+
+        protected override bool ShallAnalyze(IPropertySymbol symbol) => base.ShallAnalyze(symbol) && symbol.Type.TypeKind == TypeKind.Struct;
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name;
+
+            if (symbolName.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = "Counted" + symbolName.WithoutSuffix("Counter").ToUpperCaseAt(0);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1505_CodeFixProvider)), Shared]
+    public sealed class MiKo_1505_CodeFixProvider : FieldNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1505";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_1505_FieldsWithCounterSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1505";
+
+        private const string Counter = "Counter";
+
+        public MiKo_1505_FieldsWithCounterSuffixAnalyzer() : base(Id, SymbolKind.Field)
+        {
+        }
+
+        protected override bool ShallAnalyze(IFieldSymbol symbol)
+        {
+            if (symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith(Counter, StringComparison.OrdinalIgnoreCase))
+            {
+                if (symbol.ContainingType.IsTestClass())
+                {
+                    // ignore only structs in tests
+                    return false;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name;
+
+            if (symbol.Type.TypeKind == TypeKind.Struct && symbolName.EndsWith(Counter, StringComparison.OrdinalIgnoreCase))
+            {
+                var prefix = GetFieldPrefix(symbolName);
+
+                // be aware of field prefixes, such as 'm_'
+                var betterName = prefix + "counted" + symbolName.AsSpan().Slice(prefix.Length, symbolName.Length - prefix.Length - Counter.Length).ToUpperCaseAt(0);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1506_CodeFixProvider)), Shared]
+    public sealed class MiKo_1506_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1506";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_1506_VariablesWithCounterSuffixAnalyzer : NamingLocalVariableAnalyzer
+    {
+        public const string Id = "MiKo_1506";
+
+        public MiKo_1506_VariablesWithCounterSuffixAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) && symbol.TypeKind == TypeKind.Struct;
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+
+                    if (name.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var betterName = "counted" + name.WithoutSuffix("Counter").ToUpperCaseAt(0);
+
+                        yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+using MiKoSolutions.Analyzers.Linguistics;
+
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -28,14 +30,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     var identifier = identifiers[index];
                     var name = identifier.ValueText;
 
-                    if (name.EndsWith("Counter", StringComparison.OrdinalIgnoreCase))
+                    if (name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
                     {
-                        var betterName = "counted" + name.WithoutSuffix("Counter").ToUpperCaseAt(0);
+                        var betterName = FindBetterName(name);
 
                         yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
                     }
                 }
             }
+        }
+
+        private static string FindBetterName(string name)
+        {
+            return "counted" + Pluralizer.MakePluralName(name.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1507_CodeFixProvider)), Shared]
+    public sealed class MiKo_1507_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1507";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_1507_ParametersWithCounterSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1507";
+
+        public MiKo_1507_ParametersWithCounterSuffixAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            if (HasIssue(symbol))
+            {
+                var betterName = "counted" + symbol.Name.WithoutSuffix("Counter").ToUpperCaseAt(0);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static bool HasIssue(IParameterSymbol symbol) => symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith("Counter", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+using MiKoSolutions.Analyzers.Linguistics;
+
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -19,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             if (HasIssue(symbol))
             {
-                var betterName = "counted" + symbol.Name.WithoutSuffix("Counter").ToUpperCaseAt(0);
+                var betterName = FindBetterName(symbol);
 
                 return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
             }
@@ -27,6 +29,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static bool HasIssue(IParameterSymbol symbol) => symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith("Counter", StringComparison.OrdinalIgnoreCase);
+        private static bool HasIssue(IParameterSymbol symbol) => symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase);
+
+        private static string FindBetterName(IParameterSymbol symbol)
+        {
+            return "counted" + Pluralizer.MakePluralName(symbol.Name.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -33,9 +33,27 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return expected;
         }
 
+        protected static string GetFieldPrefix(string fieldName)
+        {
+            var fieldPrefixes = Constants.Markers.FieldPrefixes;
+            var prefixesLength = fieldPrefixes.Length;
+
+            for (var index = 0; index < prefixesLength; index++)
+            {
+                var prefix = fieldPrefixes[index];
+
+                if (prefix.Length > 0 && fieldName.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    return prefix;
+                }
+            }
+
+            return string.Empty;
+        }
+
         protected sealed override IEnumerable<Diagnostic> AnalyzeNamespace(INamespaceSymbol symbol, Compilation compilation) => ShallAnalyze(symbol)
-                                                                                                                                ? AnalyzeName(symbol, compilation)
-                                                                                                                                : Array.Empty<Diagnostic>();
+                                                                                                                                    ? AnalyzeName(symbol, compilation)
+                                                                                                                                    : Array.Empty<Diagnostic>();
 
         protected sealed override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation) => ShallAnalyze(symbol)
                                                                                                                            ? AnalyzeName(symbol, compilation)

--- a/MiKo.Analyzer.Shared/Rules/Naming/PropertyNamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/PropertyNamingCodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    public abstract class PropertyNamingCodeFixProvider : NamingCodeFixProvider
+    {
+        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<PropertyDeclarationSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1088_SingletonInstancesShouldBeNamedInstanceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1088_SingletonInstancesShouldBeNamedInstanceAnalyzerTests.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     [TestFixture]
     public sealed class MiKo_1088_SingletonInstancesShouldBeNamedInstanceAnalyzerTests : CodeFixVerifier
     {
-        private static readonly string[] FieldPrefixes = ["m_", "s_", "t_", "_", string.Empty,];
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
 
         [Test]
         public void No_issue_is_reported_for_test_class() => No_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1501_FilterAnalyzerTests.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     [TestFixture]
     public sealed class MiKo_1501_FilterAnalyzerTests : CodeFixVerifier
     {
-        private static readonly string[] FieldPrefixes = ["m_", "s_", "t_", "_", string.Empty,];
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
         private static readonly string[] FilterNames = ["Filter", "filter"];
 
         [Test]
@@ -61,7 +61,7 @@ namespace Bla
         public void An_issue_is_reported_for_method_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public void " + name + @"Something(int i) { }
   }
@@ -72,7 +72,7 @@ namespace Bla
         public void An_issue_is_reported_for_event_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public event EventHandler " + name + @"Something;
   }
@@ -83,7 +83,7 @@ namespace Bla
         public void An_issue_is_reported_for_property_with_([ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public int " + name + @"Something { get; set;}
   }
@@ -94,9 +94,9 @@ namespace Bla
         public void An_issue_is_reported_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix, [ValueSource(nameof(FilterNames))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
-      private int " + fieldPrefix + name + @"Something(int i) { }
+      private int " + fieldPrefix + name + @"Something;
   }
 }
 ");

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1502_ProcessAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1502_ProcessAnalyzerTests.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     [TestFixture]
     public sealed class MiKo_1502_ProcessAnalyzerTests : CodeFixVerifier
     {
-        private static readonly string[] FieldPrefixes = ["m_", "s_", "t_", "_", string.Empty,];
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
         private static readonly string[] Names = ["Process", "process", "Processor", "processor"];
 
         [Test]
@@ -71,7 +71,7 @@ namespace Bla
         public void An_issue_is_reported_for_type_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class Test" + name + @"Me
+  public class Test" + name + @"Me
   {
       public void DoSomething(int i) { }
   }
@@ -82,7 +82,7 @@ namespace Bla
         public void An_issue_is_reported_for_method_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public void " + name + @"Something(int i) { }
   }
@@ -93,7 +93,7 @@ namespace Bla
         public void An_issue_is_reported_for_event_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public event EventHandler " + name + @"Something;
   }
@@ -104,7 +104,7 @@ namespace Bla
         public void An_issue_is_reported_for_property_with_([ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       public int " + name + @"Something { get; set;}
   }
@@ -115,7 +115,7 @@ namespace Bla
         public void An_issue_is_reported_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix, [ValueSource(nameof(Names))] string name) => An_issue_is_reported_for(@"
 namespace Bla
 {
-  public static class TestMe
+  public class TestMe
   {
       private int " + fieldPrefix + name + @"Something(int i) { }
   }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzerTests.cs
@@ -86,62 +86,43 @@ namespace Bla
 }
 ");
 
-        [Test]
-        public void Code_gets_fixed_for_method_with_Counter_suffix()
+        [TestCase("SomeCounter", "SomeCount")]
+        [TestCase("IncrementCounter", "Increment")]
+        [TestCase("DecrementCounter", "Decrement")]
+        public void Code_gets_fixed_for_method_(string originalName, string fixedName)
         {
-            const string OriginalCode = @"
+            const string Template = @"
 namespace Bla
 {
     public class TestMe
     {
-        private int SomeCounter() => 42;
+        private int ###() => 42;
     }
 }
 ";
 
-            const string FixedCode = @"
-namespace Bla
-{
-    public class TestMe
-    {
-        private int SomeCount() => 42;
-    }
-}
-";
-
-            VerifyCSharpFix(OriginalCode, FixedCode);
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
-        [Test]
-        public void Code_gets_fixed_for_local_function_with_Counter_suffix()
+        [TestCase("SomeCounter", "SomeCount")]
+        [TestCase("IncrementCounter", "Increment")]
+        [TestCase("DecrementCounter", "Decrement")]
+        public void Code_gets_fixed_for_local_function_(string originalName, string fixedName)
         {
-            const string OriginalCode = @"
+            const string Template = @"
 namespace Bla
 {
     public class TestMe
     {
         private void DoSomething()
         {
-            int SomeCounter() => 42;
+            int ###() => 42;
         }
     }
 }
 ";
 
-            const string FixedCode = @"
-namespace Bla
-{
-    public class TestMe
-    {
-        private void DoSomething()
-        {
-            int SomeCount() => 42;
-        }
-    }
-}
-";
-
-            VerifyCSharpFix(OriginalCode, FixedCode);
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
         protected override string GetDiagnosticId() => MiKo_1503_MethodsWithCounterSuffixAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzerTests.cs
@@ -1,0 +1,153 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1503_MethodsWithCounterSuffixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_value_type_method_without_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int Something() => 42;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_method_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private object SomeCounter() => 42;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_local_function_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private void DoSomething()
+      {
+        object SomeCounter() => 42;
+      }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Counter_suffix() => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+  [TestFixture]
+  public class TestMe
+  {
+      private int SomeCounter() => 42;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_value_type_local_function_with_Counter_in_its_name() => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private void DoSomething()
+      {
+          int SomeCounter() => 42;
+      }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_with_Counter_suffix() => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int SomeCounter() => 42;
+  }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_method_with_Counter_suffix()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int SomeCounter() => 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int SomeCount() => 42;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_local_function_with_Counter_suffix()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int SomeCounter() => 42;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int SomeCount() => 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1503_MethodsWithCounterSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1503_MethodsWithCounterSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1503_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzerTests.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1504_PropertiesWithCounterSuffixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_value_type_property_without_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int Something { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_property_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private object SomeCounter { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_property_with_Counter_suffix() => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+  [TestFixture]
+  public class TestMe
+  {
+      private int SomeCounter { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_property_with_Counter_suffix() => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int SomeCounter { get; set; }
+  }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_property_with_Counter_suffix()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int SomeCounter { get; set; }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int CountedSome { get; set; }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1504_PropertiesWithCounterSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1504_PropertiesWithCounterSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1504_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzerTests.cs
@@ -58,30 +58,21 @@ namespace Bla
 }
 ");
 
-        [Test]
-        public void Code_gets_fixed_for_property_with_Counter_suffix()
+        [TestCase("DataCounter", "CountedData")]
+        [TestCase("TransactionCounter", "CountedTransactions")]
+        public void Code_gets_fixed_for_property_with_(string originalName, string fixedName)
         {
-            const string OriginalCode = @"
+            const string Template = @"
 namespace Bla
 {
     public class TestMe
     {
-        private int SomeCounter { get; set; }
+        private int ### { get; set; }
     }
 }
 ";
 
-            const string FixedCode = @"
-namespace Bla
-{
-    public class TestMe
-    {
-        private int CountedSome { get; set; }
-    }
-}
-";
-
-            VerifyCSharpFix(OriginalCode, FixedCode);
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
         protected override string GetDiagnosticId() => MiKo_1504_PropertiesWithCounterSuffixAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzerTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1505_FieldsWithCounterSuffixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
+
+        [Test]
+        public void No_issue_is_reported_for_value_type_field_without_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int Something;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_field_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private object SomeCounter;
+  }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix) => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+  [TestFixture]
+  public class TestMe
+  {
+      private int " + fieldPrefix + @"SomeCounter;
+  }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix) => An_issue_is_reported_for(@"
+namespace Bla
+{
+  public class TestMe
+  {
+      private int " + fieldPrefix + @"SomeCounter;
+  }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_field_with_([ValueSource(nameof(FieldPrefixes))] string fieldPrefix)
+        {
+            var originalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int " + fieldPrefix + @"SomeCounter;
+    }
+}
+";
+
+            var fixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int " + fieldPrefix + @"countedSome;
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1505_FieldsWithCounterSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1505_FieldsWithCounterSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1505_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzerTests.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1506_VariablesWithCounterSuffixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_value_type_variable_without_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_variable_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            object somethingCounter = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_variable_with_Counter_in_its_name() => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int somethingCounter = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_with_Counter_in_its_name() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int somethingCounter = 42;
+        }
+    }
+}
+
+");
+
+        [Test]
+        public void Code_gets_fixed_for_variable_with_Counter_in_its_name()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int somethingCounter = 42;
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int countedSomething = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1506_VariablesWithCounterSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1506_VariablesWithCounterSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1506_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzerTests.cs
@@ -71,36 +71,24 @@ namespace Bla
 
 ");
 
-        [Test]
-        public void Code_gets_fixed_for_variable_with_Counter_in_its_name()
+        [TestCase("dataCounter", "countedData")]
+        [TestCase("transactionCounter", "countedTransactions")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
         {
-            const string OriginalCode = @"
+            const string Template = @"
 namespace Bla
 {
     public class TestMe
     {
         private void DoSomething()
         {
-            int somethingCounter = 42;
+            int ### = 42;
         }
     }
 }
 ";
 
-            const string FixedCode = @"
-namespace Bla
-{
-    public class TestMe
-    {
-        private void DoSomething()
-        {
-            int countedSomething = 42;
-        }
-    }
-}
-";
-
-            VerifyCSharpFix(OriginalCode, FixedCode);
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
         protected override string GetDiagnosticId() => MiKo_1506_VariablesWithCounterSuffixAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzerTests.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1507_ParametersWithCounterSuffixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_value_type_parameter_without_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_reference_type_parameter_with_Counter_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(object somethingCounter)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_parameter_with_Counter_in_its_name() => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int somethingCounter)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_with_Counter_in_its_name() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int somethingCounter)
+        {
+        }
+    }
+}
+
+");
+
+        [Test]
+        public void Code_gets_fixed_for_parameter_with_Counter_in_its_name()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int somethingCounter)
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int countedSomething)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1507_ParametersWithCounterSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1507_ParametersWithCounterSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1507_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzerTests.cs
@@ -67,34 +67,23 @@ namespace Bla
 
 ");
 
-        [Test]
-        public void Code_gets_fixed_for_parameter_with_Counter_in_its_name()
+        [TestCase("dataCounter", "countedData")]
+        [TestCase("transactionCounter", "countedTransactions")]
+        public void Code_gets_fixed_for_parameter_with_(string originalName, string fixedName)
         {
-            const string OriginalCode = @"
+            const string Template = @"
 namespace Bla
 {
     public class TestMe
     {
-        private void DoSomething(int somethingCounter)
+        private void DoSomething(int ###)
         {
         }
     }
 }
 ";
 
-            const string FixedCode = @"
-namespace Bla
-{
-    public class TestMe
-    {
-        private void DoSomething(int countedSomething)
-        {
-        }
-    }
-}
-";
-
-            VerifyCSharpFix(OriginalCode, FixedCode);
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
         protected override string GetDiagnosticId() => MiKo_1507_ParametersWithCounterSuffixAnalyzer.Id;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 480 rules that are currently provided by the analyzer.
+The following tables lists all the 485 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -161,6 +161,11 @@ The following tables lists all the 480 rules that are currently provided by the 
 |MiKo_1409|Do not prefix or suffix namespaces with underscores|&#x2713;|\-|
 |MiKo_1501|Do not use 'Filter' in names|&#x2713;|\-|
 |MiKo_1502|Do not use 'Process' in names|&#x2713;|\-|
+|MiKo_1503|Methods should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1504|Properties should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1505|Fields should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1506|Local variables should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1507|Parameters should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add analyzers for `Counter` suffix renaming
- Introduce code fix providers for MiKo_1503-1507 rules
- Update resource strings and utility base classes
- Refine unit tests and project file references

(resolves #1239)
