### PR TITLE
Added new rule MiKo_2237 for multiple XML documentation

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1173,7 +1173,7 @@ namespace MiKoSolutions.Analyzers
         {
             var token = value.FindStructuredTriviaToken();
 
-            return token.HasStructuredTrivia && HasDocumentationCommentTriviaSyntax(token);
+            return token.HasStructuredTrivia && token.HasDocumentationCommentTriviaSyntax();
         }
 
         internal static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(this SyntaxNode value)
@@ -1182,7 +1182,7 @@ namespace MiKoSolutions.Analyzers
 
             if (token.HasStructuredTrivia)
             {
-                var comment = GetDocumentationCommentTriviaSyntax(token);
+                var comment = token.GetDocumentationCommentTriviaSyntax();
 
                 if (comment != null)
                 {
@@ -1599,6 +1599,14 @@ namespace MiKoSolutions.Analyzers
         internal static bool HasTrailingComment(this SyntaxNode value) => value != null && value.GetTrailingTrivia().Any(_ => _.IsComment());
 
         internal static bool HasTrailingEndOfLine(this SyntaxNode value) => value != null && value.GetTrailingTrivia().Any(_ => _.IsEndOfLine());
+
+        internal static bool HasMinimumCSharpVersion(this SyntaxTree value, LanguageVersion expectedVersion)
+        {
+            var languageVersion = ((CSharpParseOptions)value.Options).LanguageVersion;
+
+            // ignore the latest versions (or above)
+            return languageVersion >= expectedVersion && expectedVersion < LanguageVersion.LatestMajor;
+        }
 
         internal static bool HasLinqExtensionMethod(this SyntaxNode value, SemanticModel semanticModel) => value.LinqExtensionMethods(semanticModel).Any();
 
@@ -2337,14 +2345,6 @@ namespace MiKoSolutions.Analyzers
                 default:
                     return false;
             }
-        }
-
-        internal static bool HasMinimumCSharpVersion(this SyntaxTree value, LanguageVersion expectedVersion)
-        {
-            var languageVersion = ((CSharpParseOptions)value.Options).LanguageVersion;
-
-            // ignore the latest versions (or above)
-            return languageVersion >= expectedVersion && expectedVersion < LanguageVersion.LatestMajor;
         }
 
         internal static bool IsInsideTestClass(this SyntaxNode value) => value.Ancestors<ClassDeclarationSyntax>().Any(_ => _.IsTestClass());
@@ -4188,75 +4188,6 @@ namespace MiKoSolutions.Analyzers
             }
 
             return finalTrivia;
