### PR TITLE
Added rules MiKo_3227 and MiKo_3228 that check for (in-)equality checks on literals and propose to use 'is' instead

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1909,6 +1909,22 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
+        internal static bool IsEnum(this IsPatternExpressionSyntax value, SemanticModel semanticModel) => value.Expression.IsEnum(semanticModel);
+
+        internal static bool IsEnum(this MemberAccessExpressionSyntax value, SemanticModel semanticModel) => value.Expression.IsEnum(semanticModel);
+
+        internal static bool IsEnum(this ExpressionSyntax value, SemanticModel semanticModel)
+        {
+            if (value is MemberAccessExpressionSyntax maes)
+            {
+                return maes.IsEnum(semanticModel);
+            }
+
+            var type = value.GetTypeSymbol(semanticModel);
+
+            return type.IsEnum();
+        }
+
         internal static bool IsEventRegistration(this StatementSyntax value, SemanticModel semanticModel)
         {
             if (value is ExpressionStatementSyntax e && e.Expression is AssignmentExpressionSyntax assignment)
@@ -1970,7 +1986,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        internal static bool IsExpression(this SyntaxNode value, SemanticModel semanticModel)
+        internal static bool IsExpressionTree(this SyntaxNode value, SemanticModel semanticModel)
         {
             foreach (var a in value.AncestorsWithinMethods<ArgumentSyntax>())
             {
@@ -3542,6 +3558,29 @@ namespace MiKoSolutions.Analyzers
             }
 
             return value;
+        }
+
+        internal static T WithoutTrailingSpaces<T>(this T value) where T : SyntaxNode
+        {
+            var trivia = value.GetTrailingTrivia();
+            var triviaCount = trivia.Count;
+
+            if (triviaCount <= 0)
+            {
+                return value;
+            }
+
+            var i = triviaCount - 1;
+
+            for (; i > -1; i--)
+            {
+                if (trivia[i].IsKind(SyntaxKind.WhitespaceTrivia) is false)
+                {
+                    break;
+                }
+            }
+
+            return value.WithTrailingTrivia(i > 0 ? trivia.Take(i) : SyntaxTriviaList.Empty);
         }
 
         internal static SyntaxList<XmlNodeSyntax> WithoutTrailingXmlComment(this in SyntaxList<XmlNodeSyntax> value)

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -216,6 +216,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3226_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3227_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -319,6 +319,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3225_LogicalConditionsAreTheSameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13822,6 +13822,78 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is&apos; pattern.
+        /// </summary>
+        internal static string MiKo_3227_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3227_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Equality checks using &apos;is&apos; pattern matching are more intuitive and easier to read than the &apos;==&apos; equality operator. This makes them the preferred choice for clarity and comprehension..
+        /// </summary>
+        internal static string MiKo_3227_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3227_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;is&apos; instead of &apos;==&apos;.
+        /// </summary>
+        internal static string MiKo_3227_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3227_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer pattern matching for equality checks.
+        /// </summary>
+        internal static string MiKo_3227_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3227_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is not&apos; pattern.
+        /// </summary>
+        internal static string MiKo_3228_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3228_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inequality checks using &apos;is not&apos; pattern matching are more intuitive and easier to read than the &apos;!=&apos; inequality operator. This makes them the preferred choice for clarity and comprehension..
+        /// </summary>
+        internal static string MiKo_3228_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3228_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;is not&apos; instead of &apos;!=&apos;.
+        /// </summary>
+        internal static string MiKo_3228_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3228_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer pattern matching for inequality checks.
+        /// </summary>
+        internal static string MiKo_3228_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3228_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4836,6 +4836,30 @@ Instead, use non-generic types as type arguments. This approach makes the code's
   <data name="MiKo_3226_Title" xml:space="preserve">
     <value>Read-only fields with initializers should be const</value>
   </data>
+  <data name="MiKo_3227_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is' pattern</value>
+  </data>
+  <data name="MiKo_3227_Description" xml:space="preserve">
+    <value>Equality checks using 'is' pattern matching are more intuitive and easier to read than the '==' equality operator. This makes them the preferred choice for clarity and comprehension.</value>
+  </data>
+  <data name="MiKo_3227_MessageFormat" xml:space="preserve">
+    <value>Use 'is' instead of '=='</value>
+  </data>
+  <data name="MiKo_3227_Title" xml:space="preserve">
+    <value>Prefer pattern matching for equality checks</value>
+  </data>
+  <data name="MiKo_3228_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is not' pattern</value>
+  </data>
+  <data name="MiKo_3228_Description" xml:space="preserve">
+    <value>Inequality checks using 'is not' pattern matching are more intuitive and easier to read than the '!=' inequality operator. This makes them the preferred choice for clarity and comprehension.</value>
+  </data>
+  <data name="MiKo_3228_MessageFormat" xml:space="preserve">
+    <value>Use 'is not' instead of '!='</value>
+  </data>
+  <data name="MiKo_3228_Title" xml:space="preserve">
+    <value>Prefer pattern matching for inequality checks</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return;
             }
 
