### PR TITLE
Added new rule MiKo_1117 that reports inprecise test names

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -447,6 +447,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1113_TestMethodsShouldNotBeNamedGivenWhenThenAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1200_ExceptionCatchBlockAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1201_ExceptionParameterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4245,6 +4245,34 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Tests with names like &apos;EventIsRaised&apos; or &apos;ExceptionThrown&apos; are too vague because they don&apos;t specify the particular event or exception involved.
+        ///To make them clearer and more descriptive, the names should include details about the exact event being raised or the exception being thrown..
+        /// </summary>
+        internal static string MiKo_1117_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1117_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test name should contain the exact event being raised or the exception being thrown.
+        /// </summary>
+        internal static string MiKo_1117_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1117_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test methods should be named more precisely.
+        /// </summary>
+        internal static string MiKo_1117_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1117_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rename exception.
         /// </summary>
         internal static string MiKo_1200_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1553,6 +1553,16 @@ A clearer name would be "Send_sends_email_to_valid_address", which is easier to 
   <data name="MiKo_1115_Title" xml:space="preserve">
     <value>Test methods should be named in a fluent way</value>
   </data>
+  <data name="MiKo_1117_Description" xml:space="preserve">
+    <value>Tests with names like 'EventIsRaised' or 'ExceptionThrown' are too vague because they don't specify the particular event or exception involved.
+To make them clearer and more descriptive, the names should include details about the exact event being raised or the exception being thrown.</value>
+  </data>
+  <data name="MiKo_1117_MessageFormat" xml:space="preserve">
+    <value>Test name should contain the exact event being raised or the exception being thrown</value>
+  </data>
+  <data name="MiKo_1117_Title" xml:space="preserve">
+    <value>Test methods should be named more precisely</value>
+  </data>
   <data name="MiKo_1200_CodeFixTitle" xml:space="preserve">
     <value>Rename exception</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1117";
