### PR TITLE
MiKo_2080 can now fix some more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -31,6 +31,20 @@ namespace MiKoSolutions.Analyzers
 
         internal static string GetText(this Location value) => value.SourceTree?.GetText().ToString(value.SourceSpan);
 
+        internal static string GetText(this Location value, int length)
+        {
+            var tree = value.SourceTree;
+
+            if (tree is null)
+            {
+                return null;
+            }
+
+            var start = value.SourceSpan.Start;
+
+            return tree.GetText().ToString(TextSpan.FromBounds(start, start + length));
+        }
+
         internal static string GetSurroundingWord(this Location value)
         {
             var tree = value.SourceTree;

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -48,7 +48,12 @@ namespace System
 
             if (HasFlag(handling, FirstWordHandling.MakeLowerCase))
             {
-                word = valueSpan.FirstWord().ToLowerCaseAt(0);
+                var firstWord = valueSpan.FirstWord();
+
+                // only make lower case in case we have a word that is not all in upper case
+                word = firstWord.Length > 1 && firstWord.IsAllUpperCase()
+                       ? firstWord.ToString()
+                       : firstWord.ToLowerCaseAt(0);
             }
             else if (HasFlag(handling, FirstWordHandling.MakeUpperCase))
             {
@@ -1481,6 +1486,30 @@ namespace System
         public static bool IsSingleWord(this ReadOnlySpan<char> value) => value.HasWhitespaces() is false;
 
 //// ncrunch: no coverage start
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAllUpperCase(this string value) => value.AsSpan().IsAllUpperCase();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAllUpperCase(this ReadOnlySpan<char> value)
+        {
+            var valueLength = value.Length;
+
+            if (valueLength > 0)
+            {
+                for (var i = 0; i < valueLength; i++)
+                {
+                    if (value[i].IsUpperCase() is false)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsUpperCase(this char value)

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -1118,7 +1118,20 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsAsyncTaskBased(this IMethodSymbol value) => value.IsAsync || value.ReturnType.IsTask();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsBoolean(this ITypeSymbol value) => value.SpecialType == SpecialType.System_Boolean;
+        internal static bool IsBoolean(this ITypeSymbol value)
+        {
+            if (value is null)
+            {
+                return false;
+            }
+
+            if (value.SpecialType == SpecialType.System_Boolean)
+            {
+                return true;
+            }
+
+            return value.IsNullable() && value is INamedTypeSymbol type && type.TypeArguments[0].SpecialType == SpecialType.System_Boolean;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsByte(this ITypeSymbol value) => value.SpecialType == SpecialType.System_Byte;
@@ -1586,7 +1599,7 @@ namespace MiKoSolutions.Analyzers
 
         // ignore special situation for task factory
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsNullable(this ITypeSymbol value) => value.IsValueType && value.Name == nameof(Nullable);
+        internal static bool IsNullable(this ITypeSymbol value) => value.IsValueType && value.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsObject(this ITypeSymbol value) => value.SpecialType == SpecialType.System_Object;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -258,7 +258,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                          "/Return ", "/Returns ", // typos
                                                                      };
 
-            private static string[] CreateOtherReplacementMapKeys() => new[] { "Defines ", "Specifies ", "This " };
+            private static string[] CreateOtherReplacementMapKeys() => new[] { "Defines ", "Specifies ", "Use this ", "This " };
         }
 
         //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -241,7 +241,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return results;
             }
 
-            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A cache for ", "A Cache for ", "Cache for ", "Stores " };
+            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A cache for ", "A Cache for ", "Cache for ", "A dictionary of ", "Dictionary of ", "Stores ", "Holds " };
 
             private static string[] CreateGetReplacementMapKeys() => new[] { "Gets ", "Get " };
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -84,9 +84,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                    .ThenBy(_ => _)
                                                                    .ToArray(_ => new Pair(_, "The unique identifier for the type of "));
 
-                CleanupMapKeys = new[] { " a the ", " an the ", " the the " };
+                CleanupMap = new[]
+                                 {
+                                     new Pair(" a the ", " the "),
+                                     new Pair(" an the ", " the "),
+                                     new Pair(" the the ", " the "),
+                                     new Pair("The a ", "The "),
+                                     new Pair("The an ", "The "),
+                                     new Pair("The the ", "The "),
+                                 };
 
-                CleanupMap = CleanupMapKeys.ToArray(_ => new Pair(_, " the "));
+                CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);
             }
 #pragma warning restore CA1861
 
@@ -163,7 +171,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     starts.Add("Specifies " + lowerText);
                 }
 