-            if (node.IsExpression(semanticModel))
+            if (node.IsExpressionTree(semanticModel))
             {
                 // ignore expression trees
                 return;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3088_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3088_CodeFixProvider.cs
@@ -16,6 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         public override string FixableDiagnosticId => "MiKo_3088";
 
-        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, LiteralExpressionSyntax literal) => UnaryNot(IsPattern(operand, literal));
+        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, ExpressionSyntax expression) => UnaryNot(IsPattern(operand, expression));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3227_CodeFixProvider)), Shared]
+    public sealed class MiKo_3227_CodeFixProvider : UsePatternMatchingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3227";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
@@ -20,6 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case SyntaxKind.CharacterLiteralExpression:
                 case SyntaxKind.NumericLiteralExpression:
+                case SyntaxKind.StringLiteralExpression:
                     return true;
 
                 default:
@@ -33,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case LiteralExpressionSyntax literal: return IsResponsibleNode(literal.Kind());
                 case PrefixUnaryExpressionSyntax unary: return IsResponsibleNode(unary.Operand.Kind());
-                case MemberAccessExpressionSyntax maes: return maes.IsEnum(semanticModel);
+                case MemberAccessExpressionSyntax maes: return maes.IsConst(semanticModel);
                 default:
                     return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -9,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3227";
 
-        public MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer() : base(Id, SyntaxKind.EqualsExpression, LanguageVersion.CSharp9)
+        public MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer() : base(Id, SyntaxKind.EqualsExpression)
         {
         }
 
@@ -21,6 +22,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case SyntaxKind.NumericLiteralExpression:
                     return true;
 
