### PR TITLE
Added new rule 'MiKo_2235' that reports 'going to' and replaces it with 'will'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -134,6 +134,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -151,6 +151,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_EmptySummaryAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_DocumentationShouldUseToAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_GoingToPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8774,6 +8774,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;going to&apos; with &apos;will&apos;.
+        /// </summary>
+        internal static string MiKo_2235_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2235_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The phrase &quot;going to&quot; is more verbose and effectively means &quot;will.&quot; Opting for &quot;will&quot; instead promotes clarity and conciseness, making your code&apos;s behavior easier to understand..
+        /// </summary>
+        internal static string MiKo_2235_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2235_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;{0}&apos; with &apos;will&apos;.
+        /// </summary>
+        internal static string MiKo_2235_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2235_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should use &apos;will&apos; instead of &apos;going to&apos;.
+        /// </summary>
+        internal static string MiKo_2235_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2235_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3098,6 +3098,18 @@ However, these suppressions should remain inline comments and must not be part o
   <data name="MiKo_2234_Title" xml:space="preserve">
     <value>Documentation should use 'to' instead of 'that is to' or 'which is to'</value>
   </data>
+  <data name="MiKo_2235_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'going to' with 'will'</value>
+  </data>
+  <data name="MiKo_2235_Description" xml:space="preserve">
+    <value>The phrase "going to" is more verbose and effectively means "will." Opting for "will" instead promotes clarity and conciseness, making your code's behavior easier to understand.</value>
+  </data>
+  <data name="MiKo_2235_MessageFormat" xml:space="preserve">
+    <value>Replace '{0}' with 'will'</value>
+  </data>
+  <data name="MiKo_2235_Title" xml:space="preserve">
+    <value>Documentation should use 'will' instead of 'going to'</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2235_CodeFixProvider)), Shared]
+    public sealed class MiKo_2235_CodeFixProvider : OverallDocumentationCodeFixProvider
+    {
+        private static readonly Pair[] ReplacementMap =
+                                                        {
+                                                            new Pair("'s going to", " will"),
+                                                            new Pair("'re going to", " will"),
+                                                            new Pair("is going to", "will"),
+                                                            new Pair("are going to", "will"),
+                                                            new Pair("going to", "will"),
+
+                                                            // upper-case terms
+                                                            new Pair("Is going to", "Will"),
+                                                            new Pair("Are going to", "Will"),
+                                                            new Pair("Going to", "Will"),
+                                                        };
+
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
+
+        public override string FixableDiagnosticId => "MiKo_2235";
+
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2235_GoingToPhraseAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2235";
+
+        private const string Phrase = "going to";
+
+        public MiKo_2235_GoingToPhraseAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            var textTokens = comment.GetXmlTextTokens();
+            var textTokensCount = textTokens.Count;
+
+            if (textTokensCount == 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            List<Diagnostic> issues = null;
+
+            for (var index = 0; index < textTokensCount; index++)
+            {
+                var token = textTokens[index];
+
+                var allLocations = GetAllLocations(token, Phrase, StringComparison.OrdinalIgnoreCase);
+                var allLocationsCount = allLocations.Count;
+
+                if (allLocationsCount > 0)
+                {
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(allLocationsCount);
+                    }
+
+                    for (var locationIndex = 0; locationIndex < allLocationsCount; locationIndex++)
+                    {
+                        issues.Add(Issue(allLocations[locationIndex]));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzerTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2235_GoingToPhraseAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] XmlTags = ["summary", "remarks", "returns", "example", "value", "exception"];
+
+        private static readonly string[] Phrases =
+                                                   [
+                                                       "It's going to be something.",
+                                                       "It is going to be something.",
+                                                       "It is (going to be) something.",
+                                                       "We're going to be something.",
+                                                       "We are going to be something.",
+                                                       "We are (going to be) something.",
+                                                   ];
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_items() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public event EventHandler<T> MyEvent;
+
+    public void DoSomething() { }
+
+    public int Age { get; set; }
+
+    private bool m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+using System;
+
+/// <summary>Will be something.</summary>
+/// <remarks>Will be something.</remarks>
+public class TestMe
+{
+    /// <summary>Will be something.</summary>
+    /// <remarks>Will be something.</remarks>
+    public event EventHandler<T> MyEvent;
+
+    /// <summary>Will be something.</summary>
+    /// <remarks>Will be something.</remarks>
+    public void DoSomething() { }
+
+    /// <summary>Will be something.</summary>
+    /// <remarks>Will be something.</remarks>
+    public int Age { get; set; }
+
+    /// <summary>Will be something.</summary>
+    /// <remarks>Will be something.</remarks>
+    private bool m_field;
+}
+");
+
+        [Test, Combinatorial]
+        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+using System;
+
+/// <" + tag + ">" + phrase + "</" + tag + @">
+public class TestMe
+{
+}
+");
+
+        [TestCase("It's going to be something", "It will be something")]
+        [TestCase("That's going to be something", "That will be something")]
+        [TestCase("where it is going to be something", "where it will be something")]
+        [TestCase("is going to be something", "will be something")]
+        [TestCase("(We're going to be something)", "(We will be something)")]
+        [TestCase("You're going to be something", "You will be something")]
+        [TestCase("are going to be something", "will be something")]
+        [TestCase("are (going to be) something", "are (will be) something")]
+        public void Code_gets_fixed_(string originalPhrase, string fixedPhrase)
+        {
+            const string Template = @"
+using System;
+
+public interface ITestMe
+{
+    /// <summary>###</summary>
+    int DoSomething()
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalPhrase), Template.Replace("###", fixedPhrase));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2235_GoingToPhraseAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2235_GoingToPhraseAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2235_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 487 rules that are currently provided by the analyzer.
+The following tables lists all the 488 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -277,6 +277,7 @@ The following tables lists all the 487 rules that are currently provided by the 
 |MiKo_2232|&lt;summary&gt; documentation should not be empty|&#x2713;|&#x2713;|
 |MiKo_2233|XML tags should be placed on single line|&#x2713;|&#x2713;|
 |MiKo_2234|Documentation should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
+|MiKo_2235|Documentation should use 'will' instead of 'going to'|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Add analyzer for "going to" phrase detection

- Implement code fix to replace "going to" with "will"

- Introduce localization resources for rule MiKo_2235

- Update tests, project files and README with new rule

(resolves #1260)