### PR TITLE
Renamed 'StartIssue' methods to clarify their intent

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Event;
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsEventHandler();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsEnum();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsAsyncTaskBased();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Phrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Phrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -39,9 +39,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        protected override Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
+        protected override Diagnostic NonTextStartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
                                                                   DocumentationCommentTriviaSyntax comment,

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsCommand();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.TypeKind == TypeKind.Delegate;
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2047_AttributeSummaryDefaultPhraseAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.InheritsFrom<Attribute>();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrases);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrases);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && (type.IsValueConverter() || type.IsMultiValueConverter());
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
@@ -42,9 +42,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
 
-        protected override Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
+        protected override Diagnostic NonTextStartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, GetProposal(symbol));
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, GetProposal(symbol));
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
@@ -19,9 +19,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
 
-        protected override Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
+        protected override Diagnostic NonTextStartIssue(ISymbol symbol, SyntaxNode node) => null; // this is no issue as we do not start with any word
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.Comments.TryStartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.Comments.TryStartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase);
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return false;
         }
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location)
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location)
         {
             var proposal = GetStartingPhrase((IFieldSymbol)symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_EnumMemberAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.ContainingType.IsEnum();
 
-        protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(location);
+        protected override Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(location);
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
@@ -14,9 +14,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected virtual Diagnostic StartIssue(ISymbol symbol, SyntaxNode node) => StartIssue(symbol, node.GetLocation());
+        protected virtual Diagnostic NonTextStartIssue(ISymbol symbol, SyntaxNode node) => Issue(symbol.Name, node.GetLocation());
 
-        protected virtual Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location);
+        protected virtual Diagnostic TextStartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location);
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
                                                                   DocumentationCommentTriviaSyntax comment,
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             continue; // skip over the start tag and name syntax
                         }
 
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                        return NonTextStartIssue(symbol, node); // it's no text, so it must be something different
                     }
 
                     case XmlElementEndTagSyntax endTag:
@@ -84,13 +84,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         {
                             if (ConsiderEmptyTextAsIssue(symbol))
                             {
-                                return StartIssue(symbol, element.GetContentsLocation()); // it's an empty text
+                                return TextStartIssue(symbol, element.GetContentsLocation()); // it's an empty text
                             }
 
                             continue;
                         }
 
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                        return NonTextStartIssue(symbol, node); // it's no text, so it must be something different
                     }
 
                     case XmlNameSyntax _:
@@ -140,7 +140,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                                 var location = CreateLocation(token, start, end);
 
-                                return StartIssue(symbol, location);
+                                return TextStartIssue(symbol, location);
                             }
 
                             // it's a valid text, so we quit
@@ -152,7 +152,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
 
                     default:
-                        return StartIssue(symbol, node); // it's no text, so it must be something different
+                        return NonTextStartIssue(symbol, node); // it's no text, so it must be something different
                 }
             }
 


### PR DESCRIPTION
- Renamed `StartIssue` to `TextStartIssue` for text diagnostics

- Renamed `StartIssue` to `NonTextStartIssue` for non-text diagnostics