-                string[] verbs = { "to indicate", "that indicates", "which indicates", "indicating", "to control", "that controls", "which controls", "controlling" };
+                string[] verbs = { "to indicate", "that indicates", "which indicates", "indicating", "to control", "that controls", "which controls", "controlling", "controling" }; // typo
                 string[] continuations = { " if", " whether or not", " whether", " that", string.Empty };
 
                 var results = new HashSet<string>();
@@ -188,27 +196,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var end = continuation + " ";
 
                         results.Add(start + " control" + end);
+                        results.Add(start + " control," + end);
                         results.Add(start + " indicate" + end);
+                        results.Add(start + " indicate," + end);
                     }
                 }
 
-                results.Add("Indicating if ");
-                results.Add("Indicating that ");
-                results.Add("Indicating whether or not");
-                results.Add("Indicating whether ");
+                foreach (var start in new[] { "Indicating", "Indicates", "Controlling", "Controling", "Controls" })
+                {
+                    foreach (var continuation in continuations)
+                    {
+                        if (continuation.IsNullOrEmpty() is false)
+                        {
+                            var end = continuation + " ";
 
-                results.Add("Indicates if ");
-                results.Add("Indicates that ");
-
-                results.Add("Controlling if ");
-                results.Add("Controlling that ");
-                results.Add("Controlling whether or not");
-                results.Add("Controlling whether ");
-
-                results.Add("Controls if ");
-                results.Add("Controls that ");
-                results.Add("Controls whether or not ");
-                results.Add("Controls whether ");
+                            results.Add(start + end);
+                            results.Add(start + "," + end);
+                        }
+                    }
+                }
 
                 return results;
             }
@@ -241,11 +247,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return results;
             }
 
-            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A cache for ", "A Cache for ", "Cache for ", "A dictionary of ", "Dictionary of ", "Stores ", "Holds " };
+            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A cache for ", "A Cache for ", "Cache for ", "A dictionary of ", "Dictionary of ", "Stores ", "Holds ", "This is " };
 
-            private static string[] CreateGetReplacementMapKeys() => new[] { "Gets ", "Get " };
+            private static string[] CreateGetReplacementMapKeys() => new[]
+                                                                     {
+                                                                         "Gets ", "Gets a ", "Gets an ", "Gets the ", "Get ", "Get a ", "Get an ", "Get the ",
+                                                                         "Sets ", "Sets a ", "Sets an ", "Sets the ", "Set ", "Set a ", "Set an ", "Set the ",
+                                                                         "Gets or sets a ", "Gets or Sets a ", "Get or set a ", "Get or Set a ",
+                                                                         "Gets or sets an ", "Gets or Sets an ", "Get or set an ", "Get or Set an ",
+                                                                         "Gets or sets the ", "Gets or Sets the ", "Get or set the ", "Get or Set the ",
+                                                                         "Return a ", "Return an ", "Return the ", "Returns a ", "Returns an ", "Returns the ", "Return ", "Returns ",
+                                                                         "/Return a ", "/Return an ", "/Return the ", "/Returns a ", "/Returns an ", "/Returns the ", "/Return ", "/Returns ", // typos
+                                                                     };
 
