### PR TITLE
MiKo_6063 now keeps the leading trivia (whitespaces) from the invocation it updates

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             if (syntax is InvocationExpressionSyntax invocation)
             {
-                return invocation.WithExpression(PlacedOnSameLine(invocation.Expression));
+                return invocation.WithExpression(PlacedOnSameLine(invocation.Expression)).WithLeadingTriviaFrom(invocation);
             }
 
             return syntax;

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzerTests.cs
@@ -100,6 +100,55 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_if_invocation_is_on_different_line_inside_lambda()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        DoSomethingCore(_ =>
+                             {
+                                 TestMe
+                                    .DoSomething(1, 2, 3)
+                                    .ConfigureAwait(false);
+                             });
+    }
+
+    private static Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+
+    private void DoSomethingCore(Action<object> callback) { }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public void DoSomething(TestMe someObject)
+    {
+        DoSomethingCore(_ =>
+                             {
+                                 TestMe.DoSomething(1, 2, 3)
+                                    .ConfigureAwait(false);
+                             });
+    }
+
+    private static Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+
+    private void DoSomethingCore(Action<object> callback) { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6063_InvocationIsOnSameLineAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6063_InvocationIsOnSameLineAnalyzer();


### PR DESCRIPTION
- Preserve leading trivia in updated invocation expression.

- Add new test to validate lambda invocation formatting.
