### PR TITLE
Changed arrays to spans where appropriate

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -660,6 +660,24 @@ namespace System.Linq
 
         internal static bool None<T>(this IEnumerable<T> source, Func<T, bool> predicate) => source.All(_ => predicate(_) is false);
 
+        internal static bool None<T>(this in ReadOnlySpan<T> source, Func<T, bool> predicate)
+        {
+            var sourceLength = source.Length;
+
+            if (sourceLength > 0)
+            {
+                for (var index = 0; index < sourceLength; index++)
+                {
+                    if (predicate(source[index]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
         internal static bool MoreThan<T>(this IEnumerable<T> source, in int count)
         {
             switch (source)

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -152,7 +152,7 @@ namespace System.Text
             return value;
         }
 
-        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, string[] texts, string replacement)
+        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<string> texts, string replacement)
         {
             var length = texts.Length;
 
@@ -465,7 +465,7 @@ namespace System.Text
 
         public static StringBuilder Without(this StringBuilder value, string phrase) => value.ReplaceWithProbe(phrase, string.Empty);
 
-        public static StringBuilder Without(this StringBuilder value, string[] phrases) => value.ReplaceAllWithProbe(phrases, string.Empty);
+        public static StringBuilder Without(this StringBuilder value, in ReadOnlySpan<string> phrases) => value.ReplaceAllWithProbe(phrases, string.Empty);
 
         public static StringBuilder Without(this StringBuilder value, in char c1, in char c2)
         {

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -90,7 +90,7 @@ namespace System
             return word.ConcatenatedWith(continuation);
         }
 
-        public static IReadOnlyList<int> AllIndicesOf(this string value, string finding, in StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        public static int[] AllIndicesOf(this string value, string finding, in StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             // Perf: This code sits on the hot path and is invoked quite often (several million times), so we directly use 'string.IsNullOrWhiteSpace(value)'
             //       (otherwise, it would cost about 1/10 of the overall time here which is - given the several million times - recognizable)
@@ -113,7 +113,7 @@ namespace System
             return AllIndicesNonOrdinal(value, finding, comparison);
         }
 
-        public static IReadOnlyList<int> AllIndicesOf(this in ReadOnlySpan<char> value, string finding, in StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        public static int[] AllIndicesOf(this in ReadOnlySpan<char> value, string finding, in StringComparison comparison = StringComparison.OrdinalIgnoreCase)
         {
             if (value.IsNullOrWhiteSpace())
             {
@@ -711,9 +711,9 @@ namespace System
         public static bool ContainsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> characters) => value.Length > 0 && value.IndexOfAny(characters) >= 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ContainsAny(this string value, string[] phrases) => value.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
+        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases) => value.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
 
-        public static bool ContainsAny(this string value, string[] phrases, in StringComparison comparison)
+        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value.HasCharacters())
             {
@@ -806,7 +806,7 @@ namespace System
         public static bool EndsWithAny(this string value, in ReadOnlySpan<char> suffixCharacters) => value.HasCharacters() && suffixCharacters.Contains(value[value.Length - 1]);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWithAny(this string value, string[] suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
+        public static bool EndsWithAny(this string value, in ReadOnlySpan<string> suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
 
         public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> suffixCharacters)
         {
@@ -829,9 +829,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWithAny(this in ReadOnlySpan<char> value, string[] suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
+        public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
 
-        public static bool EndsWithAny(this string value, string[] suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this string value, in ReadOnlySpan<string> suffixes, in StringComparison comparison)
         {
             if (value.HasCharacters())
             {
@@ -883,7 +883,7 @@ namespace System
             return false;
         }
 
-        public static bool EndsWithAny(this in ReadOnlySpan<char> value, string[] suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes, in StringComparison comparison)
         {
             var valueLength = value.Length;
             var suffixesLength = suffixes.Length;
@@ -927,9 +927,9 @@ namespace System
         public static bool EqualsAny(this string value, IEnumerable<string> phrases) => EqualsAny(value, phrases, StringComparison.OrdinalIgnoreCase);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EqualsAny(this in ReadOnlySpan<char> value, string[] phrases) => EqualsAny(value, phrases, StringComparison.OrdinalIgnoreCase);
+        public static bool EqualsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases) => EqualsAny(value, phrases, StringComparison.OrdinalIgnoreCase);
 
-        public static bool EqualsAny(this string value, string[] phrases, in StringComparison comparison)
+        public static bool EqualsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value.HasCharacters())
             {
@@ -953,7 +953,7 @@ namespace System
         {
             if (phrases is string[] array)
             {
-                return value.EqualsAny(array, comparison);
+                return value.EqualsAny(array.AsSpan(), comparison);
             }
 
             if (value.HasCharacters())
@@ -970,7 +970,7 @@ namespace System
             return false;
         }
 
-        public static bool EqualsAny(this in ReadOnlySpan<char> value, string[] phrases, in StringComparison comparison)
+        public static bool EqualsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value.Length > 0)
             {
@@ -1286,7 +1286,7 @@ namespace System
             }
         }
 
-        public static int IndexOfAny(this in ReadOnlySpan<char> value, string[] phrases, in StringComparison comparison)
+        public static int IndexOfAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value.Length > 0)
             {
@@ -1317,7 +1317,7 @@ namespace System
             return -1;
         }
 
-        public static int IndexOfAny(this string value, string[] phrases, in StringComparison comparison)
+        public static int IndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value.HasCharacters())
             {
@@ -1344,7 +1344,7 @@ namespace System
             return -1;
         }
 
-        public static int LastIndexOfAny(this string value, string[] phrases, in StringComparison comparison)
+        public static int LastIndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
         {
             if (value is null)
             {
@@ -1562,12 +1562,12 @@ namespace System
         public static bool StartsWithAny(this in ReadOnlySpan<char> value, IEnumerable<char> characters) => value.Length > 0 && characters.Contains(value[0]);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWithAny(this string value, string[] prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
+        public static bool StartsWithAny(this string value, in ReadOnlySpan<string> prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWithAny(this in ReadOnlySpan<char> value, string[] prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
+        public static bool StartsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
 
-        public static bool StartsWithAny(this string value, string[] prefixes, in StringComparison comparison)
+        public static bool StartsWithAny(this string value, in ReadOnlySpan<string> prefixes, in StringComparison comparison)
         {
             if (value.HasCharacters())
             {
@@ -1591,7 +1591,7 @@ namespace System
             return false;
         }
 
-        public static bool StartsWithAny(this in ReadOnlySpan<char> value, string[] prefixes, in StringComparison comparison)
+        public static bool StartsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> prefixes, in StringComparison comparison)
         {
             if (value.Length > 0)
             {
@@ -1679,7 +1679,7 @@ namespace System
 
 #pragma warning restore CA1308
 
-            return MakeLowerCaseAt(source.AsSpan(), index);
+            return source.AsSpan().MakeLowerCaseAt(index);
         }
 
         /// <summary>
@@ -1754,7 +1754,7 @@ namespace System
                 return source;
             }
 
-            return MakeUpperCaseAt(source.AsSpan(), index);
+            return source.AsSpan().MakeUpperCaseAt(index);
         }
 
         /// <summary>
@@ -1831,7 +1831,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Without(this string value, string phrase) => value.Replace(phrase, string.Empty);
 
-        public static string Without(this string value, string[] phrases) => value.AsCachedBuilder().Without(phrases).Trimmed().ToStringAndRelease();
+        public static string Without(this string value, in ReadOnlySpan<string> phrases) => value.AsCachedBuilder().Without(phrases).Trimmed().ToStringAndRelease();
 
         public static string WithoutFirstWord(this string value) => WithoutFirstWord(value.AsSpan()).ToString();
 
@@ -1850,9 +1850,9 @@ namespace System
             return text.Slice(firstSpace);
         }
 
-        public static ReadOnlySpan<char> WithoutFirstWords(this string value, params string[] words) => WithoutFirstWords(value.AsSpan(), words);
+        public static ReadOnlySpan<char> WithoutFirstWords(this string value, in ReadOnlySpan<string> words) => WithoutFirstWords(value.AsSpan(), words);
 
-        public static ReadOnlySpan<char> WithoutFirstWords(this in ReadOnlySpan<char> value, params string[] words)
+        public static ReadOnlySpan<char> WithoutFirstWords(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> words)
         {
             var text = value.TrimStart();
 
@@ -1985,37 +1985,45 @@ namespace System
             return value;
         }
 
-        public static ReadOnlySpan<char> WithoutSuffixes(this in ReadOnlySpan<char> value, string[] suffixes)
+        public static ReadOnlySpan<char> WithoutSuffixes(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes)
         {
-            return RemoveSuffixes(RemoveSuffixes(value)); // do it twice to remove consecutive suffixes
-
-            ReadOnlySpan<char> RemoveSuffixes(ReadOnlySpan<char> slice)
-            {
-                var suffixesLength = suffixes.Length;
-
-                // ReSharper disable once ForCanBeConvertedToForeach
-                for (var index = 0; index < suffixesLength; index++)
-                {
-                    var suffix = suffixes[index].AsSpan();
-
-                    if (slice.EndsWith(suffix))
-                    {
-                        var length = slice.Length - suffix.Length;
-
-                        if (length <= 0)
-                        {
-                            return ReadOnlySpan<char>.Empty;
-                        }
-
-                        slice = slice.Slice(0, length);
-                    }
-                }
-
-                return slice;
-            }
+            // do it twice to remove consecutive suffixes
+            return value.RemoveSuffixes(suffixes)
+                        .RemoveSuffixes(suffixes);
         }
 
         public static WordsReadOnlySpanEnumerator WordsAsSpan(this in ReadOnlySpan<char> value) => new WordsReadOnlySpanEnumerator(value);
+
+        private static ReadOnlySpan<char> RemoveSuffixes(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes)
+        {
+            if (value.Length <= 0)
+            {
+                return ReadOnlySpan<char>.Empty;
+            }
+
+            var slice = value;
+            var suffixesLength = suffixes.Length;
+
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var index = 0; index < suffixesLength; index++)
+            {
+                var suffix = suffixes[index].AsSpan();
+
+                if (slice.EndsWith(suffix))
+                {
+                    var length = slice.Length - suffix.Length;
+
+                    if (length <= 0)
+                    {
+                        return ReadOnlySpan<char>.Empty;
+                    }
+
+                    slice = slice.Slice(0, length);
+                }
+            }
+
+            return slice;
+        }
 
         private static bool HasWhitespaces(this in ReadOnlySpan<char> value, int start = 0)
         {
@@ -2032,7 +2040,7 @@ namespace System
             return false;
         }
 
-        private static string MakeUpperCaseAt(in ReadOnlySpan<char> source, in int index)
+        private static string MakeUpperCaseAt(this in ReadOnlySpan<char> source, in int index)
         {
             unsafe
             {
@@ -2049,7 +2057,7 @@ namespace System
             }
         }
 
-        private static string MakeLowerCaseAt(in ReadOnlySpan<char> source, in int index)
+        private static string MakeLowerCaseAt(this in ReadOnlySpan<char> source, in int index)
         {
             unsafe
             {
@@ -2279,11 +2287,11 @@ namespace System
             }
         }
 
-        private static IReadOnlyList<int> AllIndicesOrdinal(in ReadOnlySpan<char> span, in ReadOnlySpan<char> other)
+        private static int[] AllIndicesOrdinal(in ReadOnlySpan<char> span, in ReadOnlySpan<char> other)
         {
             var otherLength = other.Length;
 
-            List<int> indices = null;
+            int[] indices = null;
 
             for (var index = 0; ; index += otherLength)
             {
@@ -2299,20 +2307,24 @@ namespace System
 
                 if (indices is null)
                 {
-                    indices = new List<int>(1);
+                    indices = new int[1];
+                }
+                else
+                {
+                    Array.Resize(ref indices, indices.Length + 1);
                 }
 
-                indices.Add(index);
+                indices[indices.Length - 1] = index;
             }
 
-            return indices ?? (IReadOnlyList<int>)Array.Empty<int>();
+            return indices ?? Array.Empty<int>();
         }
 
-        private static IReadOnlyList<int> AllIndicesNonOrdinal(string value, string finding, in StringComparison comparison)
+        private static int[] AllIndicesNonOrdinal(string value, string finding, in StringComparison comparison)
         {
             var findingLength = finding.Length;
 
-            List<int> indices = null;
+            int[] indices = null;
 
             for (var index = 0; ; index += findingLength)
             {
@@ -2326,13 +2338,17 @@ namespace System
 
                 if (indices is null)
                 {
-                    indices = new List<int>(1);
+                    indices = new int[1];
+                }
+                else
+                {
+                    Array.Resize(ref indices, indices.Length + 1);
                 }
 
-                indices.Add(index);
+                indices[indices.Length - 1] = index;
             }
 
-            return indices ?? (IReadOnlyList<int>)Array.Empty<int>();
+            return indices ?? Array.Empty<int>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
@@ -12,9 +13,10 @@ namespace System
 
         public static SplitReadOnlySpanEnumerator SplitBy(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> separatorChars, StringSplitOptions options) => new SplitReadOnlySpanEnumerator(value, separatorChars, options);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static SplitReadOnlySpanEnumerator SplitBy(this in ReadOnlySpan<char> value, char[] separatorChars, StringSplitOptions options) => SplitBy(value, separatorChars.AsSpan(), options);
 
-        public static IReadOnlyList<string> SplitBy(this in ReadOnlySpan<char> value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
+        public static IReadOnlyList<string> SplitBy(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
         {
             if (value.IsNullOrWhiteSpace())
             {
@@ -30,12 +32,11 @@ namespace System
                 var finding = findings[findingsIndex];
 
                 var indices = value.AllIndicesOf(finding, comparison);
+                var indicesLength = indices.Length;
 
-                tuples.Capacity += indices.Count;
+                tuples.Capacity += indicesLength;
 
-                var indicesCount = indices.Count;
-
-                for (var i = 0; i < indicesCount; i++)
+                for (var i = 0; i < indicesLength; i++)
                 {
                     var index = indices[i];
 
@@ -71,7 +72,7 @@ namespace System
             return results;
         }
 
-        public static IReadOnlyList<string> SplitBy(this string value, string[] findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
+        public static IReadOnlyList<string> SplitBy(this string value, in ReadOnlySpan<string> findings, StringComparison comparison = StringComparison.OrdinalIgnoreCase, StringSplitOptions options = StringSplitOptions.None)
         {
             if (value is null)
             {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2566,7 +2566,7 @@ namespace MiKoSolutions.Analyzers
             return source.ReplaceText(new[] { phrase }, replacement);
         }
 
-        internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, string[] phrases, string replacement)
+        internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, in ReadOnlySpan<string> phrases, string replacement)
         {
             var resultLength = source.Count;
 
@@ -2640,7 +2640,7 @@ namespace MiKoSolutions.Analyzers
             return value.ReplaceTokens(map.Keys, (original, rewritten) => map[original]);
         }
 
-        internal static XmlTextSyntax ReplaceText(this XmlTextSyntax value, string[] phrases, string replacement)
+        internal static XmlTextSyntax ReplaceText(this XmlTextSyntax value, in ReadOnlySpan<string> phrases, string replacement)
         {
             var textTokens = value.TextTokens;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return GetAllLocations(textToken.ValueText, textToken.SyntaxTree, textToken.SpanStart, value, comparison, startOffset, endOffset);
         }
 
-        protected static IReadOnlyList<Location> GetAllLocations(in SyntaxToken textToken, string[] values, StringComparison comparison = StringComparison.Ordinal, in int startOffset = 0, in int endOffset = 0)
+        protected static IReadOnlyList<Location> GetAllLocations(in SyntaxToken textToken, in ReadOnlySpan<string> values, StringComparison comparison = StringComparison.Ordinal, in int startOffset = 0, in int endOffset = 0)
         {
             return GetAllLocations(textToken.ValueText, textToken.SyntaxTree, textToken.SpanStart, values, comparison, startOffset, endOffset);
         }
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return GetAllLocations(trivia.ToFullString(), trivia.SyntaxTree, trivia.SpanStart, value, comparison, startOffset, endOffset);
         }
 
-        protected static IReadOnlyList<Location> GetAllLocations(in SyntaxTrivia trivia, string[] values, StringComparison comparison = StringComparison.Ordinal, in int startOffset = 0, in int endOffset = 0)
+        protected static IReadOnlyList<Location> GetAllLocations(in SyntaxTrivia trivia, in ReadOnlySpan<string> values, StringComparison comparison = StringComparison.Ordinal, in int startOffset = 0, in int endOffset = 0)
         {
             return GetAllLocations(trivia.ToFullString(), trivia.SyntaxTree, trivia.SpanStart, values, comparison, startOffset, endOffset);
         }
@@ -185,7 +185,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var allIndices = text.AllIndicesOf(value, comparison);
 
-            if (allIndices is int[] array && array.Length == 0)
+            if (allIndices.Length == 0)
             {
                 // nothing to inspect
                 return Array.Empty<Location>();
@@ -194,7 +194,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return GetAllLocationsWithLoop(syntaxTree, spanStart, value, startOffset, endOffset, allIndices);
         }
 
-        private static IReadOnlyList<Location> GetAllLocations(string text, SyntaxTree syntaxTree, in int spanStart, string[] values, StringComparison comparison, in int startOffset, in int endOffset)
+        private static IReadOnlyList<Location> GetAllLocations(string text, SyntaxTree syntaxTree, in int spanStart, in ReadOnlySpan<string> values, StringComparison comparison, in int startOffset, in int endOffset)
         {
             var textLength = text.Length;
 
@@ -225,7 +225,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var allIndices = text.AllIndicesOf(value, comparison);
 
-            if (allIndices is int[] array && array.Length == 0)
+            if (allIndices.Length == 0)
             {
                 // nothing to inspect
                 return Array.Empty<Location>();
@@ -234,14 +234,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return GetAllLocationsWithLoop(text, syntaxTree, spanStart, value, nextCharValidationCallback, startOffset, endOffset, textLength, allIndices);
         }
 
-        private static IReadOnlyList<Location> GetAllLocationsWithLoop(SyntaxTree syntaxTree, in int spanStart, string value, in int startOffset, in int endOffset, IReadOnlyList<int> allIndices)
+        private static IReadOnlyList<Location> GetAllLocationsWithLoop(SyntaxTree syntaxTree, in int spanStart, string value, in int startOffset, in int endOffset, in ReadOnlySpan<int> allIndices)
         {
             List<Location> alreadyReportedLocations = null;
-            var count = allIndices.Count;
+            var length = allIndices.Length;
 
             List<Location> results = null;
 
-            for (var index = 0; index < count; index++)
+            for (var index = 0; index < length; index++)
             {
                 var position = allIndices[index];
 
@@ -278,7 +278,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return results ?? (IReadOnlyList<Location>)Array.Empty<Location>();
         }
 
-        private static IReadOnlyList<Location> GetAllLocationsWithLoop(string text, SyntaxTree syntaxTree, in int spanStart, string[] values, StringComparison comparison, in int startOffset, in int endOffset, in int textLength)
+        private static IReadOnlyList<Location> GetAllLocationsWithLoop(string text, SyntaxTree syntaxTree, in int spanStart, in ReadOnlySpan<string> values, StringComparison comparison, in int startOffset, in int endOffset, in int textLength)
         {
             List<Location> alreadyReportedLocations = null;
             var valuesCount = values.Length;
@@ -297,15 +297,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var allIndices = text.AllIndicesOf(value, comparison);
 
-                if (allIndices is int[] array && array.Length == 0)
+                if (allIndices.Length == 0)
                 {
                     // nothing to inspect
                     continue;
                 }
 
-                var count = allIndices.Count;
+                var length = allIndices.Length;
 
-                for (var index = 0; index < count; index++)
+                for (var index = 0; index < length; index++)
                 {
                     var position = allIndices[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -80,12 +80,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlElementSyntax Comment(XmlElementSyntax comment, IEnumerable<XmlNodeSyntax> nodes) => Comment(comment, nodes.ToSyntaxList());
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string[] text, string additionalComment = null)
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, string additionalComment = null)
         {
             return Comment(comment, text[0], additionalComment);
         }
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string[] text, in SyntaxList<XmlNodeSyntax> additionalComment)
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, in SyntaxList<XmlNodeSyntax> additionalComment)
         {
             return Comment(comment, text[0], additionalComment);
         }
@@ -104,14 +104,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Comment(comment, XmlText(text + additionalComment));
         }
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, string[] terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepLeadingSpace)
+        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepLeadingSpace)
         {
             var result = Comment<XmlElementSyntax>(syntax, terms, replacementMap, firstWordHandling);
 
             return CombineTexts(result);
         }
 
-        protected static T Comment<T>(T syntax, string[] terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepLeadingSpace) where T : SyntaxNode
+        protected static T Comment<T>(T syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepLeadingSpace) where T : SyntaxNode
         {
             var minimumLength = MinLength(terms);
 
@@ -126,7 +126,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return syntax.ReplaceNodes(textMap.Keys, (_, __) => textMap[_]);
 
 //// ncrunch: no coverage start
-            int MinLength(ReadOnlySpan<string> source)
+            int MinLength(in ReadOnlySpan<string> source)
             {
                 var sourceLength = source.Length;
 
@@ -150,7 +150,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return minimum;
             }
 
-            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, string[] phrases, in ReadOnlySpan<Pair> map, in FirstWordHandling handling)
+            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, in ReadOnlySpan<string> phrases, in ReadOnlySpan<Pair> map, in FirstWordHandling handling)
             {
                 Dictionary<XmlTextSyntax, XmlTextSyntax> result = null;
 
@@ -371,7 +371,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, string[] phrases, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, in ReadOnlySpan<string> phrases, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
         {
             return CommentStartingWith(comment, phrases[0], firstWordHandling);
         }
@@ -556,7 +556,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlElementSyntax Para(in SyntaxList<XmlNodeSyntax> nodes) => SyntaxFactory.XmlParaElement(nodes);
 
-        protected static XmlElementSyntax ParameterComment(ParameterSyntax parameter, string[] comments) => ParameterComment(parameter, comments[0]);
+        protected static XmlElementSyntax ParameterComment(ParameterSyntax parameter, in ReadOnlySpan<string> comments) => ParameterComment(parameter, comments[0]);
 
         protected static XmlElementSyntax ParameterComment(ParameterSyntax parameter, string comment) => Comment(SyntaxFactory.XmlParamElement(parameter.GetName()), comment);
 
@@ -581,7 +581,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static T ReplaceText<T>(T comment, XmlTextSyntax text, string phrase, string replacement) where T : SyntaxNode => ReplaceText(comment, text, new[] { phrase }, replacement);
 
-        protected static T ReplaceText<T>(T comment, XmlTextSyntax text, string[] phrases, string replacement) where T : SyntaxNode
+        protected static T ReplaceText<T>(T comment, XmlTextSyntax text, in ReadOnlySpan<string> phrases, string replacement) where T : SyntaxNode
         {
             var modifiedText = text.ReplaceText(phrases, replacement);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                         && comment.EndsWith("etc.", StringComparison.OrdinalIgnoreCase) is false;
 
         internal static bool ContainsDoublePeriod(in ReadOnlySpan<char> comment) => comment.Contains("..", _ => AllowedChars.Contains(_) is false, StringComparison.Ordinal)
-                                                                              && comment.EndsWith("...", StringComparison.Ordinal) is false;
+                                                                                 && comment.EndsWith("...", StringComparison.Ordinal) is false;
 
         internal static bool ContainsPhrase(string phrase, in ReadOnlySpan<char> comment)
         {
@@ -40,6 +40,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return comment.Slice(indexAfterPhrase).StartsWithAny(Constants.Comments.Delimiters);
         }
 
-        internal static bool ContainsPhrases(string[] phrases, in ReadOnlySpan<char> comment) => comment.ToString().ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
+        internal static bool ContainsPhrases(in ReadOnlySpan<string> phrases, in ReadOnlySpan<char> comment) => comment.ToString().ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -189,7 +189,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static string[] SplitCommentsOnParametersInText(string comment, string[] parametersAsTextReferences)
+        private static string[] SplitCommentsOnParametersInText(string comment, in ReadOnlySpan<string> parametersAsTextReferences)
         {
             var parametersAsTextReferencesLength = parametersAsTextReferences.Length;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzer.cs
@@ -70,13 +70,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return issues;
         }
 
-        private static List<string> Phrases(string[] phrases, string typeName, string eventName)
+        private static List<string> Phrases(in ReadOnlySpan<string> phrases, string typeName, string eventName)
         {
+            var phrasesLength = phrases.Length;
+
             var eventFullName = typeName + "." + eventName;
 
-            var results = new List<string>(2 * phrases.Length);
-            results.AddRange(phrases.Select(_ => _.FormatWith(eventName))); // output as message to user
-            results.AddRange(phrases.Select(_ => _.FormatWith(eventFullName)));
+            var results = new List<string>(2 * phrasesLength);
+
+            foreach (var phrase in phrases)
+            {
+                results.Add(phrase.FormatWith(eventName)); // output as message to user
+                results.Add(phrase.FormatWith(eventFullName));
+            }
 
             return results;
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
@@ -87,13 +87,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
 
-        private static List<string> Phrases(string[] phrases, string typeName, string propertyName)
+        private static List<string> Phrases(in ReadOnlySpan<string> phrases, string typeName, string propertyName)
         {
-            var propertyFullName = typeName + "." + propertyName;
+            var phrasesLength = phrases.Length;
 
-            var results = new List<string>(2 * phrases.Length);
-            results.AddRange(phrases.Select(_ => _.FormatWith(propertyName))); // output as message to user
-            results.AddRange(phrases.Select(_ => _.FormatWith(propertyFullName)));
+            var propertyFullName = typeName + "." + propertyName;
+            var results = new List<string>(2 * phrasesLength);
+
+            for (var index = 0; index < phrasesLength; index++)
+            {
+                var phrase = phrases[index];
+
+                results.Add(phrase.FormatWith(propertyName)); // output as message to user
+                results.Add(phrase.FormatWith(propertyFullName));
+            }
 
             return results;
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -252,7 +252,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return FixComment(prepared, info.Keys, info.Map, finalCommentContinuation);
         }
 
-        private static XmlElementSyntax FixComment(XmlElementSyntax prepared, string[] replacementMapKeys, in ReadOnlySpan<Pair> replacementMap, string commentContinue = null)
+        private static XmlElementSyntax FixComment(XmlElementSyntax prepared, in ReadOnlySpan<string> replacementMapKeys, in ReadOnlySpan<Pair> replacementMap, string commentContinue = null)
         {
             var startFixed = CommentStartingWith(prepared, StartPhraseParts0, SeeLangword_True(), commentContinue ?? StartPhraseParts1);
             var bothFixed = CommentEndingWith(startFixed, EndPhraseParts0, SeeLangword_False(), EndPhraseParts1);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                        };
         }
 
-        private static string[] AdjustPhrases(IParameterSymbol parameter, string[] phrases)
+        private static string[] AdjustPhrases(IParameterSymbol parameter, in ReadOnlySpan<string> phrases)
         {
             var parameterType = parameter.Type;
             var qualifiedName = parameterType.FullyQualifiedName();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
@@ -34,9 +34,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        private Diagnostic[] AnalyzeParameterComment(string parameterName, XmlElementSyntax parameterComment, string comment, string[] phrases)
+        private Diagnostic[] AnalyzeParameterComment(string parameterName, XmlElementSyntax parameterComment, string comment, in ReadOnlySpan<string> phrases)
         {
-            if (comment.EqualsAny(phrases))
+            if (comment.AsSpan().EqualsAny(phrases))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -91,7 +91,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static SyntaxList<XmlNodeSyntax> RemoveStartingWord(XmlElementSyntax comment) => RemoveStartingWord(comment.WithoutFirstXmlNewLine(), Constants.Comments.ParameterStartingCodefixPhrase);
 
-        private static SyntaxList<XmlNodeSyntax> RemoveStartingWord(XmlElementSyntax comment, params string[] words)
+        private static SyntaxList<XmlNodeSyntax> RemoveStartingWord(XmlElementSyntax comment, in ReadOnlySpan<string> words)
         {
             var contents = comment.Content;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
@@ -209,17 +209,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                    : AnalyzeParameter(symbol, commentXml, comment, phrases);
         }
 
-        private Diagnostic[] AnalyzeParameter(IParameterSymbol symbol, string commentXml, DocumentationCommentTriviaSyntax comment, string[] phrase)
+        private Diagnostic[] AnalyzeParameter(IParameterSymbol symbol, string commentXml, DocumentationCommentTriviaSyntax comment, in ReadOnlySpan<string> phrases)
         {
             var parameterCommentXml = symbol.GetComment(commentXml);
 
-            if (phrase.None(_ => _ == parameterCommentXml))
+            if (phrases.None(_ => _ == parameterCommentXml))
             {
                 var parameterComment = comment.GetParameterComment(symbol.Name);
 
                 var issue = parameterComment is null
-                            ? Issue(symbol, Constants.XmlTag.Param, phrase[0])
-                            : Issue(symbol.Name, parameterComment, Constants.XmlTag.Param, phrase[0]);
+                            ? Issue(symbol, Constants.XmlTag.Param, phrases[0])
+                            : Issue(symbol.Name, parameterComment, Constants.XmlTag.Param, phrases[0]);
 
                 return new[] { issue };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -408,7 +408,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return issues;
         }
 
-        private void AnalyzeForPhrases(List<Diagnostic> issues, in SyntaxToken token, string[] phrases, string replacement, StringComparison comparison = StringComparison.Ordinal)
+        private void AnalyzeForPhrases(List<Diagnostic> issues, in SyntaxToken token, in ReadOnlySpan<string> phrases, string replacement, StringComparison comparison = StringComparison.Ordinal)
         {
             var locations = GetAllLocations(token, phrases, comparison);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var problematicIndices = sentenceText.AllIndicesOf(problematicWord, StringComparison.Ordinal);
 
-                    if (problematicIndices.Count > 0)
+                    if (problematicIndices.Length > 0)
                     {
                         indices.AddRange(problematicIndices);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -21,16 +21,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected virtual bool ShallAnalyzeReturnType(ITypeSymbol returnType) => true;
 
-        protected Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, string[] phrase)
+        protected Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, in ReadOnlySpan<string> phrases)
         {
-            if (commentXml.StartsWithAny(phrase, StringComparison.Ordinal) is false)
+            if (commentXml.StartsWithAny(phrases, StringComparison.Ordinal) is false)
             {
                 var nodes = comment.GetXmlSyntax(xmlTag);
 
                 if (nodes.Count > 0)
                 {
                     var symbolName = symbol.Name;
-                    var text = phrase[0];
+                    var text = phrases[0];
 
                     return nodes.Select(_ => Issue(symbolName, _.GetContentsLocation(), xmlTag, text)).ToArray();
                 }
@@ -39,16 +39,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, params string[] phrase)
+        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, params string[] phrases)
         {
-            if (phrase.None(_ => _.Equals(commentXml, StringComparison.Ordinal)))
+            if (phrases.None(_ => _.Equals(commentXml, StringComparison.Ordinal)))
             {
                 var nodes = comment.GetXmlSyntax(xmlTag);
 
                 if (nodes.Count > 0)
                 {
                     var symbolName = symbol.Name;
-                    var text = phrase[0];
+                    var text = phrases[0];
 
                     return nodes.Select(_ => Issue(symbolName, _.GetContentsLocation(), xmlTag, text)).ToArray();
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1056_DependencyPropertyFieldPrefixAnalyzer.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            var betterNames = propertyNames.Select(_ => _ + Constants.DependencyProperty.FieldSuffix).ToList();
+            var betterNames = propertyNames.ToArray(_ => _ + Constants.DependencyProperty.FieldSuffix);
             var betterName = betterNames[0];
 
             return new[] { Issue(symbol, betterNames.HumanizedConcatenated(), CreateBetterNameProposal(betterName)) };

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            var betterNames = propertyNames.Select(_ => _ + Constants.DependencyPropertyKey.FieldSuffix).ToList();
+            var betterNames = propertyNames.ToArray(_ => _ + Constants.DependencyPropertyKey.FieldSuffix);
             var betterName = betterNames[0];
 
             return new[] { Issue(symbol, betterNames.HumanizedConcatenated(), CreateBetterNameProposal(betterName)) };


### PR DESCRIPTION
- Introduce `ReadOnlySpan<T>` overloads replacing `string[]` parameters

- Optimize `None<T>` and `AllIndicesOf` for `ReadOnlySpan` performance

- Refactor extensions and analyzers to use spans and `int[]` results

- Update code fix providers and naming analyzers accordingly
