### PR TITLE
version increased to v0.0.48

### DIFF
--- a/BenchmarkConsole/BenchmarkConsole.csproj
+++ b/BenchmarkConsole/BenchmarkConsole.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiKo.Analyzer.2019/MiKo.Analyzer.2019.csproj
+++ b/MiKo.Analyzer.2019/MiKo.Analyzer.2019.csproj
@@ -9,10 +9,10 @@
 	
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
     <AssemblyName>MiKoSolutions.Analyzers.2019</AssemblyName>
-    <AssemblyVersion>0.0.47.0</AssemblyVersion>
-    <FileVersion>0.0.47.0</FileVersion>
+    <AssemblyVersion>0.0.48.0</AssemblyVersion>
+    <FileVersion>0.0.48.0</FileVersion>
     <Company>MiKo Solutions</Company>
-    <Version>0.0.47</Version>
+    <Version>0.0.48</Version>
     <Copyright>Copyright © 2018-2025 by MiKo Solutions. All rights reserved.</Copyright>
 
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
+++ b/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
@@ -9,10 +9,10 @@
 
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
     <AssemblyName>MiKoSolutions.Analyzers.2022</AssemblyName>
-    <AssemblyVersion>0.0.47.0</AssemblyVersion>
-    <FileVersion>0.0.47.0</FileVersion>
+    <AssemblyVersion>0.0.48.0</AssemblyVersion>
+    <FileVersion>0.0.48.0</FileVersion>
     <Company>MiKo Solutions</Company>
-    <Version>0.0.47</Version>
+    <Version>0.0.48</Version>
     <Copyright>Copyright © 2018-2025 by MiKo Solutions. All rights reserved.</Copyright>
 
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
@@ -27,7 +27,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/MiKo.Analyzer.Codefixes.2019/MiKo.Analyzer.CodeFixes.2019.csproj
+++ b/MiKo.Analyzer.Codefixes.2019/MiKo.Analyzer.CodeFixes.2019.csproj
@@ -9,10 +9,10 @@
 
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
     <AssemblyName>MiKoSolutions.Analyzers.CodeFixes.2019</AssemblyName>
-    <AssemblyVersion>0.0.47.0</AssemblyVersion>
-    <FileVersion>0.0.47.0</FileVersion>
+    <AssemblyVersion>0.0.48.0</AssemblyVersion>
+    <FileVersion>0.0.48.0</FileVersion>
     <Company>MiKo Solutions</Company>
-    <Version>0.0.47</Version>
+    <Version>0.0.48</Version>
     <Copyright>Copyright © 2018-2025 by MiKo Solutions. All rights reserved.</Copyright>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 

--- a/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
+++ b/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
@@ -9,10 +9,10 @@
 
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
     <AssemblyName>MiKoSolutions.Analyzers.CodeFixes.2022</AssemblyName>
-    <AssemblyVersion>0.0.47.0</AssemblyVersion>
-    <FileVersion>0.0.47.0</FileVersion>
+    <AssemblyVersion>0.0.48.0</AssemblyVersion>
+    <FileVersion>0.0.48.0</FileVersion>
     <Company>MiKo Solutions</Company>
-    <Version>0.0.47</Version>
+    <Version>0.0.48</Version>
     <Copyright>Copyright © 2018-2025 by MiKo Solutions. All rights reserved.</Copyright>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2022</DefineConstants>
@@ -24,7 +24,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/MiKo.Analyzer.Package.2019/MiKo.Analyzer.Package.2019.csproj
+++ b/MiKo.Analyzer.Package.2019/MiKo.Analyzer.Package.2019.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <PackageId>MiKoSolutions.Analyzers</PackageId>
-    <PackageVersion>0.0.47</PackageVersion>
+    <PackageVersion>0.0.48</PackageVersion>
     <Authors>Ralf Koban</Authors>
     <PackageLicenseUrl>https://github.com/RalfKoban/MiKo-Analyzers/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RalfKoban/MiKo-Analyzers</PackageProjectUrl>

