### PR TITLE
Added new rule MiKo_6063 that reports if invocation is placed on other line and provided fix to place it on same line

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -399,6 +399,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6062_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6063_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -561,6 +561,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6060_SwitchCasesAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6062_ComplexInitializerElementExpressionsAreIndentedBesideOpenBraceAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6063_InvocationIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -16786,6 +16786,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Place invocation on same line.
+        /// </summary>
+        internal static string MiKo_6063_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6063_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code readability improves when invocations span a single line. This makes the code clearer and easier to follow..
+        /// </summary>
+        internal static string MiKo_6063_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6063_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place invocation on same line.
+        /// </summary>
+        internal static string MiKo_6063_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6063_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invocations should be placed on same line.
+        /// </summary>
+        internal static string MiKo_6063_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6063_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
         internal static string MiKo_6070_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5826,6 +5826,18 @@ This organization ensures clarity and makes the code easier to find, understand 
   <data name="MiKo_6062_Title" xml:space="preserve">
     <value>Expressions within complex initializer expressions should be placed beside open brace</value>
   </data>
+  <data name="MiKo_6063_CodeFixTitle" xml:space="preserve">
+    <value>Place invocation on same line</value>
+  </data>
+  <data name="MiKo_6063_Description" xml:space="preserve">
+    <value>Code readability improves when invocations span a single line. This makes the code clearer and easier to follow.</value>
+  </data>
+  <data name="MiKo_6063_MessageFormat" xml:space="preserve">
+    <value>Place invocation on same line</value>
+  </data>
+  <data name="MiKo_6063_Title" xml:space="preserve">
+    <value>Invocations should be placed on same line</value>
+  </data>
   <data name="MiKo_6070_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_CodeFixProvider.cs
@@ -1,0 +1,24 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6063_CodeFixProvider)), Shared]
+    public sealed class MiKo_6063_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6063";
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is InvocationExpressionSyntax invocation)
+            {
+                return invocation.WithExpression(PlacedOnSameLine(invocation.Expression));
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzer.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_6063_InvocationIsOnSameLineAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6063";
+
+        public MiKo_6063_InvocationIsOnSameLineAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.InvocationExpression);
+
+        private static bool HasIssue(InvocationExpressionSyntax invocation)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax member && member.IsKind(SyntaxKind.SimpleMemberAccessExpression) && member.Name is IdentifierNameSyntax name && member.Expression is IdentifierNameSyntax expression)
+            {
+                if (name.GetStartingLine() != expression.GetStartingLine())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax invocation && HasIssue(invocation))
+            {
+                ReportDiagnostics(context, Issue(invocation));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzerTests.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6063_InvocationIsOnSameLineAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_if_invocation_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        var result = await someObject.DoSomething(1, 2, 3)
+                                .ConfigureAwait(false);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_property_is_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        var result = await someObject.SomeProperty
+            .DoSomething(1, 2, 3)
+            .ConfigureAwait(false);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_invocation_is_on_different_line() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        var result = await someObject
+                                .DoSomething(1, 2, 3)
+                                .ConfigureAwait(false);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_if_invocation_is_on_different_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        var result = await someObject
+                                .DoSomething(1, 2, 3)
+                                .ConfigureAwait(false);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        var result = await someObject.DoSomething(1, 2, 3)
+                                .ConfigureAwait(false);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6063_InvocationIsOnSameLineAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6063_InvocationIsOnSameLineAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6063_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 489 rules that are currently provided by the analyzer.
+The following tables lists all the 490 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -529,5 +529,6 @@ The following tables lists all the 489 rules that are currently provided by the 
 |MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6061|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6062|Expressions within complex initializer expressions should be placed beside open brace|&#x2713;|&#x2713;|
+|MiKo_6063|Invocations should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6070|Console statements should be surrounded by blank lines|&#x2713;|&#x2713;|
 |MiKo_6071|Local using statements should be surrounded by blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add analyzer to enforce same-line invocations.

- Introduce code fix provider for same-line invocations.

- Add resource strings and project file updates.

- Update tests and README documentation.

(resolves #1209)