### PR TITLE
Refactored code to increase performance and minimize GC collection times

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -13,8 +13,8 @@ namespace System.Text
 {
     internal static class StringBuilderExtensions
     {
-        private const int QuickCompareLengthThreshold = 6;
-        private const int QuickCompareRentLengthThreshold = 24;
+        private const int QuickSubstringProbeLengthThreshold = 6;
+        private const int QuickSubstringProbeRentLengthThreshold = 24;
 
         public static StringBuilder AdjustFirstWord(this StringBuilder value, in FirstWordHandling handling)
         {
@@ -500,7 +500,7 @@ namespace System.Text
 
             if (difference > 0)
             {
-                if (otherValueLength > QuickCompareLengthThreshold)
+                if (otherValueLength > QuickSubstringProbeLengthThreshold)
                 {
                     var otherFirst = other[0];
 
@@ -509,7 +509,7 @@ namespace System.Text
 
                     var length = difference + 1; // increased by 1 to have the complete difference investigated
 
-                    if (difference >= QuickCompareRentLengthThreshold)
+                    if (difference >= QuickSubstringProbeRentLengthThreshold)
                     {
                         // use rented arrays here (if we have larger differences, the start and end may be in different chunks)
                         return QuickSubstringProbeAtIndicesWithRent(ref current, otherFirst, otherLast, length, lastIndex);

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 // ncrunch: rdi off
 // ReSharper disable once CheckNamespace
@@ -12,9 +11,6 @@ namespace System
         public static SplitReadOnlySpanEnumerator SplitBy(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> separatorChars) => SplitBy(value, separatorChars, StringSplitOptions.None);
 
         public static SplitReadOnlySpanEnumerator SplitBy(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> separatorChars, in StringSplitOptions options) => new SplitReadOnlySpanEnumerator(value, separatorChars, options);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static SplitReadOnlySpanEnumerator SplitBy(this in ReadOnlySpan<char> value, char[] separatorChars, in StringSplitOptions options) => SplitBy(value, separatorChars.AsSpan(), options);
 
         public static IReadOnlyList<string> SplitBy(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> findings, in StringComparison comparison = StringComparison.OrdinalIgnoreCase, in StringSplitOptions options = StringSplitOptions.None)
         {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -524,7 +524,7 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
-        internal static SyntaxNode GetEnclosing(this SyntaxNode value, params SyntaxKind[] syntaxKinds)
+        internal static SyntaxNode GetEnclosing(this SyntaxNode value, in ReadOnlySpan<SyntaxKind> syntaxKinds)
         {
             var node = value;
 
@@ -1651,9 +1651,12 @@ namespace MiKoSolutions.Analyzers
             return value.InsertNodesBefore(nodeInList, new[] { modifiedNode });
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsKind(this SyntaxNode value, in SyntaxKind kind) => value?.RawKind == (int)kind;
+
         internal static bool IsAnyKind(this SyntaxNode value, ISet<SyntaxKind> kinds) => kinds.Contains(value.Kind());
 
-        internal static bool IsAnyKind(this SyntaxNode value, params SyntaxKind[] kinds)
+        internal static bool IsAnyKind(this SyntaxNode value, in ReadOnlySpan<SyntaxKind> kinds)
         {
             var kindsLength = kinds.Length;
 
@@ -3430,9 +3433,9 @@ namespace MiKoSolutions.Analyzers
             return contents.ToSyntaxList();
         }
 
-        internal static SyntaxList<XmlNodeSyntax> WithoutText(this XmlElementSyntax value, params string[] texts) => value.Content.WithoutText(texts);
+        internal static SyntaxList<XmlNodeSyntax> WithoutText(this XmlElementSyntax value, in ReadOnlySpan<string> texts) => value.Content.WithoutText(texts);
 
-        internal static SyntaxList<XmlNodeSyntax> WithoutText(this in SyntaxList<XmlNodeSyntax> values, params string[] texts)
+        internal static SyntaxList<XmlNodeSyntax> WithoutText(this in SyntaxList<XmlNodeSyntax> values, in ReadOnlySpan<string> texts)
         {
             var length = texts.Length;
 
@@ -3453,7 +3456,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static XmlTextSyntax WithoutTrailing(this XmlTextSyntax value, string text) => value.WithoutTrailing(new[] { text });
 
-        internal static XmlTextSyntax WithoutTrailing(this XmlTextSyntax value, params string[] texts)
+        internal static XmlTextSyntax WithoutTrailing(this XmlTextSyntax value, in ReadOnlySpan<string> texts)
         {
             var textTokens = value.TextTokens.ToList();
 
@@ -3502,7 +3505,7 @@ namespace MiKoSolutions.Analyzers
             return value;
         }
 
-        internal static XmlTextSyntax WithoutTrailingCharacters(this XmlTextSyntax value, char[] characters)
+        internal static XmlTextSyntax WithoutTrailingCharacters(this XmlTextSyntax value, in ReadOnlySpan<char> characters)
         {
             var textTokens = value.TextTokens.ToList();
 
@@ -3633,9 +3636,9 @@ namespace MiKoSolutions.Analyzers
             return trimmed;
         }
 
-        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this XmlElementSyntax value, params string[] startTexts) => value.Content.WithoutStartText(startTexts);
+        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this XmlElementSyntax value, in ReadOnlySpan<string> startTexts) => value.Content.WithoutStartText(startTexts);
 
-        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this in SyntaxList<XmlNodeSyntax> values, params string[] startTexts)
+        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this in SyntaxList<XmlNodeSyntax> values, in ReadOnlySpan<string> startTexts)
         {
             if (values.Count > 0 && values[0] is XmlTextSyntax textSyntax)
             {
@@ -3645,9 +3648,9 @@ namespace MiKoSolutions.Analyzers
             return values;
         }
 
-        internal static XmlTextSyntax WithoutStartText(this XmlTextSyntax value, params string[] startTexts)
+        internal static XmlTextSyntax WithoutStartText(this XmlTextSyntax value, in ReadOnlySpan<string> startTexts)
         {
-            if (startTexts is null || startTexts.Length == 0)
+            if (startTexts.Length == 0)
             {
                 return value;
             }
@@ -4060,7 +4063,7 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
-        private static bool Is(this SyntaxNode value, string tagName, params string[] contents)
+        private static bool Is(this SyntaxNode value, string tagName, in ReadOnlySpan<string> contents)
         {
             if (value is XmlElementSyntax syntax && string.Equals(tagName, syntax.GetName(), StringComparison.OrdinalIgnoreCase))
             {
@@ -4154,7 +4157,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        private static SyntaxTrivia[] CalculateWhitespaceTriviaWithComment(in int count, SyntaxTrivia[] finalTrivia)
+        private static SyntaxTrivia[] CalculateWhitespaceTriviaWithComment(in int count, in SyntaxTrivia[] finalTrivia)
         {
             var triviaGroupedByLines = finalTrivia.GroupBy(_ => _.GetStartingLine());
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,6 +16,9 @@ namespace MiKoSolutions.Analyzers
     internal static class SyntaxTokenExtensions
     {
         internal static IEnumerable<T> Ancestors<T>(this in SyntaxToken value) where T : SyntaxNode => value.Parent.Ancestors<T>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsKind(this in SyntaxToken value, in SyntaxKind kind) => value.RawKind == (int)kind;
 
         internal static SyntaxToken AsToken(this SyntaxKind value) => SyntaxFactory.Token(value);
 
@@ -165,7 +169,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsAnyKind(this in SyntaxToken value, ISet<SyntaxKind> kinds) => kinds.Contains(value.Kind());
 
-        internal static bool IsAnyKind(this in SyntaxToken value, params SyntaxKind[] kinds)
+        internal static bool IsAnyKind(this in SyntaxToken value, in ReadOnlySpan<SyntaxKind> kinds)
         {
             var valueKind = value.Kind();
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -49,9 +49,12 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsWhiteSpace(this in SyntaxTrivia value) => value.IsKind(SyntaxKind.WhitespaceTrivia);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsKind(this in SyntaxTrivia value, in SyntaxKind kind) => value.RawKind == (int)kind;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsAnyKind(this in SyntaxTrivia value, ISet<SyntaxKind> kinds) => kinds.Contains(value.Kind());
 
-        internal static bool IsAnyKind(this in SyntaxTrivia value, params SyntaxKind[] kinds)
+        internal static bool IsAnyKind(this in SyntaxTrivia value, in ReadOnlySpan<SyntaxKind> kinds)
         {
             var valueKind = value.Kind();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -782,7 +782,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class StringStartComparer : IComparer<string>
         {
-            private readonly string[] m_specialOrder;
+            private readonly Memory<string> m_specialOrder;
 
             internal StringStartComparer(params string[] specialOrder) => m_specialOrder = specialOrder;
 
@@ -793,7 +793,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (notNullX && notNullY)
                 {
-                    var orders = m_specialOrder.AsSpan();
+                    var orders = m_specialOrder.Span;
 
                     return GetOrder(x.AsSpan(), orders) - GetOrder(y.AsSpan(), orders);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -782,7 +782,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class StringStartComparer : IComparer<string>
         {
-            private readonly Memory<string> m_specialOrder;
+            private readonly string[] m_specialOrder;
 
             internal StringStartComparer(params string[] specialOrder) => m_specialOrder = specialOrder;
 
@@ -793,7 +793,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (notNullX && notNullY)
                 {
-                    var orders = m_specialOrder.Span;
+                    var orders = m_specialOrder.AsSpan();
 
                     return GetOrder(x.AsSpan(), orders) - GetOrder(y.AsSpan(), orders);
                 }
@@ -817,9 +817,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 for (var i = 0; i < length; i++)
                 {
-                    var order = orders[i];
-
-                    if (text.StartsWith(order.AsSpan()))
+                    if (text.StartsWith(orders[i].AsSpan()))
                     {
                         return i;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
@@ -156,7 +156,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        private Diagnostic[] AnalyzeOverloadsSummaryPhrase(IMethodSymbol symbol, DocumentationCommentTriviaSyntax comment, params string[] defaultPhrases)
+        private Diagnostic[] AnalyzeOverloadsSummaryPhrase(IMethodSymbol symbol, DocumentationCommentTriviaSyntax comment, string[] defaultPhrases)
         {
             var summaries = symbol.GetOverloadSummaries();
 
@@ -180,7 +180,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return AnalyzeStartingPhrase(symbol, Constants.XmlTag.Remarks, comments, comment, defaultPhrases);
         }
 
-        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, string xmlTag, IEnumerable<string> comments, DocumentationCommentTriviaSyntax comment, params string[] phrases)
+        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, string xmlTag, IEnumerable<string> comments, DocumentationCommentTriviaSyntax comment, string[] phrases)
         {
             if (comments.None(_ => phrases.Exists(__ => _.StartsWith(__, StringComparison.Ordinal))))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -39,7 +39,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, params string[] phrases)
+        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, string phrase) => AnalyzePhrase(symbol, comment, commentXml, xmlTag, new[] { phrase });
+
+        protected Diagnostic[] AnalyzePhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, in ReadOnlySpan<string> phrases)
         {
             if (phrases.None(_ => _.Equals(commentXml, StringComparison.Ordinal)))
             {


### PR DESCRIPTION
- Renamed `QuickCompare` to `QuickSubstringProbe` with new thresholds

- Swapped array params for `ReadOnlySpan` types

- Added `AggressiveInlining` and `IsKind` helpers

- Removed redundant overloads and cleaned up APIs
