### PR TITLE
MiKo_3226 'declaration' renamed to 'field', MiKo_1501 message now uses '

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4642,7 +4642,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename &apos;Filter&apos; to something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`.
+        ///   Looks up a localized string similar to Rename &apos;Filter&apos; to something like &apos;IncludeBy&apos;, &apos;ExcludeBy&apos;, &apos;Remove&apos;, &apos;Skip&apos; or &apos;Take&apos;.
         /// </summary>
         internal static string MiKo_1501_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1687,7 +1687,7 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
     <value>When naming something 'Filter', it is not clear whether the criteria to filter on gets included or excluded in the result. So instead, it should be named something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`. That makes it clear about what gets filtered.</value>
   </data>
   <data name="MiKo_1501_MessageFormat" xml:space="preserve">
-    <value>Rename 'Filter' to something like `IncludeBy`, `ExcludeBy`, `Remove`, `Skip` or `Take`</value>
+    <value>Rename 'Filter' to something like 'IncludeBy', 'ExcludeBy', 'Remove', 'Skip' or 'Take'</value>
   </data>
   <data name="MiKo_1501_Title" xml:space="preserve">
     <value>Do not use 'Filter' in names</value>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs
@@ -18,13 +18,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private void AnalyzeField(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is FieldDeclarationSyntax declaration && declaration.IsReadOnly())
+            if (context.Node is FieldDeclarationSyntax field && field.IsReadOnly())
             {
-                foreach (var variable in declaration.Declaration.Variables)
+                foreach (var variable in field.Declaration.Variables)
                 {
                     if (variable.Initializer?.Value is LiteralExpressionSyntax)
                     {
-                        ReportDiagnostics(context, Issue(declaration));
+                        ReportDiagnostics(context, Issue(field));
                     }
                 }
             }


### PR DESCRIPTION
- Renamed variable from 'declaration' to 'field' for clarity in MiKo_3226 analyzer.

- Modified resource and comment strings formatting for MiKo_1501.

