### PR TITLE
MiKo_2237 no longer crashs with a NullReferenceException in case of multiline documentation comments /* */

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -152,7 +152,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            return results;
+            return results ?? Array.Empty<DocumentationCommentTriviaSyntax>();
         }
 
         internal static SyntaxTrivia[] GetComment(this in SyntaxToken value) => value.GetAllTrivia().Where(_ => _.IsComment()).ToArray();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
@@ -132,6 +132,35 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_commented_out_const_field_with_multiline_documentation() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /** This is some text for field 1. It is important to have this field here! */
+    private const MyField1 = ""42"";
+
+    /** This is some text for commented out field 2. */
+    // private const MyField2 = ""42"";
+
+    /** This is some text for field 3. */
+    private const MyField3 = ""42"";
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_gaps_between_multiline_documentation() => No_issue_is_reported_for(@"
+using System;
+
+/** This is some text before the gap. */
+
+/** This is some text after the gap. */
+public class TestMe
+{
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_gaps_between_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Prevent NullReferenceException by returning empty array

- Add tests for multiline documentation comment cases
