### PR TITLE
Linq Count methods changed into code, switch case oder changed

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Metrics/Counter.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/Counter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
@@ -42,21 +41,54 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
         public static int CountCyclomaticComplexity(BlockSyntax body, in SyntaxKind syntaxKindToIgnore = SyntaxKind.None)
         {
-            var count = SyntaxNodeCollector.Collect<SyntaxNode>(body, syntaxKindToIgnore).Count(_ => CCSyntaxKinds.Contains(_.RawKind));
+            var count = 1;
 
-            return 1 + count;
+            var list = SyntaxNodeCollector.Collect<SyntaxNode>(body, syntaxKindToIgnore);
+            var listCount = list.Count;
+
+            if (listCount > 0)
+            {
+                for (var index = 0; index < listCount; index++)
+                {
+                    if (CCSyntaxKinds.Contains(list[index].RawKind))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
         }
 
         public static int CountCyclomaticComplexity(ArrowExpressionClauseSyntax body, in SyntaxKind syntaxKindToIgnore = SyntaxKind.None)
         {
-            var count = SyntaxNodeCollector.Collect<SyntaxNode>(body, syntaxKindToIgnore).Count(_ => CCSyntaxKinds.Contains(_.RawKind));
+            var count = 1;
 
-            return 1 + count;
+            var list = SyntaxNodeCollector.Collect<SyntaxNode>(body, syntaxKindToIgnore);
+            var listCount = list.Count;
+
+            if (listCount > 0)
+            {
+                for (var index = 0; index < listCount; index++)
+                {
+                    if (CCSyntaxKinds.Contains(list[index].RawKind))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
         }
 
         internal static int CountLinesOfCode(SyntaxNode body, in SyntaxKind syntaxKindToIgnore = SyntaxKind.None)
         {
             var nodes = SyntaxNodeCollector.Collect<StatementSyntax>(body, syntaxKindToIgnore);
+
+            if (nodes.Count == 0)
+            {
+                return 0;
+            }
 
             var lines = new HashSet<int>();
 

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MetricsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MetricsAnalyzer.cs
@@ -46,12 +46,12 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
         {
             switch (context.Node)
             {
+                case MethodDeclarationSyntax m: return m.Body;
                 case AccessorDeclarationSyntax a: return a.Body;
                 case ConstructorDeclarationSyntax c: return c.Body;
-                case DestructorDeclarationSyntax d: return d.Body;
-                case MethodDeclarationSyntax m: return m.Body;
                 case OperatorDeclarationSyntax o: return o.Body;
                 case ConversionOperatorDeclarationSyntax co: return co.Body;
+                case DestructorDeclarationSyntax d: return d.Body;
                 case LocalFunctionStatementSyntax l: return l.Body;
                 default: return null;
             }
@@ -62,11 +62,11 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
             switch (context.Node)
             {
                 case AccessorDeclarationSyntax a: return a.ExpressionBody;
-                case ConstructorDeclarationSyntax c: return c.ExpressionBody;
-                case DestructorDeclarationSyntax d: return d.ExpressionBody;
                 case MethodDeclarationSyntax m: return m.ExpressionBody;
                 case OperatorDeclarationSyntax o: return o.ExpressionBody;
                 case ConversionOperatorDeclarationSyntax co: return co.ExpressionBody;
+                case ConstructorDeclarationSyntax c: return c.ExpressionBody;
+                case DestructorDeclarationSyntax d: return d.ExpressionBody;
                 case LocalFunctionStatementSyntax l: return l.ExpressionBody;
                 default: return null;
             }


### PR DESCRIPTION
- Replace LINQ Count with manual loops

- Add early return in `CountLinesOfCode`

- Remove unused `System.Linq` import

- Reorder switch cases in analyzer
