### PR TITLE
MiKo_2019 codefix adjusted to change 1st word to a 3rd person singular verb, incl. related adjustments for MiKo_2002 and MiKo_2012

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -466,7 +466,7 @@ namespace MiKoSolutions.Analyzers
                                                                               "Builder",
                                                                               "Called ",
                                                                               "Class",
-                                                                              "Command",
+                                                                              Names.Command,
                                                                               "Component",
                                                                               "Constructor",
                                                                               "Converter",
@@ -485,7 +485,7 @@ namespace MiKoSolutions.Analyzers
                                                                               "Extension class of",
                                                                               "Extension of",
                                                                               "Extension method ",
-                                                                              "Factory",
+                                                                              Names.Factory,
                                                                               "Fake ",
                                                                               "Field",
                                                                               "For ",
@@ -1118,10 +1118,13 @@ namespace MiKoSolutions.Analyzers
 
         internal static class Names
         {
+#pragma warning disable SA1303 // Const field names should begin with upper-case letter
+            internal const string command = "command";
+#pragma warning restore SA1303 // Const field names should begin with upper-case letter
+            internal const string Command = "Command";
+            internal const string Counter = "Counter";
             internal const string Create = "Create";
             internal const string Factory = "Factory";
-
-            internal const string Counter = "Counter";
 
             internal const string DefaultPropertyParameterName = "value";
 

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -457,6 +457,7 @@ namespace MiKoSolutions.Analyzers
             internal static readonly string[] MeaninglessStartingPhrase =
                                                                           {
                                                                               "A ",
+                                                                              "Abstract ",
                                                                               "Action",
                                                                               "Adapter",
                                                                               "An ",
@@ -536,12 +537,29 @@ namespace MiKoSolutions.Analyzers
                                                                       "that is called",
                                                                       "that is capable",
                                                                       "that is used",
+                                                                      "that can be used",
+                                                                      "that could be used",
+                                                                      "that may be used",
+                                                                      "that might be used",
+                                                                      "that shall be used",
+                                                                      "that should be used",
+                                                                      "that will be used",
+                                                                      "that would be used",
                                                                       "used for",
                                                                       "used to",
                                                                       "capable to",
+                                                                      "able to",
                                                                       "which is called",
                                                                       "which is capable",
                                                                       "which is used",
+                                                                      "which can be used",
+                                                                      "which could be used",
+                                                                      "which may be used",
+                                                                      "which might be used",
+                                                                      "which shall be used",
+                                                                      "which should be used",
+                                                                      "which will be used",
+                                                                      "which would be used",
                                                                   };
 
             internal static readonly string[] MeaninglessFieldStartingPhrase = MeaninglessStartingPhrase.Except(FieldStartingPhrase).OrderBy(_ => _.Length).ToArray();

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -475,6 +475,21 @@ namespace System.Text
             return value.ToString(start, length - start);
         }
 
+        public static StringBuilder TrimStart(this StringBuilder value, char[] characters)
+        {
+            var charactersLength = characters.Length;
+
+            for (var index = 0; index < charactersLength; index++)
+            {
+                if (value.Length > 0 && value[0] == characters[index])
+                {
+                    value.Remove(0, 1);
+                }
+            }
+
+            return value;
+        }
+
         public static string TrimEnd(this StringBuilder value)
         {
             var length = value.Length;
@@ -487,6 +502,23 @@ namespace System.Text
             var end = value.CountTrailingWhitespaces();
 
             return value.ToString(0, length - end);
+        }
+
+        public static StringBuilder TrimEnd(this StringBuilder value, char[] characters)
+        {
+            var charactersLength = characters.Length;
+
+            for (var index = 0; index < charactersLength; index++)
+            {
+                var i = value.Length - 1;
+
+                if (i >= 0 && value[i] == characters[index])
+                {
+                    value.Remove(i, 1);
+                }
+            }
+
+            return value;
         }
 
         public static StringBuilder TrimEndBy(this StringBuilder value, int count)
@@ -532,7 +564,20 @@ namespace System.Text
 
         public static StringBuilder WithoutMultipleWhiteSpaces(this StringBuilder value) => value.ReplaceAllWithCheck(Constants.Comments.MultiWhitespaceStrings, Constants.Comments.SingleWhitespaceString); // ncrunch: no coverage
 
-        public static StringBuilder WithoutNewLines(this StringBuilder value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty); // ncrunch: no coverage
+        public static StringBuilder WithoutNewLines(this StringBuilder value) => value.Without('\r').Without('\n'); // ncrunch: no coverage
+
+        public static StringBuilder Without(this StringBuilder value, char c)
+        {
+            for (var position = value.Length - 1; position > -1; position--)
+            {
+                if (value[position] == c)
+                {
+                    value.Remove(position, 1);
+                }
+            }
+
+            return value;
+        }
 
         public static StringBuilder Without(this StringBuilder value, string phrase) => value.ReplaceWithCheck(phrase, string.Empty); // ncrunch: no coverage
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -489,6 +489,38 @@ namespace System
             }
         }
 
+        public static string ConcatenatedWith(this string value, ReadOnlySpan<char> arg0, char arg1)
+        {
+            if (value is null)
+            {
+                return arg0.ConcatenatedWith(arg1);
+            }
+
+            var valueLength = value.Length;
+
+            if (value.Length == 0)
+            {
+                return arg0.ConcatenatedWith(arg1);
+            }
+
+            var arg0Length = arg0.Length;
+
+            var length = valueLength + arg0Length + 1;
+
+            unsafe
+            {
+                var buffer = stackalloc char[length];
+                buffer[length - 1] = arg1;
+
+                var bufferSpan = new Span<char>(buffer, length);
+
+                value.AsSpan().CopyTo(bufferSpan);
+                arg0.CopyTo(bufferSpan.Slice(valueLength));
+
+                return new string(buffer, 0, length);
+            }
+        }
+
         public static string ConcatenatedWith(this string value, ReadOnlySpan<char> arg0, string arg1)
         {
             if (value is null)

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1858,7 +1858,7 @@ namespace MiKoSolutions.Analyzers
 
             var name = value.ToString();
 
-            if (name.Contains("Command") && name.Contains("CommandManager") is false)
+            if (name.Contains(Constants.Names.Command) && name.Contains("CommandManager") is false)
             {
                 return semanticModel.LookupSymbols(value.GetLocation().SourceSpan.Start, name: name).FirstOrDefault() is ITypeSymbol symbol && symbol.IsCommand();
             }

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -57,6 +57,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2016_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2017_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2018_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2019_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2020_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2021_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2022_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5446,6 +5446,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start &lt;summary&gt; with a third person singular verb.
+        /// </summary>
+        internal static string MiKo_2019_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2019_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; documentation should always begin with a third person singular verb, such as &quot;Provides&quot;. This concise description of the functionality that the class, property, etc. offers or represents ensures clarity and helps maintain a uniform documentation style..
         /// </summary>
         internal static string MiKo_2019_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1962,6 +1962,9 @@ This ensures clarity and precision in your code.</value>
   <data name="MiKo_2018_Title" xml:space="preserve">
     <value>Documentation should not use the ambiguous terms 'Check' or 'Test'</value>
   </data>
+  <data name="MiKo_2019_CodeFixTitle" xml:space="preserve">
+    <value>Start &lt;summary&gt; with a third person singular verb</value>
+  </data>
   <data name="MiKo_2019_Description" xml:space="preserve">
     <value>&lt;summary&gt; documentation should always begin with a third person singular verb, such as "Provides". This concise description of the functionality that the class, property, etc. offers or represents ensures clarity and helps maintain a uniform documentation style.</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_CodeFixProvider.cs
@@ -12,13 +12,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2002";
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        internal static SyntaxNode GetUpdatedSyntax(XmlElementSyntax comment)
         {
-            var comment = (XmlElementSyntax)syntax;
-
             var cref = comment.Content.LastOrDefault(_ => _.IsSeeCref()) ?? SeeCref(Constants.TODO);
 
             return Comment(comment, Constants.Comments.EventArgsSummaryStartingPhrase, cref, " event.");
         }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => GetUpdatedSyntax((XmlElementSyntax)syntax);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             return HasEventSummary(summaries.Value)
                    ? Array.Empty<Diagnostic>()
-                   : new[] { Issue(symbol, StartingPhraseConcrete, "\"" + EndingPhraseConcrete) };
+                   : new[] { Issue(summaryXmls[0].GetContentsLocation(), StartingPhraseConcrete, "\"" + EndingPhraseConcrete) };
         }
 
         private static bool HasEventSummary(IEnumerable<string> summaries)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -98,6 +98,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         return MiKo_2060_CodeFixProvider.GetUpdatedSyntax(comment);
                     }
                 }
