### PR TITLE
'FindTriviaToAnalyze' now has a hardcoded initial capacity

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
@@ -192,7 +192,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     if (triviaToAnalyze is null)
                     {
-                        triviaToAnalyze = new List<SyntaxTrivia>();
+                        triviaToAnalyze = new List<SyntaxTrivia>(4);
                     }
 
                     triviaToAnalyze.Add(trivia);


### PR DESCRIPTION
- Pre-size trivia list with capacity 4 to enhance list allocation performance.
