### PR TITLE
'MakeLowerCase/MakeUpperCase' renamed to 'StartLowerCase/StartUpperCase' to reflect the meaning

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -26,13 +26,13 @@ namespace System.Text
             // only keep it if there is already a leading space (otherwise it may be on the same line without any leading space, and we would fix it in a wrong way)
             value.TrimLeadingSpacesTo(handling.HasSet(FirstWordHandling.KeepLeadingSpace) ? 1 : 0);
 
-            if (handling.HasSet(FirstWordHandling.MakeLowerCase))
+            if (handling.HasSet(FirstWordHandling.StartLowerCase))
             {
-                value.MakeLowerCase();
+                value.StartLowerCase();
             }
-            else if (handling.HasSet(FirstWordHandling.MakeUpperCase))
+            else if (handling.HasSet(FirstWordHandling.StartUpperCase))
             {
-                value.MakeUpperCase();
+                value.StartUpperCase();
             }
 
             if (handling.HasSet(FirstWordHandling.MakeInfinite))
@@ -620,7 +620,7 @@ namespace System.Text
             return whitespaces;
         }
 
-        private static void MakeLowerCase(this StringBuilder value)
+        private static void StartLowerCase(this StringBuilder value)
         {
             var valueLength = value.Length;
 
@@ -643,7 +643,7 @@ namespace System.Text
             }
         }
 
-        private static void MakeUpperCase(this StringBuilder value)
+        private static void StartUpperCase(this StringBuilder value)
         {
             var valueLength = value.Length;
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -42,7 +42,7 @@ namespace System
 
             string word;
 
-            if (handling.HasSet(FirstWordHandling.MakeLowerCase))
+            if (handling.HasSet(FirstWordHandling.StartLowerCase))
             {
                 var firstWord = valueSpan.FirstWord();
 
@@ -51,7 +51,7 @@ namespace System
                        ? firstWord.ToString()
                        : firstWord.ToLowerCaseAt(0);
             }
-            else if (handling.HasSet(FirstWordHandling.MakeUpperCase))
+            else if (handling.HasSet(FirstWordHandling.StartUpperCase))
             {
                 word = valueSpan.FirstWord().ToUpperCaseAt(0);
             }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3695,9 +3695,9 @@ namespace MiKoSolutions.Analyzers
             return value;
         }
 
-        internal static SyntaxList<XmlNodeSyntax> WithStartText(this XmlElementSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase) => value.Content.WithStartText(startText, firstWordHandling);
+        internal static SyntaxList<XmlNodeSyntax> WithStartText(this XmlElementSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase) => value.Content.WithStartText(startText, firstWordHandling);
 
