### PR TITLE
Added new rule MiKo_2236 that reports 'e.g.' and replaces it with 'for example'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -135,6 +135,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -152,6 +152,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_DocumentationShouldUseToAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_GoingToPhraseAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_ExampleAbbreviationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8783,7 +8783,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The phrase &quot;going to&quot; is more verbose and effectively means &quot;will.&quot; Opting for &quot;will&quot; instead promotes clarity and conciseness, making your code&apos;s behavior easier to understand..
+        ///   Looks up a localized string similar to The phrase &apos;going to&apos; is more verbose and effectively means &apos;will&apos;. Opting for &apos;will&apos; instead promotes clarity and conciseness, making your code&apos;s behavior easier to understand..
         /// </summary>
         internal static string MiKo_2235_Description {
             get {
@@ -8806,6 +8806,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_2235_Title {
             get {
                 return ResourceManager.GetString("MiKo_2235_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;e.g.&apos; with &apos;for example&apos;.
+        /// </summary>
+        internal static string MiKo_2236_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2236_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-native speakers need to learn abbreviations like &apos;e.g.&apos; to understand them. Therefore, using &apos;for example&apos; is preferable because it directly conveys the intended meaning without requiring additional learning..
+        /// </summary>
+        internal static string MiKo_2236_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2236_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;{0}&apos; with &apos;for example&apos;.
+        /// </summary>
+        internal static string MiKo_2236_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2236_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should use &apos;for example&apos; instead of abbreviation &apos;e.g.&apos;.
+        /// </summary>
+        internal static string MiKo_2236_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2236_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3102,13 +3102,25 @@ However, these suppressions should remain inline comments and must not be part o
     <value>Replace 'going to' with 'will'</value>
   </data>
   <data name="MiKo_2235_Description" xml:space="preserve">
-    <value>The phrase "going to" is more verbose and effectively means "will." Opting for "will" instead promotes clarity and conciseness, making your code's behavior easier to understand.</value>
+    <value>The phrase 'going to' is more verbose and effectively means 'will'. Opting for 'will' instead promotes clarity and conciseness, making your code's behavior easier to understand.</value>
   </data>
   <data name="MiKo_2235_MessageFormat" xml:space="preserve">
     <value>Replace '{0}' with 'will'</value>
   </data>
   <data name="MiKo_2235_Title" xml:space="preserve">
     <value>Documentation should use 'will' instead of 'going to'</value>
+  </data>
+  <data name="MiKo_2236_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'e.g.' with 'for example'</value>
+  </data>
+  <data name="MiKo_2236_Description" xml:space="preserve">
+    <value>Non-native speakers need to learn abbreviations like 'e.g.' to understand them. Therefore, using 'for example' is preferable because it directly conveys the intended meaning without requiring additional learning.</value>
+  </data>
+  <data name="MiKo_2236_MessageFormat" xml:space="preserve">
+    <value>Replace '{0}' with 'for example'</value>
+  </data>
+  <data name="MiKo_2236_Title" xml:space="preserve">
+    <value>Documentation should use 'for example' instead of abbreviation 'e.g.'</value>
   </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2236_CodeFixProvider)), Shared]
+    public sealed class MiKo_2236_CodeFixProvider : OverallDocumentationCodeFixProvider
+    {
+        private static readonly Pair[] ReplacementMap =
+                                                        {
+                                                            new Pair("e.g.", "for example"),
+                                                            new Pair("i.e.", "for example"),
+                                                            new Pair("e. g.", "for example"),
+                                                            new Pair("i. e.", "for example"),
+
+                                                            // upper-case terms
+                                                            new Pair("E.g.", "For example"),
+                                                            new Pair("I.e.", "For example"),
+                                                            new Pair("E. g.", "For example"),
+                                                            new Pair("I. e.", "For example"),
+                                                        };
+
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
+
+        public override string FixableDiagnosticId => "MiKo_2236";
+
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2236_ExampleAbbreviationAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2236";
+
+        private static readonly string[] Phrases = { "e.g.", "i.e.", "e. g.", "i. e." };
+
+        public MiKo_2236_ExampleAbbreviationAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            var textTokens = comment.GetXmlTextTokens();
+            var textTokensCount = textTokens.Count;
+
+            if (textTokensCount == 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            List<Diagnostic> issues = null;
+
+            for (var index = 0; index < textTokensCount; index++)
+            {
+                var token = textTokens[index];
+
+                var allLocations = GetAllLocations(token, Phrases, StringComparison.OrdinalIgnoreCase);
+                var allLocationsCount = allLocations.Count;
+
+                if (allLocationsCount > 0)
+                {
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(allLocationsCount);
+                    }
+
+                    for (var locationIndex = 0; locationIndex < allLocationsCount; locationIndex++)
+                    {
+                        issues.Add(Issue(allLocations[locationIndex]));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2236_ExampleAbbreviationAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] XmlTags = ["summary", "remarks", "returns", "example", "value", "exception"];
+
+        private static readonly string[] Phrases =
+        [
+            "It's e.g. something.",
+            "It is e.g. something.",
+            "It's i.e. something.",
+            "It is i.e. something.",
+            "(E.g. something)",
+            "(e.g. something)",
+        ];
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_items() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public event EventHandler<T> MyEvent;
+
+    public void DoSomething() { }
+
+    public int Age { get; set; }
+
+    private bool m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+using System;
+
+/// <summary>It is for example something.</summary>
+/// <remarks>It is for example something.</remarks>
+public class TestMe
+{
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public event EventHandler<T> MyEvent;
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public void DoSomething() { }
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public int Age { get; set; }
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    private bool m_field;
+}
+");
+
+        [Test, Combinatorial]
+        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+using System;
+
+/// <" + tag + ">" + phrase + "</" + tag + @">
+public class TestMe
+{
+}
+");
+
+        [TestCase("It's e.g. something", "It's for example something")]
+        [TestCase("It's i.e. something", "It's for example something")]
+        [TestCase("It's e. g. something", "It's for example something")]
+        [TestCase("It's i. e. something", "It's for example something")]
+        [TestCase("It's something (i.e. whatever)", "It's something (for example whatever)")]
+        [TestCase("E.g. something", "For example something")]
+        [TestCase("I.e. something", "For example something")]
+        [TestCase("E. g. something", "For example something")]
+        [TestCase("I. e. something", "For example something")]
+        public void Code_gets_fixed_(string originalPhrase, string fixedPhrase)
+        {
+            const string Template = @"
+using System;
+
+public interface ITestMe
+{
+    /// <summary>###</summary>
+    int DoSomething()
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalPhrase), Template.Replace("###", fixedPhrase));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2236_ExampleAbbreviationAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2236_ExampleAbbreviationAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2236_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 488 rules that are currently provided by the analyzer.
+The following tables lists all the 489 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -278,6 +278,7 @@ The following tables lists all the 488 rules that are currently provided by the 
 |MiKo_2233|XML tags should be placed on single line|&#x2713;|&#x2713;|
 |MiKo_2234|Documentation should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
 |MiKo_2235|Documentation should use 'will' instead of 'going to'|&#x2713;|&#x2713;|
+|MiKo_2236|Documentation should use 'for example' instead of abbreviation 'e.g.'|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Add new analyzer MiKo_2236 to flag 'e.g.' and 'i.e.' abbreviation usage.

- Provide code fix to replace 'e.g.' and 'i.e.' with 'for example'.

- Introduce tests to validate analyzer and code fix.

(resolves #1258)