+                else if (name.Contains(nameof(EventArgs)))
+                {
+                    return MiKo_2002_CodeFixProvider.GetUpdatedSyntax(comment);
+                }
 
                 if (text.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -16,34 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2012_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
 //// ncrunch: rdi off
-        private static readonly string[] Verbs =
-                                                 {
-                                                     "Adopt",
-                                                     "Allow",
-                                                     "Build",
-                                                     "Construct",
-                                                     "Create",
-                                                     "Describe",
-                                                     "Detect",
-                                                     "Enhance",
-                                                     "Extend",
-                                                     "Generate",
-                                                     "Initialize",
-                                                     "Handle",
-                                                     "Manipulate",
-                                                     "Offer",
-                                                     "Perform",
-                                                     "Provide",
-                                                     "Process",
-                                                     "Represent",
-                                                     "Store",
-                                                     "Wrap",
-                                                 };
-
-        private static readonly Dictionary<string, string> ThirdPersonVerbs = Verbs.ToDictionary(_ => _, Verbalizer.MakeThirdPersonSingularVerb);
-
-        private static readonly Dictionary<string, string> GerundVerbs = Verbs.ToDictionary(_ => _, Verbalizer.MakeGerundVerb);
-
         private static readonly string[] DefaultPhrases =
                                                           {
                                                               "A default impl",
@@ -62,46 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                               "The implementation ",
                                                           };
 
-        private static readonly string[] UsedToPhrases =
-                                                         {
-                                                             "Attribute that ",
-                                                             "A class to ",
-                                                             "A class used to ",
-                                                             "A class that is used to ",
-                                                             "A class which is used to ",
-                                                             "An class to ",
-                                                             "An class used to ",
-                                                             "An class that is used to ",
-                                                             "An class which is used to ",
-                                                             "Class to ",
-                                                             "Class used to ",
-                                                             "Class that is used to ",
-                                                             "Class which is used to ",
-                                                             "The class used to ",
-                                                             "The class is used to ",
-                                                             "The class that is used to ",
-                                                             "This class is used to ",
-                                                             "A interface to ",
-                                                             "An interface to ",
-                                                             "A interface used to ",
-                                                             "An interface used to ",
-                                                             "A interface that is used to ",
-                                                             "A interface which is used to ",
-                                                             "An interface that is used to ",
-                                                             "An interface which is used to ",
-                                                             "Interface to ",
-                                                             "Interface used to ",
-                                                             "Interface that is used to ",
-                                                             "Interface which is used to ",
-                                                             "The interface used to ",
-                                                             "The interface is used to ",
-                                                             "The interface that is used to ",
-                                                             "The interface which is used to ",
-                                                             "This interface is used to ",
-                                                             "Used to ",
-                                                         };
-
-        private static readonly string[] ComponentPhrases = CreateComponentPhrases().ToArray();
+        private static readonly string[] UsedToPhrases = CreateUsedToPhrases().ToArray();
 
         private static readonly Pair[] ReplacementMap = CreateReplacementMap();
 
@@ -123,6 +56,78 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2012";
 
+        internal static SyntaxNode GetUpdatedSyntax(XmlElementSyntax comment, XmlTextSyntax textSyntax)
+        {
+            var text = textSyntax.GetTextWithoutTrivia().AsSpan();
+
+            if (text.StartsWith("Interaction logic for", StringComparison.Ordinal))
+            {
+                // seems like this is the default comment for WPF controls
+                return Comment(comment, XmlText("Represents a TODO"));
+            }
+
+            if (comment.GetEnclosing(Declarations) is MemberDeclarationSyntax member)
+            {
+                var name = member.GetName();
+
+                if (name.Contains("Command", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (text.StartsWithAny(MiKo_2038_CodeFixProvider.CommandStartingPhrases, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return MiKo_2038_CodeFixProvider.GetUpdatedSyntax(comment);
+                    }
+                }
+                else if (name.Contains("Factory", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (MiKo_2060_CodeFixProvider.CanFix(text))
+                    {
+                        return MiKo_2060_CodeFixProvider.GetUpdatedSyntax(comment);
+                    }
+                }
+            }
+
+            if (text.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
+            {
+                return Comment(comment, ReplacementMapKeys, ReplacementMap);
+            }
+
+            foreach (var phrase in UsedToPhrases)
+            {
+                if (text.StartsWith(phrase, StringComparison.Ordinal))
+                {
+                    var remainingText = text.Slice(phrase.Length);
+
+                    var firstWord = remainingText.FirstWord();
+                    var index = remainingText.IndexOf(firstWord);
+                    var replacementForFirstWord = Verbalizer.MakeThirdPersonSingularVerb(firstWord.ToString()).ToUpperCaseAt(0);
+
+                    var replacedText = replacementForFirstWord.ConcatenatedWith(remainingText.Slice(index + firstWord.Length));
+
+                    return Comment(comment, replacedText, comment.Content.RemoveAt(0));
+                }
+            }
+
+            if (text.StartsWithAny(Constants.Comments.AAnThePhraseWithSpaces, StringComparison.Ordinal))
+            {
+                var ancestor = comment.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+
+                switch (ancestor)
+                {
+                    case PropertyDeclarationSyntax property:
+                    {
+                        var startingPhrase = GetPropertyStartingPhrase(property.AccessorList);
+
+                        return CommentStartingWith(comment, startingPhrase);
+                    }
+
+                    case BaseTypeDeclarationSyntax _:
+                        return CommentStartingWith(comment, "Represents ");
+                }
+            }
+
+            return comment;
+        }
+
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
         {
             var comment = (XmlElementSyntax)syntax;
@@ -137,77 +142,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (content.FirstOrDefault() is XmlTextSyntax t)
             {
-                var text = t.GetTextWithoutTrivia().AsSpan();
-
-                if (text.StartsWith("Interaction logic for", StringComparison.Ordinal))
-                {
-                    // seems like this is the default comment for WPF controls
-                    return Comment(comment, XmlText("Represents a TODO"));
-                }
-
-                if (syntax.GetEnclosing(Declarations) is MemberDeclarationSyntax member)
-                {
-                    var name = member.GetName();
-
-                    if (name.Contains("Command", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (text.StartsWithAny(MiKo_2038_CodeFixProvider.CommandStartingPhrases, StringComparison.OrdinalIgnoreCase))
-                        {
-                            return MiKo_2038_CodeFixProvider.GetUpdatedSyntax(comment);
-                        }
-                    }
-                    else if (name.Contains("Factory", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (MiKo_2060_CodeFixProvider.CanFix(text))
-                        {
-                            return MiKo_2060_CodeFixProvider.GetUpdatedSyntax(comment);
-                        }
-                    }
-                }
-
-                if (text.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
-                {
-                    return Comment(comment, ReplacementMapKeys, ReplacementMap);
-                }
-
-                foreach (var phrase in ComponentPhrases.Concat(UsedToPhrases))
-                {
-                    if (text.StartsWith(phrase, StringComparison.Ordinal))
-                    {
-                        var remainingText = text.Slice(phrase.Length);
-
-                        var firstWord = remainingText.FirstWord();
-                        var index = remainingText.IndexOf(firstWord);
-                        var replacementForFirstWord = Verbalizer.MakeThirdPersonSingularVerb(firstWord.ToString()).ToUpperCaseAt(0);
-
-                        var replacedText = replacementForFirstWord.ConcatenatedWith(remainingText.Slice(index + firstWord.Length));
-
-                        return Comment(comment, replacedText, content.RemoveAt(0));
-                    }
-                }
-
-                if (text.StartsWithAny(Constants.Comments.AAnThePhraseWithSpaces, StringComparison.Ordinal))
-                {
-                    var ancestor = syntax.FirstAncestorOrSelf<MemberDeclarationSyntax>();
-
-                    switch (ancestor)
-                    {
-                        case PropertyDeclarationSyntax property:
-                        {
-                            var startingPhrase = GetPropertyStartingPhrase(property.AccessorList);
-
-                            return CommentStartingWith(comment, startingPhrase);
-                        }
-
-                        case BaseTypeDeclarationSyntax _:
-                            return CommentStartingWith(comment, "Represents ");
-                    }
-                }
+                return GetUpdatedSyntax(comment, t);
             }
 
-            var updatedComment = Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeLowerCase);
-
-            return updatedComment;
+            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeLowerCase);
         }
 
         private static XmlEmptyElementSyntax GetUpdatedSyntaxWithInheritdoc(SyntaxList<XmlNodeSyntax> content)
@@ -282,11 +220,46 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static Pair[] CreateReplacementMap()
         {
-            var entries = CreateReplacementMapEntries().ToArray(_ => _.Key, AscendingStringComparer.Default); // sort by first character
-            var result = new Dictionary<string, string>(entries.Length);
+            var verbs = new[]
+                        {
+                            "Adopt",
+                            "Build",
+                            "Construct",
+                            "Create",
+                            "Describe",
+                            "Detect",
+                            "Enhance",
+                            "Extend",
+                            "Generate",
+                            "Initialize",
+                            "Handle",
+                            "Manipulate",
+                            "Offer",
+                            "Perform",
+                            "Provide",
+                            "Process",
+                            "Represent",
+                            "Store",
+                            "Wrap",
+                        };
 
-            foreach (var entry in entries)
+            var thirdPersonVerbs = verbs.ToDictionary(_ => _, Verbalizer.MakeThirdPersonSingularVerb);
+            var gerundVerbs = verbs.ToDictionary(_ => _, Verbalizer.MakeGerundVerb);
+
+            return CreateReplacementMap(verbs, thirdPersonVerbs, gerundVerbs);
+        }
+
+        private static Pair[] CreateReplacementMap(string[] verbs, Dictionary<string, string> thirdPersonVerbs, Dictionary<string, string> gerundVerbs)
+        {
+            var entries = CreateReplacementMapEntries(verbs, thirdPersonVerbs, gerundVerbs).ToArray(_ => _.Key, AscendingStringComparer.Default); // sort by first character
+            var entriesLength = entries.Length;
+
+            var result = new Dictionary<string, string>(entriesLength);
+
+            for (var index = 0; index < entriesLength; index++)
             {
+                var entry = entries[index];
+
                 if (result.ContainsKey(entry.Key) is false)
                 {
                     result[entry.Key] = entry.Value;
@@ -296,7 +269,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return result.ToArray(_ => new Pair(_.Key, _.Value));
         }
 
-        private static IEnumerable<Pair> CreateReplacementMapEntries()
+        private static IEnumerable<Pair> CreateReplacementMapEntries(string[] verbs, Dictionary<string, string> thirdPersonVerbs, Dictionary<string, string> gerundVerbs)
         {
             // event arguments
             yield return new Pair("Event argument for ", Constants.Comments.EventArgsSummaryStartingPhrase);
@@ -386,13 +359,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("View Model that represents ", "Represents the view model of ");
             yield return new Pair("View model that represents ", "Represents the view model of ");
 
-            foreach (var phrase in CreatePhrases())
+            foreach (var phrase in CreatePhrases(verbs, thirdPersonVerbs, gerundVerbs))
             {
                 yield return phrase;
             }
         }
 
-        private static IEnumerable<Pair> CreatePhrases()
+        private static IEnumerable<Pair> CreatePhrases(string[] verbs, Dictionary<string, string> thirdPersonVerbs, Dictionary<string, string> gerundVerbs)
         {
             var beginnings = new[]
                                  {
@@ -446,19 +419,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                       "will",
                                   };
 
-            var verbsLength = Verbs.Length;
+            var verbsLength = verbs.Length;
             var beginningsLength = beginnings.Length;
             var middlePartsLength = middleParts.Length;
 
             for (var verbIndex = 0; verbIndex < verbsLength; verbIndex++)
             {
-                var word = Verbs[verbIndex];
+                var word = verbs[verbIndex];
                 var noun = word.ToUpperCaseAt(0);
                 var verb = word.ToLowerCaseAt(0);
 
-                var thirdPersonStart = ThirdPersonVerbs[word];
+                var thirdPersonStart = thirdPersonVerbs[word];
                 var thirdPersonVerb = thirdPersonStart.ToLowerCaseAt(0);
-                var gerundVerb = GerundVerbs[word].ToLowerCaseAt(0);
+                var gerundVerb = gerundVerbs[word].ToLowerCaseAt(0);
 
                 var fix = thirdPersonStart + " ";
 
@@ -485,33 +458,54 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static IEnumerable<string> CreateComponentPhrases()
+        private static IEnumerable<string> CreateUsedToPhrases()
         {
-            var starts = new[] { "A component", "An component", "The component", "This component", "Component" };
-            var middles = new[] { string.Empty, "is ", "that is ", "which is " };
-            var lasts = new[] { "to", "able to", "capable to", "used to" };
+            string[] subjects =
+                                {
+                                    "A class", "An class", "The class", "This class", "Class",
+                                    "A base class", "An base class", "The base class", "This base class", "Base class",
+                                    "A abstract base class", "An abstract base class", "The abstract base class", "This abstract base class", "Abstract base class",
+                                    "A interface", "An interface", "The interface", "This interface", "Interface",
+                                    "A component", "An component", "The component", "This component", "Component",
+                                    "A attribute", "An attribute", "The attribute", "This attribute", "Attribute",
+                                };
+            string[] conjunctions = { "that", "which" };
+            string[] conditionals = { "is", "can be", "could be", "may be", "might be", "shall be", "should be", "will be", "would be" };
 
-            var startsLength = starts.Length;
-            var middlesLength = middles.Length;
-            var lastsLength = lasts.Length;
-
-            for (var startIndex = 0; startIndex < startsLength; startIndex++)
+            foreach (var subject in subjects)
             {
-                var start = starts[startIndex];
+                yield return string.Concat(subject, " to ");
+                yield return string.Concat(subject, " allows to ");
+                yield return string.Concat(subject, " used to ");
+                yield return string.Concat(subject, " able to ");
+                yield return string.Concat(subject, " capable to ");
 
-                for (var middleIndex = 0; middleIndex < middlesLength; middleIndex++)
+                foreach (var conditional in conditionals)
                 {
-                    var middle = middles[middleIndex];
-                    var begin = string.Concat(start, " ", middle);
+                    yield return string.Concat(subject, " ", conditional, " used to ");
+                    yield return string.Concat(subject, " ", conditional, " able to ");
+                    yield return string.Concat(subject, " ", conditional, " capable to ");
+                }
 
-                    for (var lastIndex = 0; lastIndex < lastsLength; lastIndex++)
+                // ReSharper disable once LoopCanBePartlyConvertedToQuery
+                foreach (var conjunction in conjunctions)
+                {
+                    var beginning = string.Concat(subject, " ", conjunction, " ");
+
+                    yield return string.Concat(beginning, "allows to ");
+
+                    foreach (var conditional in conditionals)
                     {
-                        var last = lasts[lastIndex];
-
-                        yield return string.Concat(begin, last, " ");
+                        yield return string.Concat(beginning, conditional, " used to ");
+                        yield return string.Concat(beginning, conditional, " able to ");
+                        yield return string.Concat(beginning, conditional, " capable to ");
                     }
                 }
             }
+
+            yield return "Used to ";
+            yield return "Able to ";
+            yield return "Capable to ";
         }
 
 //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -89,7 +89,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var trimmedSummary = valueText.AsCachedBuilder()
                                           .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
                                           .Without(Constants.Comments.RecursivelyStartingPhrase) // skip over recursively starting phrase
-                                          .Without(",") // skip over first comma
+                                          .Without(',') // skip over first comma
                                           .TrimmedStart()
                                           .ToStringAndRelease();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Composition;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -24,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comment = (XmlElementSyntax)syntax;
 
-            var startText = comment.Content.ToString().Without("/").TrimStart(Constants.Comments.Delimiters);
+            var startText = comment.Content.ToString().AsCachedBuilder().Without('/').WithoutNewLines().TrimStart(Constants.Comments.Delimiters).ToStringAndRelease();
 
             if (startText.IsNullOrWhiteSpace())
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var builder = valueText.AsCachedBuilder()
                                    .Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
                                    .Without(Constants.Comments.RecursivelyStartingPhrase) // skip over recursively starting phrase
-                                   .Without(","); // skip over first comma
+                                   .Without(','); // skip over first comma
 
             problematicText = builder.FirstWord(out _);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-using MiKoSolutions.Analyzers.Linguistics;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
@@ -17,13 +14,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                 {
                                                                     "Repository ",
                                                                 };
-
-        private static readonly Pair[] ReplacementMap =
-                                                        {
-                                                            new Pair("Called to "),
-                                                        };
-
-        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
 
         public override string FixableDiagnosticId => "MiKo_2019";
 
@@ -42,15 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         return CommentStartingWith(summary, "Represents a ");
                     }
 
-                    var updatedSummary = MiKo_2012_CodeFixProvider.GetUpdatedSyntax(summary, textSyntax);
-
-                    if (ReferenceEquals(summary, updatedSummary))
-                    {
-                        // nothing updated, so update by ourselves
-                        return Comment(summary, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepLeadingSpace);
-                    }
-
-                    return updatedSummary;
+                    return MiKo_2012_CodeFixProvider.GetUpdatedSyntax(summary, textSyntax);
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2019_CodeFixProvider)), Shared]
+    public sealed class MiKo_2019_CodeFixProvider : SummaryDocumentationCodeFixProvider
+    {
+        private static readonly string[] RepresentsCandidates =
+                                                                {
+                                                                    "Repository ",
+                                                                };
+
+        private static readonly Pair[] ReplacementMap =
+                                                        {
+                                                            new Pair("Interface that may be used to "),
+                                                            new Pair("Interface that allows to "),
+                                                            new Pair("Interface which may be used to "),
+                                                            new Pair("Interface which allows to "),
+                                                        };
+
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
+
+        public override string FixableDiagnosticId => "MiKo_2019";
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is XmlElementSyntax summary)
+            {
+                var content = summary.Content;
+
+                if (content.Count > 0 && content[0] is XmlTextSyntax textSyntax)
+                {
+                    var startText = textSyntax.GetTextWithoutTrivia();
+
+                    if (startText.StartsWithAny(RepresentsCandidates, StringComparison.Ordinal))
+                    {
+                        return CommentStartingWith(summary, "Represents a ");
+                    }
+
+                    if (startText.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
+                    {
+                        return Comment(summary, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepLeadingSpace);
+                    }
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -20,10 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Pair[] ReplacementMap =
                                                         {
-                                                            new Pair("Interface that may be used to "),
-                                                            new Pair("Interface that allows to "),
-                                                            new Pair("Interface which may be used to "),
-                                                            new Pair("Interface which allows to "),
+                                                            new Pair("Called to "),
                                                         };
 
         private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
@@ -45,10 +42,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         return CommentStartingWith(summary, "Represents a ");
                     }
 
-                    if (startText.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
+                    var updatedSummary = MiKo_2012_CodeFixProvider.GetUpdatedSyntax(summary, textSyntax);
+
+                    if (ReferenceEquals(summary, updatedSummary))
                     {
+                        // nothing updated, so update by ourselves
                         return Comment(summary, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepLeadingSpace);
                     }
+
+                    return updatedSummary;
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -16,23 +16,23 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        internal static readonly string[] CommandStartingPhrases =
-                                                                   {
-                                                                       "A command ",
-                                                                       "A standard command ",
-                                                                       "A toggle command ",
-                                                                       "The command ",
-                                                                       "The standard command ",
-                                                                       "The toggle command ",
-                                                                       "This command ",
-                                                                       "This standard command ",
-                                                                       "This toggle command ",
-                                                                       "Command ",
-                                                                       "command ",
-                                                                       "A class ",
-                                                                       "The class ",
-                                                                       "This class ",
-                                                                   };
+        private static readonly string[] CommandStartingPhrases =
+                                                                  {
+                                                                      "A command ",
+                                                                      "A standard command ",
+                                                                      "A toggle command ",
+                                                                      "The command ",
+                                                                      "The standard command ",
+                                                                      "The toggle command ",
+                                                                      "This command ",
+                                                                      "This standard command ",
+                                                                      "This toggle command ",
+                                                                      "Command ",
+                                                                      "command ",
+                                                                      "A class ",
+                                                                      "The class ",
+                                                                      "This class ",
+                                                                  };
 
         private static readonly Pair[] CommandReplacementMap = CreateCommandReplacementMapEntries().OrderByDescending(_ => _.Key.Length)
                                                                                                    .ThenBy(_ => _.Key)
@@ -43,6 +43,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2038";
+
+        internal static bool CanFix(ReadOnlySpan<char> text) => text.StartsWithAny(CommandStartingPhrases, StringComparison.OrdinalIgnoreCase);
 
         internal static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Composition;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -22,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comment = (XmlElementSyntax)syntax;
 
-            var startText = comment.Content.ToString().Without("/").TrimStart(Constants.Comments.Delimiters);
+            var startText = comment.Content.ToString().AsCachedBuilder().Without('/').WithoutNewLines().TrimStart(Constants.Comments.Delimiters).ToStringAndRelease();
 
             if (startText.IsNullOrWhiteSpace())
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -381,9 +381,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     AnalyzeForPhrases(issues, token, UsedToDetermineInSingular, UsedToDetermineInSingularReplacement, StringComparison.OrdinalIgnoreCase);
                     AnalyzeForPhrases(issues, token, UsedToDetermineInPlural, UsedToDetermineInPluralReplacement, StringComparison.OrdinalIgnoreCase);
 
-                    issues.AddRange(AnalyzeForSpecialPhrase(token, IsUsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_).ToUpperCaseAt(0)));
-                    issues.AddRange(AnalyzeForSpecialPhrase(token, AreUsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_).ToUpperCaseAt(0)));
-                    issues.AddRange(AnalyzeForSpecialPhrase(token, UsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_).ToUpperCaseAt(0)));
+                    issues.AddRange(AnalyzeForSpecialPhrase(token, IsUsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_.ToUpperCaseAt(0))));
+                    issues.AddRange(AnalyzeForSpecialPhrase(token, AreUsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_.ToUpperCaseAt(0))));
+                    issues.AddRange(AnalyzeForSpecialPhrase(token, UsedToPhraseStartUpperCase, _ => Verbalizer.MakeThirdPersonSingularVerb(_.ToUpperCaseAt(0))));
                     issues.AddRange(AnalyzeForSpecialPhrase(token, IsUsedToPhrase, Verbalizer.MakeThirdPersonSingularVerb));
                     issues.AddRange(AnalyzeForSpecialPhrase(token, AreUsedToPhrase, Verbalizer.MakeInfiniteVerb));
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
@@ -12,10 +12,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1044";
 
-        private const string Suffix = "Command";
+        private const string Suffix = Constants.Names.Command;
 
         private static readonly string[] SingleSuffix = { Suffix };
-        private static readonly string[] Suffixes = { "_command", Suffix };
+        private static readonly string[] Suffixes = { "_" + Constants.Names.command, Suffix };
 
         public MiKo_1044_CommandSuffixAnalyzer() : base(Id, (SymbolKind)(-1))
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1045";
 
-        internal const string Suffix = "Command";
+        internal const string Suffix = Constants.Names.Command;
 
         private const string IsPrefix = "Is";
         private static readonly string[] HasArePrefix = { "Has", "Are" };

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzer.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static readonly HashSet<string> WellknownNames = new HashSet<string>
                                                                      {
-                                                                         "command",
+                                                                         Constants.Names.command,
                                                                          "cancellationToken",
                                                                          "formatProvider",
                                                                          "progress",

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
@@ -77,10 +77,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     name = name.Without("Extended");
                 }
 
-                if (name.EndsWith("Command", StringComparison.Ordinal))
+                if (name.EndsWith(Constants.Names.Command, StringComparison.Ordinal))
                 {
                     // commands should be suffixed with 'Command' only
-                    name = "Command";
+                    name = Constants.Names.Command;
                 }
 
                 switch (name)

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -203,6 +203,11 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("", "", "", ExpectedResult = "")]
         public static string ConcatenatedWith_with_string_and_string_and_span_(string s1, string s2, string span) => s1.ConcatenatedWith(s2, span.AsSpan());
 
+        [TestCase(" Some ", "", '.', ExpectedResult = " Some .")]
+        [TestCase(" Some ", " text ", '.', ExpectedResult = " Some  text .")]
+        [TestCase("", "", '.', ExpectedResult = ".")]
+        public static string ConcatenatedWith_with_string_and_span_and_char_(string s, string span, char c) => s.ConcatenatedWith(span.AsSpan(), c);
+
         [TestCase(" Some ", "", " with more ", ExpectedResult = " Some  with more ")]
         [TestCase(" Some ", " text ", " with more ", ExpectedResult = " Some  text  with more ")]
         [TestCase(" Some ", " text ", "", ExpectedResult = " Some  text ")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -324,11 +324,13 @@ public class TestMe : ITestMe
 }
 ");
 
+        [TestCase("Able to render something", "Renders something")]
+        [TestCase("Capable to render something", "Renders something")]
         [TestCase("A class that adopts", "Adopts")]
         [TestCase("A interface that adopts", "Adopts")]
         [TestCase("An interface that adopts", "Adopts")]
         [TestCase("Class that adopts", "Adopts")]
-        [TestCase("Class that allows", "Allows")]
+        [TestCase("Class that allows to do", "Does")]
         [TestCase("Class that creates", "Creates")]
         [TestCase("Class that describes", "Describes")]
         [TestCase("Class that enhances", "Enhances")]
@@ -441,6 +443,14 @@ public class TestMe : ITestMe
         [TestCase("The interface offers", "Provides")]
         [TestCase("The interface that adopts", "Adopts")]
         [TestCase("The interface which adopts", "Adopts")]
+        [TestCase("The interface that may be used to adopt", "Adopts")]
+        [TestCase("The interface which may be used to adopt", "Adopts")]
+        [TestCase("The interface that might be used to adopt", "Adopts")]
+        [TestCase("The interface which might be used to adopt", "Adopts")]
+        [TestCase("The interface that can be used to adopt", "Adopts")]
+        [TestCase("The interface which can be used to adopt", "Adopts")]
+        [TestCase("The interface that could be used to adopt", "Adopts")]
+        [TestCase("The interface which could be used to adopt", "Adopts")]
         [TestCase("This class adopts", "Adopts")]
         [TestCase("This class offers", "Provides")]
         [TestCase("This class provides", "Provides")]
@@ -751,20 +761,116 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
 
-        [TestCase("A class to render something", "Renders something")]
-        [TestCase("An class to render something", "Renders something")]
-        [TestCase("A class that is used to render something", "Renders something")]
-        [TestCase("An class that is used to render something", "Renders something")]
-        [TestCase("A class which is used to render something", "Renders something")]
-        [TestCase("An class which is used to render something", "Renders something")]
-        [TestCase("Class to render something", "Renders something")]
-        [TestCase("Class used to render something", "Renders something")]
-        [TestCase("The class is used to render something", "Renders something")]
-        [TestCase("The class that is used to render something", "Renders something")]
-        [TestCase("This class is used to render something", "Renders something")]
-        [TestCase("Used to render something", "Renders something")]
+        [TestCase("A class that can be used to")]
+        [TestCase("A class that could be used to")]
+        [TestCase("A class that is used to")]
+        [TestCase("A class that may be used to")]
+        [TestCase("A class that might be used to")]
+        [TestCase("A class that shall be used to")]
+        [TestCase("A class that should be used to")]
+        [TestCase("A class that will be used to")]
+        [TestCase("A class that would be used to")]
+        [TestCase("A class to")]
+        [TestCase("A class which is used to")]
+        [TestCase("Abstract base class that can be used to")]
+        [TestCase("Abstract base class that could be used to")]
+        [TestCase("Abstract base class that is used to")]
+        [TestCase("Abstract base class that may be used to")]
+        [TestCase("Abstract base class that might be used to")]
+        [TestCase("Abstract base class that shall be used to")]
+        [TestCase("Abstract base class that should be used to")]
+        [TestCase("Abstract base class that will be used to")]
+        [TestCase("Abstract base class that would be used to")]
+        [TestCase("Abstract base class to")]
+        [TestCase("Abstract base class which is used to")]
+        [TestCase("An abstract base class that can be used to")]
+        [TestCase("An abstract base class that could be used to")]
+        [TestCase("An abstract base class that is used to")]
+        [TestCase("An abstract base class that may be used to")]
+        [TestCase("An abstract base class that might be used to")]
+        [TestCase("An abstract base class that shall be used to")]
+        [TestCase("An abstract base class that should be used to")]
+        [TestCase("An abstract base class that will be used to")]
+        [TestCase("An abstract base class that would be used to")]
+        [TestCase("An abstract base class to")]
+        [TestCase("An abstract base class which is used to")]
+        [TestCase("An base class that can be used to")]
+        [TestCase("An base class that could be used to")]
+        [TestCase("An base class that is used to")]
+        [TestCase("An base class that may be used to")]
+        [TestCase("An base class that might be used to")]
+        [TestCase("An base class that shall be used to")]
+        [TestCase("An base class that should be used to")]
+        [TestCase("An base class that will be used to")]
+        [TestCase("An base class that would be used to")]
+        [TestCase("An base class to")]
+        [TestCase("An base class which is used to")]
+        [TestCase("An class that is used to")]
+        [TestCase("An class to")]
+        [TestCase("An class which is used to")]
+        [TestCase("Base class that can be used to")]
+        [TestCase("Base class that could be used to")]
+        [TestCase("Base class that is used to")]
+        [TestCase("Base class that may be used to")]
+        [TestCase("Base class that might be used to")]
+        [TestCase("Base class that shall be used to")]
+        [TestCase("Base class that should be used to")]
+        [TestCase("Base class that will be used to")]
+        [TestCase("Base class that would be used to")]
+        [TestCase("Base class to")]
+        [TestCase("Base class which is used to")]
+        [TestCase("Class to")]
+        [TestCase("Class used to")]
+        [TestCase("The abstract base class that can be used to")]
+        [TestCase("The abstract base class that could be used to")]
+        [TestCase("The abstract base class that is used to")]
+        [TestCase("The abstract base class that may be used to")]
+        [TestCase("The abstract base class that might be used to")]
+        [TestCase("The abstract base class that shall be used to")]
+        [TestCase("The abstract base class that should be used to")]
+        [TestCase("The abstract base class that will be used to")]
+        [TestCase("The abstract base class that would be used to")]
+        [TestCase("The abstract base class to")]
+        [TestCase("The abstract base class which is used to")]
+        [TestCase("The base class that can be used to")]
+        [TestCase("The base class that could be used to")]
+        [TestCase("The base class that is used to")]
+        [TestCase("The base class that may be used to")]
+        [TestCase("The base class that might be used to")]
+        [TestCase("The base class that shall be used to")]
+        [TestCase("The base class that should be used to")]
+        [TestCase("The base class that will be used to")]
+        [TestCase("The base class that would be used to")]
+        [TestCase("The base class to")]
+        [TestCase("The base class which is used to")]
+        [TestCase("The class can be used to")]
+        [TestCase("The class could be used to")]
+        [TestCase("The class is used to")]
+        [TestCase("The class may be used to")]
+        [TestCase("The class might be used to")]
+        [TestCase("The class shall be used to")]
+        [TestCase("The class should be used to")]
+        [TestCase("The class that is used to")]
+        [TestCase("The class will be used to")]
+        [TestCase("The class would be used to")]
+        [TestCase("This class is used to")]
+        [TestCase("Used to")]
+        public void Code_gets_fixed_for_class_(string startingPhrase)
+        {
+            const string Template = @"
+/// <summary>
+/// ### something.
+/// </summary>
+public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
+        }
+
         [TestCase("A workflow that updates something.", "Represents a workflow that updates something.")]
-        public void Code_gets_fixed_for_class_(string originalComment, string fixedComment)
+        public void Code_gets_fixed_for_workflow_class_(string originalComment, string fixedComment)
         {
             const string Template = @"
 /// <summary>
@@ -778,34 +884,42 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
 
-        [TestCase("A interface to render something", "Renders something")]
-        [TestCase("An interface to render something", "Renders something")]
-        [TestCase("A interface that is used to render something", "Renders something")]
-        [TestCase("An interface that is used to render something", "Renders something")]
-        [TestCase("A interface which is used to render something", "Renders something")]
-        [TestCase("An interface which is used to render something", "Renders something")]
-        [TestCase("Interface to render something", "Renders something")]
-        [TestCase("Interface used to render something", "Renders something")]
-        [TestCase("The interface is used to render something", "Renders something")]
-        [TestCase("The interface that is used to render something", "Renders something")]
-        [TestCase("This interface is used to render something", "Renders something")]
-        [TestCase("Used to render something", "Renders something")]
-        [TestCase("A workflow that updates something.", "Represents a workflow that updates something.")]
-        public void Code_gets_fixed_for_interface_(string originalComment, string fixedComment)
+        [TestCase("A interface to")]
+        [TestCase("An interface to")]
+        [TestCase("A interface that is used to")]
+        [TestCase("An interface that is used to")]
+        [TestCase("An interface that can be used to")]
+        [TestCase("An interface that could be used to")]
+        [TestCase("An interface that may be used to")]
+        [TestCase("An interface that might be used to")]
+        [TestCase("An interface that shall be used to")]
+        [TestCase("An interface that should be used to")]
+        [TestCase("An interface that will be used to")]
+        [TestCase("An interface that would be used to")]
+        [TestCase("A interface which is used to")]
+        [TestCase("An interface which is used to")]
+        [TestCase("Interface to")]
+        [TestCase("Interface used to")]
+        [TestCase("The interface is used to")]
+        [TestCase("The interface that is used to")]
+        [TestCase("This interface is used to")]
+        [TestCase("Used to")]
+        public void Code_gets_fixed_for_interface_(string startingPhrase)
         {
             const string Template = @"
 /// <summary>
-/// ###.
+/// ### something.
 /// </summary>
 public interface ITestMe
 {
 }
 ";
 
-            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+            VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
         }
 
-        [TestCase("Attribute that allows to render something", "Allows to render something")]
+        [TestCase("Attribute that allows to do something", "Does something")]
+        [TestCase("Attribute which allows to do something", "Does something")]
         public void Code_gets_fixed_for_attribute_(string originalComment, string fixedComment)
         {
             const string Template = @"
@@ -876,60 +990,77 @@ public class TestMeViewModel
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
 
-        [TestCase("A component to render something", "Renders something")]
-        [TestCase("A component that is used to render something", "Renders something")]
-        [TestCase("A component which is used to render something", "Renders something")]
-        [TestCase("A component used to render something", "Renders something")]
-        [TestCase("A component that is able to render something", "Renders something")]
-        [TestCase("A component which is able to render something", "Renders something")]
-        [TestCase("A component that is capable to render something", "Renders something")]
-        [TestCase("A component which is capable to render something", "Renders something")]
-        [TestCase("A component able to render something", "Renders something")]
-        [TestCase("A component capable to render something", "Renders something")]
-        [TestCase("An component to render something", "Renders something")]
-        [TestCase("An component that is used to render something", "Renders something")]
-        [TestCase("An component which is used to render something", "Renders something")]
-        [TestCase("An component used to render something", "Renders something")]
-        [TestCase("An component that is able to render something", "Renders something")]
-        [TestCase("An component which is able to render something", "Renders something")]
-        [TestCase("An component that is capable to render something", "Renders something")]
-        [TestCase("An component which is capable to render something", "Renders something")]
-        [TestCase("An component able to render something", "Renders something")]
-        [TestCase("An component capable to render something", "Renders something")]
-        [TestCase("Component to render something", "Renders something")]
-        [TestCase("Component that is used to render something", "Renders something")]
-        [TestCase("Component which is used to render something", "Renders something")]
-        [TestCase("Component used to render something", "Renders something")]
-        [TestCase("Component that is able to render something", "Renders something")]
-        [TestCase("Component which is able to render something", "Renders something")]
-        [TestCase("Component that is capable to render something", "Renders something")]
-        [TestCase("Component which is capable to render something", "Renders something")]
-        [TestCase("Component able to render something", "Renders something")]
-        [TestCase("Component capable to render something", "Renders something")]
-        [TestCase("The component to render something", "Renders something")]
-        [TestCase("The component that is used to render something", "Renders something")]
-        [TestCase("The component which is used to render something", "Renders something")]
-        [TestCase("The component used to render something", "Renders something")]
-        [TestCase("The component is used to render something", "Renders something")]
-        [TestCase("The component is able to render something", "Renders something")]
-        [TestCase("The component is capable to render something", "Renders something")]
-        [TestCase("The component that is able to render something", "Renders something")]
-        [TestCase("The component which is able to render something", "Renders something")]
-        [TestCase("The component that is capable to render something", "Renders something")]
-        [TestCase("The component which is capable to render something", "Renders something")]
-        [TestCase("The component able to render something", "Renders something")]
-        [TestCase("The component capable to render something", "Renders something")]
-        [TestCase("This component is used to render something", "Renders something")]
-        [TestCase("This component is able to render something", "Renders something")]
-        [TestCase("This component is capable to render something", "Renders something")]
-        public void Code_gets_fixed_for_component_text_(string originalComment, string fixedComment)
+        [TestCase("A component to")]
+        [TestCase("A component that is used to")]
+        [TestCase("A component which is used to")]
+        [TestCase("A component used to")]
+        [TestCase("A component that is able to")]
+        [TestCase("A component which is able to")]
+        [TestCase("A component that is capable to")]
+        [TestCase("A component which is capable to")]
+        [TestCase("A component able to")]
+        [TestCase("A component capable to")]
+        [TestCase("An component to")]
+        [TestCase("An component that is used to")]
+        [TestCase("An component which is used to")]
+        [TestCase("An component used to")]
+        [TestCase("An component that is able to")]
+        [TestCase("An component which is able to")]
+        [TestCase("An component that is capable to")]
+        [TestCase("An component which is capable to")]
+        [TestCase("An component able to")]
+        [TestCase("An component capable to")]
+        [TestCase("Component to")]
+        [TestCase("Component that is used to")]
+        [TestCase("Component which is used to")]
+        [TestCase("Component used to")]
+        [TestCase("Component that is able to")]
+        [TestCase("Component which is able to")]
+        [TestCase("Component that is capable to")]
+        [TestCase("Component which is capable to")]
+        [TestCase("Component able to")]
+        [TestCase("Component capable to")]
+        [TestCase("The component to")]
+        [TestCase("The component that is used to")]
+        [TestCase("The component which is used to")]
+        [TestCase("The component used to")]
+        [TestCase("The component is used to")]
+        [TestCase("The component is able to")]
+        [TestCase("The component is capable to")]
+        [TestCase("The component that is able to")]
+        [TestCase("The component which is able to")]
+        [TestCase("The component that is capable to")]
+        [TestCase("The component which is capable to")]
+        [TestCase("The component able to")]
+        [TestCase("The component capable to")]
+        [TestCase("This component is used to")]
+        [TestCase("This component is able to")]
+        [TestCase("This component is capable to")]
+        public void Code_gets_fixed_for_component_text_(string startingPhrase)
         {
             const string Template = @"
 /// <summary>
-/// ###.
+/// ### something.
 /// </summary>
 public class TestMe
 {
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
+        }
+
+        [TestCase("Used to set something", "Sets something")]
+        [TestCase("Used to get something", "Gets something")]
+        public void Code_gets_fixed_for_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ###.
+    /// </summary>
+    public int Property { get; set; }
 }
 ";
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -1050,17 +1050,124 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
         }
 
-        [TestCase("Used to set something", "Sets something")]
-        [TestCase("Used to get something", "Gets something")]
+        [TestCase("Used to get", "Gets")]
+        [TestCase("The", "Gets the")]
+        public void Code_gets_fixed_for_getter_only_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public int Property { get; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Used to set", "Sets")]
+        [TestCase("The", "Sets the")]
+        public void Code_gets_fixed_for_setter_only_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public int Property { set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Used to set", "Gets or sets")]
+        [TestCase("Used to get", "Gets or sets")]
+        [TestCase("The", "Gets or sets the")]
         public void Code_gets_fixed_for_property_text_(string originalComment, string fixedComment)
         {
             const string Template = @"
 public class TestMe
 {
     /// <summary>
-    /// ###.
+    /// ### something.
     /// </summary>
     public int Property { get; set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Used to get", "Gets a value indicating")]
+        [TestCase("The", "Gets a value indicating the")]
+        [TestCase("The value indicating", "Gets a value indicating the")]
+        public void Code_gets_fixed_for_boolean_getter_only_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public bool Property { get; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Used to set", "Sets a value indicating")]
+        [TestCase("The", "Sets a value indicating the")]
+        [TestCase("The value indicating", "Sets a value indicating the")]
+        public void Code_gets_fixed_for_boolean_setter_only_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public bool Property { set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Used to set", "Gets or sets a value indicating")]
+        [TestCase("Used to get", "Gets or sets a value indicating")]
+        [TestCase("Used to get or set", "Gets or sets a value indicating")]
+        [TestCase("The", "Gets or sets a value indicating the")]
+        [TestCase("The value indicating", "Gets or sets a value indicating the")]
+        public void Code_gets_fixed_for_boolean_property_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public bool Property { get; set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        [TestCase("Called to do", "Does")]
+        public void Code_gets_fixed_for_method_text_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public void DoSomething() {  }
 }
 ";
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -869,6 +869,22 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
         }
 
+        [TestCase("Event args for something", @"Provides data for the <see cref=""TODO""/> event")]
+        [TestCase(@"Event args for <see cref=""IWhatever""/> event", @"Provides data for the <see cref=""IWhatever""/> event")]
+        public void Code_gets_fixed_for_EventArgs_class_(string startingPhrase, string fixedPhrase)
+        {
+            const string Template = @"
+/// <summary>
+/// ###.
+/// </summary>
+public class TestMeEventArgs
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", startingPhrase), Template.Replace("###", fixedPhrase));
+        }
+
         [TestCase("A workflow that updates something.", "Represents a workflow that updates something.")]
         public void Code_gets_fixed_for_workflow_class_(string originalComment, string fixedComment)
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
 
@@ -275,8 +276,47 @@ public class TestMe
 }
 ");
 
+        [TestCase("Repository that does something", "Represents a repository that does something")]
+        public void Code_gets_fixed_for_class_(string originalText, string fixedText)
+        {
+            const string Template = @"
+using System;
+
+/// <summary>
+/// ###
+/// </summary>
+public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("Interface that may be used to update something", "Updates something")]
+        [TestCase("Interface that allows to update something", "Updates something")]
+        [TestCase("Interface which may be used to update something", "Updates something")]
+        [TestCase("Interface which allows to update something", "Updates something")]
+        public void Code_gets_fixed_for_interface_(string originalText, string fixedText)
+        {
+            const string Template = @"
+using System;
+
+/// <summary>
+/// ###
+/// </summary>
+public interface TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2019_CodeFixProvider();
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -457,6 +457,7 @@ public class TestMe
 
         [TestCase("Called to inform about something", "Informs about something")]
         [TestCase("Called to save something", "Saves something")]
+        [TestCase("Save something", "Saves something")]
         public void Code_gets_fixed_for_method_text_(string originalText, string fixedText)
         {
             const string Template = @"
@@ -466,6 +467,24 @@ public interface TestMe
 {
     /// <summary>
     /// ###
+    /// </summary>
+    public void DoSomething() { }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("Convert the given", "Converts the given")]
+        public void Code_gets_fixed_for_method_text_with_see_link_(string originalText, string fixedText)
+        {
+            const string Template = @"
+using System;
+
+public interface TestMe
+{
+    /// <summary>
+    /// ### <see cref=""int""/> to a <see cref=""string""/>.
     /// </summary>
     public void DoSomething() { }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -276,8 +276,72 @@ public class TestMe
 }
 ");
 
-        [TestCase("Repository that does something", "Represents a repository that does something")]
-        public void Code_gets_fixed_for_class_(string originalText, string fixedText)
+        [TestCase("Class that allows to update something", "Updates something")]
+        [TestCase("Class that can be used to update something", "Updates something")]
+        [TestCase("Class that could be used to update something", "Updates something")]
+        [TestCase("Class that may be used to update something", "Updates something")]
+        [TestCase("Class that shall be used to update something", "Updates something")]
+        [TestCase("Class that should be used to update something", "Updates something")]
+        [TestCase("Class that will be used to update something", "Updates something")]
+        [TestCase("Class that would be used to update something", "Updates something")]
+        [TestCase("Class which can be used to update something", "Updates something")]
+        [TestCase("Class which could be used to update something", "Updates something")]
+        [TestCase("Class which may be used to update something", "Updates something")]
+        [TestCase("Class which shall be used to update something", "Updates something")]
+        [TestCase("Class which should be used to update something", "Updates something")]
+        [TestCase("Class which will be used to update something", "Updates something")]
+        [TestCase("Class which would be used to update something", "Updates something")]
+        [TestCase("Class which allows to update something", "Updates something")]
+        [TestCase("A class that allows to update something", "Updates something")]
+        [TestCase("A class that can be used to update something", "Updates something")]
+        [TestCase("A class that could be used to update something", "Updates something")]
+        [TestCase("A class that may be used to update something", "Updates something")]
+        [TestCase("A class that shall be used to update something", "Updates something")]
+        [TestCase("A class that should be used to update something", "Updates something")]
+        [TestCase("A class that will be used to update something", "Updates something")]
+        [TestCase("A class that would be used to update something", "Updates something")]
+        [TestCase("A class which can be used to update something", "Updates something")]
+        [TestCase("A class which could be used to update something", "Updates something")]
+        [TestCase("A class which may be used to update something", "Updates something")]
+        [TestCase("A class which shall be used to update something", "Updates something")]
+        [TestCase("A class which should be used to update something", "Updates something")]
+        [TestCase("A class which will be used to update something", "Updates something")]
+        [TestCase("A class which would be used to update something", "Updates something")]
+        [TestCase("A class which allows to update something", "Updates something")]
+        [TestCase("An class that allows to update something", "Updates something")]
+        [TestCase("An class that can be used to update something", "Updates something")]
+        [TestCase("An class that could be used to update something", "Updates something")]
+        [TestCase("An class that may be used to update something", "Updates something")]
+        [TestCase("An class that shall be used to update something", "Updates something")]
+        [TestCase("An class that should be used to update something", "Updates something")]
+        [TestCase("An class that will be used to update something", "Updates something")]
+        [TestCase("An class that would be used to update something", "Updates something")]
+        [TestCase("An class which can be used to update something", "Updates something")]
+        [TestCase("An class which could be used to update something", "Updates something")]
+        [TestCase("An class which may be used to update something", "Updates something")]
+        [TestCase("An class which shall be used to update something", "Updates something")]
+        [TestCase("An class which should be used to update something", "Updates something")]
+        [TestCase("An class which will be used to update something", "Updates something")]
+        [TestCase("An class which would be used to update something", "Updates something")]
+        [TestCase("An class which allows to update something", "Updates something")]
+        [TestCase("The class that allows to update something", "Updates something")]
+        [TestCase("The class that can be used to update something", "Updates something")]
+        [TestCase("The class that could be used to update something", "Updates something")]
+        [TestCase("The class that may be used to update something", "Updates something")]
+        [TestCase("The class that shall be used to update something", "Updates something")]
+        [TestCase("The class that should be used to update something", "Updates something")]
+        [TestCase("The class that will be used to update something", "Updates something")]
+        [TestCase("The class that would be used to update something", "Updates something")]
+        [TestCase("The class which can be used to update something", "Updates something")]
+        [TestCase("The class which could be used to update something", "Updates something")]
+        [TestCase("The class which may be used to update something", "Updates something")]
+        [TestCase("The class which shall be used to update something", "Updates something")]
+        [TestCase("The class which should be used to update something", "Updates something")]
+        [TestCase("The class which will be used to update something", "Updates something")]
+        [TestCase("The class which would be used to update something", "Updates something")]
+        [TestCase("The class which allows to update something", "Updates something")]
+        [TestCase("This class allows to update something", "Updates something")]
+        public void Code_gets_fixed_for_class_text_(string originalText, string fixedText)
         {
             const string Template = @"
 using System;
@@ -293,11 +357,72 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
         }
 
-        [TestCase("Interface that may be used to update something", "Updates something")]
         [TestCase("Interface that allows to update something", "Updates something")]
+        [TestCase("Interface that can be used to update something", "Updates something")]
+        [TestCase("Interface that could be used to update something", "Updates something")]
+        [TestCase("Interface that may be used to update something", "Updates something")]
+        [TestCase("Interface that shall be used to update something", "Updates something")]
+        [TestCase("Interface that should be used to update something", "Updates something")]
+        [TestCase("Interface that will be used to update something", "Updates something")]
+        [TestCase("Interface that would be used to update something", "Updates something")]
+        [TestCase("Interface which can be used to update something", "Updates something")]
+        [TestCase("Interface which could be used to update something", "Updates something")]
         [TestCase("Interface which may be used to update something", "Updates something")]
+        [TestCase("Interface which shall be used to update something", "Updates something")]
+        [TestCase("Interface which should be used to update something", "Updates something")]
+        [TestCase("Interface which will be used to update something", "Updates something")]
+        [TestCase("Interface which would be used to update something", "Updates something")]
         [TestCase("Interface which allows to update something", "Updates something")]
-        public void Code_gets_fixed_for_interface_(string originalText, string fixedText)
+        [TestCase("A interface that allows to update something", "Updates something")]
+        [TestCase("A interface that can be used to update something", "Updates something")]
+        [TestCase("A interface that could be used to update something", "Updates something")]
+        [TestCase("A interface that may be used to update something", "Updates something")]
+        [TestCase("A interface that shall be used to update something", "Updates something")]
+        [TestCase("A interface that should be used to update something", "Updates something")]
+        [TestCase("A interface that will be used to update something", "Updates something")]
+        [TestCase("A interface that would be used to update something", "Updates something")]
+        [TestCase("A interface which can be used to update something", "Updates something")]
+        [TestCase("A interface which could be used to update something", "Updates something")]
+        [TestCase("A interface which may be used to update something", "Updates something")]
+        [TestCase("A interface which shall be used to update something", "Updates something")]
+        [TestCase("A interface which should be used to update something", "Updates something")]
+        [TestCase("A interface which will be used to update something", "Updates something")]
+        [TestCase("A interface which would be used to update something", "Updates something")]
+        [TestCase("A interface which allows to update something", "Updates something")]
+        [TestCase("An interface that allows to update something", "Updates something")]
+        [TestCase("An interface that can be used to update something", "Updates something")]
+        [TestCase("An interface that could be used to update something", "Updates something")]
+        [TestCase("An interface that may be used to update something", "Updates something")]
+        [TestCase("An interface that shall be used to update something", "Updates something")]
+        [TestCase("An interface that should be used to update something", "Updates something")]
+        [TestCase("An interface that will be used to update something", "Updates something")]
+        [TestCase("An interface that would be used to update something", "Updates something")]
+        [TestCase("An interface which can be used to update something", "Updates something")]
+        [TestCase("An interface which could be used to update something", "Updates something")]
+        [TestCase("An interface which may be used to update something", "Updates something")]
+        [TestCase("An interface which shall be used to update something", "Updates something")]
+        [TestCase("An interface which should be used to update something", "Updates something")]
+        [TestCase("An interface which will be used to update something", "Updates something")]
+        [TestCase("An interface which would be used to update something", "Updates something")]
+        [TestCase("An interface which allows to update something", "Updates something")]
+        [TestCase("The interface that allows to update something", "Updates something")]
+        [TestCase("The interface that can be used to update something", "Updates something")]
+        [TestCase("The interface that could be used to update something", "Updates something")]
+        [TestCase("The interface that may be used to update something", "Updates something")]
+        [TestCase("The interface that shall be used to update something", "Updates something")]
+        [TestCase("The interface that should be used to update something", "Updates something")]
+        [TestCase("The interface that will be used to update something", "Updates something")]
+        [TestCase("The interface that would be used to update something", "Updates something")]
+        [TestCase("The interface which can be used to update something", "Updates something")]
+        [TestCase("The interface which could be used to update something", "Updates something")]
+        [TestCase("The interface which may be used to update something", "Updates something")]
+        [TestCase("The interface which shall be used to update something", "Updates something")]
+        [TestCase("The interface which should be used to update something", "Updates something")]
+        [TestCase("The interface which will be used to update something", "Updates something")]
+        [TestCase("The interface which would be used to update something", "Updates something")]
+        [TestCase("The interface which allows to update something", "Updates something")]
+        [TestCase("This interface allows to update something", "Updates something")]
+        public void Code_gets_fixed_for_interface_text_(string originalText, string fixedText)
         {
             const string Template = @"
 using System;
@@ -307,6 +432,42 @@ using System;
 /// </summary>
 public interface TestMe
 {
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("Repository that does something", "Represents a repository that does something")]
+        public void Code_gets_fixed_for_special_class_text_(string originalText, string fixedText)
+        {
+            const string Template = @"
+using System;
+
+/// <summary>
+/// ###
+/// </summary>
+public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("Called to inform about something", "Informs about something")]
+        [TestCase("Called to save something", "Saves something")]
+        public void Code_gets_fixed_for_method_text_(string originalText, string fixedText)
+        {
+            const string Template = @"
+using System;
+
+public interface TestMe
+{
+    /// <summary>
+    /// ###
+    /// </summary>
+    public void DoSomething() { }
 }
 ";
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The following tables lists all the 486 rules that are currently provided by the 
 |MiKo_2016|Documentation for asynchronous methods should start with specific phrase|&#x2713;|&#x2713;|
 |MiKo_2017|Dependency properties should be documented as done by the .NET Framework|&#x2713;|&#x2713;|
 |MiKo_2018|Documentation should not use the ambiguous terms 'Check' or 'Test'|&#x2713;|&#x2713;|
-|MiKo_2019|&lt;summary&gt; documentation should start with a third person singular verb (for example "Provides ")|&#x2713;|\-|
+|MiKo_2019|&lt;summary&gt; documentation should start with a third person singular verb (for example "Provides ")|&#x2713;|&#x2713;|
 |MiKo_2020|Inherited documentation should be used with &lt;inheritdoc /&gt; marker|&#x2713;|&#x2713;|
 |MiKo_2021|Documentation of parameter should have a default starting phrase|&#x2713;|&#x2713;|
 |MiKo_2022|Documentation of [out] parameters should have a default starting phrase|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Consolidate command constant usage into `Constants.Names`.

- Optimize and extend string builder trimming and removal methods.

- Refactor code fix providers to adjust XML documentation with third person singular verbs.

- Expand and update tests to cover new overloads and phrase adjustments.