-        internal static SyntaxList<XmlNodeSyntax> WithStartText(this in SyntaxList<XmlNodeSyntax> values, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        internal static SyntaxList<XmlNodeSyntax> WithStartText(this in SyntaxList<XmlNodeSyntax> values, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
         {
             if (values.Count > 0)
             {
@@ -3709,7 +3709,7 @@ namespace MiKoSolutions.Analyzers
             return XmlText(startText).ToSyntaxList<XmlNodeSyntax>();
         }
 
-        internal static XmlTextSyntax WithStartText(this XmlTextSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        internal static XmlTextSyntax WithStartText(this XmlTextSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
         {
             var tokens = value.TextTokens;
 

--- a/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
@@ -46,9 +46,9 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             return A(firstWordHandling);
 
-            string A(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.MakeLowerCase) ? "a " : "A ";
+            string A(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.StartLowerCase) ? "a " : "A ";
 
-            string An(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.MakeLowerCase) ? "an " : "An ";
+            string An(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.StartLowerCase) ? "an " : "An ";
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Linguistics/FirstWordHandling.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/FirstWordHandling.cs
@@ -21,12 +21,12 @@ namespace MiKoSolutions.Analyzers.Linguistics
         /// <summary>
         /// Attempt to make the word starting with an upper case.
         /// </summary>
-        MakeUpperCase = 1 << 1,
+        StartUpperCase = 1 << 1,
 
         /// <summary>
         /// Attempt to make the word starting with a lower case.
         /// </summary>
-        MakeLowerCase = 1 << 2,
+        StartLowerCase = 1 << 2,
 
         /// <summary>
         /// Attempt to make it an infinite verb.

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -501,8 +501,8 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
                 switch (handling)
                 {
-                    case FirstWordHandling.MakeLowerCase: return word.ToLowerCaseAt(0);
-                    case FirstWordHandling.MakeUpperCase: return word.ToUpperCaseAt(0);
+                    case FirstWordHandling.StartLowerCase: return word.ToLowerCaseAt(0);
+                    case FirstWordHandling.StartUpperCase: return word.ToUpperCaseAt(0);
                     default:
                         return word.ToString();
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -371,19 +371,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, in ReadOnlySpan<string> phrases, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, in ReadOnlySpan<string> phrases, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
         {
             return CommentStartingWith(comment, phrases[0], firstWordHandling);
         }
 
-        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
         {
             var content = CommentStartingWith(comment.Content, phrase, firstWordHandling);
 
             return CommentWithContent(comment, content);
         }
 
-        protected static SyntaxList<XmlNodeSyntax> CommentStartingWith(SyntaxList<XmlNodeSyntax> content, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.MakeLowerCase)
+        protected static SyntaxList<XmlNodeSyntax> CommentStartingWith(SyntaxList<XmlNodeSyntax> content, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
         {
             // when necessary adjust beginning text
             // Note: when on new line, then the text is not the 1st one but the 2nd one

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return fixedComment;
         }
 
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeLowerCase);
+        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
 
 //// ncrunch: rdi off
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (text.StartsWithAny(EmptyReplacementsMapKeys, StringComparison.Ordinal))
             {
-                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordHandling.MakeUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepLeadingSpace);
+                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordHandling.StartUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepLeadingSpace);
             }
 
             if (comment.GetEnclosing(Declarations) is MemberDeclarationSyntax member)
@@ -162,7 +162,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return GetUpdatedSyntax(comment, t);
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeLowerCase);
+            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
         }
 
         private static XmlEmptyElementSyntax GetUpdatedSyntaxWithInheritdoc(in SyntaxList<XmlNodeSyntax> content)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -136,16 +136,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                    .Without("Enum")
                                                    .WithoutAbbreviations()
                                                    .AdjustFirstWord(FirstWordHandling.MakePlural)
-                                                   .SeparateWords(' ', FirstWordHandling.MakeLowerCase);
+                                                   .SeparateWords(' ', FirstWordHandling.StartLowerCase);
                     }
                     else
                     {
-                        continuation = continuation.AdjustFirstWord(FirstWordHandling.MakeLowerCase);
+                        continuation = continuation.AdjustFirstWord(FirstWordHandling.StartLowerCase);
                     }
                 }
                 else
                 {
-                    continuation = continuation.AdjustFirstWord(FirstWordHandling.MakeLowerCase);
+                    continuation = continuation.AdjustFirstWord(FirstWordHandling.StartLowerCase);
                 }
 
                 var finalText = continuation.Insert(0, startingPhrase)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
@@ -18,6 +18,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override string Title => Resources.MiKo_2016_CodeFixTitle.FormatWith(Phrase);
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => CommentStartingWith((XmlElementSyntax)syntax, Phrase, FirstWordHandling.MakeLowerCase | FirstWordHandling.MakeThirdPersonSingular);
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => CommentStartingWith((XmlElementSyntax)syntax, Phrase, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeThirdPersonSingular);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -229,7 +229,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 commentContinuation.Append(ReplacementTo);
 
-                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(subText, FirstWordHandling.MakeLowerCase);
+                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(subText, FirstWordHandling.StartLowerCase);
 
                 commentContinuation.Append(continuation);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
@@ -40,8 +40,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             // TODO RKN: Update comment base on whether we have a Flags enum or not (defined as part of the properties of the reported issue)
             var updatedComment = isFlagged
-                                 ? Comment(comment, FlagsReplacementMapKeys, FlagsReplacementMap, FirstWordHandling.MakeLowerCase | FirstWordHandling.MakeThirdPersonSingular)
-                                 : Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeLowerCase);
+                                 ? Comment(comment, FlagsReplacementMapKeys, FlagsReplacementMap, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeThirdPersonSingular)
+                                 : Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
 
             return CommentStartingWith(updatedComment, phrase);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
-                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordHandling.MakeLowerCase);
+                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordHandling.StartLowerCase);
                     var startText = switchedText.AsCachedBuilder().Insert(0, ' ').TrimmedEnd().ToStringAndRelease();
 
                     var updatedContents = contents.Remove(t);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -85,7 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var text = typeName.AsCachedBuilder()
                                        .AdjustFirstWord(FirstWordHandling.MakePlural)
-                                       .SeparateWords(' ', FirstWordHandling.MakeLowerCase)
+                                       .SeparateWords(' ', FirstWordHandling.StartLowerCase)
                                        .ToStringAndRelease();
 
                     if (text.Length > 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -50,9 +50,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (syntax is XmlElementSyntax element)
             {
-                var comment = Comment(element, CommandReplacementMapKeys, CommandReplacementMap, FirstWordHandling.MakeLowerCase);
+                var comment = Comment(element, CommandReplacementMapKeys, CommandReplacementMap, FirstWordHandling.StartLowerCase);
 
-                return CommentStartingWith(comment, Constants.Comments.CommandSummaryStartingPhrase, FirstWordHandling.MakeLowerCase | FirstWordHandling.MakeInfinite);
+                return CommentStartingWith(comment, Constants.Comments.CommandSummaryStartingPhrase, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeInfinite);
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             else
             {
                 var summary = summaries[0];
-                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordHandling.MakeLowerCase);
+                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordHandling.StartLowerCase);
                 var newSummary = CommentStartingWith(preparedSummary, Phrase);
 
                 return comment.ReplaceNode(summary, newSummary);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -78,12 +78,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         }
                         else
                         {
-                            article = ArticleProvider.GetArticleFor(unsuffixedSpan, FirstWordHandling.MakeLowerCase);
+                            article = ArticleProvider.GetArticleFor(unsuffixedSpan, FirstWordHandling.StartLowerCase);
                         }
 
                         unsuffixed = unsuffixed.ToLowerCaseAt(0);
 