-            private static string[] CreateOtherReplacementMapKeys() => new[] { "Specifies the ", "Specifies an ", "Specifies a " };
+            private static string[] CreateOtherReplacementMapKeys() => new[] { "Specifies the ", "Specifies an ", "Specifies a ", "This " };
         }
 
         //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -251,16 +251,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             private static string[] CreateGetReplacementMapKeys() => new[]
                                                                      {
-                                                                         "Gets ", "Gets a ", "Gets an ", "Gets the ", "Get ", "Get a ", "Get an ", "Get the ",
-                                                                         "Sets ", "Sets a ", "Sets an ", "Sets the ", "Set ", "Set a ", "Set an ", "Set the ",
-                                                                         "Gets or sets a ", "Gets or Sets a ", "Get or set a ", "Get or Set a ",
-                                                                         "Gets or sets an ", "Gets or Sets an ", "Get or set an ", "Get or Set an ",
-                                                                         "Gets or sets the ", "Gets or Sets the ", "Get or set the ", "Get or Set the ",
-                                                                         "Return a ", "Return an ", "Return the ", "Returns a ", "Returns an ", "Returns the ", "Return ", "Returns ",
-                                                                         "/Return a ", "/Return an ", "/Return the ", "/Returns a ", "/Returns an ", "/Returns the ", "/Return ", "/Returns ", // typos
+                                                                         "Gets ", "Get ",
+                                                                         "Sets ", "Set ",
+                                                                         "Gets or sets ", "Gets or Sets ", "Get or set ", "Get or Set ",
+                                                                         "Return ", "Returns ",
+                                                                         "/Return ", "/Returns ", // typos
                                                                      };
 
-            private static string[] CreateOtherReplacementMapKeys() => new[] { "Specifies the ", "Specifies an ", "Specifies a ", "This " };
+            private static string[] CreateOtherReplacementMapKeys() => new[] { "Specifies ", "This " };
         }
 
         //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -46,9 +46,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var keys = CreateReplacementMapKeys().OrderByDescending(_ => _.Length) // get longest items first as shorter items may be part of the longer ones and would cause problems
                                                      .ThenBy(_ => _)
-                                                     .ToArray();
+                                                     .ToList();
 
-                ReplacementMap = keys.ToArray(_ => new Pair(_));
+                ReplacementMap = keys.Select(_ => new Pair(_))
+                                     .Concat(new[] { new Pair("Factory ", "a factory ") })
+                                     .ToArray();
+
+                keys.Add("Factory ");
 
                 ReplacementMapKeys = GetTermsForQuickLookup(keys);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -44,15 +44,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 #pragma warning disable CA1861
             public MapData()
             {
-                var keys = CreateReplacementMapKeys().OrderByDescending(_ => _.Length) // get longest items first as shorter items may be part of the longer ones and would cause problems
-                                                     .ThenBy(_ => _)
-                                                     .ToList();
+                ReplacementMap = CreateReplacementMapKeys().OrderByDescending(_ => _.Length) // get longest items first as shorter items may be part of the longer ones and would cause problems
+                                                           .ThenBy(_ => _)
+                                                           .Select(_ => new Pair(_))
+                                                           .Concat(new[] { new Pair("Factory ", "a factory ") })
+                                                           .ToArray();
 
-                ReplacementMap = keys.Select(_ => new Pair(_))
-                                     .Concat(new[] { new Pair("Factory ", "a factory ") })
-                                     .ToArray();
-
-                keys.Add("Factory ");
+                var keys = ReplacementMap.ToArray(_ => _.Key);
 
                 ReplacementMapKeys = GetTermsForQuickLookup(keys);
 
@@ -247,7 +245,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return results;
             }
 
-            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A cache for ", "A Cache for ", "Cache for ", "A dictionary of ", "Dictionary of ", "Stores ", "Holds ", "This is " };
+            private static string[] CreateCollectionReplacementMapKeys() => new[] { "A list of ", "List of ", "A dictionary of ", "Dictionary of ", "Cache for ", "A Cache for ", "A cache for ", "Stores ", "Holds ", "This is " };
 
             private static string[] CreateGetReplacementMapKeys() => new[]
                                                                      {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -258,7 +258,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                          "/Return ", "/Returns ", // typos
                                                                      };
 
