### PR TITLE
Multiple 'PlacedOnSameLine' methods extracted

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -74,118 +74,6 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return SyntaxFactory.SeparatedList(updatedExpressions, expressions.GetSeparators());
         }
 
-        protected static T PlacedOnSameLine<T>(T syntax) where T : SyntaxNode
-        {
-            switch (syntax)
-            {
-                case null:
-                    return null;
-
-                case CaseSwitchLabelSyntax label:
-                    return label.WithoutTrivia()
-                                .WithKeyword(label.Keyword.WithoutTrailingTrivia())
-                                .WithValue(PlacedOnSameLine(label.Value).WithLeadingSpace().WithoutTrailingTrivia())
-                                .WithColonToken(label.ColonToken.WithoutLeadingTrivia()) as T;
-
-                case CasePatternSwitchLabelSyntax patternLabel:
-                    return patternLabel.WithoutTrivia()
-                                       .WithKeyword(patternLabel.Keyword.WithoutTrailingTrivia())
-                                       .WithPattern(PlacedOnSameLine(patternLabel.Pattern).WithLeadingSpace().WithoutTrailingTrivia())
-                                       .WithWhenClause(PlacedOnSameLine(patternLabel.WhenClause))
-                                       .WithColonToken(patternLabel.ColonToken.WithoutLeadingTrivia()) as T;
-
-                case SwitchExpressionArmSyntax arm:
-                    return arm.WithoutTrailingTrivia()
-                              .WithEqualsGreaterThanToken(arm.EqualsGreaterThanToken.WithLeadingSpace().WithoutTrailingTrivia())
-                              .WithExpression(PlacedOnSameLine(arm.Expression))
-                              .WithWhenClause(PlacedOnSameLine(arm.WhenClause))
-                              .WithPattern(PlacedOnSameLine(arm.Pattern)) as T;
-
-                case MemberAccessExpressionSyntax maes:
-                    return maes.WithoutTrivia()
-                               .WithName(PlacedOnSameLine(maes.Name))
-                               .WithOperatorToken(maes.OperatorToken.WithoutTrivia())
-                               .WithExpression(PlacedOnSameLine(maes.Expression)) as T;
-
-                case BinaryExpressionSyntax binary:
-                    return binary.WithoutTrivia()
-                                 .WithLeft(PlacedOnSameLine(binary.Left))
-                                 .WithOperatorToken(binary.OperatorToken.WithLeadingSpace().WithoutTrailingTrivia())
-                                 .WithRight(PlacedOnSameLine(binary.Right)) as T;
-
-                case IsPatternExpressionSyntax pattern:
-                    return pattern.WithoutTrivia()
-                                  .WithPattern(PlacedOnSameLine(pattern.Pattern))
-                                  .WithIsKeyword(pattern.IsKeyword.WithLeadingSpace().WithoutTrailingTrivia())
-                                  .WithExpression(PlacedOnSameLine(pattern.Expression)) as T;
-
-                case InvocationExpressionSyntax invocation:
-                    return invocation.WithoutTrivia()
-                                     .WithExpression(PlacedOnSameLine(invocation.Expression))
-                                     .WithArgumentList(PlacedOnSameLine(invocation.ArgumentList)) as T;
-
-                case WhenClauseSyntax clause:
-                    return clause?.WithoutTrivia()
-                                  .WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
-                                  .WithCondition(PlacedOnSameLine(clause.Condition)) as T;
-
-                case ConstantPatternSyntax constantPattern:
-                    return constantPattern.WithoutTrivia()
-                                          .WithExpression(PlacedOnSameLine(constantPattern.Expression)) as T;
-
-                case DeclarationPatternSyntax declaration:
-                    return declaration.WithoutTrivia()
-                                      .WithType(declaration.Type.WithoutTrailingTrivia())
-                                      .WithDesignation(PlacedOnSameLine(declaration.Designation)) as T;
-
-                case SingleVariableDesignationSyntax singleVariable:
-                    return singleVariable.WithoutTrivia()
-                                         .WithIdentifier(singleVariable.Identifier.WithoutTrivia()) as T;
-
-                case ArgumentListSyntax argumentList:
-                    return argumentList.WithoutTrivia()
-                                       .WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
-                                       .WithArguments(PlacedOnSameLine(argumentList.Arguments))
-                                       .WithCloseParenToken(argumentList.CloseParenToken.WithoutTrivia()) as T;
-
-                case ArgumentSyntax argument:
-                    return argument.WithoutTrivia()
-                                   .WithRefKindKeyword(argument.RefKindKeyword.WithoutLeadingTrivia().WithTrailingSpace())
-                                   .WithRefOrOutKeyword(argument.RefOrOutKeyword.WithoutLeadingTrivia().WithTrailingSpace())
-                                   .WithNameColon(PlacedOnSameLine(argument.NameColon))
-                                   .WithExpression(PlacedOnSameLine(argument.Expression)) as T;
-
-                case GenericNameSyntax genericName:
-                    return genericName.WithoutTrivia()
-                                      .WithIdentifier(genericName.Identifier.WithoutTrivia())
-                                      .WithTypeArgumentList(PlacedOnSameLine(genericName.TypeArgumentList)) as T;
-
-                case SimpleNameSyntax simpleName:
-                    return simpleName.WithoutTrivia() as T;
-
-                case TypeArgumentListSyntax typeArgumentList:
-                    return typeArgumentList.WithoutTrivia()
-                                           .WithArguments(PlacedOnSameLine(typeArgumentList.Arguments))
-                                           .WithGreaterThanToken(typeArgumentList.GreaterThanToken.WithoutTrivia())
-                                           .WithLessThanToken(typeArgumentList.LessThanToken.WithoutTrivia()) as T;
-
-                case ThrowExpressionSyntax throwExpression:
-                    return throwExpression.WithoutTrivia()
-                                          .WithThrowKeyword(throwExpression.ThrowKeyword.WithoutTrivia())
-                                          .WithExpression(PlacedOnSameLine(throwExpression.Expression)) as T;
-
-                case ObjectCreationExpressionSyntax creation:
-                    return creation.WithoutTrivia()
-                                   .WithNewKeyword(creation.NewKeyword.WithoutTrivia())
-                                   .WithType(PlacedOnSameLine(creation.Type).WithLeadingSpace())
-                                   .WithArgumentList(PlacedOnSameLine(creation.ArgumentList))
-                                   .WithInitializer(PlacedOnSameLine(creation.Initializer)) as T;
-
-                default:
-                    return syntax.WithoutTrivia();
-            }
-        }
-
         protected static SeparatedSyntaxList<T> PlacedOnSameLine<T>(SeparatedSyntaxList<T> syntax) where T : SyntaxNode
         {
             var updatedItems = syntax.GetWithSeparators()
@@ -206,5 +94,126 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             return SyntaxFactory.SeparatedList<T>(updatedItems);
         }