+                default:
+                    return false;
+            }
+        }
+
+        protected override bool IsResponsibleNode(ExpressionSyntax node, SemanticModel semanticModel)
+        {
+            switch (node)
+            {
+                case LiteralExpressionSyntax literal: return IsResponsibleNode(literal.Kind());
+                case PrefixUnaryExpressionSyntax unary: return IsResponsibleNode(unary.Operand.Kind());
+                case MemberAccessExpressionSyntax maes: return maes.IsEnum(semanticModel);
                 default:
                     return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer : UsePatternMatchingForBinaryExpressionAnalyzer
+    {
+        public const string Id = "MiKo_3227";
+
+        public MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer() : base(Id, SyntaxKind.EqualsExpression, LanguageVersion.CSharp9)
+        {
+        }
+
+        protected override bool IsResponsibleNode(in SyntaxKind kind)
+        {
+            switch (kind)
+            {
+                case SyntaxKind.CharacterLiteralExpression:
+                case SyntaxKind.NumericLiteralExpression:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_CodeFixProvider.cs
@@ -16,6 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         public override string FixableDiagnosticId => "MiKo_3228";
 
-        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, LiteralExpressionSyntax literal) => UnaryNot(IsPattern(operand, literal));
+        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, ExpressionSyntax expression) => UnaryNot(IsPattern(operand, expression));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_CodeFixProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3228_CodeFixProvider)), Shared]
+    public sealed class MiKo_3228_CodeFixProvider : UsePatternMatchingCodeFixProvider
+    {
+        public MiKo_3228_CodeFixProvider() : base(SyntaxKind.NotEqualsExpression)
+        {
+        }
+
+        public override string FixableDiagnosticId => "MiKo_3228";
+
+        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, LiteralExpressionSyntax literal) => UnaryNot(IsPattern(operand, literal));
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer : UsePatternMatchingForBinaryExpressionAnalyzer
+    {
+        public const string Id = "MiKo_3228";
+
+        public MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer() : base(Id, SyntaxKind.NotEqualsExpression, LanguageVersion.CSharp9)
+        {
+        }
+
+        protected override bool IsResponsibleNode(in SyntaxKind kind)
+        {
+            switch (kind)
+            {
+                case SyntaxKind.CharacterLiteralExpression:
+                case SyntaxKind.NumericLiteralExpression:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
@@ -20,6 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case SyntaxKind.CharacterLiteralExpression:
                 case SyntaxKind.NumericLiteralExpression:
+                case SyntaxKind.StringLiteralExpression:
                     return true;
 
                 default:
@@ -33,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case LiteralExpressionSyntax literal: return IsResponsibleNode(literal.Kind());
                 case PrefixUnaryExpressionSyntax unary when unary.IsKind(SyntaxKind.UnaryMinusExpression): return IsResponsibleNode(unary.Operand.Kind());
-                case MemberAccessExpressionSyntax maes: return maes.IsEnum(semanticModel);
+                case MemberAccessExpressionSyntax maes: return maes.IsConst(semanticModel);
                 default:
                     return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -21,6 +22,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case SyntaxKind.NumericLiteralExpression:
                     return true;
 
+                default:
+                    return false;
+            }
+        }
+
+        protected override bool IsResponsibleNode(ExpressionSyntax node, SemanticModel semanticModel)
+        {
+            switch (node)
+            {
+                case LiteralExpressionSyntax literal: return IsResponsibleNode(literal.Kind());
+                case PrefixUnaryExpressionSyntax unary when unary.IsKind(SyntaxKind.UnaryMinusExpression): return IsResponsibleNode(unary.Operand.Kind());
+                case MemberAccessExpressionSyntax maes: return maes.IsEnum(semanticModel);
                 default:
                     return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForBinaryExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForBinaryExpressionAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -14,13 +15,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             if (context.Node is BinaryExpressionSyntax node)
             {
-                if (node.IsExpression(context.SemanticModel))
+                var semanticModel = context.SemanticModel;
+
+                if (node.IsExpressionTree(semanticModel))
                 {
                     // ignore expression trees
                     return;
                 }
 
-                if (IsResponsibleNode(node.Right) || IsResponsibleNode(node.Left))
+                if (IsResponsibleNode(node.Right, semanticModel) || IsResponsibleNode(node.Left, semanticModel))
                 {
                     ReportIssue(context, node.OperatorToken);
                 }
@@ -29,6 +32,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected abstract bool IsResponsibleNode(in SyntaxKind kind);
 
-        private bool IsResponsibleNode(CSharpSyntaxNode syntax) => syntax != null && IsResponsibleNode(syntax.Kind());
+        protected virtual bool IsResponsibleNode(ExpressionSyntax node, SemanticModel semanticModel) => node != null && IsResponsibleNode(node.Kind());
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static IsPatternExpressionSyntax IsPattern(ExpressionSyntax operand, PatternSyntax pattern) => SyntaxFactory.IsPatternExpression(operand, pattern);
 
-        protected static IsPatternExpressionSyntax IsPattern(ExpressionSyntax operand, LiteralExpressionSyntax literal) => IsPattern(operand, SyntaxFactory.ConstantPattern(literal));
+        protected static IsPatternExpressionSyntax IsPattern(ExpressionSyntax operand, ExpressionSyntax expression) => IsPattern(operand, SyntaxFactory.ConstantPattern(expression));
 
         protected static IsPatternExpressionSyntax IsFalsePattern(ExpressionSyntax operand) => IsPattern(operand, FalseLiteral());
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3081_UsePatternMatchingForLogicalNotExpressionAnalyzerTests.cs
@@ -190,8 +190,8 @@ public class TestMe
 ");
 
         [TestCase(
-                     "class TestMe { bool DoSomething(bool a) { if (!a) return true; return false; } }",
-                     "class TestMe { bool DoSomething(bool a) { if (a is false) return true; return false; } }")]
+             "class TestMe { bool DoSomething(bool a) { if (!a) return true; return false; } }",
+             "class TestMe { bool DoSomething(bool a) { if (a is false) return true; return false; } }")]
         [TestCase(
              "class TestMe { bool DoSomething(bool a) { return !a; } }",
              "class TestMe { bool DoSomething(bool a) { return a is false; } }")]

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
@@ -84,6 +84,7 @@ public class TestMe
         [TestCase("int", "42")]
         [TestCase("int", "-42")]
         [TestCase("char", "'X'")]
+        [TestCase("string", @"""some text""")]
         [TestCase("StringComparison", "StringComparison.Ordinal")]
         public void An_issue_is_reported_for_a_left_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
 using System;
@@ -103,6 +104,7 @@ public class TestMe
         [TestCase("int", "42")]
         [TestCase("int", "-42")]
         [TestCase("char", "'X'")]
+        [TestCase("string", @"""some text""")]
         [TestCase("StringComparison", "StringComparison.Ordinal")]
         public void An_issue_is_reported_for_a_right_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
 using System;
@@ -134,6 +136,11 @@ public class TestMe
         [TestCase("class TestMe { bool Do(char a) => a == 'X'; }", "class TestMe { bool Do(char a) => a is 'X'; }")]
         [TestCase("class TestMe { bool Do(char a) => 'X' == a; }", "class TestMe { bool Do(char a) => a is 'X'; }")]
 
+        [TestCase(@"class TestMe { bool Do(string a) { return (a == ""some text""); } }", @"class TestMe { bool Do(string a) { return (a is ""some text""); } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return (""some text"" == a); } }", @"class TestMe { bool Do(string a) { return (a is ""some text""); } }")]
+        [TestCase(@"class TestMe { bool Do(string a) => a == ""some text""; }", @"class TestMe { bool Do(string a) => a is ""some text""; }")]
+        [TestCase(@"class TestMe { bool Do(string a) => ""some text"" == a; }", @"class TestMe { bool Do(string a) => a is ""some text""; }")]
+
         [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (a == StringComparison.Ordinal); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is StringComparison.Ordinal); } }")]
         [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (StringComparison.Ordinal == a); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is StringComparison.Ordinal); } }")]
         [TestCase("using System; class TestMe { bool Do(StringComparison a) => a == StringComparison.Ordinal; }", "using System; class TestMe { bool Do(StringComparison a) => a is StringComparison.Ordinal; }")]