-                        var firstWordHandling = FirstWordHandling.MakeLowerCase;
+                        var firstWordHandling = FirstWordHandling.StartLowerCase;
 
                         if (isPlural)
                         {
@@ -106,7 +106,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.MakeUpperCase | FirstWordHandling.KeepLeadingSpace);
+            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartUpperCase | FirstWordHandling.KeepLeadingSpace);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -79,19 +79,19 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("This is a test", FirstWordHandling.KeepLeadingSpace, "This is a test")]
         [TestCase(" This is a test", FirstWordHandling.KeepLeadingSpace, " This is a test")]
         [TestCase("   This is a test", FirstWordHandling.KeepLeadingSpace, " This is a test")]
-        [TestCase("This is a test", FirstWordHandling.MakeLowerCase, "this is a test")]
-        [TestCase("this is a test", FirstWordHandling.MakeLowerCase, "this is a test")]
-        [TestCase(" THis is a Test", FirstWordHandling.MakeLowerCase, "tHis is a Test")]
-        [TestCase("   THis is a Test", FirstWordHandling.MakeLowerCase, "tHis is a Test")]
-        [TestCase(" THis is a Test", FirstWordHandling.MakeLowerCase | FirstWordHandling.KeepLeadingSpace, " tHis is a Test")]
-        [TestCase("   THis is a Test", FirstWordHandling.MakeLowerCase | FirstWordHandling.KeepLeadingSpace, " tHis is a Test")]
-        [TestCase("This is a test", FirstWordHandling.MakeUpperCase, "This is a test")]
-        [TestCase("this is a test", FirstWordHandling.MakeUpperCase, "This is a test")]
-        [TestCase(" this is a test", FirstWordHandling.MakeUpperCase, "This is a test")]
-        [TestCase("   this is a test", FirstWordHandling.MakeUpperCase, "This is a test")]
-        [TestCase("this is a test", FirstWordHandling.MakeUpperCase | FirstWordHandling.KeepLeadingSpace, "This is a test")]
-        [TestCase(" this is a test", FirstWordHandling.MakeUpperCase | FirstWordHandling.KeepLeadingSpace, " This is a test")]
-        [TestCase("   this is a test", FirstWordHandling.MakeUpperCase | FirstWordHandling.KeepLeadingSpace, " This is a test")]
+        [TestCase("This is a test", FirstWordHandling.StartLowerCase, "this is a test")]
+        [TestCase("this is a test", FirstWordHandling.StartLowerCase, "this is a test")]
+        [TestCase(" THis is a Test", FirstWordHandling.StartLowerCase, "tHis is a Test")]
+        [TestCase("   THis is a Test", FirstWordHandling.StartLowerCase, "tHis is a Test")]
+        [TestCase(" THis is a Test", FirstWordHandling.StartLowerCase | FirstWordHandling.KeepLeadingSpace, " tHis is a Test")]
+        [TestCase("   THis is a Test", FirstWordHandling.StartLowerCase | FirstWordHandling.KeepLeadingSpace, " tHis is a Test")]
+        [TestCase("This is a test", FirstWordHandling.StartUpperCase, "This is a test")]
+        [TestCase("this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
+        [TestCase(" this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
+        [TestCase("   this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
+        [TestCase("this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepLeadingSpace, "This is a test")]
+        [TestCase(" this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepLeadingSpace, " This is a test")]
+        [TestCase("   this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepLeadingSpace, " This is a test")]
         [TestCase("represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
         [TestCase(" represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
         [TestCase("   represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
@@ -118,6 +118,20 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("message", FirstWordHandling.MakePlural | FirstWordHandling.KeepLeadingSpace, "messages")]
         [TestCase(" message", FirstWordHandling.MakePlural | FirstWordHandling.KeepLeadingSpace, " messages")]
         [TestCase("   message", FirstWordHandling.MakePlural | FirstWordHandling.KeepLeadingSpace, " messages")]
+
+        [TestCase("Abc", FirstWordHandling.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abc", FirstWordHandling.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("ABC", FirstWordHandling.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("aBC", FirstWordHandling.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("AbC", FirstWordHandling.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abC", FirstWordHandling.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
+
+        [TestCase("Abc", FirstWordHandling.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abc", FirstWordHandling.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("ABC", FirstWordHandling.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("aBC", FirstWordHandling.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("AbC", FirstWordHandling.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abC", FirstWordHandling.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
         public static void AdjustFirstWordHandling(string s, in FirstWordHandling handling, string expectedResult)
         {
             var resultFromSB = new StringBuilder(s).AdjustFirstWord(handling).ToString();


### PR DESCRIPTION
- Rename `MakeLowerCase`/`MakeUpperCase` to `StartLowerCase`/`StartUpperCase`

- Update extension methods to use new enum names

- Adjust all `CodeFixProvider`s for renamed handling flags

- Update unit tests to reference `StartLowerCase`/`StartUpperCase`