+
+        protected static T PlacedOnSameLine<T>(T syntax) where T : SyntaxNode
+        {
+            switch (syntax)
+            {
+                case null: return null;
+                case ArgumentListSyntax argumentList: return PlacedOnSameLine(argumentList) as T;
+                case ArgumentSyntax argument: return PlacedOnSameLine(argument) as T;
+                case BinaryExpressionSyntax binary: return PlacedOnSameLine(binary) as T;
+                case CasePatternSwitchLabelSyntax patternLabel: return PlacedOnSameLine(patternLabel) as T;
+                case CaseSwitchLabelSyntax label: return PlacedOnSameLine(label) as T;
+                case ConstantPatternSyntax constantPattern: return PlacedOnSameLine(constantPattern) as T;
+                case DeclarationPatternSyntax declaration: return PlacedOnSameLine(declaration) as T;
+                case InvocationExpressionSyntax invocation: return PlacedOnSameLine(invocation) as T;
+                case IsPatternExpressionSyntax pattern: return PlacedOnSameLine(pattern) as T;
+                case MemberAccessExpressionSyntax maes: return PlacedOnSameLine(maes) as T;
+                case NameSyntax name: return PlacedOnSameLine(name) as T;
+                case ObjectCreationExpressionSyntax creation: return PlacedOnSameLine(creation) as T;
+                case SingleVariableDesignationSyntax singleVariable: return PlacedOnSameLine(singleVariable) as T;
+                case SwitchExpressionArmSyntax arm: return PlacedOnSameLine(arm) as T;
+                case ThrowExpressionSyntax throwExpression: return PlacedOnSameLine(throwExpression) as T;
+                case TypeArgumentListSyntax typeArgumentList: return PlacedOnSameLine(typeArgumentList) as T;
+                case WhenClauseSyntax clause: return PlacedOnSameLine(clause) as T;
+                default:
+                    return syntax.WithoutTrivia();
+            }
+        }
+
+        private static ArgumentSyntax PlacedOnSameLine(ArgumentSyntax argument) => argument.WithoutTrivia()
+                                                                                           .WithRefKindKeyword(argument.RefKindKeyword.WithoutLeadingTrivia().WithTrailingSpace())
+                                                                                           .WithRefOrOutKeyword(argument.RefOrOutKeyword.WithoutLeadingTrivia().WithTrailingSpace())
+                                                                                           .WithNameColon(PlacedOnSameLine(argument.NameColon))
+                                                                                           .WithExpression(PlacedOnSameLine(argument.Expression));
+
+        private static ArgumentListSyntax PlacedOnSameLine(ArgumentListSyntax argumentList) => argumentList.WithoutTrivia()
+                                                                                                           .WithOpenParenToken(argumentList.OpenParenToken.WithoutTrivia())
+                                                                                                           .WithArguments(PlacedOnSameLine(argumentList.Arguments))
+                                                                                                           .WithCloseParenToken(argumentList.CloseParenToken.WithoutTrivia());
+
+        private static BinaryExpressionSyntax PlacedOnSameLine(BinaryExpressionSyntax binary) => binary.WithoutTrivia()
+                                                                                                       .WithLeft(PlacedOnSameLine(binary.Left))
+                                                                                                       .WithOperatorToken(binary.OperatorToken.WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                       .WithRight(PlacedOnSameLine(binary.Right));
+
+        private static CasePatternSwitchLabelSyntax PlacedOnSameLine(CasePatternSwitchLabelSyntax patternLabel) => patternLabel.WithoutTrivia()
+                                                                                                                               .WithKeyword(patternLabel.Keyword.WithoutTrailingTrivia())
+                                                                                                                               .WithPattern(PlacedOnSameLine(patternLabel.Pattern).WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                                               .WithWhenClause(PlacedOnSameLine(patternLabel.WhenClause))
+                                                                                                                               .WithColonToken(patternLabel.ColonToken.WithoutLeadingTrivia());
+
+        private static CaseSwitchLabelSyntax PlacedOnSameLine(CaseSwitchLabelSyntax label) => label.WithoutTrivia()
+                                                                                                   .WithKeyword(label.Keyword.WithoutTrailingTrivia())
+                                                                                                   .WithValue(PlacedOnSameLine(label.Value).WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                   .WithColonToken(label.ColonToken.WithoutLeadingTrivia());
+
+        private static ConstantPatternSyntax PlacedOnSameLine(ConstantPatternSyntax constantPattern) => constantPattern.WithoutTrivia()
+                                                                                                                       .WithExpression(PlacedOnSameLine(constantPattern.Expression));
+
+        private static DeclarationPatternSyntax PlacedOnSameLine(DeclarationPatternSyntax declaration) => declaration.WithoutTrivia()
+                                                                                                                     .WithType(declaration.Type.WithoutTrailingTrivia())
+                                                                                                                     .WithDesignation(PlacedOnSameLine(declaration.Designation));
+
+        private static InvocationExpressionSyntax PlacedOnSameLine(InvocationExpressionSyntax invocation) => invocation.WithoutTrivia()
+                                                                                                                       .WithExpression(PlacedOnSameLine(invocation.Expression))
+                                                                                                                       .WithArgumentList(PlacedOnSameLine(invocation.ArgumentList));
+
+        private static IsPatternExpressionSyntax PlacedOnSameLine(IsPatternExpressionSyntax pattern) => pattern.WithoutTrivia()
+                                                                                                               .WithPattern(PlacedOnSameLine(pattern.Pattern))
+                                                                                                               .WithIsKeyword(pattern.IsKeyword.WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                               .WithExpression(PlacedOnSameLine(pattern.Expression));
+
+        private static MemberAccessExpressionSyntax PlacedOnSameLine(MemberAccessExpressionSyntax maes) => maes.WithoutTrivia()
+                                                                                                               .WithName(PlacedOnSameLine(maes.Name))
+                                                                                                               .WithOperatorToken(maes.OperatorToken.WithoutTrivia())
+                                                                                                               .WithExpression(PlacedOnSameLine(maes.Expression));
+
+        private static NameSyntax PlacedOnSameLine(NameSyntax name)
+        {
+            switch (name)
+            {
+                // note that 'GenericNameSyntax' inherits from 'SimpleNameSyntax', so we have to check that first
+                case GenericNameSyntax genericName:
+                    return genericName.WithoutTrivia()
+                                      .WithIdentifier(genericName.Identifier.WithoutTrivia())
+                                      .WithTypeArgumentList(PlacedOnSameLine(genericName.TypeArgumentList));
+
+                case SimpleNameSyntax simpleName:
+                    return simpleName.WithoutTrivia();
+
+                default:
+                    return name.WithoutTrivia();
+            }
+        }
+
+        private static ObjectCreationExpressionSyntax PlacedOnSameLine(ObjectCreationExpressionSyntax creation) => creation.WithoutTrivia()
+                                                                                                                           .WithNewKeyword(creation.NewKeyword.WithoutTrivia())
+                                                                                                                           .WithType(PlacedOnSameLine(creation.Type).WithLeadingSpace())
+                                                                                                                           .WithArgumentList(PlacedOnSameLine(creation.ArgumentList))
+                                                                                                                           .WithInitializer(PlacedOnSameLine(creation.Initializer));
+
+        private static SingleVariableDesignationSyntax PlacedOnSameLine(SingleVariableDesignationSyntax singleVariable) => singleVariable.WithoutTrivia()
+                                                                                                                                         .WithIdentifier(singleVariable.Identifier.WithoutTrivia());
+
+        private static SwitchExpressionArmSyntax PlacedOnSameLine(SwitchExpressionArmSyntax arm) => arm.WithoutTrailingTrivia()
+                                                                                                       .WithEqualsGreaterThanToken(arm.EqualsGreaterThanToken.WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                       .WithExpression(PlacedOnSameLine(arm.Expression))
+                                                                                                       .WithWhenClause(PlacedOnSameLine(arm.WhenClause))
+                                                                                                       .WithPattern(PlacedOnSameLine(arm.Pattern));
+
+        private static ThrowExpressionSyntax PlacedOnSameLine(ThrowExpressionSyntax throwExpression) => throwExpression.WithoutTrivia()
+                                                                                                                       .WithThrowKeyword(throwExpression.ThrowKeyword.WithoutTrivia())
+                                                                                                                       .WithExpression(PlacedOnSameLine(throwExpression.Expression));
+
+        private static TypeArgumentListSyntax PlacedOnSameLine(TypeArgumentListSyntax typeArgumentList) => typeArgumentList.WithoutTrivia()
+                                                                                                                           .WithArguments(PlacedOnSameLine(typeArgumentList.Arguments))
+                                                                                                                           .WithGreaterThanToken(typeArgumentList.GreaterThanToken.WithoutTrivia())
+                                                                                                                           .WithLessThanToken(typeArgumentList.LessThanToken.WithoutTrivia());
+
+        private static WhenClauseSyntax PlacedOnSameLine(WhenClauseSyntax clause) => clause?.WithoutTrivia()
+                                                                                           .WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                           .WithCondition(PlacedOnSameLine(clause.Condition));
     }
 }


### PR DESCRIPTION
- Refactored PlacedOnSameLine method implementation.

- Removed long switch-case version.

- Delegated handling to specialized helper methods.

- Improved readability and consistency.