@@ -162,6 +169,40 @@ public class TestMe
     public bool DoSomething(StringComparison comparison, object o1, object o2) => o1 != null
                                                                                && comparison is StringComparison.Ordinal
                                                                                && o2 != null;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_const_string()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => s == Constants.SomeValue;
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => s is Constants.SomeValue;
 }
 ";
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzerTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzerTests : CodeFixVerifier
+    {
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+        [Test, Combinatorial]
+        public void No_issue_is_reported_for_comparisons_of_2_variables_of_type_(
+                                                                             [Values("bool", "char", "int", "string", "object")] string type,
+                                                                             [Values("==", "!=")] string @operator)
+            => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(" + type + " a, " + type + @" b)
+    {
+        if (a " + @operator + @" b)
+            return true;
+        else
+            return false;
+    }
+}
+", languageVersion: LanguageVersion.CSharp9);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+        [TestCase("int", "42")]
+        [TestCase("char", "'X'")]
+        public void An_issue_is_reported_for_a_left_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(" + type + @" a)
+    {
+        if (" + value + @" != a)
+            return true;
+        else
+            return false;
+    }
+}
+", languageVersion: LanguageVersion.CSharp9);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+        [TestCase("int", "42")]
+        [TestCase("char", "'X'")]
+        public void An_issue_is_reported_for_a_right_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(" + type + @" a)
+    {
+        if (a != " + value + @")
+            return true;
+        else
+            return false;
+    }
+}
+", languageVersion: LanguageVersion.CSharp9);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+
+        [TestCase("class TestMe { bool Do(int a) { return (a != 42); } }", "class TestMe { bool Do(int a) { return (a is not 42); } }")]
+        [TestCase("class TestMe { bool Do(int a) { return (42 != a); } }", "class TestMe { bool Do(int a) { return (a is not 42); } }")]
+        [TestCase("class TestMe { bool Do(int a) => a != 42; }", "class TestMe { bool Do(int a) => a is not 42; }")]
+        [TestCase("class TestMe { bool Do(int a) => 42 != a; }", "class TestMe { bool Do(int a) => a is not 42; }")]
+
+        [TestCase("class TestMe { bool Do(char a) { return (a != 'X'); } }", "class TestMe { bool Do(char a) { return (a is not 'X'); } }")]
+        [TestCase("class TestMe { bool Do(char a) { return ('X' != a); } }", "class TestMe { bool Do(char a) { return (a is not 'X'); } }")]
+        [TestCase("class TestMe { bool Do(char a) => a != 'X'; }", "class TestMe { bool Do(char a) => a is not 'X'; }")]
+        [TestCase("class TestMe { bool Do(char a) => 'X' != a; }", "class TestMe { bool Do(char a) => a is not 'X'; }")]
+        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode, languageVersion: LanguageVersion.CSharp9);
+
+        protected override string GetDiagnosticId() => MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3228_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
         [Test, Combinatorial]
         public void No_issue_is_reported_for_comparisons_of_2_variables_of_type_(
-                                                                             [Values("bool", "char", "int", "string", "object")] string type,
+                                                                             [Values("bool", "char", "int", "string", "object", "StringComparison")] string type,
                                                                              [Values("==", "!=")] string @operator)
             => No_issue_is_reported_for(@"
 using System;
@@ -37,8 +37,65 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+        [Test]
+        public void No_issue_is_reported_for_on_lambda_with_enum_property_access() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Dto
+{
+    public StringComparison Comparison;
+}
+
+public class TestMe
+{
+    public bool DoSomething(IEnumerable<Dto> dto, StringComparison comparison)
+    {
+        if (dto.Any(_ => _.Comparison != comparison))
+            return true;
+        else
+            return false;
+    }
+}
+", languageVersion: LanguageVersion.CSharp9);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
+        [Test]
+        public void No_issue_is_reported_for_on_lambda_with_nested_enum_property_access() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Dto
+{
+    public SubDto Nested;
+}
+
+public class SubDto
+{
+    public StringComparison Comparison;
+}
+
+public class TestMe
+{
+    public bool DoSomething(IEnumerable<Dto> dto, StringComparison comparison)
+    {
+        if (dto.Any(_ => _.Nested.Comparison != comparison))
+            return true;
+        else
+            return false;
+    }
+}
+", languageVersion: LanguageVersion.CSharp9);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
         [TestCase("int", "42")]
+        [TestCase("int", "-42")]
         [TestCase("char", "'X'")]
+        [TestCase("StringComparison", "StringComparison.Ordinal")]
         public void An_issue_is_reported_for_a_left_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
 using System;
 
@@ -57,7 +114,9 @@ public class TestMe
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = Justifications.StyleCop.SA1116)]
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = Justifications.StyleCop.SA1117)]
         [TestCase("int", "42")]