+
+        private static readonly string[] UnclearTerms =
+                                                        {
+                                                            "_exception_thrown",
+                                                            "_throws_exception",
+                                                            "Event_Is_Raised", // TODO RKN: needed?
+                                                            "EventFired", // TODO RKN: needed?
+                                                            "EventIsFired", // TODO RKN: needed?
+                                                            "EventIsRaised", // TODO RKN: needed?
+                                                            "EventOccured", // TODO RKN: needed?
+                                                            "EventOccurred", // TODO RKN: needed?
+                                                            "EventRaised", // TODO RKN: needed?
+                                                            "ExceptionThrown", // TODO RKN: needed?
+                                                            "FiresEvent",
+                                                            "IfEventIsRaised",
+                                                            "OccuredEvent",
+                                                            "OccurredEvent",
+                                                            "Raised_Event",
+                                                            "RaisedEvent",
+                                                            "Raises_Event",
+                                                            "RaisesEvent",
+                                                            "ThrowsException",
+                                                            "When_Event_Is_Raised",
+                                                            "WhenEventIsRaised",
+                                                        };
+
+        private static readonly string[] KnownExceptions =
+                                                           {
+                                                               "NoException",
+                                                               nameof(ArgumentException),
+                                                               nameof(ArgumentNullException),
+                                                               nameof(ArgumentOutOfRangeException),
+                                                               nameof(InvalidOperationException),
+                                                               nameof(TaskCanceledException),
+                                                               nameof(NotSupportedException),
+                                                               nameof(OperationCanceledException),
+                                                               nameof(ObjectDisposedException),
+                                                               nameof(NotImplementedException),
+                                                               nameof(NullReferenceException),
+                                                           };
+
+        public MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod();
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => HasIssue(symbol.Name.AsCachedBuilder().ReplaceAllWithCheck(KnownExceptions, "#").ToStringAndRelease())
+                                                                                                                 ? new[] { Issue(symbol) }
+                                                                                                                 : Array.Empty<Diagnostic>();
+
+        private static bool HasIssue(string symbolName) => symbolName.ContainsAny(UnclearTerms, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] CorrectMethodNames =
+                                                              [
+                                                                  "Something_raises_Whatever_event",
+                                                                  "Something_NoExceptionThrown",
+                                                                  "Something_" + nameof(ArgumentException) + "Thrown",
+                                                                  "Something_" + nameof(ArgumentNullException) + "Thrown",
+                                                                  "Something_" + nameof(ArgumentOutOfRangeException) + "Thrown",
+                                                                  "Something_" + nameof(InvalidOperationException) + "Thrown",
+                                                                  "Something_" + nameof(TaskCanceledException) + "Thrown",
+                                                                  "Something_" + nameof(NotSupportedException) + "Thrown",
+                                                                  "Something_" + nameof(OperationCanceledException) + "Thrown",
+                                                                  "Something_" + nameof(ObjectDisposedException) + "Thrown",
+                                                                  "Something_" + nameof(NotImplementedException) + "Thrown",
+                                                                  "Something_" + nameof(NullReferenceException) + "Thrown",
+                                                                  "Something_throws_" + nameof(ArgumentException),
+                                                                  "Something_throws_" + nameof(ArgumentNullException),
+                                                                  "Something_throws_" + nameof(ArgumentOutOfRangeException),
+                                                                  "Something_throws_" + nameof(InvalidOperationException),
+                                                                  "Something_throws_" + nameof(TaskCanceledException),
+                                                                  "Something_throws_" + nameof(NotSupportedException),
+                                                                  "Something_throws_" + nameof(OperationCanceledException),
+                                                                  "Something_throws_" + nameof(ObjectDisposedException),
+                                                                  "Something_throws_" + nameof(NotImplementedException),
+                                                                  "Something_throws_" + nameof(NullReferenceException),
+                                                              ];
+
+        private static readonly string[] WrongMethodNames =
+                                                            [
+                                                                "Something_EventRaised",
+                                                                "Something_EventIsRaised",
+                                                                "Something_IfEventIsRaised",
+                                                                "Something_WhenEventIsRaised",
+                                                                "Something_Event_Is_Raised",
+                                                                "Something_If_Event_Is_Raised",
+                                                                "Something_When_Event_Is_Raised",
+                                                                "Something_RaisedEvent",
+                                                                "Something_RaisesEvent",
+                                                                "Something_Raised_Event",
+                                                                "Something_Raises_Event",
+                                                                "Something_EventOccurred",
+                                                                "Something_EventOccured",
+                                                                "Something_OccurredEvent",
+                                                                "Something_OccuredEvent",
+                                                                "Something_EventIsFired",
+                                                                "Something_EventFired",
+                                                                "Something_FiresEvent",
+                                                                "Something_ExceptionThrown",
+                                                                "Something_ThrowsException",
+                                                                "Something_exception_thrown",
+                                                                "Something_throws_exception",
+                                                            ];
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_class([ValueSource(nameof(WrongMethodNames))] string methodName) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void " + methodName + @"() { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_correct_name_(
+                                                                        [ValueSource(nameof(CorrectMethodNames))] string methodName,
+                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                        [ValueSource(nameof(Tests))] string test)
+        => No_issue_is_reported_for(@"
+[" + fixture + @"]
+public class TestMe
+{
+    [" + test + @"]
+    public void " + methodName + @"() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_wrong_name_(
+                                                                      [ValueSource(nameof(WrongMethodNames))] string methodName,
+                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                      [ValueSource(nameof(Tests))] string test)
+            => An_issue_is_reported_for(@"
+[" + fixture + @"]
+public class TestMe
+{
+    [" + test + @"]
+    public void " + methodName + @"() { }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Build history](https://buildstats.info/appveyor/chart/RalfKoban/miko-analyzers)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/history)
 
 ## Available Rules
-The following tables lists all the 486 rules that are currently provided by the analyzer.
+The following tables lists all the 487 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -146,6 +146,7 @@ The following tables lists all the 486 rules that are currently provided by the 
 |MiKo_1113|Test methods should not be named according BDD style|&#x2713;|\-|
 |MiKo_1114|Test methods should not be named 'HappyPath' or 'BadPath'|&#x2713;|\-|
 |MiKo_1115|Test methods should be named in a fluent way|&#x2713;|&#x2713;|
+|MiKo_1117|Test methods should be named more precisely|&#x2713;|\-|
 |MiKo_1200|Name exceptions in catch blocks consistently|&#x2713;|&#x2713;|
 |MiKo_1201|Name exceptions as parameters consistently|&#x2713;|&#x2713;|
 |MiKo_1300|Unimportant identifiers in lambda statements should be named '_'|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Implements new analyzer for precise test naming.
- Adds unit tests for MiKo_1117 analyzer.
- Updates resource strings and project file.
- Revises README to reflect new rule count.

(resolves #788)