-            private static string[] CreateOtherReplacementMapKeys() => new[] { "Specifies ", "This " };
+            private static string[] CreateOtherReplacementMapKeys() => new[] { "Defines ", "Specifies ", "This " };
         }
 
         //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         public const string Id = "MiKo_2080";
 
         private const string StartingDefaultPhrase = "The ";
-        private const string StartingEnumerableDefaultPhrase = "Contains ";
+        private const string StartingEnumerableDefaultPhrase = "Contains the ";
         private const string StartingBooleanDefaultPhrase = "Indicates whether ";
         private const string StartingGuidDefaultPhrase = "The unique identifier for ";
 

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -40,6 +40,14 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("1", ExpectedResult = true)]
         public static bool StartsWithNumber_works_(string input) => input.StartsWithNumber();
 
+        [TestCase("", ExpectedResult = false)]
+        [TestCase("A", ExpectedResult = true)]
+        [TestCase("a", ExpectedResult = false)]
+        [TestCase("Aa", ExpectedResult = false)]
+        [TestCase("aA", ExpectedResult = false)]
+        [TestCase("AA", ExpectedResult = true)]
+        public static bool IsAllUpperCase_works_(string input) => input.AsSpan().IsAllUpperCase();
+
         [Test]
         public static void SplitBy_splits_by_single_item_that_is_contained_multiple_times()
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -317,7 +317,7 @@ public class TestMe
         [TestCase("An unique identifier for some comment", "The unique identifier for some comment")]
         [TestCase("Get some comment", "The unique identifier for some comment")]
         [TestCase("Gets some comment", "The unique identifier for some comment")]
-        [TestCase("Gets the some comment", "The unique identifier for the some comment")]
+        [TestCase("Gets the some comment", "The unique identifier for the some comment", Ignore = "Just for now")]
         [TestCase("Guid of some comment", "The unique identifier for some comment")]
         [TestCase("GUID of some comment", "The unique identifier for some comment")]
         [TestCase("Guid of the comment", "The unique identifier for the comment")]
@@ -395,6 +395,7 @@ public class TestMe
         [TestCase("A cache for some comment", "Contains some comment")]
         [TestCase("Stores some comment", "Contains some comment")]
         [TestCase("Holds some comment", "Contains some comment")]
