### PR TITLE
Renamed 'ArrayCreationExpressionMaintainabilityAnalyzer' to 'ArrayCreationExpressionPerformanceAnalyzer'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -492,7 +492,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\Orderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\OrderingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\TestMethodsOrderingAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\ArrayCreationExpressionMaintainabilityAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\ArrayCreationExpressionPerformanceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5001_DebugLogIsEnabledAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5002_DebugFormatInsteadDebugLogAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5003_LogExceptionAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Performance/ArrayCreationExpressionPerformanceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/ArrayCreationExpressionPerformanceAnalyzer.cs
@@ -9,11 +9,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Performance
 {
-    public abstract class ArrayCreationExpressionMaintainabilityAnalyzer : PerformanceAnalyzer
+    public abstract class ArrayCreationExpressionPerformanceAnalyzer : PerformanceAnalyzer
     {
         private static readonly SyntaxKind[] Expressions = { SyntaxKind.ArrayCreationExpression, SyntaxKind.ArrayInitializerExpression };
 
-        protected ArrayCreationExpressionMaintainabilityAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
+        protected ArrayCreationExpressionPerformanceAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5013_EmptyArrayAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5013_EmptyArrayAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Performance
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_5013_EmptyArrayAnalyzer : ArrayCreationExpressionMaintainabilityAnalyzer
+    public sealed class MiKo_5013_EmptyArrayAnalyzer : ArrayCreationExpressionPerformanceAnalyzer
     {
         public const string Id = "MiKo_5013";
 


### PR DESCRIPTION
- Renamed analyzer base class for performance focus

- Updated derived analyzer references accordingly

- Modified project file include path for renaming