--- a/MiKo.Analyzer.Package.2022/MiKo.Analyzer.Package.2022.csproj
+++ b/MiKo.Analyzer.Package.2022/MiKo.Analyzer.Package.2022.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <PackageId>MiKoSolutions.Analyzers</PackageId>
-    <PackageVersion>0.0.47</PackageVersion>
+    <PackageVersion>0.0.48</PackageVersion>
     <Authors>Ralf Koban</Authors>
     <PackageLicenseUrl>https://github.com/RalfKoban/MiKo-Analyzers/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RalfKoban/MiKo-Analyzers</PackageProjectUrl>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MiKoSolutions.Analyzers</RootNamespace>
     <AssemblyName>MiKoSolutions.Analyzers.Shared</AssemblyName>
-    <AssemblyVersion>0.0.47.0</AssemblyVersion>
-    <FileVersion>0.0.47.0</FileVersion>
+    <AssemblyVersion>0.0.48.0</AssemblyVersion>
+    <FileVersion>0.0.48.0</FileVersion>
     <Company>MiKo Solutions</Company>
-    <Version>0.0.47</Version>
+    <Version>0.0.48</Version>
     <Copyright>Copyright © 2018-2025 by MiKo Solutions. All rights reserved.</Copyright>
 
   
@@ -35,8 +35,8 @@
 
   <!-- Required by NCrunch on remote machines as those machines do not have the package installed -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.8" />
     <PackageReference Include="log4net" Version="3.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/MiKo.Analyzer.Vsix2019/source.extension.vsixmanifest
+++ b/MiKo.Analyzer.Vsix2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="MiKo_Analyzer.e6f8e373-5a44-4dde-80ae-68a22f8a1679" Version="0.0.47" Language="en-US" Publisher="Ralf Koban"/>
+    <Identity Id="MiKo_Analyzer.e6f8e373-5a44-4dde-80ae-68a22f8a1679" Version="0.0.48" Language="en-US" Publisher="Ralf Koban"/>
     <DisplayName>MiKo Analyzers</DisplayName>
     <Description xml:space="preserve">A diagnostic extension for the .NET Compiler Platform ("Roslyn") that checks for different metrics such as Lines of Code or Cyclomatic Complexity; in addition to several documentation, maintainability, naming, ordering and performance rules.</Description>
     <MoreInfo>https://github.com/RalfKoban/MiKo-Analyzers</MoreInfo>

--- a/MiKo.Analyzer.Vsix2022/source.extension.vsixmanifest
+++ b/MiKo.Analyzer.Vsix2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="MiKo_Analyzer.d072a90b-c2d9-4539-973d-225324cbc585" Version="0.0.47" Language="en-US" Publisher="Ralf Koban"/>
+    <Identity Id="MiKo_Analyzer.d072a90b-c2d9-4539-973d-225324cbc585" Version="0.0.48" Language="en-US" Publisher="Ralf Koban"/>
     <DisplayName>MiKo Analyzers</DisplayName>
     <Description xml:space="preserve">A diagnostic extension for the .NET Compiler Platform ("Roslyn") that checks for different metrics such as Lines of Code or Cyclomatic Complexity; in addition to several documentation, maintainability, naming, ordering and performance rules.</Description>
     <MoreInfo>https://github.com/RalfKoban/MiKo-Analyzers</MoreInfo>
@@ -9,13 +9,13 @@
     <Preview>true</Preview>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.11,18.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.13,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.11,18.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.13,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.11,18.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.13,18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
   </Installation>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MiKo-Analyzers
-Provides analyzers that are based on the .NET Compiler Platform (Roslyn) and can be used inside Visual Studio 2019 (v16.11) or 2022 (v17.11).
+Provides analyzers that are based on the .NET Compiler Platform (Roslyn) and can be used inside Visual Studio 2019 (v16.11) or 2022 (v17.13).
 
 How to install an Roslyn analyzer is described [here](https://learn.microsoft.com/en-us/visualstudio/code-quality/install-roslyn-analyzers?view=vs-2022).
 


### PR DESCRIPTION
- Bump overall version to `0.0.48`
- Update `Microsoft.CodeAnalysis` packages to `4.13.0`
- Revise VSIX manifests and README supported versions
