### PR TITLE
'MakeFirstWordInfiniteVerb' moved from 'DocumentationCodeFixProvider' into 'Verbalizer'

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -457,6 +457,58 @@ namespace MiKoSolutions.Analyzers.Linguistics
             }
         }
 
+        public static string MakeFirstWordInfiniteVerb(string text, in FirstWordHandling handling = FirstWordHandling.None)
+        {
+            if (text.IsNullOrWhiteSpace())
+            {
+                return text;
+            }
+
+            return MakeFirstWordInfiniteVerb(text.AsSpan(), handling);
+        }
+
+        public static string MakeFirstWordInfiniteVerb(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling = FirstWordHandling.None)
+        {
+            if (text.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            // it may happen that the text starts with a special character, such as an ':'
+            // so remove those special characters
+            var valueText = text.TrimStart(Constants.SentenceMarkers);
+
+            if (valueText.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            // first word
+            var firstWord = GetFirstWord(valueText, firstWordHandling);
+
+            var infiniteVerb = MakeInfiniteVerb(firstWord);
+
+            if (firstWord != infiniteVerb)
+            {
+                return infiniteVerb.ConcatenatedWith(valueText.WithoutFirstWord());
+            }
+
+            return text.ToString();
+
+            string GetFirstWord(in ReadOnlySpan<char> span, in FirstWordHandling handling)
+            {
+                var word = span.FirstWord();
+
+                switch (handling)
+                {
+                    case FirstWordHandling.MakeLowerCase: return word.ToLowerCaseAt(0);
+                    case FirstWordHandling.MakeUpperCase: return word.ToUpperCaseAt(0);
+                    default:
+                        return word.ToString();
+                }
+            }
+        }
+
         public static string MakeThirdPersonSingularVerb(string value)
         {
             if (value.IsNullOrWhiteSpace())

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -229,7 +229,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 commentContinuation.Append(ReplacementTo);
 
-                var continuation = MakeFirstWordInfiniteVerb(subText, FirstWordHandling.MakeLowerCase);
+                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(subText, FirstWordHandling.MakeLowerCase);
 
                 commentContinuation.Append(continuation);
             }

--- a/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
@@ -244,6 +244,16 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("maintains", ExpectedResult = "maintains")]
         public static string MakeThirdPersonSingularVerb_finds_proper_3rd_person_singular_verb_(string name) => Verbalizer.MakeThirdPersonSingularVerb(name);
 
+        [TestCase("", ExpectedResult = "")]
+        [TestCase("   ", ExpectedResult = "   ")]
+        [TestCase("Maintains something whatever it takes", ExpectedResult = "Maintain something whatever it takes")]
+        [TestCase("maintains something whatever it takes", ExpectedResult = "maintain something whatever it takes")]
+        [TestCase(" Maintain something whatever it takes", ExpectedResult = " Maintain something whatever it takes")]
+        [TestCase(" maintain something whatever it takes", ExpectedResult = " maintain something whatever it takes")]
+        [TestCase("   Maintains something whatever it takes", ExpectedResult = "Maintain something whatever it takes")]
+        [TestCase("   maintains something whatever it takes", ExpectedResult = "maintain something whatever it takes")]
+        public static string MakeFirstWordInfiniteVerb_finds_proper_infinite_verb_(string name) => Verbalizer.MakeFirstWordInfiniteVerb(name);
+
         [TestCase("access", ExpectedResult = false)]
         [TestCase("accesses", ExpectedResult = true)]
         [TestCase("adapts", ExpectedResult = true)]


### PR DESCRIPTION
- Extract infinite verb logic into `Verbalizer`

- Update codefix providers to delegate verb handling

- Add unit tests for first-word infinite verb

- Simplify term lookup ordering by length in `DocumentationCodeFixProvider.GetTermsForQuickLookup`