+        [TestCase("This is some comment", "Contains some comment")]
         public void Code_gets_fixed_for_collection_field_(string originalComment, string fixedComment)
         {
             const string Template = @"
@@ -418,6 +419,49 @@ public class TestMe
         [TestCase("Shall indicate UPPER CASE comment", "The UPPER CASE comment")]
         [TestCase("Specifies a specific value. The range is a value between 1 and 254", "The specific value. The range is a value between 1 and 254")]
         [TestCase("Specifies the specific value. A valid value is between 1 and 254", "The specific value. A valid value is between 1 and 254")]
+        [TestCase("Gets or sets the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets or sets a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets or sets an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets or Sets the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets or Sets a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets or Sets an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get or set the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get or set a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get or set an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Gets an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Get an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Sets the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Sets a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Sets an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Set the remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Set a remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Set an remaining days in evaluation mode", "The remaining days in evaluation mode")]
+        [TestCase("Returns a value for something", "The value for something")]
+        [TestCase("Returns an value for something", "The value for something")]
+        [TestCase("Returns the value for something", "The value for something")]
+        [TestCase("Returns value for something", "The value for something")]
+        [TestCase("Return a value for something", "The value for something")]
+        [TestCase("Return an value for something", "The value for something")]
+        [TestCase("Return the value for something", "The value for something")]
+        [TestCase("Return value for something", "The value for something")]
+        [TestCase("/Returns a value for something", "The value for something")] // typo
+        [TestCase("/Returns an value for something", "The value for something")] // typo
+        [TestCase("/Returns the value for something", "The value for something")] // typo
+        [TestCase("/Returns value for something", "The value for something")] // typo
+        [TestCase("/Return a value for something", "The value for something")] // typo
+        [TestCase("/Return an value for something", "The value for something")] // typo
+        [TestCase("/Return the value for something", "The value for something")] // typo
+        [TestCase("/Return value for something", "The value for something")] // typo
+        [TestCase("This value for something", "The value for something")]
+        [TestCase("Indicates that this something", "The something")]
+        [TestCase("Indicates, that this something", "The something")]
+        [TestCase("Holds the something", "The something")]
+        [TestCase("Holds a something", "The something")]
+        [TestCase("Holds an something", "The something")]
         public void Code_gets_fixed_for_normal_field_(string originalComment, string fixedComment)
         {
             const string Template = @"
@@ -446,21 +490,21 @@ public class TestMe
         [ExcludeFromCodeCoverage]
         private static HashSet<string> CreateWrongBooleanPhrases()
         {
-            string[] starts =
-                              [
-                                  "Flag", "A flag", "The flag", "Value", "A value", "The value",
-                                  "Boolean", "A Boolean", "A boolean", "The Boolean", "The boolean", "Boolean value", "A Boolean value", "A boolean value", "The Boolean value", "The boolean value",
-                                  "Bool", "Bool value", "A bool", "A bool value", "The bool", "The bool value",
-                                  "Contains a value", "Contains a flag", "Contains the value", "Contains the flag",
-                                  "Contains a boolean", "Contains a Boolean", "Contains a boolean value", "Contains the boolean value",
-                                  "Contains a bool", "Contains a bool value", "Contains the bool value",
-                              ];
+            string[] booleanStarts =
+                                     [
+                                         "Flag", "A flag", "The flag", "Value", "A value", "The value",
+                                         "Boolean", "A Boolean", "A boolean", "The Boolean", "The boolean", "Boolean value", "A Boolean value", "A boolean value", "The Boolean value", "The boolean value",
+                                         "Bool", "Bool value", "A bool", "A bool value", "The bool", "The bool value",
+                                         "Contains a value", "Contains a flag", "Contains the value", "Contains the flag",
+                                         "Contains a boolean", "Contains a Boolean", "Contains a boolean value", "Contains the boolean value",
+                                         "Contains a bool", "Contains a bool value", "Contains the bool value",
+                                     ];
             string[] middles = ["indicating", "that indicates", "to indicate", "which indicates", "controlling", "that controls", "to control", "which controls"];
             string[] ends = ["if", "that", "whether", "whether or not"];
 
             var results = new HashSet<string>();
 
-            foreach (var start in starts)
+            foreach (var start in booleanStarts)
             {
                 foreach (var middle in middles)
                 {
@@ -476,66 +520,46 @@ public class TestMe
                 }
             }
 
-            results.Add("Controls if");
-            results.Add("Controls that");
-            results.Add("Controls whether");
-            results.Add("Controls whether or not");
-            results.Add("Indicates if");
-            results.Add("Indicates that");
+            string[] nonBooleanStarts =
+                                        [
+                                            "Controls",
+                                            "Indicates",
+                                            "Controling", // typo
+                                            "Controlling",
+                                            "Indicating",
+                                            "Indicates",
+                                            "Shall control",
+                                            "Shall indicate",
+                                            "Should control",
+                                            "Should indicate",
+                                            "To control",
+                                            "To indicate",
+                                            "Will control",
+                                            "Will indicate",
+                                            "Would control",
+                                            "Would indicate",
+                                        ];
 
-            results.Add("Controlling if");
-            results.Add("Controlling that");
-            results.Add("Controlling whether");
-            results.Add("Controlling whether or not");
-            results.Add("Indicating if");
-            results.Add("Indicating that");
-            results.Add("Indicating whether");
-            results.Add("Indicating whether or not");
+            string[] commas = [string.Empty, ","];
 
-            results.Add("Shall control if");
-            results.Add("Shall control that");
-            results.Add("Shall control whether");
-            results.Add("Shall control whether or not");
-            results.Add("Shall indicate if");
-            results.Add("Shall indicate that");
-            results.Add("Shall indicate whether");
-            results.Add("Shall indicate whether or not");
+            foreach (var start in nonBooleanStarts)
+            {
+                foreach (var comma in commas)
+                {
+                    var begin = string.Concat(start, comma, " ");
 
-            results.Add("Should control if");
-            results.Add("Should control that");
-            results.Add("Should control whether");
-            results.Add("Should control whether or not");
-            results.Add("Should indicate if");
-            results.Add("Should indicate that");
-            results.Add("Should indicate whether");
-            results.Add("Should indicate whether or not");
+                    foreach (var end in ends)
+                    {
+                        var phrase = begin + end;
 
-            results.Add("To control if");
-            results.Add("To control that");
-            results.Add("To control whether");
-            results.Add("To control whether or not");
-            results.Add("To indicate if");
-            results.Add("To indicate that");
-            results.Add("To indicate whether");
-            results.Add("To indicate whether or not");
+                        results.Add(phrase);
+                    }
+                }
+            }
 
-            results.Add("Will control if");
-            results.Add("Will control that");
-            results.Add("Will control whether");
-            results.Add("Will control whether or not");
-            results.Add("Will indicate if");
-            results.Add("Will indicate that");
-            results.Add("Will indicate whether");
-            results.Add("Will indicate whether or not");
-
-            results.Add("Would control if");
-            results.Add("Would control that");
-            results.Add("Would control whether");
-            results.Add("Would control whether or not");
-            results.Add("Would indicate if");
-            results.Add("Would indicate that");
-            results.Add("Would indicate whether");
-            results.Add("Would indicate whether or not");
+            // those are allowed boolean terms
+            results.Remove("Indicates whether");
+            results.Remove("Indicates whether or not");
 
             return results;
         }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -387,17 +387,17 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
 
-        [TestCase("Some comment", "Contains some comment")]
-        [TestCase("List of some comment", "Contains some comment")]
-        [TestCase("A list of some comment", "Contains some comment")]
-        [TestCase("Dictionary of some comment", "Contains some comment")]
-        [TestCase("A dictionary of some comment", "Contains some comment")]
-        [TestCase("Cache for some comment", "Contains some comment")]
-        [TestCase("A Cache for some comment", "Contains some comment")]
-        [TestCase("A cache for some comment", "Contains some comment")]
-        [TestCase("Stores some comment", "Contains some comment")]
-        [TestCase("Holds some comment", "Contains some comment")]
-        [TestCase("This is some comment", "Contains some comment")]
+        [TestCase("Some comment", "Contains the some comment")]
+        [TestCase("List of some comment", "Contains the some comment")]
+        [TestCase("A list of some comment", "Contains the some comment")]
+        [TestCase("Dictionary of some comment", "Contains the some comment")]
+        [TestCase("A dictionary of some comment", "Contains the some comment")]
+        [TestCase("Cache for some comment", "Contains the some comment")]
+        [TestCase("A Cache for some comment", "Contains the some comment")]
+        [TestCase("A cache for some comment", "Contains the some comment")]
+        [TestCase("Stores some comment", "Contains the some comment")]
+        [TestCase("Holds some comment", "Contains the some comment")]
+        [TestCase("This is some comment", "Contains the some comment")]
         public void Code_gets_fixed_for_collection_field_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -292,6 +292,25 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", "Indicates whether"));
         }
 
+        [Test]
+        public void Code_gets_fixed_for_nullable_non_constant_boolean_field_([ValueSource(nameof(WrongBooleanPhrases))] string originalComment)
+        {
+            const string Template = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    /// <summary>
+    /// ### some comment.
+    /// </summary>
+    private bool? m_field;
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", "Indicates whether"));
+        }
+
         [TestCase("A Guid of some comment", "The unique identifier for some comment")]
         [TestCase("A GUID of some comment", "The unique identifier for some comment")]
         [TestCase("A unique identifier for some comment", "The unique identifier for some comment")]
@@ -307,6 +326,7 @@ public class TestMe
         [TestCase("Some comment", "The unique identifier for some comment")]
         [TestCase("The Guid of some comment", "The unique identifier for some comment")]
         [TestCase("The GUID of some comment", "The unique identifier for some comment")]
+        [TestCase("Factory for some stuff", "The unique identifier for a factory for some stuff")]
         public void Code_gets_fixed_for_Guid_field_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -465,6 +465,7 @@ public class TestMe
         [TestCase("Holds a something", "The something")]
         [TestCase("Holds an something", "The something")]
         [TestCase("Defines a something", "The something")]
+        [TestCase("Use this something", "The something")]
         public void Code_gets_fixed_for_normal_field_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -327,6 +327,8 @@ public class TestMe
         [TestCase("The Guid of some comment", "The unique identifier for some comment")]
         [TestCase("The GUID of some comment", "The unique identifier for some comment")]
         [TestCase("Factory for some stuff", "The unique identifier for a factory for some stuff")]
+        [TestCase("Guid for some comment", "The unique identifier for some comment")]
+        [TestCase("GUID for some comment", "The unique identifier for some comment")]
         public void Code_gets_fixed_for_Guid_field_(string originalComment, string fixedComment)
         {
             const string Template = @"
@@ -462,6 +464,7 @@ public class TestMe
         [TestCase("Holds the something", "The something")]
         [TestCase("Holds a something", "The something")]
         [TestCase("Holds an something", "The something")]
+        [TestCase("Defines a something", "The something")]
         public void Code_gets_fixed_for_normal_field_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -415,6 +415,7 @@ public class TestMe
 
         [TestCase("Some comment", "The some comment")]
         [TestCase("Shall indicate some comment", "The some comment")]
+        [TestCase("Shall indicate UPPER CASE comment", "The UPPER CASE comment")]
         [TestCase("Specifies a specific value. The range is a value between 1 and 254", "The specific value. The range is a value between 1 and 254")]
         [TestCase("Specifies the specific value. A valid value is between 1 and 254", "The specific value. A valid value is between 1 and 254")]
         public void Code_gets_fixed_for_normal_field_(string originalComment, string fixedComment)

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -317,7 +317,7 @@ public class TestMe
         [TestCase("An unique identifier for some comment", "The unique identifier for some comment")]
         [TestCase("Get some comment", "The unique identifier for some comment")]
         [TestCase("Gets some comment", "The unique identifier for some comment")]
-        [TestCase("Gets the some comment", "The unique identifier for the some comment", Ignore = "Just for now")]
+        [TestCase("Gets the some comment", "The unique identifier for the some comment")]
         [TestCase("Guid of some comment", "The unique identifier for some comment")]
         [TestCase("GUID of some comment", "The unique identifier for some comment")]
         [TestCase("Guid of the comment", "The unique identifier for the comment")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -388,10 +388,13 @@ public class TestMe
         [TestCase("Some comment", "Contains some comment")]
         [TestCase("List of some comment", "Contains some comment")]
         [TestCase("A list of some comment", "Contains some comment")]
+        [TestCase("Dictionary of some comment", "Contains some comment")]
+        [TestCase("A dictionary of some comment", "Contains some comment")]
         [TestCase("Cache for some comment", "Contains some comment")]
         [TestCase("A Cache for some comment", "Contains some comment")]
         [TestCase("A cache for some comment", "Contains some comment")]
         [TestCase("Stores some comment", "Contains some comment")]
+        [TestCase("Holds some comment", "Contains some comment")]
         public void Code_gets_fixed_for_collection_field_(string originalComment, string fixedComment)
         {
             const string Template = @"


### PR DESCRIPTION
- Refactor phrase mappings and add extensive tests.

- Add new `GetText` overload with length support.

- Implement `IsAllUpperCase` and preserve uppercase words.

- Extend `IsBoolean` and `IsNullable` for nullable booleans.
