### PR TITLE
MiKo_1115 can now fix some more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -54,6 +54,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                       Rejected,
                                                                       Consumed,
                                                                       "Once",
+                                                                      "DoesNot",
+                                                                      "Create",
+                                                                      "Append",
                                                                   };
 
         private static readonly string[] SpecialFirstPhrases =

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -152,7 +152,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ReplaceWithCheck("DoesNotThrow", "_does_not_throw_")
                                    .ReplaceWithCheck("NotThrows", "ThrowsNo")
                                    .ReplaceWithCheck("NotThrow", "ThrowsNo")
+                                   .ReplaceWithCheck("NoThrows", "ThrowsNo")
+                                   .ReplaceWithCheck("NoThrow", "ThrowsNo")
                                    .ReplaceWithCheck("NoError", "HasNoError")
+                                   .ReplaceWithCheck("Already", "IsAlready")
                                    .ReplaceWithCheck(nameof(ArgumentNullException) + "Thrown", "Throws" + nameof(ArgumentNullException))
                                    .ReplaceWithCheck(nameof(ArgumentException) + "Thrown", "Throws" + nameof(ArgumentException))
                                    .ReplaceWithCheck(nameof(ArgumentOutOfRangeException) + "Thrown", "Throws" + nameof(ArgumentOutOfRangeException))
@@ -192,6 +195,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ReplaceWithCheck("O_bject", "_object")
                                    .ReplaceWithCheck("R_eference", "_reference")
                                    .ReplaceWithCheck("T_ype", "_type")
+                                   .ReplaceWithCheck("_is_is_", "_is_")
                                    .ToStringAndRelease();
 
             return result;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -220,6 +220,16 @@ public class TestMeTests
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [TestCase("AddHideDirective", "AddHideDirective_HideDirectiveAlreadyPresent_DoesNotAppendDirective", "AddHideDirective_does_not_append_directive_if_hide_directive_is_already_present")]
+        [TestCase("AddHideDirective", "AddHideDirective_HideDirectiveIsAlreadyPresent_DoesNotAppendDirective", "AddHideDirective_does_not_append_directive_if_hide_directive_is_already_present")]
+        [TestCase("AddHideDirective", "AddHideDirective_SomeDirectiveAlreadyPresent_AppendsHideDirective", "AddHideDirective_appends_hide_directive_if_some_directive_is_already_present")]
+        [TestCase("AddHideDirective", "AddHideDirective_SomeDirectiveIsAlreadyPresent_AppendsHideDirective", "AddHideDirective_appends_hide_directive_if_some_directive_is_already_present")]
+        [TestCase("AddHideDirective", "AddHideDirective_NoDirectivesSetYet_CreatesDirectiveListWithHideDirective", "AddHideDirective_creates_directive_list_with_hide_directive_if_no_directives_set_yet")]
+        [TestCase("GetStringDirectiveNoThrow", "GetStringDirectiveNoThrow_ReceivesListWithMatchButNotAsString_ReturnsNull", "GetStringDirectiveNoThrow_returns_null_if_it_receives_list_with_match_but_not_as_string")]
+        public void Code_gets_fixed_for_(string methodName, string originalName, string fixedName) => VerifyCSharpFix(
+                                                                                                                  "class TestMe { [Test] public void " + originalName + "() { " + methodName + "(); } }",
+                                                                                                                  "class TestMe { [Test] public void " + fixedName + "() { " + methodName + "(); } }");
+
         protected override string GetDiagnosticId() => MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer();


### PR DESCRIPTION
- Added new phrases "DoesNot", "Create", "Append".
- Introduced additional naming replacement rules.
  - Added replacement for "NoThrows" and "NoThrow".
  - Replaced "Already" with "IsAlready".
  - Added normalization for "_is_is_". 

