### PR TITLE
Removed unneeded null check & added [in] modifiers

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -13,8 +13,8 @@ namespace System.Text
 {
     internal static class StringBuilderExtensions
     {
-        private const int QuickCompareLengthThreshold = 4;
-        private const int QuickCompareRentLengthThreshold = 22;
+        private const int QuickCompareLengthThreshold = 6;
+        private const int QuickCompareRentLengthThreshold = 24;
 
         public static bool IsNullOrWhiteSpace(this StringBuilder value) => value is null || value.CountLeadingWhitespaces() == value.Length;
 
@@ -245,12 +245,6 @@ namespace System.Text
             {
                 var pair = replacementPairs[index];
                 var oldValue = pair.Key;
-
-                if (oldValue.IsNullOrEmpty())
-                {
-                    // cannot replace any empty value
-                    continue;
-                }
 
                 if (QuickCompare(ref value, ref oldValue))
                 {
@@ -606,9 +600,7 @@ namespace System.Text
         private static bool QuickCompare(ref StringBuilder current, ref string other)
         {
             var otherValueLength = other.Length;
-            var currentValueLength = current.Length;
-
-            var difference = currentValueLength - otherValueLength;
+            var difference = current.Length - otherValueLength;
 
             if (difference < 0)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -533,7 +533,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return results;
                 }
 
-                Pair[] ToMapArray(ReadOnlySpan<Pair> map, HashSet<string> keys, Pair[] others)
+                Pair[] ToMapArray(in ReadOnlySpan<Pair> map, HashSet<string> keys, Pair[] others)
                 {
                     var resultIndex = 0;
                     var results = new Pair[keys.Count + others.Length];

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/StringMaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/StringMaintainabilityCodeFixProvider.cs
@@ -27,9 +27,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     return syntax;
             }
 
-            string GetFixedText(SyntaxToken token) => GetCleanedText(token.ValueText.AsSpan().TrimEnd()).ConcatenatedWith(ending);
+            string GetFixedText(in SyntaxToken token) => GetCleanedText(token.ValueText.AsSpan().TrimEnd()).ConcatenatedWith(ending);
 
-            ReadOnlySpan<char> GetCleanedText(ReadOnlySpan<char> text)
+            ReadOnlySpan<char> GetCleanedText(in ReadOnlySpan<char> text)
             {
                 var lastCharIndex = text.Length - 1;
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
@@ -52,9 +52,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             return betterName.ToString();
 
-            bool StartsWithCan(ReadOnlySpan<char> name) => name.Length > 4 && name[3].IsUpperCaseLetter() && name.StartsWith("Can", StringComparison.Ordinal);
+            bool StartsWithCan(in ReadOnlySpan<char> name) => name.Length > 4 && name[3].IsUpperCaseLetter() && name.StartsWith("Can", StringComparison.Ordinal);
 
-            ReadOnlySpan<char> WithoutIsHasArePrefix(ReadOnlySpan<char> name)
+            ReadOnlySpan<char> WithoutIsHasArePrefix(in ReadOnlySpan<char> name)
             {
                 var nameLength = name.Length;
 


### PR DESCRIPTION
- Bump quick-compare thresholds `QuickCompareLengthThreshold` to 6 and `QuickCompareRentLengthThreshold` to 24

- Remove redundant empty-value replacement guard

- Inline length computation in `QuickCompare`

- Added [in] modifiers to local functions