### PR TITLE
Added comments to deactivate NCrunch coverage, changed string comparison to Ordinal

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -334,7 +334,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return new ConcreteMapInfo(mappedDataValue.ReplacementMapForThe, mappedDataValue.ReplacementMapKeysForThe, mappedDataValue.UniqueReplacementMapKeysForThe);
                 }
 
-                if (text.StartsWith(StartWithParenthesis, StringComparison.OrdinalIgnoreCase))
+                if (text.StartsWith(StartWithParenthesis, StringComparison.Ordinal))
                 {
                     return new ConcreteMapInfo(mappedDataValue.ReplacementMapForParenthesis, mappedDataValue.ReplacementMapKeysForParenthesis, mappedDataValue.UniqueReplacementMapKeysForParenthesis);
                 }
@@ -720,7 +720,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var condition = conditions[conditionIndex];
 
                     // we have lots of loops, so cache data to avoid unnecessary calculations
-                    var end = " " + condition + " "; // TODO RKN: Change string creation
+                    var end = condition.SurroundedWith(' '); // TODO RKN: Change string creation
 
                     // for performance reasons we use for loops here
                     for (var verbIndex = 0; verbIndex < verbsLength; verbIndex++)
@@ -828,7 +828,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return int.MaxValue;
             }
         }
-
 //// ncrunch: no coverage end
 //// ncrunch: rdi default
     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -175,6 +175,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         }
 
 //// ncrunch: rdi off
+//// ncrunch: no coverage start
 
         private sealed class MapData
         {
@@ -299,7 +300,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
         }
+//// ncrunch: no coverage end
+//// ncrunch: rdi default
     }
-
-    //// ncrunch: rdi default
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -41,6 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         }
 
 //// ncrunch: rdi off
+//// ncrunch: no coverage start
 
         private sealed class MapData
         {
@@ -335,7 +336,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             private static string[] CreateOtherReplacementMapKeys() => new[] { "Defines ", "Specifies ", "Use this ", "This " };
         }
-
-        //// ncrunch: rdi default
+//// ncrunch: no coverage end
+//// ncrunch: rdi default
     }
 }


### PR DESCRIPTION
- Updated string comparison and performance improvements.

- Replaced inline concatenation with SurroundedWith method.

- Standardized NCrunch comment markers across code files.
