### PR TITLE
MiKo_1063 now recognizes 'El' as abbreviation for 'Element'

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -181,6 +181,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                           new Pair("DTO", string.Empty),
                                                           new Pair("Ef", "EntityFramework"),
                                                           new Pair("EF", "EntityFramework"),
+                                                          new Pair("El", "Element"),
                                                           new Pair("Encr", "Encrypt"),
                                                           new Pair("Env", "Environment"),
                                                           new Pair("Environ", "Environment"),

--- a/MiKo.Analyzer.Tests/Linguistics/AbbreviationDetectorTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/AbbreviationDetectorTests.cs
@@ -176,6 +176,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("DTO", ExpectedResult = "")]
         [TestCase("Ef", ExpectedResult = "EntityFramework")]
         [TestCase("EF", ExpectedResult = "EntityFramework")]
+        [TestCase("El", ExpectedResult = "Element")]
         [TestCase("Encr", ExpectedResult = "Encrypt")]
         [TestCase("Env", ExpectedResult = "Environment")]
         [TestCase("Environ", ExpectedResult = "Environment")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -157,6 +157,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                            "Doc",
                                                            "Dst",
                                                            "Ef",
+                                                           "El",
                                                            "Encr",
                                                            "Env",
                                                            "Environ",


### PR DESCRIPTION
- Add `El` abbreviation mapping to `Element`

- Add unit test case for `El`

- Include `El` in naming analyzer tests