+        [TestCase("int", "-42")]
         [TestCase("char", "'X'")]
+        [TestCase("StringComparison", "StringComparison.Ordinal")]
         public void An_issue_is_reported_for_a_right_sided_comparison_of_(string type, string value) => An_issue_is_reported_for(@"
 using System;
 
@@ -80,12 +139,49 @@ public class TestMe
         [TestCase("class TestMe { bool Do(int a) { return (42 != a); } }", "class TestMe { bool Do(int a) { return (a is not 42); } }")]
         [TestCase("class TestMe { bool Do(int a) => a != 42; }", "class TestMe { bool Do(int a) => a is not 42; }")]
         [TestCase("class TestMe { bool Do(int a) => 42 != a; }", "class TestMe { bool Do(int a) => a is not 42; }")]
+        [TestCase("class TestMe { bool Do(int a) { return (a != -42); } }", "class TestMe { bool Do(int a) { return (a is not -42); } }")]
+        [TestCase("class TestMe { bool Do(int a) { return (-42 != a); } }", "class TestMe { bool Do(int a) { return (a is not -42); } }")]
+        [TestCase("class TestMe { bool Do(int a) => a != -42; }", "class TestMe { bool Do(int a) => a is not -42; }")]
+        [TestCase("class TestMe { bool Do(int a) => -42 != a; }", "class TestMe { bool Do(int a) => a is not -42; }")]
 
         [TestCase("class TestMe { bool Do(char a) { return (a != 'X'); } }", "class TestMe { bool Do(char a) { return (a is not 'X'); } }")]
         [TestCase("class TestMe { bool Do(char a) { return ('X' != a); } }", "class TestMe { bool Do(char a) { return (a is not 'X'); } }")]
         [TestCase("class TestMe { bool Do(char a) => a != 'X'; }", "class TestMe { bool Do(char a) => a is not 'X'; }")]
         [TestCase("class TestMe { bool Do(char a) => 'X' != a; }", "class TestMe { bool Do(char a) => a is not 'X'; }")]
+
+        [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (a != StringComparison.Ordinal); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is not StringComparison.Ordinal); } }")]
+        [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (StringComparison.Ordinal != a); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is not StringComparison.Ordinal); } }")]
+        [TestCase("using System; class TestMe { bool Do(StringComparison a) => a != StringComparison.Ordinal; }", "using System; class TestMe { bool Do(StringComparison a) => a is not StringComparison.Ordinal; }")]
+        [TestCase("using System; class TestMe { bool Do(StringComparison a) => StringComparison.Ordinal != a; }", "using System; class TestMe { bool Do(StringComparison a) => a is not StringComparison.Ordinal; }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode, languageVersion: LanguageVersion.CSharp9);
+
+        [Test]
+        public void Code_gets_fixed_for_multiline_condition()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison, object o1, object o2) => o1 == null
+                                                                               && comparison != StringComparison.Ordinal
+                                                                               && o2 == null;
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison, object o1, object o2) => o1 == null
+                                                                               && comparison is not StringComparison.Ordinal
+                                                                               && o2 == null;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode, languageVersion: LanguageVersion.CSharp9);
+        }
 
         protected override string GetDiagnosticId() => MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.Id;
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 494 rules that are currently provided by the analyzer.
+The following tables lists all the 496 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -434,6 +434,8 @@ The following tables lists all the 494 rules that are currently provided by the 
 |MiKo_3224|Value comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3225|Redundant comparisons can be simplified|&#x2713;|&#x2713;|
 |MiKo_3226|Read-only fields with initializers should be const|&#x2713;|&#x2713;|
+|MiKo_3227|Prefer pattern matching for equality checks|&#x2713;|&#x2713;|
+|MiKo_3228|Prefer pattern matching for inequality checks|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
* Add literal equality/inequality pattern matching analyzers
  - MiKo_3227 for `==` to `is`
  - MiKo_3228 for `!=` to `is not`

* Extend syntax extensions: `IsConst`, `IsEnum` and `WithoutTrailingSpaces`

* Refactor expression-tree detection to `IsExpressionTree`

* Update resources, project config and README

(resolves #1328)