-        }
-
-        private static bool HasDocumentationCommentTriviaSyntax(SyntaxToken token)
-        {
-            var leadingTrivia = token.LeadingTrivia;
-            var count = leadingTrivia.Count;
-
-            // Perf: quick check to avoid costly loop
-            if (count >= 2)
-            {
-                if (leadingTrivia[count == 4 ? 2 : 1].IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
-                {
-                    return true;
-                }
-            }
-
-            for (var index = 0; index < count; index++)
-            {
-                if (leadingTrivia[index].IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(SyntaxToken value)
-        {
-            var leadingTrivia = value.LeadingTrivia;
-            var count = leadingTrivia.Count;
-
-            // Perf: quick check to avoid costly loop
-            if (count >= 2)
-            {
-                var trivia = leadingTrivia[count == 4 ? 2 : 1];
-
-                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
-                {
-                    return new[] { syntax };
-                }
-            }
-
-            DocumentationCommentTriviaSyntax[] results = null;
-            var resultsIndex = 0;
-
-            for (var index = 0; index < count; index++)
-            {
-                var trivia = leadingTrivia[index];
-
-                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
-                {
-                    if (results is null)
-                    {
-                        results = new DocumentationCommentTriviaSyntax[1];
-                    }
-                    else
-                    {
-                        // seems we have more separate comments, so increase by one
-                        Array.Resize(ref results, results.Length + 1);
-                    }
-
-                    results[resultsIndex] = syntax;
-
-                    resultsIndex++;
-                }
-            }
-
-            return results;
         }
 
         private static SyntaxToken FindStructuredTriviaToken(this SyntaxNode value)

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -136,6 +136,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -153,6 +153,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2234_DocumentationShouldUseToAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_GoingToPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_ExampleAbbreviationAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_MultipleDocumentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8846,6 +8846,44 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove empty lines between documentation.
+        /// </summary>
+        internal static string MiKo_2237_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2237_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XML documentation helps organize your code and allows tools like Sandcastle or IntelliSense to create useful references.
+        ///Empty lines in XML comments can confuse these tools, leading to errors or problems.
+        ///Keeping your comments compact and continuous makes them easier to read and ensures your documentation stays clear and reliable for both developers and tools..
+        /// </summary>
+        internal static string MiKo_2237_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2237_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove empty lines between documentation.
+        /// </summary>
+        internal static string MiKo_2237_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2237_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should not be separated by empty lines.
+        /// </summary>
+        internal static string MiKo_2237_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2237_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3122,6 +3122,20 @@ However, these suppressions should remain inline comments and must not be part o
   <data name="MiKo_2236_Title" xml:space="preserve">
     <value>Documentation should use 'for example' instead of abbreviation 'e.g.'</value>
   </data>
+  <data name="MiKo_2237_CodeFixTitle" xml:space="preserve">
+    <value>Remove empty lines between documentation</value>
+  </data>
+  <data name="MiKo_2237_Description" xml:space="preserve">
+    <value>XML documentation helps organize your code and allows tools like Sandcastle or IntelliSense to create useful references.
+Empty lines in XML comments can confuse these tools, leading to errors or problems.
+Keeping your comments compact and continuous makes them easier to read and ensures your documentation stays clear and reliable for both developers and tools.</value>
+  </data>
+  <data name="MiKo_2237_MessageFormat" xml:space="preserve">
+    <value>Remove empty lines between documentation</value>
+  </data>
+  <data name="MiKo_2237_Title" xml:space="preserve">
+    <value>Documentation should not be separated by empty lines</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2237_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2237_CodeFixProvider.cs
@@ -1,0 +1,35 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2237_CodeFixProvider)), Shared]
+    public sealed class MiKo_2237_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2237";
+
+        protected override bool IsTrivia => true;
+
+        protected override SyntaxToken GetUpdatedToken(SyntaxToken token, Diagnostic issue)
+        {
+            var issueLocation = issue.Location;
+
+            var leadingTrivia = token.LeadingTrivia;
+            var leadingTriviaCount = leadingTrivia.Count;
+
+            for (var index = 1; index < leadingTriviaCount; index++)
+            {
+                var trivia = leadingTrivia[index];
+
+                if (trivia.GetLocation().Equals(issueLocation))
+                {
+                    return token.WithLeadingTrivia(leadingTrivia.RemoveAt(index - 1));
+                }
+            }
+
+            return token;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2237_MultipleDocumentationAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2237";
+
+        public MiKo_2237_MultipleDocumentationAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            var documentation = comment.ParentTrivia.Token.Parent.GetDocumentationCommentTriviaSyntax();
+
+            if (documentation.Length > 1)
+            {
+                if (documentation.IndexOf(comment) > 0)
+                {
+                    return new[] { Issue(comment) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2237_MultipleDocumentationAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] XmlTags = ["summary", "remarks"];
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_items() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public event EventHandler<T> MyEvent;
+
+    public void DoSomething() { }
+
+    public int Age { get; set; }
+
+    private bool m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_documented_items_with_multiple_elements() => No_issue_is_reported_for(@"
+using System;
+
+/// <summary>It is for example something.</summary>
+/// <remarks>It is for example something.</remarks>
+public class TestMe
+{
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public event EventHandler<T> MyEvent;
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public void DoSomething() { }
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    public int Age { get; set; }
+
+    /// <summary>It is for example something.</summary>
+    /// <remarks>It is for example something.</remarks>
+    private bool m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_documented_items_with_single_elements() => No_issue_is_reported_for(@"
+using System;
+
+/// <summary>It is for example something.</summary>
+public class TestMe
+{
+    /// <summary>It is for example something.</summary>
+    public event EventHandler<T> MyEvent;
+
+    /// <summary>It is for example something.</summary>
+    public void DoSomething() { }
+
+    /// <summary>It is for example something.</summary>
+    public int Age { get; set; }
+
+    /// <summary>It is for example something.</summary>
+    private bool m_field;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_gaps_between_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+using System;
+
+/// <" + tag + ">This is some text before the gap.</" + tag + @">
+
+/// <" + tag + ">This is some text after the gap.</" + tag + @">
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_gaps_between_summaries()
+        {
+            const string OriginalCode = @"
+using System;
+
+/// <summary>This is some text before the gap.</summary>
+
+/// <summary>This is some text after the gap.</summary>
+public class TestMe
+{
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+/// <summary>This is some text before the gap.</summary>
+/// <summary>This is some text after the gap.</summary>
+public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2237_MultipleDocumentationAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2237_MultipleDocumentationAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2237_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 491 rules that are currently provided by the analyzer.
+The following tables lists all the 492 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -279,6 +279,7 @@ The following tables lists all the 491 rules that are currently provided by the 
 |MiKo_2234|Documentation should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
 |MiKo_2235|Documentation should use 'will' instead of 'going to'|&#x2713;|&#x2713;|
 |MiKo_2236|Documentation should use 'for example' instead of abbreviation 'e.g.'|&#x2713;|&#x2713;|
+|MiKo_2237|Documentation should not be separated by empty lines|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Add new rule MiKo_2237 for XML documentation merging

- Introduce code fix to remove empty documentation gaps

- Refactor extension methods to use token-based trivia check

- Update resources, project files and tests for new rule

(resolves #1013)