### PR TITLE
Applied rules MiKo_3227 and MiKo_3228 to own code (dogfooding)

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/CommentExtensions.cs
@@ -152,7 +152,7 @@ namespace MiKoSolutions.Analyzers
                 return Array.Empty<string>();
             }
 
-            if (cleanedComments.Count == 1)
+            if (cleanedComments.Count is 1)
             {
                 return new[] { TrimComment(cleanedComments[0]) };
             }

--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -16,8 +16,8 @@ namespace System.Linq
         {
             switch (values)
             {
-                case IReadOnlyCollection<T> rc when rc.Count == 0:
-                case ICollection<T> c when c.Count == 0:
+                case IReadOnlyCollection<T> rc when rc.Count is 0:
+                case ICollection<T> c when c.Count is 0:
                     return;
             }
 
@@ -593,11 +593,11 @@ namespace System.Linq
             return default;
         }
 
-        internal static int IndexOf<T>(this T[] source, T value) => source.Length == 0 ? -1 : Array.IndexOf(source, value);
+        internal static int IndexOf<T>(this T[] source, T value) => source.Length is 0 ? -1 : Array.IndexOf(source, value);
 
-        internal static int IndexOf<T>(this T[] source, Func<T, bool> predicate) => source.Length == 0 ? -1 : source.IndexOf(new Predicate<T>(predicate));
+        internal static int IndexOf<T>(this T[] source, Func<T, bool> predicate) => source.Length is 0 ? -1 : source.IndexOf(new Predicate<T>(predicate));
 
-        internal static int IndexOf<T>(this T[] source, Predicate<T> predicate) => source.Length == 0 ? -1 : Array.FindIndex(source, predicate);
+        internal static int IndexOf<T>(this T[] source, Predicate<T> predicate) => source.Length is 0 ? -1 : Array.FindIndex(source, predicate);
 
         internal static int IndexOf<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
@@ -623,36 +623,36 @@ namespace System.Linq
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsEmptyArray<T>(this IEnumerable<T> source) => source is T[] array && array.Length == 0;
+        internal static bool IsEmptyArray<T>(this IEnumerable<T> source) => source is T[] array && array.Length is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None(this in SyntaxTriviaList source) => source.Count == 0;
+        internal static bool None(this in SyntaxTriviaList source) => source.Count is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this in SyntaxList<T> source) where T : SyntaxNode => source.Count == 0;
+        internal static bool None<T>(this in SyntaxList<T> source) where T : SyntaxNode => source.Count is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this in SeparatedSyntaxList<T> source) where T : SyntaxNode => source.Count == 0;
+        internal static bool None<T>(this in SeparatedSyntaxList<T> source) where T : SyntaxNode => source.Count is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None(this in SyntaxTokenList source) => source.Count == 0;
+        internal static bool None(this in SyntaxTokenList source) => source.Count is 0;
 
         internal static bool None<T>(this IEnumerable<T> source) => source.Any() is false;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this IReadOnlyCollection<T> source) => source.Count == 0;
+        internal static bool None<T>(this IReadOnlyCollection<T> source) => source.Count is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this in ImmutableArray<T> source) => source.Length == 0;
+        internal static bool None<T>(this in ImmutableArray<T> source) => source.Length is 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this in SyntaxList<T> source, in SyntaxKind kind) where T : SyntaxNode => source.IndexOf(kind) == -1;
+        internal static bool None<T>(this in SyntaxList<T> source, in SyntaxKind kind) where T : SyntaxNode => source.IndexOf(kind) is -1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool None(this in SyntaxTokenList source, in SyntaxKind kind) => source.Any(kind) is false;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool None<T>(this in SeparatedSyntaxList<T> source, in SyntaxKind kind) where T : SyntaxNode => source.IndexOf(kind) == -1;
+        internal static bool None<T>(this in SeparatedSyntaxList<T> source, in SyntaxKind kind) where T : SyntaxNode => source.IndexOf(kind) is -1;
 
         internal static bool None<T>(this in SyntaxList<T> source, Func<T, bool> predicate) where T : SyntaxNode => source.All(_ => predicate(_) is false);
 

--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers
 
             var lastIndexOfFirstSpace = text.LastIndexOfAny(Constants.WhiteSpaceCharacters);
 
-            if (lastIndexOfFirstSpace == -1)
+            if (lastIndexOfFirstSpace is -1)
             {
                 return null;
             }
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers
                                         ? 0
                                         : followUpText.IndexOfAny(Constants.WhiteSpaceCharacters);
 
-            if (firstIndexOfNextSpace == -1)
+            if (firstIndexOfNextSpace is -1)
             {
                 return null;
             }

--- a/MiKo.Analyzer.Shared/Extensions/SplitReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SplitReadOnlySpanEnumerator.cs
@@ -116,7 +116,7 @@ namespace System
         {
             var spanBeforeMoveNext = m_spanAfterMoveNext;
 
-            if (spanBeforeMoveNext.Length == 0)
+            if (spanBeforeMoveNext.Length is 0)
             {
                 // we reached the end of the string
                 return false;
@@ -124,7 +124,7 @@ namespace System
 
             var index = spanBeforeMoveNext.IndexOfAny(m_separatorChars);
 
-            if (index == -1)
+            if (index is -1)
             {
                 // The remaining string is an empty string
                 m_spanAfterMoveNext = ReadOnlySpan<char>.Empty;

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace System.Text
 
         public static StringBuilder AdjustFirstWord(this StringBuilder value, in FirstWordHandling handling)
         {
-            if (value.IsNullOrEmpty() || value[0] == '<')
+            if (value.IsNullOrEmpty() || value[0] is '<')
             {
                 return value;
             }
@@ -125,7 +125,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNullOrEmpty(this StringBuilder value) => value is null || value.Length == 0;
+        public static bool IsNullOrEmpty(this StringBuilder value) => value is null || value.Length is 0;
 
         public static bool IsNullOrWhiteSpace(this StringBuilder value) => value is null || value.CountLeadingWhitespaces() == value.Length;
 
@@ -221,7 +221,7 @@ namespace System.Text
                     if (multipleUpperCases)
                     {
                         // let's see if we start with an IXyz interface
-                        if (previousC == 'I')
+                        if (previousC is 'I')
                         {
                             // seems we are in an IXyz interface
                             multipleUpperCases = false;
@@ -241,7 +241,7 @@ namespace System.Text
                     }
 
                     // let's consider an upper-case 'A' as a special situation as that is a single word
-                    var isSpecialCharA = c == 'A';
+                    var isSpecialCharA = c is 'A';
 
                     multipleUpperCases = isSpecialCharA is false;
 
@@ -293,7 +293,7 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return value;
             }
@@ -318,7 +318,7 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return string.Empty;
             }
@@ -333,7 +333,7 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return value;
             }
@@ -347,7 +347,7 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return string.Empty;
             }
@@ -376,7 +376,7 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return string.Empty;
             }
@@ -405,7 +405,7 @@ namespace System.Text
 
         public static StringBuilder TrimEndBy(this StringBuilder value, in int count)
         {
-            if (count == 0)
+            if (count is 0)
             {
                 return value;
             }
@@ -429,14 +429,14 @@ namespace System.Text
         {
             var length = value.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return value;
             }
 
             var end = value.CountTrailingWhitespaces();
 
-            if (end == 0)
+            if (end is 0)
             {
                 return value;
             }
@@ -699,7 +699,7 @@ namespace System.Text
 
         private static void TrimLeadingSpacesTo(this StringBuilder value, in int count)
         {
-            if (value[0] == ' ')
+            if (value[0] is ' ')
             {
                 var whitespaces = value.CountLeadingWhitespaces();
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -102,7 +102,7 @@ namespace System
                 return Array.Empty<int>();
             }
 
-            if (comparison == StringComparison.Ordinal)
+            if (comparison is StringComparison.Ordinal)
             {
                 // Perf: about 1/3 the times the strings are compared ordinal, so splitting this up increases the overall performance significantly
                 return AllIndicesOrdinal(value.AsSpan(), finding.AsSpan());
@@ -123,7 +123,7 @@ namespace System
                 return Array.Empty<int>();
             }
 
-            if (comparison == StringComparison.Ordinal)
+            if (comparison is StringComparison.Ordinal)
             {
                 // performance optimization for 'StringComparison.Ordinal' to avoid multiple strings from being created (see 'IndexOf' method inside 'MemoryExtensions')
                 return AllIndicesOrdinal(value, finding.AsSpan());
@@ -141,7 +141,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static SyntaxToken AsToken(this string source, in SyntaxKind kind = SyntaxKind.StringLiteralToken)
         {
-            if (kind == SyntaxKind.IdentifierToken)
+            if (kind is SyntaxKind.IdentifierToken)
             {
                 return SyntaxFactory.Identifier(source);
             }
@@ -205,14 +205,14 @@ namespace System
         {
             var spanLength = span.Length;
 
-            if (spanLength == 0)
+            if (spanLength is 0)
             {
                 return value;
             }
 
             var valueLength = value?.Length ?? 0;
 
-            if (valueLength == 0)
+            if (valueLength is 0)
             {
                 return span.ToString();
             }
@@ -277,14 +277,14 @@ namespace System
         {
             var spanLength = value.Length;
 
-            if (spanLength == 0)
+            if (spanLength is 0)
             {
                 return arg0;
             }
 
             var arg0Length = arg0?.Length ?? 0;
 
-            if (arg0Length == 0)
+            if (arg0Length is 0)
             {
                 return value.ToString();
             }
@@ -376,7 +376,7 @@ namespace System
         {
             var valueLength = value.Length;
 
-            if (valueLength == 0)
+            if (valueLength is 0)
             {
                 return string.Concat(arg0, arg1);
             }
@@ -402,7 +402,7 @@ namespace System
         {
             var valueLength = value.Length;
 
-            if (valueLength == 0)
+            if (valueLength is 0)
             {
                 return string.Concat(arg0, arg1);
             }
@@ -429,7 +429,7 @@ namespace System
         {
             var valueLength = value.Length;
 
-            if (valueLength == 0)
+            if (valueLength is 0)
             {
                 return arg0.ConcatenatedWith(arg1);
             }
@@ -461,7 +461,7 @@ namespace System
 
             var valueLength = value.Length;
 
-            if (value.Length == 0)
+            if (value.Length is 0)
             {
                 return arg0.ConcatenatedWith(arg1);
             }
@@ -493,7 +493,7 @@ namespace System
 
             var valueLength = value.Length;
 
-            if (value.Length == 0)
+            if (value.Length is 0)
             {
                 return arg0.ConcatenatedWith(arg1);
             }
@@ -525,7 +525,7 @@ namespace System
 
             var valueLength = value.Length;
 
-            if (value.Length == 0)
+            if (value.Length is 0)
             {
                 return arg0.ConcatenatedWith(arg1);
             }
@@ -608,7 +608,7 @@ namespace System
 
             if (difference < 0)
             {
-                if (comparison == StringComparison.Ordinal)
+                if (comparison is StringComparison.Ordinal)
                 {
                     return value.AsSpan().IndexOf(finding.AsSpan()) >= 0;
                 }
@@ -616,7 +616,7 @@ namespace System
                 return value.IndexOf(finding, comparison) >= 0;
             }
 
-            if (difference == 0)
+            if (difference is 0)
             {
                 return QuickEquals(comparison);
 
@@ -717,7 +717,7 @@ namespace System
             {
                 var valueSpan = value.AsSpan();
                 var phrasesLength = phrases.Length;
-                var ordinalComparison = comparison == StringComparison.Ordinal;
+                var ordinalComparison = comparison is StringComparison.Ordinal;
 
                 for (var index = 0; index < phrasesLength; index++)
                 {
@@ -1279,7 +1279,7 @@ namespace System
             if (value.Length > 0)
             {
                 // performance optimization to avoid unnecessary 'ToString' calls on 'ReadOnlySpan' (see implementation inside MemoryExtensions)
-                if (comparison == StringComparison.Ordinal)
+                if (comparison is StringComparison.Ordinal)
                 {
                     var phrasesLength = phrases.Length;
 
@@ -1309,7 +1309,7 @@ namespace System
         {
             if (value.HasCharacters())
             {
-                if (comparison == StringComparison.Ordinal)
+                if (comparison is StringComparison.Ordinal)
                 {
                     return IndexOfAny(value.AsSpan(), phrases, comparison);
                 }
@@ -1890,7 +1890,7 @@ namespace System
 
         public static ReadOnlySpan<char> WithoutNumberSuffix(this in ReadOnlySpan<char> value)
         {
-            if (value.Length == 0)
+            if (value.Length is 0)
             {
                 return ReadOnlySpan<char>.Empty;
             }
@@ -2285,7 +2285,7 @@ namespace System
             {
                 var newIndex = span.Slice(index).IndexOf(other); // performs ordinal comparison
 
-                if (newIndex == -1)
+                if (newIndex is -1)
                 {
                     // nothing more to find
                     break;
@@ -2318,7 +2318,7 @@ namespace System
             {
                 index = value.IndexOf(finding, index, comparison);
 
-                if (index == -1)
+                if (index is -1)
                 {
                     // nothing more to find
                     break;

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers
         internal static IEnumerable<IMethodSymbol> GetMethods(this ITypeSymbol value, MethodKind kind)
         {
             // note that methods with MethodKind.Constructor cannot be referenced by name
-            var methods = kind == MethodKind.Ordinary
+            var methods = kind is MethodKind.Ordinary
                           ? value.GetNamedMethods()
                           : value.GetMethods();
 
@@ -171,7 +171,7 @@ namespace MiKoSolutions.Analyzers
             return functions ?? (IReadOnlyList<LocalFunctionStatementSyntax>)Array.Empty<LocalFunctionStatementSyntax>();
         }
 
-        internal static bool ContainsExtensionMethods(this INamedTypeSymbol value) => value.TypeKind == TypeKind.Class && value.IsStatic && value.MightContainExtensionMethods && value.GetExtensionMethods().Any();
+        internal static bool ContainsExtensionMethods(this INamedTypeSymbol value) => value.TypeKind is TypeKind.Class && value.IsStatic && value.MightContainExtensionMethods && value.GetExtensionMethods().Any();
 
         internal static INamedTypeSymbol FindContainingType(this in SyntaxNodeAnalysisContext value) => FindContainingType(value.ContainingSymbol);
 
@@ -322,7 +322,7 @@ namespace MiKoSolutions.Analyzers
             var members = value.GetMembers();
             var length = members.Length;
 
-            if (length == 0)
+            if (length is 0)
             {
                 return Array.Empty<TSymbol>();
             }
@@ -664,7 +664,7 @@ namespace MiKoSolutions.Analyzers
         {
             var attributes = value.GetAttributes();
 
-            if (attributes.Length == 0)
+            if (attributes.Length is 0)
             {
                 return false;
             }
@@ -676,7 +676,7 @@ namespace MiKoSolutions.Analyzers
         {
             var attributes = value.GetAttributes();
 
-            if (attributes.Length == 0)
+            if (attributes.Length is 0)
             {
                 return false;
             }
@@ -688,7 +688,7 @@ namespace MiKoSolutions.Analyzers
         {
             var attributes = value.GetAttributes();
 
-            if (attributes.Length == 0)
+            if (attributes.Length is 0)
             {
                 return false;
             }
@@ -700,7 +700,7 @@ namespace MiKoSolutions.Analyzers
         {
             var parameters = value.Parameters;
 
-            if (parameters.Length == 0)
+            if (parameters.Length is 0)
             {
                 return false;
             }
@@ -1089,12 +1089,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsAspNetCoreController(this IMethodSymbol value)
         {
-            if (value.DeclaredAccessibility == Accessibility.Public)
+            if (value.DeclaredAccessibility is Accessibility.Public)
             {
                 var returnType = value.ReturnType;
 
-                return returnType.TypeKind == TypeKind.Interface
-                    && returnType.FullyQualifiedName() == "Microsoft.AspNetCore.Mvc.IActionResult"
+                return returnType.TypeKind is TypeKind.Interface
+                    && returnType.FullyQualifiedName() is "Microsoft.AspNetCore.Mvc.IActionResult"
                     && value.ContainingType.InheritsFrom("ControllerBase", "Microsoft.AspNetCore.Mvc.ControllerBase");
             }
 
@@ -1107,7 +1107,7 @@ namespace MiKoSolutions.Analyzers
             {
                 case "Configure":
                 case "ConfigureServices":
-                    return value.ReturnsVoid && value.ContainingType?.Name == "Startup";
+                    return value.ReturnsVoid && value.ContainingType?.Name is "Startup";
 
                 default:
                     return false;
@@ -1125,22 +1125,22 @@ namespace MiKoSolutions.Analyzers
                 return false;
             }
 
-            if (value.SpecialType == SpecialType.System_Boolean)
+            if (value.SpecialType is SpecialType.System_Boolean)
             {
                 return true;
             }
 
-            return value.IsNullable() && value is INamedTypeSymbol type && type.TypeArguments[0].SpecialType == SpecialType.System_Boolean;
+            return value.IsNullable() && value is INamedTypeSymbol type && type.TypeArguments[0].SpecialType is SpecialType.System_Boolean;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsByte(this ITypeSymbol value) => value.SpecialType == SpecialType.System_Byte;
+        internal static bool IsByte(this ITypeSymbol value) => value.SpecialType is SpecialType.System_Byte;
 
         internal static bool IsByteArray(this ITypeSymbol value) => value is IArrayTypeSymbol array && array.ElementType.IsByte();
 
         internal static bool IsIGrouping(this ITypeSymbol value)
         {
-            if (value.TypeKind == TypeKind.Interface)
+            if (value.TypeKind is TypeKind.Interface)
             {
                 switch (value.Name)
                 {
@@ -1154,7 +1154,7 @@ namespace MiKoSolutions.Analyzers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsCancellationToken(this ITypeSymbol value) => value.TypeKind == TypeKind.Struct && value.ToString() == TypeNames.CancellationToken;
+        internal static bool IsCancellationToken(this ITypeSymbol value) => value.TypeKind is TypeKind.Struct && value.ToString() == TypeNames.CancellationToken;
 
         internal static bool IsCoerceValueCallback(this IMethodSymbol value)
         {
@@ -1162,7 +1162,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var parameters = value.Parameters;
 
-                return parameters.Length == 2 && parameters[0].Type.IsDependencyObject() && parameters[1].Type.IsObject();
+                return parameters.Length is 2 && parameters[0].Type.IsDependencyObject() && parameters[1].Type.IsObject();
             }
 
             return false;
@@ -1174,7 +1174,7 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsConstructor(this ISymbol value) => value is IMethodSymbol m && m.IsConstructor();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsConstructor(this IMethodSymbol value) => value.MethodKind == MethodKind.Constructor;
+        internal static bool IsConstructor(this IMethodSymbol value) => value.MethodKind is MethodKind.Constructor;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsPrimaryConstructor(this ISymbol value) => value is IMethodSymbol m && m.IsPrimaryConstructor();
@@ -1199,11 +1199,11 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsDependencyObject(this ITypeSymbol value) => value.InheritsFrom("DependencyObject", "System.Windows.DependencyObject");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsDependencyProperty(this ITypeSymbol value) => value.Name == Constants.DependencyProperty.TypeName || value.Name == Constants.DependencyProperty.FullyQualifiedTypeName;
+        internal static bool IsDependencyProperty(this ITypeSymbol value) => value.Name is Constants.DependencyProperty.TypeName || value.Name is Constants.DependencyProperty.FullyQualifiedTypeName;
 
         internal static bool IsDependencyPropertyChangedEventArgs(this ITypeSymbol value)
         {
-            if (value.TypeKind == TypeKind.Struct && value.SpecialType == SpecialType.None)
+            if (value.TypeKind is TypeKind.Struct && value.SpecialType is SpecialType.None)
             {
                 switch (value.Name)
                 {
@@ -1220,29 +1220,29 @@ namespace MiKoSolutions.Analyzers
         {
             var parameters = value.Parameters;
 
-            return parameters.Length == 2 && parameters[0].Type.IsDependencyObject() && parameters[1].Type.IsDependencyPropertyChangedEventArgs();
+            return parameters.Length is 2 && parameters[0].Type.IsDependencyObject() && parameters[1].Type.IsDependencyPropertyChangedEventArgs();
         }
 
         internal static bool IsDependencyPropertyEventHandler(this IMethodSymbol value)
         {
             var parameters = value.Parameters;
 
-            return parameters.Length == 2 && parameters[0].Type.IsObject() && parameters[1].Type.IsDependencyPropertyChangedEventArgs();
+            return parameters.Length is 2 && parameters[0].Type.IsObject() && parameters[1].Type.IsDependencyPropertyChangedEventArgs();
         }
 
-        internal static bool IsDependencyPropertyKey(this ITypeSymbol value) => value.Name == Constants.DependencyPropertyKey.TypeName || value.Name == Constants.DependencyPropertyKey.FullyQualifiedTypeName;
+        internal static bool IsDependencyPropertyKey(this ITypeSymbol value) => value.Name is Constants.DependencyPropertyKey.TypeName || value.Name is Constants.DependencyPropertyKey.FullyQualifiedTypeName;
 
         internal static bool IsDisposable(this ITypeSymbol value)
         {
             var interfaces = value.AllInterfaces;
 
-            return interfaces.Length > 0 && interfaces.Any(_ => _.SpecialType == SpecialType.System_IDisposable);
+            return interfaces.Length > 0 && interfaces.Any(_ => _.SpecialType is SpecialType.System_IDisposable);
         }
 
         internal static bool IsEnhancedByPostSharpAdvice(this ISymbol value) => value.HasAttributeApplied("PostSharp.Aspects.Advices.Advice");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsEnum(this ITypeSymbol value) => value?.TypeKind == TypeKind.Enum;
+        internal static bool IsEnum(this ITypeSymbol value) => value?.TypeKind is TypeKind.Enum;
 
         internal static bool IsEnumerable(this ITypeSymbol value)
         {
@@ -1277,7 +1277,7 @@ namespace MiKoSolutions.Analyzers
                         return true;
                     }
 
-                    if (value.TypeKind == TypeKind.Array)
+                    if (value.TypeKind is TypeKind.Array)
                     {
                         return true;
                     }
@@ -1316,13 +1316,13 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
-        internal static bool IsPrismEvent(this ITypeSymbol value) => value.TypeKind == TypeKind.Class
-                                                                  && value.SpecialType == SpecialType.None
+        internal static bool IsPrismEvent(this ITypeSymbol value) => value.TypeKind is TypeKind.Class
+                                                                  && value.SpecialType is SpecialType.None
                                                                   && value.ToString() != "Microsoft.Practices.Prism.Events.EventBase"
                                                                   && value.InheritsFrom("Microsoft.Practices.Prism.Events.EventBase");
 
-        internal static bool IsEventArgs(this ITypeSymbol value) => value.TypeKind == TypeKind.Class
-                                                                 && value.SpecialType == SpecialType.None
+        internal static bool IsEventArgs(this ITypeSymbol value) => value.TypeKind is TypeKind.Class
+                                                                 && value.SpecialType is SpecialType.None
                                                                  && value.InheritsFrom<EventArgs>();
 
         internal static bool IsEventHandler(this IMethodSymbol value)
@@ -1345,7 +1345,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var parameters = value.Parameters;
 
-                    return parameters.Length == 2 && parameters[0].Type.IsObject() && parameters[1].Type.IsEventArgs();
+                    return parameters.Length is 2 && parameters[0].Type.IsObject() && parameters[1].Type.IsEventArgs();
                 }
             }
         }
@@ -1370,8 +1370,8 @@ namespace MiKoSolutions.Analyzers
         }
 
         internal static bool IsException(this ITypeSymbol value) => value != null
-                                                                 && value.TypeKind == TypeKind.Class
-                                                                 && value.SpecialType == SpecialType.None
+                                                                 && value.TypeKind is TypeKind.Class
+                                                                 && value.SpecialType is SpecialType.None
                                                                  && value.OriginalDefinition.InheritsFrom<Exception>();
 
         internal static bool IsException(this ArgumentSyntax value, SemanticModel semanticModel)
@@ -1405,7 +1405,7 @@ namespace MiKoSolutions.Analyzers
             }
         }
 
-        internal static bool IsGenerated(this ITypeSymbol value) => value?.TypeKind == TypeKind.Class && value.HasAttribute(Constants.Names.GeneratedAttributeNames);
+        internal static bool IsGenerated(this ITypeSymbol value) => value?.TypeKind is TypeKind.Class && value.HasAttribute(Constants.Names.GeneratedAttributeNames);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsGeneric(this ITypeSymbol value) => value is INamedTypeSymbol type && type.TypeArguments.Length > 0;
@@ -1599,10 +1599,10 @@ namespace MiKoSolutions.Analyzers
 
         // ignore special situation for task factory
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsNullable(this ITypeSymbol value) => value.IsValueType && value.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+        internal static bool IsNullable(this ITypeSymbol value) => value.IsValueType && value.OriginalDefinition.SpecialType is SpecialType.System_Nullable_T;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsObject(this ITypeSymbol value) => value.SpecialType == SpecialType.System_Object;
+        internal static bool IsObject(this ITypeSymbol value) => value.SpecialType is SpecialType.System_Object;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsPartial(this ITypeSymbol value) => value.Locations.Length > 1;
@@ -1625,7 +1625,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsRoutedEvent(this ITypeSymbol value)
         {
-            if (value.TypeKind == TypeKind.Class && value.IsSealed)
+            if (value.TypeKind is TypeKind.Class && value.IsSealed)
             {
                 switch (value.Name)
                 {
@@ -1638,7 +1638,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        internal static bool IsSerializationConstructor(this IMethodSymbol value) => value.IsConstructor() && value.Parameters.Length == 2 && value.Parameters[0].IsSerializationInfoParameter() && value.Parameters[1].IsStreamingContextParameter();
+        internal static bool IsSerializationConstructor(this IMethodSymbol value) => value.IsConstructor() && value.Parameters.Length is 2 && value.Parameters[0].IsSerializationInfoParameter() && value.Parameters[1].IsStreamingContextParameter();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsSerializationInfoParameter(this IParameterSymbol value) => value.Type.Name == nameof(SerializationInfo);
@@ -1663,12 +1663,12 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsStreamingContextParameter(this IParameterSymbol value) => value.Type.Name == nameof(StreamingContext);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsString(this ITypeSymbol value) => value?.SpecialType == SpecialType.System_String;
+        internal static bool IsString(this ITypeSymbol value) => value?.SpecialType is SpecialType.System_String;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsTask(this ITypeSymbol value) => value?.Name == nameof(Task);
 
-        internal static bool IsTestClass(this ITypeSymbol value) => value?.TypeKind == TypeKind.Class && value.IsRecord is false && value.HasAttribute(Constants.Names.TestClassAttributeNames);
+        internal static bool IsTestClass(this ITypeSymbol value) => value?.TypeKind is TypeKind.Class && value.IsRecord is false && value.HasAttribute(Constants.Names.TestClassAttributeNames);
 
         internal static bool IsTestMethod(this IMethodSymbol value) => value.IsTestSpecificMethod(Constants.Names.TestMethodAttributeNames);
 
@@ -1688,7 +1688,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var parameters = value.Parameters;
 
-                return parameters.Length == 1 && parameters[0].Type.IsObject();
+                return parameters.Length is 1 && parameters[0].Type.IsObject();
             }
 
             return false;
@@ -1811,7 +1811,7 @@ namespace MiKoSolutions.Analyzers
         {
             var typeName = value.Name.AsSpan();
 
-            if (value.TypeKind == TypeKind.Interface && typeName.Length > 1 && typeName[0] == 'I')
+            if (value.TypeKind is TypeKind.Interface && typeName.Length > 1 && typeName[0] is 'I')
             {
                 return typeName.Slice(1);
             }
@@ -1896,7 +1896,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        private static bool IsTestSpecificMethod(this IMethodSymbol value, ISet<string> attributeNames) => value?.MethodKind == MethodKind.Ordinary && value.IsPubliclyVisible() && value.HasAttribute(attributeNames);
+        private static bool IsTestSpecificMethod(this IMethodSymbol value, ISet<string> attributeNames) => value?.MethodKind is MethodKind.Ordinary && value.IsPubliclyVisible() && value.HasAttribute(attributeNames);
 
         private static List<T> GetNamedSymbols<T>(IReadOnlyList<T> symbols) where T : ISymbol
         {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
@@ -131,12 +131,12 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlEmptyElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlEmptyElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.Attributes);
                 }
 
-                case XmlElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.StartTag.Attributes);
                 }
@@ -154,12 +154,12 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlEmptyElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlEmptyElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.Attributes, type);
                 }
 
-                case XmlElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.StartTag.Attributes, type);
                 }
@@ -177,12 +177,12 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlEmptyElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlEmptyElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.Attributes, type);
                 }
 
-                case XmlElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.StartTag.Attributes, type);
                 }
@@ -213,12 +213,12 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlEmptyElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlEmptyElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.Attributes, type, member);
                 }
 
-                case XmlElementSyntax element when element.GetName() == Constants.XmlTag.See:
+                case XmlElementSyntax element when element.GetName() is Constants.XmlTag.See:
                 {
                     return IsCref(element.StartTag.Attributes, type, member);
                 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -306,8 +306,8 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlElementSyntax e: return e.GetAttributes<XmlTextAttributeSyntax>().FirstOrDefault(_ => _.GetName() == Constants.XmlTag.Attribute.Name);
-                case XmlEmptyElementSyntax ee: return ee.Attributes.OfType<XmlTextAttributeSyntax>().FirstOrDefault(_ => _.GetName() == Constants.XmlTag.Attribute.Name);
+                case XmlElementSyntax e: return e.GetAttributes<XmlTextAttributeSyntax>().FirstOrDefault(_ => _.GetName() is Constants.XmlTag.Attribute.Name);
+                case XmlEmptyElementSyntax ee: return ee.Attributes.OfType<XmlTextAttributeSyntax>().FirstOrDefault(_ => _.GetName() is Constants.XmlTag.Attribute.Name);
                 default: return null;
             }
         }
@@ -341,7 +341,7 @@ namespace MiKoSolutions.Analyzers
             return null;
         }
 
-        internal static XmlElementSyntax GetParameterComment(this DocumentationCommentTriviaSyntax value, string parameterName) => value.FirstDescendant<XmlElementSyntax>(_ => _.GetName() == Constants.XmlTag.Param && _.GetParameterName() == parameterName);
+        internal static XmlElementSyntax GetParameterComment(this DocumentationCommentTriviaSyntax value, string parameterName) => value.FirstDescendant<XmlElementSyntax>(_ => _.GetName() is Constants.XmlTag.Param && _.GetParameterName() == parameterName);
 
         internal static string GetIdentifierNameFromPropertyExpression(this PropertyDeclarationSyntax value)
         {
@@ -640,7 +640,7 @@ namespace MiKoSolutions.Analyzers
         }
 
         internal static XmlTextAttributeSyntax GetListType(this XmlElementSyntax list) => list.GetAttributes<XmlTextAttributeSyntax>()
-                                                                                              .FirstOrDefault(_ => _.GetName() == Constants.XmlTag.Attribute.Type);
+                                                                                              .FirstOrDefault(_ => _.GetName() is Constants.XmlTag.Attribute.Type);
 
         internal static string GetListType(this XmlTextAttributeSyntax listType) => listType.GetTextWithoutTrivia();
 
@@ -779,7 +779,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var text = identifier.GetName();
 
-                    if (text == "nameof" && value.Ancestors<MemberAccessExpressionSyntax>().None())
+                    if (text is "nameof" && value.Ancestors<MemberAccessExpressionSyntax>().None())
                     {
                         // nameof
                         var arguments = value.ArgumentList.Arguments;
@@ -975,7 +975,7 @@ namespace MiKoSolutions.Analyzers
                     {
                         var parameters = method.ParameterList.Parameters;
 
-                        if (parameters.Count == 0)
+                        if (parameters.Count is 0)
                         {
                             return Array.Empty<ParameterSyntax>();
                         }
@@ -987,7 +987,7 @@ namespace MiKoSolutions.Analyzers
                     {
                         var parameters = indexer.ParameterList.Parameters;
 
-                        if (parameters.Count == 0)
+                        if (parameters.Count is 0)
                         {
                             return Array.Empty<ParameterSyntax>();
                         }
@@ -1010,7 +1010,7 @@ namespace MiKoSolutions.Analyzers
                     {
                         var parameters = method.ParameterList.Parameters;
 
-                        if (parameters.Count == 0)
+                        if (parameters.Count is 0)
                         {
                             return Array.Empty<string>();
                         }
@@ -1022,7 +1022,7 @@ namespace MiKoSolutions.Analyzers
                     {
                         var parameters = indexer.ParameterList.Parameters;
 
-                        if (parameters.Count == 0)
+                        if (parameters.Count is 0)
                         {
                             return Array.Empty<string>();
                         }
@@ -1083,7 +1083,7 @@ namespace MiKoSolutions.Analyzers
 
             if (symbol is null)
             {
-                if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
+                if (symbolInfo.CandidateReason is CandidateReason.OverloadResolutionFailure)
                 {
                     // we did not find the symbol, so we take the first one, assuming that this is the right one
                     return symbolInfo.CandidateSymbols.FirstOrDefault();
@@ -1198,7 +1198,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static string GetTextTrimmedWithParaTags(this IReadOnlyList<SyntaxToken> values)
         {
-            if (values.Count == 0)
+            if (values.Count is 0)
             {
                 return string.Empty;
             }
@@ -1248,7 +1248,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return string.Empty;
             }
@@ -1403,7 +1403,7 @@ namespace MiKoSolutions.Analyzers
         {
             var summaryXmls = value.GetSummaryXmls();
 
-            if (summaryXmls.Count == 0)
+            if (summaryXmls.Count is 0)
             {
                 return Array.Empty<XmlNodeSyntax>();
             }
@@ -1664,7 +1664,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var valueKind = value.Kind();
 
-                if (kindsLength == 2)
+                if (kindsLength is 2)
                 {
                     return valueKind == kinds[0] || valueKind == kinds[1];
                 }
@@ -1753,7 +1753,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var relatedDirectives = regionTrivia.GetRelatedDirectives();
 
-                if (relatedDirectives.Count == 2)
+                if (relatedDirectives.Count is 2)
                 {
                     var endRegionTrivia = relatedDirectives[1];
 
@@ -1781,8 +1781,8 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsMoqItIsConditionMatcher(this InvocationExpressionSyntax value) => value.Expression is MemberAccessExpressionSyntax maes
                                                                                               && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression)
                                                                                               && maes.Expression is IdentifierNameSyntax invokedType
-                                                                                              && invokedType.GetName() == Constants.Moq.ConditionMatcher.It
-                                                                                              && maes.GetName() == Constants.Moq.ConditionMatcher.Is;
+                                                                                              && invokedType.GetName() is Constants.Moq.ConditionMatcher.It
+                                                                                              && maes.GetName() is Constants.Moq.ConditionMatcher.Is;
 
         internal static bool IsInsideMoqCall(this MemberAccessExpressionSyntax value)
         {
@@ -1807,7 +1807,7 @@ namespace MiKoSolutions.Analyzers
                     case Constants.Moq.Verify:
                     case Constants.Moq.VerifyGet:
                     case Constants.Moq.VerifySet:
-                    case Constants.Moq.Of when m.Expression is IdentifierNameSyntax ins && ins.GetName() == Constants.Moq.Mock:
+                    case Constants.Moq.Of when m.Expression is IdentifierNameSyntax ins && ins.GetName() is Constants.Moq.Mock:
                     {
                         // here we assume that we have a Moq call
                         return true;
@@ -1822,11 +1822,11 @@ namespace MiKoSolutions.Analyzers
         {
             result = null;
 
-            if (value.GetName() == Constants.Moq.Object)
+            if (value.GetName() is Constants.Moq.Object)
             {
                 var expression = value.Expression.WithoutParenthesis(); // let's see if we can fix it in case we remove the surrounding parenthesis
 
-                if (expression is ObjectCreationExpressionSyntax o && o.Type.GetNameOnlyPartWithoutGeneric() == Constants.Moq.Mock && o.Type is GenericNameSyntax genericName)
+                if (expression is ObjectCreationExpressionSyntax o && o.Type.GetNameOnlyPartWithoutGeneric() is Constants.Moq.Mock && o.Type is GenericNameSyntax genericName)
                 {
                     result = genericName.TypeArgumentList.Arguments.ToArray();
                 }
@@ -1855,7 +1855,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsCode(this SyntaxNode value) => value is XmlElementSyntax xes && xes.IsCode();
 
-        internal static bool IsCode(this XmlElementSyntax value) => value.GetName() == Constants.XmlTag.Code;
+        internal static bool IsCode(this XmlElementSyntax value) => value.GetName() is Constants.XmlTag.Code;
 
         internal static bool IsAssignmentOf(this StatementSyntax value, string identifierName) => value is ExpressionStatementSyntax e
                                                                                                && e.Expression is AssignmentExpressionSyntax a
@@ -1978,7 +1978,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsException<T>(this TypeSyntax value) where T : Exception => value.IsException(typeof(T));
 
-        internal static bool IsException(this XmlElementSyntax value) => value.GetName() == Constants.XmlTag.Exception;
+        internal static bool IsException(this XmlElementSyntax value) => value.GetName() is Constants.XmlTag.Exception;
 
         internal static bool IsException(this TypeSyntax value, Type exceptionType)
         {
@@ -2189,7 +2189,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSeeLangword(this SyntaxNode value)
         {
-            if (value is XmlEmptyElementSyntax syntax && syntax.GetName() == Constants.XmlTag.See)
+            if (value is XmlEmptyElementSyntax syntax && syntax.GetName() is Constants.XmlTag.See)
             {
                 var attribute = syntax.Attributes.FirstOrDefault();
 
@@ -2208,7 +2208,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSeeLangwordBool(this SyntaxNode value)
         {
-            if (value is XmlEmptyElementSyntax syntax && syntax.GetName() == Constants.XmlTag.See)
+            if (value is XmlEmptyElementSyntax syntax && syntax.GetName() is Constants.XmlTag.See)
             {
                 var attribute = syntax.Attributes.FirstOrDefault();
 
@@ -2451,7 +2451,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount == 0)
+            if (sourceCount is 0)
             {
                 return Array.Empty<TResult>();
             }
@@ -2476,7 +2476,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount == 0)
+            if (sourceCount is 0)
             {
                 return Array.Empty<T>();
             }
@@ -2530,7 +2530,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount == 0)
+            if (sourceCount is 0)
             {
                 return Array.Empty<TResult>();
             }
@@ -2614,7 +2614,7 @@ namespace MiKoSolutions.Analyzers
         {
             var resultLength = source.Count;
 
-            if (resultLength == 0)
+            if (resultLength is 0)
             {
                 return source;
             }
@@ -2641,7 +2641,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return value;
             }
@@ -2676,7 +2676,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            if (map.Count == 0)
+            if (map.Count is 0)
             {
                 return value;
             }
@@ -2691,7 +2691,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return value;
             }
@@ -2737,7 +2737,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            if (map.Count == 0)
+            if (map.Count is 0)
             {
                 return value;
             }
@@ -2752,7 +2752,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return value;
             }
@@ -2780,7 +2780,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            if (map.Count == 0)
+            if (map.Count is 0)
             {
                 return value;
             }
@@ -3076,7 +3076,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static T WithAdditionalLeadingSpaces<T>(this T value, in int additionalSpaces) where T : SyntaxNode
         {
-            if (additionalSpaces == 0)
+            if (additionalSpaces is 0)
             {
                 return value;
             }
@@ -3088,12 +3088,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static T WithAdditionalLeadingSpacesOnDescendants<T>(this T value, IReadOnlyCollection<SyntaxNodeOrToken> descendants, int additionalSpaces) where T : SyntaxNode
         {
-            if (additionalSpaces == 0)
+            if (additionalSpaces is 0)
             {
                 return value;
             }
 
-            if (descendants.Count == 0)
+            if (descendants.Count is 0)
             {
                 return value;
             }
@@ -3116,7 +3116,7 @@ namespace MiKoSolutions.Analyzers
 
             var leadingTrivia = value.GetLeadingTrivia();
 
-            if (leadingTrivia.Count == 0)
+            if (leadingTrivia.Count is 0)
             {
                 return value.WithLeadingTrivia(WhiteSpaces(count));
             }
@@ -3198,7 +3198,7 @@ namespace MiKoSolutions.Analyzers
 
             var syntaxToken = keyword.AsToken();
 
-            if (modifiers.Count == 0)
+            if (modifiers.Count is 0)
             {
                 var commentedChild = value.FirstChildToken();
 
@@ -3405,7 +3405,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var valuesCount = values.Count;
 
-            if (valuesCount == 0)
+            if (valuesCount is 0)
             {
                 return values;
             }
@@ -3421,7 +3421,7 @@ namespace MiKoSolutions.Analyzers
                     // keep in local variable to avoid multiple requests (see Roslyn implementation)
                     var originalTextTokensCount = originalTextTokens.Count;
 
-                    if (originalTextTokensCount == 0)
+                    if (originalTextTokensCount is 0)
                     {
                         continue;
                     }
@@ -3658,7 +3658,7 @@ namespace MiKoSolutions.Analyzers
 
             if (textsCount > 0)
             {
-                var text = textsCount == 1
+                var text = textsCount is 1
                            ? texts[0]
                            : texts[textsCount - 2];
 
@@ -3711,14 +3711,14 @@ namespace MiKoSolutions.Analyzers
 
         internal static XmlTextSyntax WithoutStartText(this XmlTextSyntax value, in ReadOnlySpan<string> startTexts)
         {
-            if (startTexts.Length == 0)
+            if (startTexts.Length is 0)
             {
                 return value;
             }
 
             var tokens = value.TextTokens;
 
-            if (tokens.Count == 0)
+            if (tokens.Count is 0)
             {
                 return value;
             }
@@ -3777,7 +3777,7 @@ namespace MiKoSolutions.Analyzers
         {
             var tokens = value.TextTokens;
 
-            if (tokens.Count == 0)
+            if (tokens.Count is 0)
             {
                 return XmlText(startText);
             }
@@ -3814,7 +3814,7 @@ namespace MiKoSolutions.Analyzers
                     continue;
                 }
 
-                var space = i == 0 ? string.Empty : " ";
+                var space = i is 0 ? string.Empty : " ";
 
                 // replace 3rd person word by infinite word if configured
                 var continuation = originalText.AdjustFirstWord(firstWordHandling);
@@ -3929,7 +3929,7 @@ namespace MiKoSolutions.Analyzers
 
             var usingsCount = usings.Count;
 
-            if (usingsCount == 0)
+            if (usingsCount is 0)
             {
                 return value.InsertNodeBefore(value.FirstChild(), directive);
             }
@@ -3940,7 +3940,7 @@ namespace MiKoSolutions.Analyzers
 
                 var usingName = usingDirective.Name?.ToFullString();
 
-                if (usingName == "System")
+                if (usingName is "System")
                 {
                     // skip 'System' namespace
                     continue;
@@ -4203,7 +4203,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var info = semanticModel.GetSymbolInfo(node);
 
-                if (info.CandidateReason == CandidateReason.None)
+                if (info.CandidateReason is CandidateReason.None)
                 {
                     return info.Symbol.IsLinqExtensionMethod();
                 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -94,7 +94,7 @@ namespace MiKoSolutions.Analyzers
             // Perf: quick check to avoid costly loop
             if (count >= 2)
             {
-                if (leadingTrivia[count == 4 ? 2 : 1].IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+                if (leadingTrivia[count is 4 ? 2 : 1].IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
                 {
                     return true;
                 }
@@ -119,7 +119,7 @@ namespace MiKoSolutions.Analyzers
             // Perf: quick check to avoid costly loop
             if (count >= 2)
             {
-                var trivia = leadingTrivia[count == 4 ? 2 : 1];
+                var trivia = leadingTrivia[count is 4 ? 2 : 1];
 
                 if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
                 {
@@ -221,7 +221,7 @@ namespace MiKoSolutions.Analyzers
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount == 0)
+            if (sourceCount is 0)
             {
                 return Array.Empty<SyntaxToken>();
             }

--- a/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
@@ -84,7 +84,7 @@ namespace System
 
         public ReadOnlySpanEnumeratorEntry First()
         {
-            if (m_text.Length == 0)
+            if (m_text.Length is 0)
             {
                 throw new InvalidOperationException("No item available");
             }
@@ -99,7 +99,7 @@ namespace System
 
         public ReadOnlySpanEnumeratorEntry Last()
         {
-            if (m_text.Length == 0)
+            if (m_text.Length is 0)
             {
                 throw new InvalidOperationException("No item available");
             }

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -454,7 +454,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 //// ncrunch: rdi default
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IndicatesNewWord(in char c) => c.IsUpperCase() || c == Constants.Underscore;
+        private static bool IndicatesNewWord(in char c) => c.IsUpperCase() || c is Constants.Underscore;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool CompleteTermHasIssue(in ReadOnlySpan<char> key, in ReadOnlySpan<char> value) => key.SequenceEqual(value);

--- a/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
@@ -8,7 +8,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         internal static string GetArticleFor(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling = FirstWordHandling.None)
         {
-            if (text.Length == 0)
+            if (text.Length is 0)
             {
                 return string.Empty;
             }
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
             {
                 if (text.StartsWith("uni", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (text.Length > 3 && text[3].ToUpperCase() == 'N')
+                    if (text.Length > 3 && text[3].ToUpperCase() is 'N')
                     {
                         // something like 'uninformed', so is a vowel sound
                         return An(firstWordHandling);

--- a/MiKo.Analyzer.Shared/Linguistics/AscendingStringComparer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AscendingStringComparer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             var result = string.Compare(x, 0, y, 0, Math.Min(x.Length, y.Length), StringComparison.OrdinalIgnoreCase);
 
-            if (result == 0)
+            if (result is 0)
             {
                 // same sub string, so investigate into length (if y is longer, prefer y but if x is longer, prefer x)
                 return y.Length - x.Length;

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -240,7 +240,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return false;
             }
 
-            if (length == 4 && value.Equals("will", StringComparison.OrdinalIgnoreCase))
+            if (length is 4 && value.Equals("will", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -274,7 +274,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             if (length >= 2)
             {
-                return value[length.Value - 1] == 's' && CharsForTwoCharacterEndingsWithS.Contains(value[length.Value - 2]);
+                return value[length.Value - 1] is 's' && CharsForTwoCharacterEndingsWithS.Contains(value[length.Value - 2]);
             }
 
             return false;
@@ -424,7 +424,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 {
                     var wordLength = word.Length;
 
-                    if (wordLength == 4)
+                    if (wordLength is 4)
                     {
                         // ignore short word such as "ping" or "thing"
                         return word;
@@ -718,7 +718,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 {
                     var remaining = value.Slice(phrase.Length);
 
-                    return remaining.Length == 0 || remaining[0].IsUpperCase();
+                    return remaining.Length is 0 || remaining[0].IsUpperCase();
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -112,7 +112,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static Location CreateLocation(in char value, SyntaxTree syntaxTree, in int spanStart, in int position, in int startOffset = 0, in int endOffset = 0)
         {
-            if (position == -1)
+            if (position is -1)
             {
                 return null;
             }
@@ -125,7 +125,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static Location CreateLocation(string value, SyntaxTree syntaxTree, in int spanStart, in int position, in int startOffset = 0, in int endOffset = 0)
         {
-            if (position == -1)
+            if (position is -1)
             {
                 return null;
             }
@@ -146,7 +146,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, IEnumerable<Diagnostic> issues)
         {
-            if (issues is IReadOnlyList<Diagnostic> emptyList && emptyList.Count == 0)
+            if (issues is IReadOnlyList<Diagnostic> emptyList && emptyList.Count is 0)
             {
                 return;
             }
@@ -504,7 +504,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         private Diagnostic CreateIssue(Location location, Pair[] properties, params object[] args)
         {
-            var immutableProperties = properties.Length == 0
+            var immutableProperties = properties.Length is 0
                                       ? ImmutableDictionary<string, string>.Empty
                                       : ImmutableDictionary.CreateRange(properties.Select(_ => new KeyValuePair<string, string>(_.Key, _.Value)));
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -185,7 +185,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var allIndices = text.AllIndicesOf(value, comparison);
 
-            if (allIndices.Length == 0)
+            if (allIndices.Length is 0)
             {
                 // nothing to inspect
                 return Array.Empty<Location>();
@@ -225,7 +225,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var allIndices = text.AllIndicesOf(value, comparison);
 
-            if (allIndices.Length == 0)
+            if (allIndices.Length is 0)
             {
                 // nothing to inspect
                 return Array.Empty<Location>();
@@ -297,7 +297,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var allIndices = text.AllIndicesOf(value, comparison);
 
-                if (allIndices.Length == 0)
+                if (allIndices.Length is 0)
                 {
                     // nothing to inspect
                     continue;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -450,7 +450,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
             else
             {
-                if (index == 1 && content[0].IsWhiteSpaceOnlyText())
+                if (index is 1 && content[0].IsWhiteSpaceOnlyText())
                 {
                     // seems that the non-text element is the first element, so we should remove the empty text element before
                     content = content.RemoveAt(0);
@@ -715,7 +715,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlTextSyntax XmlText(in SyntaxTokenList textTokens)
         {
-            if (textTokens.Count == 0)
+            if (textTokens.Count is 0)
             {
                 return SyntaxFactory.XmlText();
             }
@@ -783,7 +783,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var contentCount = content.Count;
 
-            if (contentCount == 0)
+            if (contentCount is 0)
             {
                 return -1;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExampleDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExampleDocumentationAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var examples = comment.GetExampleXmls();
 
-            return examples.Count == 0
+            return examples.Count is 0
                    ? Array.Empty<Diagnostic>()
                    : AnalyzeExample(symbol, examples);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationAnalyzer.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comments = GetExceptionComments(comment);
 
-            if (comments is XmlElementSyntax[] array && array.Length == 0)
+            if (comments is XmlElementSyntax[] array && array.Length is 0)
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var exceptionXmls = documentation.GetExceptionXmls();
 
-            if (exceptionXmls.Count == 0)
+            if (exceptionXmls.Count is 0)
             {
                 return Array.Empty<XmlElementSyntax>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var parameters = exceptionComment.GetParameterNames();
 
-            if (parameters.Length == 0)
+            if (parameters.Length is 0)
             {
                 return exceptionComment;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Event;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind is SymbolKind.Event;
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, StartingPhrase);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2004_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2004_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, in int index, Diagnostic issue)
         {
-            if (index == 0)
+            if (index is 0)
             {
                 // this is the sender
                 return Comment(comment, GetPhraseProposal(issue));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility == Accessibility.Public && type.IsTestClass() is false;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility is Accessibility.Public && type.IsTestClass() is false;
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
                                                                   DocumentationCommentTriviaSyntax comment,

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility == Accessibility.Public && type.IsTestClass() is false;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.IsReferenceType && type.DeclaredAccessibility is Accessibility.Public && type.IsTestClass() is false;
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
                                                                   DocumentationCommentTriviaSyntax comment,

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -167,7 +167,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlEmptyElementSyntax GetUpdatedSyntaxWithInheritdoc(in SyntaxList<XmlNodeSyntax> content)
         {
-            var inheritdoc = content.OfType<XmlEmptyElementSyntax>().FirstOrDefault(_ => _.GetName() == Constants.XmlTag.Inheritdoc);
+            var inheritdoc = content.OfType<XmlEmptyElementSyntax>().FirstOrDefault(_ => _.GetName() is Constants.XmlTag.Inheritdoc);
 
             if (inheritdoc != null)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var parameters = method.ParameterList.Parameters;
 
-            if (parameters.Count == 0)
+            if (parameters.Count is 0)
             {
                 return SyntaxFactory.DocumentationComment(summary.WithEndOfLine());
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_FireMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_FireMethodsAnalyzer.cs
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var map = new Pair[4];
 
-            if (firstWord == Constants.Comments.Asynchronously)
+            if (firstWord is Constants.Comments.Asynchronously)
             {
                 firstWord = startText.SecondWord();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var index = content.IndexOf(xmlTag);
 
-                    if (index == 0)
+                    if (index is 0)
                     {
                         // is it the first inside the comment
                         if (HasIssue(symbol, semanticModel, cref))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter)
         {
-            if (parameter.RefKind == RefKind.Out)
+            if (parameter.RefKind is RefKind.Out)
             {
                 return false; // MiKo 2022
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2022_OutParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind == RefKind.Out;
+        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind is RefKind.Out;
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var parameters = method.ParameterList.Parameters;
 
-            if (parameters.Count == 0)
+            if (parameters.Count is 0)
             {
                 return;
             }
@@ -80,7 +80,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var parameters = method.ParameterList.Parameters;
 
-            if (parameters.Count == 0)
+            if (parameters.Count is 0)
             {
                 return;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
         {
-            var wrongInheritDocs = syntax.DescendantNodes<XmlEmptyElementSyntax>(_ => _.GetName() == Constants.XmlTag.Inheritdoc && _.Attributes.OfType<XmlCrefAttributeSyntax>().Any());
+            var wrongInheritDocs = syntax.DescendantNodes<XmlEmptyElementSyntax>(_ => _.GetName() is Constants.XmlTag.Inheritdoc && _.Attributes.OfType<XmlCrefAttributeSyntax>().Any());
 
             return syntax.ReplaceNodes(wrongInheritDocs, (_, __) => Inheritdoc());
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
@@ -196,14 +196,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var falseIndex = comment.IndexOf("false", StringComparison.OrdinalIgnoreCase);
 
-            if (falseIndex == -1)
+            if (falseIndex is -1)
             {
                 return true;
             }
 
             var trueIndex = comment.IndexOf("true", StringComparison.OrdinalIgnoreCase);
 
-            if (trueIndex == -1)
+            if (trueIndex is -1)
             {
                 // cannot fix currently (false case comes as only case)
                 if (comment.Contains("otherwise", StringComparison.OrdinalIgnoreCase) is false)
@@ -262,7 +262,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static IEnumerable<XmlNodeSyntax> CreateMiddlePart(XmlElementSyntax comment, string startingPhrase, string endingPhrase)
         {
-            if (comment.Content.Count == 0)
+            if (comment.Content.Count is 0)
             {
                 // we have no comment, hence we add a "TODO" into the resulting comment
                 return new[] { XmlText(startingPhrase + Constants.TODO + endingPhrase) };
@@ -281,7 +281,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                        .WithoutText(Phrases)
                                        .WithoutFirstXmlNewLine();
 
-            if (nodes.Count == 0)
+            if (nodes.Count is 0)
             {
                 // we have no comment, hence we add a "TODO" into the resulting comment
                 return new[] { XmlText(startingPhrase + Constants.TODO + endingPhrase) };

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return newComment;
                 }
             }
-            else if (content.Count == 5)
+            else if (content.Count is 5)
             {
                 if (content[0] is XmlTextSyntax start && content[1].IsSeeCref() && content[2] is XmlTextSyntax middle && content[3].IsSeeCref() && content[4] is XmlTextSyntax)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzer.cs
@@ -18,10 +18,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.Length > 2 && symbolName[0] == 'T' && symbolName[1] == 'o' && symbolName[2].IsUpperCase())
+            if (symbolName.Length > 2 && symbolName[0] is 'T' && symbolName[1] is 'o' && symbolName[2].IsUpperCase())
             {
                 // do not report for conversion methods
-                return symbolName == "ToString";
+                return symbolName is "ToString";
             }
 
             return base.ShallAnalyze(symbol);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var startingPhrase = Constants.Comments.CollectionReturnTypeStartingPhrase;
 
-            if (returnType.TypeArgumentList.Arguments.Count == 1)
+            if (returnType.TypeArgumentList.Arguments.Count is 1)
             {
                 var typeName = GetGenericTypeArgumentTypeName(returnType);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
@@ -85,7 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            if (nodes.Count == 0)
+            if (nodes.Count is 0)
             {
                 return comment;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2041_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2041_CodeFixProvider.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // identify the now-empty summaries and remove those
             var emptySummaries = updatedSyntax.GetSummaryXmls().Where(_ => _.GetTextTrimmed().IsNullOrEmpty()).ToList();
 
-            if (emptySummaries.Count == 0)
+            if (emptySummaries.Count is 0)
             {
                 return updatedSyntax.AddContent(syntaxNodes.ToArray(_ => _.WithLeadingXmlCommentExterior().WithEndOfLine()));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.TypeKind == TypeKind.Delegate;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is INamedTypeSymbol type && type.TypeKind is TypeKind.Delegate;
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Constants.XmlTag.Summary, StartingPhrase);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2045_InvalidParameterReferenceInSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2045_InvalidParameterReferenceInSummaryAnalyzer.cs
@@ -22,13 +22,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Method;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind is SymbolKind.Method;
 
         protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {
             var method = (IMethodSymbol)symbol;
 
-            if (method.Parameters.Length == 0)
+            if (method.Parameters.Length is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzer.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var names = parameters.ToHashSet(_ => _.Name);
 
-            if (names.Count == 0)
+            if (names.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -108,7 +108,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return issues;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var summaries = comment.GetXmlSyntax(Constants.XmlTag.Summary);
 
-            if (summaries.Count == 0)
+            if (summaries.Count is 0)
             {
                 var newSummary = Comment(SyntaxFactory.XmlSummaryElement(), Phrase).WithTrailingXmlComment();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
@@ -70,20 +70,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static bool IsParameterlessCtor(IMethodSymbol symbol) => symbol.Parameters.Length == 0;
+        private static bool IsParameterlessCtor(IMethodSymbol symbol) => symbol.Parameters.Length is 0;
 
         private static bool IsMessageCtor(IMethodSymbol symbol)
         {
             var parameters = symbol.Parameters;
 
-            return parameters.Length == 1 && IsMessageParameter(parameters[0]);
+            return parameters.Length is 1 && IsMessageParameter(parameters[0]);
         }
 
         private static bool IsMessageExceptionCtor(IMethodSymbol symbol)
         {
             var parameters = symbol.Parameters;
 
-            return parameters.Length == 2 && IsMessageParameter(parameters[0]) && IsExceptionParameter(parameters[1]);
+            return parameters.Length is 2 && IsMessageParameter(parameters[0]) && IsExceptionParameter(parameters[1]);
         }
 
         private static bool IsMessageParameter(IParameterSymbol parameter) => parameter.Type.IsString();
@@ -160,7 +160,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var summaries = symbol.GetOverloadSummaries();
 
-            if (summaries.Count == 0)
+            if (summaries.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -172,7 +172,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comments = symbol.GetRemarks();
 
-            if (comments.Count == 0)
+            if (comments.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -187,7 +187,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 // find XML
                 var problematicComments = comment.GetXmlSyntax(xmlTag);
 
-                var issue = problematicComments.Count == 0
+                var issue = problematicComments.Count is 0
                             ? Issue(symbol, xmlTag, phrases[0])
                             : Issue(symbol.Name, problematicComments[0], xmlTag, phrases[0]);
 
@@ -204,7 +204,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrases = GetParameterPhrases(symbol);
 
-            return phrases.Length == 0
+            return phrases.Length is 0
                    ? Array.Empty<Diagnostic>()
                    : AnalyzeParameter(symbol, commentXml, comment, phrases);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             var template = Constants.Comments.FactoryCreateMethodSummaryStartingPhraseTemplate;
                             var returnType = ((MethodDeclarationSyntax)ancestor).ReturnType;
 
-                            if (returnType is GenericNameSyntax g && g.TypeArgumentList.Arguments.Count == 1)
+                            if (returnType is GenericNameSyntax g && g.TypeArgumentList.Arguments.Count is 1)
                             {
                                 template = Constants.Comments.FactoryCreateCollectionMethodSummaryStartingPhraseTemplate;
                                 returnType = g.TypeArgumentList.Arguments[0];
@@ -208,7 +208,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         case 'T':
                         case 't':
-                            var list = typeKey[2] == 'e' ? typeKeysWithThe : typeKeysWithThis;
+                            var list = typeKey[2] is 'e' ? typeKeysWithThe : typeKeysWithThis;
                             list.Add(typeKey);
 
                             break;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 case IMethodSymbol method:
                     return method.ContainingType.IsFactory()
-                        && method.MethodKind == MethodKind.Ordinary
+                        && method.MethodKind is MethodKind.Ordinary
                         && method.IsPubliclyVisible()
                         && method.ReturnsVoid is false
                         && method.ReturnType.SpecialType != SpecialType.System_Boolean;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -42,14 +42,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var falseIndex = comment.IndexOf("false", StringComparison.OrdinalIgnoreCase);
 
-            if (falseIndex == -1)
+            if (falseIndex is -1)
             {
                 return true;
             }
 
             var trueIndex = comment.IndexOf("true", StringComparison.OrdinalIgnoreCase);
 
-            if (trueIndex == -1)
+            if (trueIndex is -1)
             {
                 // cannot fix currently (false case comes as only case)
                 if (comment.Contains("otherwise", StringComparison.OrdinalIgnoreCase) is false)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Method;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind is SymbolKind.Method;
 
         protected override bool ConsiderEmptyTextAsIssue(ISymbol symbol) => false;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var map = new Pair[3];
 
-            if (firstWord == Constants.Comments.Asynchronously)
+            if (firstWord is Constants.Comments.Asynchronously)
             {
                 firstWord = startText.SecondWord();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrase = GetPhraseProposal(issue);
 
-            if (comment.Content.Count == 0)
+            if (comment.Content.Count is 0)
             {
                 // we do not have a comment
                 return comment.WithContent(XmlText("The item" + phrase));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.Parameters.Length > 0 && method.Name.StartsWith("Contains", StringComparison.OrdinalIgnoreCase);
 
-        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.ContainingSymbol is IMethodSymbol method && method.Parameters.IndexOf(parameter) == 0;
+        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.ContainingSymbol is IMethodSymbol method && method.Parameters.IndexOf(parameter) is 0;
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
@@ -147,7 +147,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 case TypeKind.Enum:
                 {
-                    var defaultFieldValue = parameterType.GetFields().FirstOrDefault(_ => _.ConstantValue is null || _.ConstantValue.ToString() == "0")?.Name;
+                    var defaultFieldValue = parameterType.GetFields().FirstOrDefault(_ => _.ConstantValue is null || _.ConstantValue.ToString() is "0")?.Name;
 
                     var defaultValue = defaultFieldValue != null
                                        ? parameterType.Name + "." + defaultFieldValue

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Property;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind is SymbolKind.Property;
 
         protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
                                                                   DocumentationCommentTriviaSyntax comment,

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var contents = comment.Content;
 
-            if (contents.Count == 1 && contents[0] is XmlTextSyntax txt)
+            if (contents.Count is 1 && contents[0] is XmlTextSyntax txt)
             {
                 var text = txt.GetTextWithoutTrivia();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_CodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                 {
                     // skip empty lines in commented out code, but keep normal lines
-                    if (commentedOutCode.Count == 0)
+                    if (commentedOutCode.Count is 0)
                     {
                         normalText.Add(token);
                     }
@@ -106,7 +106,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // we found some normal code at the end
             AddXmlText(result, normalText);
 
-            if (result.Count == 0)
+            if (result.Count is 0)
             {
                 // nothing to replace, so use original code
                 result.Add(text);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
@@ -80,7 +80,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var comment = e.Value.AsSpan().TrimStart();
 
                         // sentence starts lower case
-                        if (name == Constants.XmlTag.Para && comment.Length > 0 && comment[0].IsLowerCaseLetter())
+                        if (name is Constants.XmlTag.Para && comment.Length > 0 && comment[0].IsLowerCaseLetter())
                         {
                             return true;
                         }
@@ -142,7 +142,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var next = i + Gap;
 
-                if (next < last && comment[i + 1] == '.')
+                if (next < last && comment[i + 1] is '.')
                 {
                     i = next;
                     c = comment[i];

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             AddList(result, listItemText);
             AddXmlText(result, normalText);
 
-            if (result.Count == 0)
+            if (result.Count is 0)
             {
                 // nothing to replace, so use original code
                 result.Add(text);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2206_FlagAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_DocumentationDoesNotUseDoublePeriodsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var summaries = syntax.GetXmlSyntax(Constants.XmlTag.Summary);
 
             // add remarks into summary
-            if (summaries.Count == 0)
+            if (summaries.Count is 0)
             {
                 var newSummary = SyntaxFactory.XmlSummaryElement(remarks.Content.ToArray());
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_EnumerationMemberDocumentationHasNoRemarksAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var remarks = comment.GetRemarksXmls();
 
-            if (remarks.Count == 0)
+            if (remarks.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_CodeFixProvider.cs
@@ -80,13 +80,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     tokensForTexts.Remove(token);
 
-                    if (i == 0)
+                    if (i is 0)
                     {
                         // skip first line as that shall not be replaced with a <para/> tag
                         // (this happens in case the comment does not start with any XML tag)
                         noXmlTagOnCommentStart = true;
                     }
-                    else if (i == 1)
+                    else if (i is 1)
                     {
                         // skip second line as that shall not be replaced with a <para/> tag
                         // (this is the next line e.g. after a <summary> tag)
@@ -114,7 +114,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         if (syntaxToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                         {
-                            if (noXmlTagOnCommentStart && i == 4)
+                            if (noXmlTagOnCommentStart && i is 4)
                             {
                                 tokensForTexts.Remove(syntaxToken);
                             }
@@ -159,11 +159,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             replacements.Add(XmlText(tokensForTexts));
 
             // get rid of all texts that do not have any contents as they would cause a NullReferenceException inside Roslyn
-            replacements.RemoveAll(_ => _ is XmlTextSyntax t && t.TextTokens.Count == 0);
+            replacements.RemoveAll(_ => _ is XmlTextSyntax t && t.TextTokens.Count is 0);
 
             var replacementsCount = replacements.Count;
 
-            if (replacementsCount == 0)
+            if (replacementsCount is 0)
             {
                 // nothing to replace
                 return new[] { text };

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_CodeFixProvider.cs
@@ -79,7 +79,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     // problem on parent, so get ancestor list and replace all description with term nodes
                     var list = GetListElement(node);
-                    var itemsToReplace = list.DescendantNodes<XmlElementSyntax>(_ => _.GetName() == Constants.XmlTag.Description);
+                    var itemsToReplace = list.DescendantNodes<XmlElementSyntax>(_ => _.GetName() is Constants.XmlTag.Description);
 
                     return syntax.ReplaceNodes(itemsToReplace, (_, rewritten) => SyntaxFactory.XmlElement(Constants.XmlTag.Term, rewritten.Content));
                 }
@@ -90,11 +90,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     // it's either a <term> or a <description>, so first sub item should be a term, second a description
                     var nodes = node.ChildNodes<XmlElementSyntax>().ToList();
 
-                    if (nodes.Count == 2)
+                    if (nodes.Count is 2)
                     {
                         return syntax.ReplaceNodes(nodes, (original, rewritten) =>
                                                                                   {
-                                                                                      var newName = nodes.IndexOf(original) == 0
+                                                                                      var newName = nodes.IndexOf(original) is 0
                                                                                                     ? Constants.XmlTag.Term
                                                                                                     : Constants.XmlTag.Description;
 
@@ -113,6 +113,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static DocumentationCommentTriviaSyntax ReplaceNode(DocumentationCommentTriviaSyntax syntax, SyntaxNode node, XmlElementSyntax replacement) => syntax.ReplaceNode(node, replacement.WithoutWhitespaceOnlyComment());
 
-        private static XmlElementSyntax GetListElement(SyntaxNode node) => node.FirstAncestorOrSelf<XmlElementSyntax>(_ => _.GetName() == Constants.XmlTag.List);
+        private static XmlElementSyntax GetListElement(SyntaxNode node) => node.FirstAncestorOrSelf<XmlElementSyntax>(_ => _.GetName() is Constants.XmlTag.List);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var tagName = xml.GetName();
 
-                if (tagName == Constants.XmlTag.Code && xml.Attributes.Any(_ => _.GetName() == "source"))
+                if (tagName is Constants.XmlTag.Code && xml.Attributes.Any(_ => _.GetName() is "source"))
                 {
                     // ignore <code> tags with a 'source' attribute as that attribute refers to the coding snippet
                     continue;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens(_ => CodeTags.Contains(_.GetName()) is false);
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -131,7 +131,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     continue;
                 }
 
-                if (c == '.')
+                if (c is '.')
                 {
                     // we found a dot which symbols a method or property call
                     findings++;
@@ -152,17 +152,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static bool IsCompoundWord(in ReadOnlySpan<char> trimmed)
         {
-            if (trimmed.Length == 0)
+            if (trimmed.Length is 0)
             {
                 return false;
             }
 
             if (trimmed[0].IsNumber())
             {
-                return trimmed.Any(_ => _ == '.') && trimmed[1].IsLetter();
+                return trimmed.Any(_ => _ is '.') && trimmed[1].IsLetter();
             }
 
-            if (trimmed.Length == 3 && trimmed.Equals("e.g", StringComparison.OrdinalIgnoreCase))
+            if (trimmed.Length is 3 && trimmed.Equals("e.g", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -205,7 +205,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
-            if (trimmed.Any(_ => _ == '!'))
+            if (trimmed.Any(_ => _ is '!'))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -177,7 +177,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 yield break;
             }
 
-            if (elementName == Constants.XmlTag.Para && element.GetTextTrimmed().Equals(Constants.Comments.SpecialOrPhrase.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            if (elementName is Constants.XmlTag.Para && element.GetTextTrimmed().Equals(Constants.Comments.SpecialOrPhrase.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
                 // that is allowed
                 yield break;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_SpecialCodeTagCIsOnSameLineAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var node = (XmlElementSyntax)context.Node;
 
-            if (node.GetXmlTagName() == Constants.XmlTag.C)
+            if (node.GetXmlTagName() is Constants.XmlTag.C)
             {
                 var start = node.StartTag.GetStartingLine();
                 var end = node.EndTag.GetStartingLine();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var summaryXmls = comment.GetSummaryXmls();
             var remarksXmls = comment.GetRemarksXmls();
 
-            if (summaryXmls.Count == 0 && remarksXmls.Count == 0)
+            if (summaryXmls.Count is 0 && remarksXmls.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_InheritdocGetHashCodeAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsOverride && method.Parameters.IsEmpty && method.ReturnType.SpecialType == SpecialType.System_Int32 && method.Name == nameof(GetHashCode);
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsOverride && method.Parameters.IsEmpty && method.ReturnType.SpecialType is SpecialType.System_Int32 && method.Name == nameof(GetHashCode);
 
         protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = comment.GetXmlTextTokens();
             var textTokensCount = textTokens.Count;
 
-            if (textTokensCount == 0)
+            if (textTokensCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var issueCount = violationsInSummaries.Length + violationsInReturns.Length + violationsInParameters.Length;
 
-            if (issueCount == 0)
+            if (issueCount is 0)
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var summaryXmls = comment.GetSummaryXmls();
 
-            if (summaryXmls.Count == 0)
+            if (summaryXmls.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected bool IgnoreEmptyParameters { get; set; } = true;
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind == SymbolKind.Method;
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol.Kind is SymbolKind.Method;
 
         protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
@@ -120,7 +120,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var triviaToAnalyze = FindTriviaToAnalyze(node);
 
-            if (triviaToAnalyze.Count == 0)
+            if (triviaToAnalyze.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SummaryDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SummaryDocumentationAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var summaryXmls = comment.GetSummaryXmls();
 
-            if (summaryXmls.Count == 0)
+            if (summaryXmls.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
@@ -65,7 +65,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         var tagName = startTag.GetName();
 
-                        if (tagName == tag || tagName == Constants.XmlTag.Para)
+                        if (tagName == tag || tagName is Constants.XmlTag.Para)
                         {
                             continue; // skip over the start tag and name syntax
                         }
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         var tagName = endTag.GetName();
 
-                        if (tagName == Constants.XmlTag.Para)
+                        if (tagName is Constants.XmlTag.Para)
                         {
                             continue; // skip over the start tag and name syntax
                         }
@@ -96,8 +96,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
 
                     case XmlNameSyntax _:
-                    case XmlElementSyntax e when e.GetName() == Constants.XmlTag.Para:
-                    case XmlEmptyElementSyntax ee when ee.GetName() == Constants.XmlTag.Para:
+                    case XmlElementSyntax e when e.GetName() is Constants.XmlTag.Para:
+                    case XmlEmptyElementSyntax ee when ee.GetName() is Constants.XmlTag.Para:
                         continue; // skip over the start tag and name syntax
 
                     case XmlTextSyntax text:
@@ -125,7 +125,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                 continue;
                             }
 
-                            if (valueText.Length == 1 && Constants.Comments.Delimiters.Contains(valueText[0]))
+                            if (valueText.Length is 1 && Constants.Comments.Delimiters.Contains(valueText[0]))
                             {
                                 // this is a dot or something directly after the XML tag, so ignore that
                                 continue;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected static ArgumentSyntax Argument(MemberAccessExpressionSyntax expression, params ArgumentSyntax[] arguments)
         {
-            var syntax = arguments.Length == 0
+            var syntax = arguments.Length is 0
                          ? (ExpressionSyntax)expression // we do not want to have any empty argument list
                          : Invocation(expression, arguments);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3001_DelegateAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3001_DelegateAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Delegate;
+        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind is TypeKind.Delegate;
 
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => new[] { Issue(symbol) };
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return null;
             }
 
-            if (method.ReturnType.IsBoolean() && method.Parameters.Any() && method.Parameters.Last().RefKind == RefKind.Out)
+            if (method.ReturnType.IsBoolean() && method.Parameters.Any() && method.Parameters.Last().RefKind is RefKind.Out)
             {
                 return null;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3007_LinqStyleMixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3007_LinqStyleMixAnalyzer.cs
@@ -99,7 +99,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 }
             }
 
-            if (calls == 0)
+            if (calls is 0)
             {
                 return null;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Interface;
+        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind is TypeKind.Interface;
 
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => symbol.GetMethods(MethodKind.Ordinary).Select(AnalyzeOrdinaryMethod).WhereNotNull();
 
@@ -55,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var returnTypeString = returnType.ToString();
 
-            if (returnTypeString == "byte[]")
+            if (returnTypeString is "byte[]")
             {
                 return null;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3009_CommandInvokeNamedMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3009_CommandInvokeNamedMethodsAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var arguments = argumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzer.cs
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var method = node.GetEnclosingMethod(semanticModel);
 
-            if (method is null || method.Parameters.Length == 0)
+            if (method is null || method.Parameters.Length is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3014_InvalidOperationNotSupportedNotImplementedExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3014_InvalidOperationNotSupportedNotImplementedExceptionAnalyzer.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var argumentList = node.ArgumentList;
 
-            if (argumentList != null && argumentList.Arguments.Count == 0)
+            if (argumentList != null && argumentList.Arguments.Count is 0)
             {
                 return new[] { Issue(node.Type.ToString(), argumentList) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_ArgumentExceptionThrownAtWrongPlaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_ArgumentExceptionThrownAtWrongPlaceAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var method = node.GetEnclosingMethod(semanticModel);
 
-            if (method != null && method.Parameters.Length == 0)
+            if (method != null && method.Parameters.Length is 0)
             {
                 return new[] { Issue(node.Type) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var argumentList = syntax.ArgumentList;
             var arguments = argumentList.Arguments;
 
-            var errorMessage = arguments.Count == 3
+            var errorMessage = arguments.Count is 3
                                ? GetUpdatedErrorMessage(arguments.RemoveAt(1)) // actual argument seems to be part of the exception, so we have to ignore it when trying to find the error message
                                : GetUpdatedErrorMessage(argumentList);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3022_TaskReturnsIEnumerableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3022_TaskReturnsIEnumerableAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var typeArguments = ((INamedTypeSymbol)symbol.ReturnType).TypeArguments;
 
-            if (typeArguments.Length == 1 && typeArguments[0] is INamedTypeSymbol typeArgument)
+            if (typeArguments.Length is 1 && typeArguments[0] is INamedTypeSymbol typeArgument)
             {
                 var specialType = typeArgument.SpecialType;
 
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     }
                 }
 
-                if (typeArgument.TypeKind == TypeKind.Interface && typeArgument.ConstructedFrom.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+                if (typeArgument.TypeKind is TypeKind.Interface && typeArgument.ConstructedFrom.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T)
                 {
                     return new[] { ReportIssue(symbol) };
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3023_CancellationTokenSourceParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3023_CancellationTokenSourceParameterAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     var parameter = parameters[index];
                     var parameterType = parameter.Type;
 
-                    if (parameterType.TypeKind == TypeKind.Class && parameterType.ToString() == TypeNames.CancellationTokenSource)
+                    if (parameterType.TypeKind is TypeKind.Class && parameterType.ToString() == TypeNames.CancellationTokenSource)
                     {
                         yield return Issue(parameter, nameof(CancellationToken));
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3024_RefParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3024_RefParameterAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {
-            foreach (var parameter in symbol.Parameters.Where(_ => _.RefKind == RefKind.Ref && _.Type.TypeKind != TypeKind.Struct))
+            foreach (var parameter in symbol.Parameters.Where(_ => _.RefKind is RefKind.Ref && _.Type.TypeKind != TypeKind.Struct))
             {
                 var keyword = parameter.GetModifier(SyntaxKind.RefKeyword);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3025_ReuseParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3025_ReuseParameterAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (method?.Parameters.Length > 0)
             {
-                var names = method.Parameters.Where(_ => _.RefKind == RefKind.None).ToHashSet(_ => _.Name);
+                var names = method.Parameters.Where(_ => _.RefKind is RefKind.None).ToHashSet(_ => _.Name);
 
                 var name = node.Left.ToCleanedUpString();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
@@ -121,7 +121,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return;
             }
 
-            if (parameters.Count == 0)
+            if (parameters.Count is 0)
             {
                 return;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3028_AssignNullToListItemParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3028_AssignNullToListItemParameterAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 if (method?.Parameters.Length > 0)
                 {
-                    var names = method.Parameters.Where(_ => _.RefKind == RefKind.None).ToHashSet(_ => _.Name);
+                    var names = method.Parameters.Where(_ => _.RefKind is RefKind.None).ToHashSet(_ => _.Name);
 
                     var name = node.Left.ToCleanedUpString();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
@@ -71,7 +71,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 // report violations only if we have both += and -= calls
                 if (addAssignmentsCount != 0 && subtractAssignmentsCount != 0)
                 {
-                    if (addAssignmentsCount == subtractAssignmentsCount && addAssignmentsCount == 1)
+                    if (addAssignmentsCount == subtractAssignmentsCount && addAssignmentsCount is 1)
                     {
                         var addAssignment = addAssignments[0];
                         var subtractAssignment = subtractAssignments[0];

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3031_ICloneableCloneAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3031_ICloneableCloneAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnType.SpecialType == SpecialType.System_Object && symbol.IsStatic is false;
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnType.SpecialType is SpecialType.System_Object && symbol.IsStatic is false;
 
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3033_PropertyChangeEventArgsCtorUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3033_PropertyChangeEventArgsCtorUsesNameofAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = argumentList.Arguments;
 
-                if (arguments.Count == 1)
+                if (arguments.Count is 1)
                 {
                     var argument = arguments[0];
 
@@ -57,7 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (argumentExpression)
             {
-                case InvocationExpressionSyntax i when i.Expression is IdentifierNameSyntax sa && sa.GetName() == "nameof":
+                case InvocationExpressionSyntax i when i.Expression is IdentifierNameSyntax sa && sa.GetName() is "nameof":
                     return NameofHasIssue(node, i.ArgumentList.Arguments, semanticModel);
 
                 case IdentifierNameSyntax s when node.EnclosingMethodHasParameter(s.GetName(), semanticModel):

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3035_WaitOneHasTimeoutAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3035_WaitOneHasTimeoutAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         var argumentType = arguments[index].GetTypeSymbol(semanticModel);
 
-                        if (argumentType.SpecialType == SpecialType.System_Int32 || argumentType.FullyQualifiedName() == TypeNames.TimeSpan)
+                        if (argumentType.SpecialType is SpecialType.System_Int32 || argumentType.FullyQualifiedName() == TypeNames.TimeSpan)
                         {
                             // we use a timeout parameter (int or TimeSpan)
                             return false;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3036_CodeFixProvider.cs
@@ -146,7 +146,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static bool IsZero(ArgumentSyntax argument) => argument.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.NumericLiteralExpression) && double.TryParse(literal.Token.Text, out var number) && number == 0d;
+        private static bool IsZero(ArgumentSyntax argument) => argument.Expression is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.NumericLiteralExpression) && double.TryParse(literal.Token.Text, out var number) && number is 0d;
 
         private static InvocationExpressionSyntax FromDays(ArgumentSyntax argument) => Invocation(nameof(TimeSpan), nameof(TimeSpan.FromDays), argument);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3040_BooleanMethodParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3040_BooleanMethodParametersAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.MethodKind == MethodKind.Ordinary && symbol.IsTestMethod() is false;
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.MethodKind is MethodKind.Ordinary && symbol.IsTestMethod() is false;
 
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             switch (parameters.Length)
             {
                 case 0:
-                case 1 when symbol.Name == nameof(IDisposable.Dispose) && parameters[0].Name == "disposing":
+                case 1 when symbol.Name == nameof(IDisposable.Dispose) && parameters[0].Name is "disposing":
                 case 2 when symbol.HasDependencyObjectParameter():
                     return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3041_EventArgsDelegateParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3041_EventArgsDelegateParametersAnalyzer.cs
@@ -34,12 +34,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var parameters = symbol.Parameters;
 
-                    if (parameters.Length == 0)
+                    if (parameters.Length is 0)
                     {
                         return Array.Empty<Diagnostic>();
                     }
 
-                    return parameters.Where(_ => _.Type.TypeKind == TypeKind.Delegate)
+                    return parameters.Where(_ => _.Type.TypeKind is TypeKind.Delegate)
                                      .Select(_ => Issue(_.Type))
                                      .ToList();
                 }
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var returnType = symbol.GetReturnType();
 
-            return returnType?.TypeKind == TypeKind.Delegate
+            return returnType?.TypeKind is TypeKind.Delegate
                    ? new[] { Issue(returnType) }
                    : Array.Empty<Diagnostic>();
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         var typeName = invocation.GetIdentifierName();
 
-                        if (typeName == "WeakEventManager")
+                        if (typeName is "WeakEventManager")
                         {
                             var arguments = invocation.ArgumentList.Arguments;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var arguments = invocation.ArgumentList.Arguments;
 
-                    if (arguments.Count == 1)
+                    if (arguments.Count is 1)
                     {
                         // seems like a normal Equals() method
                         return IsPropertyName(invocation);
@@ -86,14 +86,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var name = expression.GetIdentifierName();
 
-            return name == "PropertyName";
+            return name is "PropertyName";
         }
 
         private static bool IsPropertyName(MemberAccessExpressionSyntax expression)
         {
             var name = expression.GetName();
 
-            return name == "PropertyName";
+            return name is "PropertyName";
         }
 
         private static bool IsPropertyNameAccess(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax syntax && syntax.IsKind(SyntaxKind.SimpleMemberAccessExpression) && IsPropertyName(syntax);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3045_EventManagerRegisterUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3045_EventManagerRegisterUsesNameofAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var arguments = symbol.GetInvocationArgumentsFrom(Constants.EventManager.RegisterRoutedEvent);
 
-            if (arguments.Count == 4)
+            if (arguments.Count is 4)
             {
                 var expression = arguments[0].Expression;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3049_EnumMemberHasDescriptionAttributeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3049_EnumMemberHasDescriptionAttributeAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var attributes = field.GetAttributes();
 
-                if (attributes.Length == 0)
+                if (attributes.Length is 0)
                 {
                     yield return Issue(field);
                 }
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var descriptionAttributes = attributes.Where(_ => _.AttributeClass.InheritsFrom(DescriptionAttributeName)).ToList();
 
-                    if (descriptionAttributes.Count == 0)
+                    if (descriptionAttributes.Count is 0)
                     {
                         yield return Issue(field);
                     }
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         foreach (var attribute in descriptionAttributes)
                         {
-                            if (attribute.ConstructorArguments.Length == 0)
+                            if (attribute.ConstructorArguments.Length is 0)
                             {
                                 yield return Issue(field);
                             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3050_DependencyPropertyPublicStaticReadOnlyFieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3050_DependencyPropertyPublicStaticReadOnlyFieldAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool ShallAnalyze(IFieldSymbol symbol) => symbol.Type.IsDependencyProperty();
 
-        protected override IEnumerable<Diagnostic> Analyze(IFieldSymbol symbol, Compilation compilation) => symbol.IsStatic && symbol.IsReadOnly && symbol.DeclaredAccessibility == Accessibility.Public
+        protected override IEnumerable<Diagnostic> Analyze(IFieldSymbol symbol, Compilation compilation) => symbol.IsStatic && symbol.IsReadOnly && symbol.DeclaredAccessibility is Accessibility.Public
                                                                                                             ? Array.Empty<Diagnostic>()
                                                                                                             : new[] { Issue(symbol) };
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         {
                             var args = nameofExpression.ArgumentList.Arguments;
 
-                            if (args.Count == 1 && args[0].Expression is IdentifierNameSyntax identifier)
+                            if (args.Count is 1 && args[0].Expression is IdentifierNameSyntax identifier)
                             {
                                 return identifier.GetName();
                             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3055_ViewModelImplementsINotifyPropertyChangedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3055_ViewModelImplementsINotifyPropertyChangedAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Class
+        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind is TypeKind.Class
                                                                       && symbol.IsRecord is false
                                                                       && symbol.Name.EndsWithAny(Constants.Markers.ViewModels, StringComparison.Ordinal)
                                                                       && symbol.IsTestClass() is false;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3061_LoggerHasCategoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3061_LoggerHasCategoryAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
-        private static bool IsLogManagerGetLoggerCall(MemberAccessExpressionSyntax node) => node.GetName() == "GetLogger"
+        private static bool IsLogManagerGetLoggerCall(MemberAccessExpressionSyntax node) => node.GetName() is "GetLogger"
                                                                                          && node.Expression is IdentifierNameSyntax i
                                                                                          && i.GetName().EndsWith("LogManager", StringComparison.Ordinal);
 
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = s.ArgumentList.Arguments;
 
-                if (arguments.Count == 1 && IsLogManagerGetLoggerCall(node))
+                if (arguments.Count is 1 && IsLogManagerGetLoggerCall(node))
                 {
                     var argument = arguments[0];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3062_ExceptionLogMessageEndsWithColonAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3062_ExceptionLogMessageEndsWithColonAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var arguments = node.ArgumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 return null;
             }
@@ -105,7 +105,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var type = methodCall.GetTypeSymbol(semanticModel);
 
             // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
-            if (type?.Name == Constants.ILog.TypeName)
+            if (type?.Name is Constants.ILog.TypeName)
             {
                 switch (argument.Expression)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3063_NonExceptionLogMessageEndsWithDotAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3063_NonExceptionLogMessageEndsWithDotAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var arguments = node.ArgumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 return null;
             }
@@ -105,7 +105,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var type = methodCall.GetTypeSymbol(semanticModel);
 
             // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
-            if (type?.Name == Constants.ILog.TypeName)
+            if (type?.Name is Constants.ILog.TypeName)
             {
                 switch (argument.Expression)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_LogMessagesContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_LogMessagesContainsNtContractionAnalyzer.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var arguments = node.ArgumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -115,7 +115,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var type = methodCall.GetTypeSymbol(semanticModel);
 
             // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
-            if (type?.Name == Constants.ILog.TypeName)
+            if (type?.Name is Constants.ILog.TypeName)
             {
                 var syntaxTree = argument.SyntaxTree;
                 var phrases = Constants.Comments.NotContractionPhrase;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_MicrosoftLoggingMessagesDoNotUseInterpolatedStringsAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         var type = methodCall.GetTypeSymbol(semanticModel);
 
-                        if (type.Name == Constants.MicrosoftLogging.TypeName && type.ContainingNamespace.FullyQualifiedName() == Constants.MicrosoftLogging.NamespaceName)
+                        if (type.Name is Constants.MicrosoftLogging.TypeName && type.ContainingNamespace.FullyQualifiedName() is Constants.MicrosoftLogging.NamespaceName)
                         {
                             var argumentSymbol = a.GetTypeSymbol(semanticModel);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var returnType = symbol.ReturnType;
 
-            if (returnType.SpecialType == SpecialType.System_Void)
+            if (returnType.SpecialType is SpecialType.System_Void)
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3072_MethodReturnsListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3072_MethodReturnsListAnalyzer.cs
@@ -18,12 +18,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol)
                                                                    && symbol.ReturnsVoid is false
                                                                    && symbol.DeclaredAccessibility != Accessibility.Private
-                                                                   && symbol.ReturnType.TypeKind == TypeKind.Class
+                                                                   && symbol.ReturnType.TypeKind is TypeKind.Class
                                                                    && symbol.IsInterfaceImplementation() is false;
 
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {
-            if (symbol.ReturnType.ContainingNamespace.FullyQualifiedName() == "System.Collections.Generic")
+            if (symbol.ReturnType.ContainingNamespace.FullyQualifiedName() is "System.Collections.Generic")
             {
                 var name = symbol.ReturnType.Name;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3075_NonPublicClassesShouldPreventInheritanceAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool ShallAnalyze(INamedTypeSymbol symbol)
         {
-            if (symbol.TypeKind == TypeKind.Class)
+            if (symbol.TypeKind is TypeKind.Class)
             {
                 switch (symbol.DeclaredAccessibility)
                 {
@@ -48,14 +48,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return Array.Empty<Diagnostic>();
             }
 
-            if (symbol.DeclaredAccessibility == Accessibility.Private)
+            if (symbol.DeclaredAccessibility is Accessibility.Private)
             {
                 // find other symbols that inherit from this one
                 var privateTypes = symbol.ContainingType.GetMembers<INamedTypeSymbol>();
 
                 if (privateTypes.Count > 0)
                 {
-                    var privateClasses = privateTypes.Where(_ => _.TypeKind == TypeKind.Class).ToList();
+                    var privateClasses = privateTypes.Where(_ => _.TypeKind is TypeKind.Class).ToList();
                     privateClasses.Remove(symbol);
 
                     foreach (var otherClass in privateClasses)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             // fix auto getter and setter
             var accessors = propertySyntax.AccessorList?.Accessors;
 
-            if (accessors?.Count == 2 && accessors.Value[0].Body is null && accessors.Value[0].ExpressionBody is null && accessors.Value[1].Body is null && accessors.Value[1].ExpressionBody is null)
+            if (accessors?.Count is 2 && accessors.Value[0].Body is null && accessors.Value[0].ExpressionBody is null && accessors.Value[1].Body is null && accessors.Value[1].ExpressionBody is null)
             {
                 // append a semicolon to the end
                 var initializer = CreateInitializer(document, propertySyntax.Type);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3079_DoNotUseIntegerForHResultAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3079_DoNotUseIntegerForHResultAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var number = node.Token.ValueText;
 
-                if (number.Length == 10 && number.StartsWith("2147", StringComparison.Ordinal) && int.TryParse(number, out var result))
+                if (number.Length is 10 && number.StartsWith("2147", StringComparison.Ordinal) && int.TryParse(number, out var result))
                 {
                     var hexValue = ((-1) * result).ToString("X");
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var usedVariables = switchStatement.Sections.Select(_ => _.Statements.SelectMany(GetAssignmentIdentifierCandidates).ToHashSet()).ToList();
 
-            if (usedVariables.Count == 0)
+            if (usedVariables.Count is 0)
             {
                 // for whatever reason we do not have any variables
                 return false;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3082_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
@@ -13,6 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind == SyntaxKind.TrueLiteralExpression || kind == SyntaxKind.FalseLiteralExpression;
+        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind is SyntaxKind.TrueLiteralExpression || kind is SyntaxKind.FalseLiteralExpression;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3083_UsePatternMatchingForNullEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3083_UsePatternMatchingForNullEqualsExpressionAnalyzer.cs
@@ -13,6 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind == SyntaxKind.NullLiteralExpression;
+        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind is SyntaxKind.NullLiteralExpression;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
@@ -386,7 +386,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var declarationType = declaration.Type;
 
-            if (declarationType is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == "var")
+            if (declarationType is IdentifierNameSyntax identifier && identifier.Identifier.ValueText is "var")
             {
                 var updatedType = GetTypeSyntax(declarationType.GetTypeSymbol(document));
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_ConditionalExpressionTooLongAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var arguments = argumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 // ignore as it cannot be shorted anymore
                 return true;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3088_UsePatternMatchingForNullNotEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3088_UsePatternMatchingForNullNotEqualsExpressionAnalyzer.cs
@@ -13,6 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind == SyntaxKind.NullLiteralExpression;
+        protected override bool IsResponsibleNode(in SyntaxKind kind) => kind is SyntaxKind.NullLiteralExpression;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var subPatterns = clause.Subpatterns;
 
-                    if (subPatterns.Count == 1)
+                    if (subPatterns.Count is 1)
                     {
                         var subPattern = subPatterns[0];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_DoNotUsePropertyPatternForConditionsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_DoNotUsePropertyPatternForConditionsAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var subPatterns = clause.Subpatterns;
 
-                    if (subPatterns.Count == 1)
+                    if (subPatterns.Count is 1)
                     {
                         var subPattern = subPatterns[0];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3093_StatementInsideLockTriggersActionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3093_StatementInsideLockTriggersActionAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 var type = identifier.GetTypeSymbol(semanticModel);
 
-                if (type?.TypeKind == TypeKind.Delegate)
+                if (type?.TypeKind is TypeKind.Delegate)
                 {
                     if (token.GetSymbol(semanticModel) is IEventSymbol)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3094_StatementInsideLockCallsParameterAnalyzer.cs
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         var type = identifier.GetTypeSymbol(semanticModel);
 
-                        if (type?.TypeKind == TypeKind.Delegate)
+                        if (type?.TypeKind is TypeKind.Delegate)
                         {
                             // found by rule MiKo 3092 or MiKo 3093
                             continue;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3095_DoNotUseEmptyBlocksAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3095_DoNotUseEmptyBlocksAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return;
             }
 
-            if (block.Statements.Count == 0 && block.DescendantTrivia().None(_ => _.IsComment()))
+            if (block.Statements.Count is 0 && block.DescendantTrivia().None(_ => _.IsComment()))
             {
                 ReportDiagnostics(context, Issue(block));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3096_UseDictionaryInsteadOfLargeSwitchAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3096_UseDictionaryInsteadOfLargeSwitchAnalyzer.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var statements = block.Statements;
 
-                    return statements.Count == 1 && IsAcceptable(context, statements[0]);
+                    return statements.Count is 1 && IsAcceptable(context, statements[0]);
                 }
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     if (IsToStringCall(i.Expression))
                     {
                         var arguments = i.ArgumentList.Arguments;
-                        var format = arguments.Count == 1
+                        var format = arguments.Count is 1
                                      ? arguments[0].Expression.ToString().WithoutQuotes()
                                      : DefaultFormat;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3104_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3104_CodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         {
                             var listWithoutAttribute = attributeList.Without(attribute);
 
-                            if (listWithoutAttribute.Attributes.Count == 0)
+                            if (listWithoutAttribute.Attributes.Count is 0)
                             {
                                 // we do not need an empty list
                                 return method.Without(attributeList);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3104_CombinatorialTestsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3104_CombinatorialTestsAnalyzer.cs
@@ -97,7 +97,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var parameters = method.Parameters;
             var parametersLength = parameters.Length;
 
-            if (parametersLength == 0)
+            if (parametersLength is 0)
             {
                 return 0;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -256,9 +256,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static InvocationExpressionSyntax FixCollectionAssertDoesNotContain(in SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[0], Does("Not", "Contain", args[1]), args);
 
-        private static InvocationExpressionSyntax FixContains(string typeName, in SeparatedSyntaxList<ArgumentSyntax> args) => typeName == "CollectionAssert" ? FixCollectionAssertContains(args) : FixStringAssertContains(args);
+        private static InvocationExpressionSyntax FixContains(string typeName, in SeparatedSyntaxList<ArgumentSyntax> args) => typeName is "CollectionAssert" ? FixCollectionAssertContains(args) : FixStringAssertContains(args);
 
-        private static InvocationExpressionSyntax FixDoesNotContain(in SeparatedSyntaxList<ArgumentSyntax> args, string typeName) => typeName == "CollectionAssert" ? FixCollectionAssertDoesNotContain(args) : FixStringAssertDoesNotContain(args);
+        private static InvocationExpressionSyntax FixDoesNotContain(in SeparatedSyntaxList<ArgumentSyntax> args, string typeName) => typeName is "CollectionAssert" ? FixCollectionAssertDoesNotContain(args) : FixStringAssertDoesNotContain(args);
 
         private static InvocationExpressionSyntax FixDoesNotEndWith(in SeparatedSyntaxList<ArgumentSyntax> args) => AssertThat(args[1], Does("Not", "EndWith", args[0]), args);
 
@@ -513,7 +513,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var genericArguments = generic.TypeArgumentList.Arguments;
 
-                if (genericArguments.Count == 1)
+                if (genericArguments.Count is 1)
                 {
                     return AssertThat(args[0], GetExceptionArgument(genericArguments[0]), args, 1);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
@@ -36,11 +36,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsXUnitAssertTrueMethod(MemberAccessExpressionSyntax node, SemanticModel semanticModel)
         {
-            if (node.GetName() == "True" && node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() == "Assert")
+            if (node.GetName() is "True" && node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() is "Assert")
             {
                 var symbol = invokedType.GetTypeSymbol(semanticModel);
 
-                if (symbol?.FullyQualifiedName() == "Xunit.Assert")
+                if (symbol?.FullyQualifiedName() is "Xunit.Assert")
                 {
                     return true;
                 }
@@ -140,7 +140,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
                 var argumentsCount = arguments.Count;
 
-                if (argumentsCount == 2 && IsXUnitAssertTrueMethod(node, context.SemanticModel))
+                if (argumentsCount is 2 && IsXUnitAssertTrueMethod(node, context.SemanticModel))
                 {
                     // XUnit does not provide user assertion messages on other methods, so we have to ignore the operators here as the user like wants to use the assertion message
                     yield break;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_OnlyMocksUseConditionMatchersAnalyzer.cs
@@ -49,7 +49,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsConditionMatcher(MemberAccessExpressionSyntax node)
         {
-            if (node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() == Constants.Moq.ConditionMatcher.It)
+            if (node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() is Constants.Moq.ConditionMatcher.It)
             {
                 switch (node.GetName())
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
@@ -120,7 +120,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 switch (node.GetName())
                 {
                     // we assume that this is an fluent assertion
-                    case "Should" when argumentsCount == 0:
+                    case "Should" when argumentsCount is 0:
                     case "ShouldNotRaise":
                     case "ShouldRaise":
                     case "ShouldRaisePropertyChangeFor":
@@ -132,20 +132,20 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     // we assume that this is a Moq call
                     case Constants.Moq.VerifyGet when argumentsCount > 0:
                     case Constants.Moq.VerifySet when argumentsCount > 0:
-                    case Constants.Moq.VerifyAll when argumentsCount == 0:
+                    case Constants.Moq.VerifyAll when argumentsCount is 0:
                     case Constants.Moq.Verify when argumentsCount > 0:
                     {
                         return true;
                     }
 
-                    case Constants.Moq.Verify when argumentsCount == 0:
+                    case Constants.Moq.Verify when argumentsCount is 0:
                     {
                         if (node.Expression is IdentifierNameSyntax ins)
                         {
                             var mockName = ins.GetName();
 
                             // no arguments, so check for a 'Verifiable' call on the same mock object
-                            return nodes.Where(_ => _.GetName() == Constants.Moq.Verifiable && _.Parent is InvocationExpressionSyntax)
+                            return nodes.Where(_ => _.GetName() is Constants.Moq.Verifiable && _.Parent is InvocationExpressionSyntax)
                                         .SelectMany(_ => _.DescendantNodes<MemberAccessExpressionSyntax>())
                                         .Any(_ => _.Expression is IdentifierNameSyntax e && e.GetName() == mockName);
                         }
@@ -155,10 +155,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     }
 
                     // we assume that this is a NSubstitute call
-                    case "Received" when argumentsCount == 0 || argumentsCount == 1:
-                    case "ReceivedWithAnyArgs" when argumentsCount == 0:
-                    case "DidNotReceive" when argumentsCount == 0:
-                    case "DidNotReceiveWithAnyArgs" when argumentsCount == 0:
+                    case "Received" when argumentsCount is 0 || argumentsCount is 1:
+                    case "ReceivedWithAnyArgs" when argumentsCount is 0:
+                    case "DidNotReceive" when argumentsCount is 0:
+                    case "DidNotReceiveWithAnyArgs" when argumentsCount is 0:
                     {
                         return true;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var name = method.GetName();
 
-                    if (name == "Parse")
+                    if (name is "Parse")
                     {
                         return method.ArgumentList?.Arguments.FirstOrDefault()?.GetName();
                     }
@@ -172,7 +172,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             // let's see if we have the special case 'Is.Not.Null'
             private static string GetStartingWord(in SeparatedSyntaxList<ArgumentSyntax> arguments)
             {
-                if (arguments.Count > 1 && arguments[1].Expression.ToString() == "Is.Not.Null")
+                if (arguments.Count > 1 && arguments[1].Expression.ToString() is "Is.Not.Null")
                 {
                     return "missing";
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzer.cs
@@ -126,7 +126,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (arguments.Count == 0)
+                if (arguments.Count is 0)
                 {
                     // we have no message
                     return false;
@@ -145,7 +145,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var count = arguments.Count;
 
-            if (expectedArgumentIndices.Length == 1)
+            if (expectedArgumentIndices.Length is 1)
             {
                 var expectedArgumentIndex = expectedArgumentIndices[0];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_CodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var typeName = type.GetName();
 
-                if (typeName == "Assert")
+                if (typeName is "Assert")
                 {
                     var args = invocation.ArgumentList.Arguments;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsFixableAssertionForLinqCall(InvocationExpressionSyntax invocation)
         {
-            if (invocation.GetIdentifierName() == "Is")
+            if (invocation.GetIdentifierName() is "Is")
             {
                 switch (invocation.GetName())
                 {
@@ -133,7 +133,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                     // we can only fix "Assert.That(xyz.Count(), Is.EqualTo(42)"
                                     return Issue(token);
 
-                                case MemberAccessExpressionSyntax am when am.GetName() == "Zero":
+                                case MemberAccessExpressionSyntax am when am.GetName() is "Zero":
                                     // we can only fix "Assert.That(xyz.Count(), Is.Zero"
                                     return Issue(token);
                             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (node.Expression is MemberAccessExpressionSyntax m)
             {
-                if (m.Expression.ToString() == "Has.Count")
+                if (m.Expression.ToString() is "Has.Count")
                 {
                     return MemberIs("Empty");
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseZeroInsteadOfEqualToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseZeroInsteadOfEqualToAnalyzer.cs
@@ -34,12 +34,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private Diagnostic[] Analyze(InvocationExpressionSyntax node)
         {
-            if (node.Expression is MemberAccessExpressionSyntax maes && maes.Name.GetName() == "EqualTo")
+            if (node.Expression is MemberAccessExpressionSyntax maes && maes.Name.GetName() is "EqualTo")
             {
                 var argumentList = node.ArgumentList;
                 var arguments = argumentList.Arguments;
 
-                if (arguments.Count == 1 && arguments[0].Expression is LiteralExpressionSyntax literal && literal.Token.ValueText == "0")
+                if (arguments.Count is 1 && arguments[0].Expression is LiteralExpressionSyntax literal && literal.Token.ValueText is "0")
                 {
                     var location = CreateLocation(node, maes.Name.Span.Start, argumentList.Span.End);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var shouldNode = statement.GetFluentAssertionShouldNode();
                 var shouldName = shouldNode.GetName();
 
-                var assertThat = shouldName == Constants.FluentAssertions.ShouldBeEquivalentTo
+                var assertThat = shouldName is Constants.FluentAssertions.ShouldBeEquivalentTo
                                  ? ConvertShouldBeEquivalentToToAssertThat(document, shouldNode)
                                  : ConvertShouldToAssertThat(document, shouldNode);
 
@@ -174,7 +174,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                         if (type != null)
                         {
-                            if (count == 1 && type.IsString())
+                            if (count is 1 && type.IsString())
                             {
                                 // we have found the extension method that uses strings
                                 return AssertThat(expression, Is("EqualTo", argument, "IgnoreCase"), arguments, removeNameColon: true);
@@ -206,7 +206,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                         if (type != null)
                         {
-                            if (count == 1 && type.IsString())
+                            if (count is 1 && type.IsString())
                             {
                                 // we have found the extension method that uses strings
                                 return AssertThat(expression, Is("Not", "EqualTo", argument, "IgnoreCase"), arguments, removeNameColon: true);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3115_TestMethodsContainCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3115_TestMethodsContainCodeAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var method = (MethodDeclarationSyntax)context.Node;
             var methodBody = method.Body;
 
-            if (methodBody != null && methodBody.Statements.Count == 0 && method.IsTestMethod() && method.IsAbstract() is false)
+            if (methodBody != null && methodBody.Statements.Count is 0 && method.IsTestMethod() && method.IsAbstract() is false)
             {
                 ReportDiagnostics(context, Issue(method));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3116_TestSetUpMethodsContainCodeAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var method = (MethodDeclarationSyntax)context.Node;
             var methodBody = method.Body;
 
-            if (methodBody != null && methodBody.Statements.Count == 0 && method.IsTestSetUpMethod() && method.IsAbstract() is false)
+            if (methodBody != null && methodBody.Statements.Count is 0 && method.IsTestSetUpMethod() && method.IsAbstract() is false)
             {
                 ReportDiagnostics(context, Issue(method));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3117_TestTearDownMethodsContainCodeAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var method = (MethodDeclarationSyntax)context.Node;
             var methodBody = method.Body;
 
-            if (methodBody != null && methodBody.Statements.Count == 0 && method.IsTestTearDownMethod() && method.IsAbstract() is false)
+            if (methodBody != null && methodBody.Statements.Count is 0 && method.IsTestTearDownMethod() && method.IsAbstract() is false)
             {
                 ReportDiagnostics(context, Issue(method));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             continue;
                         }
 
-                        if (invocation.GetIdentifierName() == "Arg")
+                        if (invocation.GetIdentifierName() is "Arg")
                         {
                             // ignore NSubstitute arguments
                             continue;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = node.ArgumentList.Arguments;
 
-                if (arguments.Count == 1)
+                if (arguments.Count is 1)
                 {
                     var issues = AnalyzeSimpleMemberAccessExpression(node, arguments[0], context);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3121_ObjectUnderTestIsNoInterfaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3121_ObjectUnderTestIsNoInterfaceAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var type = member.GetReturnTypeSymbol();
 
-                if (type?.TypeKind == TypeKind.Interface)
+                if (type?.TypeKind is TypeKind.Interface)
                 {
                     var syntax = GetTypeSyntax(member);
 
@@ -73,7 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var typeUnderTest = declaration.GetTypeSymbol(context.SemanticModel);
 
-                    if (typeUnderTest?.TypeKind == TypeKind.Interface)
+                    if (typeUnderTest?.TypeKind is TypeKind.Interface)
                     {
                         ReportDiagnostics(context, Issue(declaration.Type));
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var condition = node.Condition;
                 var conditions = GetConditionParts(condition);
 
-                if (condition.IsKind(SyntaxKind.LogicalAndExpression) && conditions.Count == 2 && conditions[0].IsKind(SyntaxKind.IsPatternExpression) && IsNegative(conditions[1]))
+                if (condition.IsKind(SyntaxKind.LogicalAndExpression) && conditions.Count is 2 && conditions[0].IsKind(SyntaxKind.IsPatternExpression) && IsNegative(conditions[1]))
                 {
                     // we do not want to report is-pattern checks for false because the inverted code looks much difficult to understand
                     return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3210_MethodsWithOverloadsAreNotAbstractOrVirtualAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3210_MethodsWithOverloadsAreNotAbstractOrVirtualAnalyzer.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private IEnumerable<Diagnostic> AnalyzeMethodOverloads(IReadOnlyCollection<IMethodSymbol> methods)
         {
-            var methodWithoutParameters = methods.FirstOrDefault(_ => _.Parameters.Length == 0);
+            var methodWithoutParameters = methods.FirstOrDefault(_ => _.Parameters.Length is 0);
 
             if (methodWithoutParameters != null)
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3211_PublicTypesShouldNotHaveFinalizerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3211_PublicTypesShouldNotHaveFinalizerAnalyzer.cs
@@ -15,9 +15,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.MethodKind == MethodKind.Destructor;
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.MethodKind is MethodKind.Destructor;
 
-        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation) => symbol.ContainingType.DeclaredAccessibility == Accessibility.Public
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation) => symbol.ContainingType.DeclaredAccessibility is Accessibility.Public
                                                                                                              ? new[] { Issue(symbol) }
                                                                                                              : Array.Empty<Diagnostic>();
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3213_PublicDisposeMethodInvokesNonPublicDisposeMethodAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3213_PublicDisposeMethodInvokesNonPublicDisposeMethodAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         }
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnsVoid
-                                                                   && symbol.Parameters.Length == 0
+                                                                   && symbol.Parameters.Length is 0
                                                                    && symbol.Name == nameof(IDisposable.Dispose)
                                                                    && symbol.ContainingType.GetMembers(nameof(IDisposable.Dispose)).Length > 1;
 
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.ThisExpression) is true && invocation.GetIdentifierName() == nameof(GC) && invocation.GetName() == nameof(GC.SuppressFinalize))
+                if (arguments.Count is 1 && arguments[0].Expression?.IsKind(SyntaxKind.ThisExpression) is true && invocation.GetIdentifierName() == nameof(GC) && invocation.GetName() == nameof(GC.SuppressFinalize))
                 {
                     return true;
                 }
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (arguments.Count == 1 && arguments[0].Expression?.IsKind(SyntaxKind.TrueLiteralExpression) is true && invocation.GetName() == nameof(IDisposable.Dispose))
+                if (arguments.Count is 1 && arguments[0].Expression?.IsKind(SyntaxKind.TrueLiteralExpression) is true && invocation.GetName() == nameof(IDisposable.Dispose))
                 {
                     return true;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3214_BeginEndScopeMethodsAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind == TypeKind.Interface;
+        protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind is TypeKind.Interface;
 
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3215_PredicateUsageAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3215_PredicateUsageAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var type = parameter.Type;
 
-                if (type.TypeKind == TypeKind.Delegate && type.Name == "Predicate" && type.TryGetGenericArgumentType(out var genericType))
+                if (type.TypeKind is TypeKind.Delegate && type.Name is "Predicate" && type.TryGetGenericArgumentType(out var genericType))
                 {
                     yield return Issue(parameter.GetSyntax<ParameterSyntax>().Type, genericType.Name);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var member = members[index];
 
-                if (member.IsVirtual && member.DeclaredAccessibility == Accessibility.Public)
+                if (member.IsVirtual && member.DeclaredAccessibility is Accessibility.Public)
                 {
                     if (member is IMethodSymbol method && method.MethodKind != MethodKind.Ordinary)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     expressionsCount++;
                 }
 
-                if (expressionsCount == 0)
+                if (expressionsCount is 0)
                 {
                     // we do not have any members to combine
                     yield break;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3223_LogicalConditionsUsingReferenceComparisonCanBeSimplifiedAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count == 1;
+        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count is 1;
 
         protected override bool IsApplicable(ITypeSymbol typeSymbol)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3224_LogicalConditionsUsingValueComparisonCanBeSimplifiedAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count == 1;
+        protected override bool IsApplicable(IReadOnlyList<ArgumentSyntax> arguments) => arguments.Count is 1;
 
         protected override bool IsApplicable(ITypeSymbol typeSymbol) => typeSymbol.IsValueType;
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_CodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var parameterList = parenthesized.ParameterList;
             var parameters = parameterList.Parameters;
 
-            if (parameters.Count == 1)
+            if (parameters.Count is 1)
             {
                 return SyntaxFactory.SimpleLambdaExpression(parameters.First(), body).WithModifiers(parenthesized.Modifiers);
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var statements = node.Block.DescendantNodes<StatementSyntax>().Take(Threshold).ToList();
 
             // simplification works only if it is a single statement
-            if (statements.Count == 1)
+            if (statements.Count is 1)
             {
                 switch (statements[0])
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var parameterList = node.ParameterList;
                 var parameters = parameterList.Parameters;
 
-                if (parameters.Count == 1 && parameters.First().Type is null)
+                if (parameters.Count is 1 && parameters.First().Type is null)
                 {
                     ReportDiagnostics(context, Issue(parameterList));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
@@ -157,7 +157,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var arguments = i.ArgumentList.Arguments;
 
-            if (arguments.Count == 1 && arguments[0].Expression is TypeOfExpressionSyntax t)
+            if (arguments.Count is 1 && arguments[0].Expression is TypeOfExpressionSyntax t)
             {
                 return new[] { t.Type };
             }

--- a/MiKo.Analyzer.Shared/Rules/Metrics/Counter.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/Counter.cs
@@ -85,7 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
         {
             var nodes = SyntaxNodeCollector.Collect<StatementSyntax>(body, syntaxKindToIgnore);
 
-            if (nodes.Count == 0)
+            if (nodes.Count is 0)
             {
                 return 0;
             }

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0004_MethodParameterCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0004_MethodParameterCountAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
                 if (parametersCount > MaxParametersCount && symbol.IsInterfaceImplementation() is false)
                 {
-                    var outParametersCount = parameters.Count(_ => _.RefKind == RefKind.Out);
+                    var outParametersCount = parameters.Count(_ => _.RefKind is RefKind.Out);
                     var count = parametersCount - outParametersCount;
 
                     if (count > MaxParametersCount)

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -117,7 +117,7 @@ namespace MiKoSolutions.Analyzers.Rules
             // collect all descendant nodes that are the first ones starting on a new line, then adjust leading space for each of those
             var startingNodes = GetNodesAndTokensStartingOnSeparateLines(syntax).ToList();
 
-            if (startingNodes.Count == 0)
+            if (startingNodes.Count is 0)
             {
                 return syntax;
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            if (symbol.MethodKind == MethodKind.PropertySet)
+            if (symbol.MethodKind is MethodKind.PropertySet)
             {
                 return false; // ignore the setter as the name there has to be 'value'
             }
@@ -79,7 +79,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var parameter = parameters[index];
 
-                var expected = count == 1
+                var expected = count is 1
                                ? symbol.Name == nameof(Equals) ? "other" : "e"
                                : GetNameForIndex(index);
 
@@ -117,7 +117,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var applicableParameters = method.Parameters.Where(_ => IsApplicable(_.Type)).ToList();
 
-            if (applicableParameters.Count == 1)
+            if (applicableParameters.Count is 1)
             {
                 return method.Name == nameof(Equals) ? "other" : "e";
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1006_EventArgsTypeUsageAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1006_EventArgsTypeUsageAnalyzer.cs
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
 
             // we either nave no correct event handler or too few/less type arguments, so try to guess the EventArgs
-            var eventArgsType = type?.TypeArguments.Length == 1 ? type.TypeArguments[0] : null;
+            var eventArgsType = type?.TypeArguments.Length is 1 ? type.TypeArguments[0] : null;
             var expectedName = eventName + nameof(EventArgs);
 
             if (IsProperlyNamed(eventArgsType, expectedName))

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1007_EventArgsNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1007_EventArgsNamespaceAnalyzer.cs
@@ -69,7 +69,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     return null; // ignore inherited events that we cannot change anymore
                 }
 
-                if (eventArgsType.FullyQualifiedName() == "System.EventArgs")
+                if (eventArgsType.FullyQualifiedName() is "System.EventArgs")
                 {
                     return null; // ignore special event args
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var prefix = FindBetterPrefix(method);
 
-            var phrase = prefix == "Has" && method.Name != SpecialHasPhrase
+            var phrase = prefix is "Has" && method.Name != SpecialHasPhrase
                          ? HasPhrase
                          : Phrase;
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzer.cs
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return false;
         }
 
-        private static bool IsStringFormatExtension(IMethodSymbol method) => method.ReturnType.SpecialType == SpecialType.System_String && method.Name.StartsWith("Format", StringComparison.Ordinal);
+        private static bool IsStringFormatExtension(IMethodSymbol method) => method.ReturnType.SpecialType is SpecialType.System_String && method.Name.StartsWith("Format", StringComparison.Ordinal);
 
         private static string FindBetterName(IParameterSymbol symbol)
         {
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Source;
             }
 
-            if (IsStringFormatExtension(symbol) && symbol.Type.SpecialType == SpecialType.System_String)
+            if (IsStringFormatExtension(symbol) && symbol.Type.SpecialType is SpecialType.System_String)
             {
                 return Format;
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
@@ -107,7 +107,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var arguments = argumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 yield break;
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            if (symbol.IsStatic && methodName == "Main")
+            if (symbol.IsStatic && methodName is "Main")
             {
                 // nothing to report here for the main method as that is the entry point of an application and as to be named 'Main'
                 return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var parameterName = methodName.AsSpan(6);
 
-                if (parameterName.Length == 0)
+                if (parameterName.Length is 0)
                 {
                     return "value";
                 }
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var parameterName = GetPreferredParameterName(method.Name);
 
-            var outParameter = method.Parameters.FirstOrDefault(_ => _.RefKind == RefKind.Out);
+            var outParameter = method.Parameters.FirstOrDefault(_ => _.RefKind is RefKind.Out);
 
             if (outParameter != null && outParameter.Name != parameterName)
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -85,7 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var findings = AbbreviationDetector.Find(symbolName);
             var findingsLength = findings.Length;
 
-            if (findingsLength == 0)
+            if (findingsLength is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1068_WorkflowMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1068_WorkflowMethodsAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.DeclaredAccessibility == Accessibility.Public && symbol.ContainingType.Name.EndsWith("Workflow", StringComparison.OrdinalIgnoreCase);
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.DeclaredAccessibility is Accessibility.Public && symbol.ContainingType.Name.EndsWith("Workflow", StringComparison.OrdinalIgnoreCase);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -170,7 +170,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static bool IsDocument(string typeName) => typeName.EndsWith("Document", StringComparison.Ordinal);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsMefAggregateCatalog(string typeName) => typeName == "AssemblyCatalog";
+        private static bool IsMefAggregateCatalog(string typeName) => typeName is "AssemblyCatalog";
 
         private static string GetPluralName(in ReadOnlySpan<char> originalName, out string name)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.TypeKind == TypeKind.Class && symbol.Name.EndsWithAny(EventArgSuffixes, StringComparison.Ordinal);
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.TypeKind is TypeKind.Class && symbol.Name.EndsWithAny(EventArgSuffixes, StringComparison.Ordinal);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1083_FieldsWithNumberSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1083_FieldsWithNumberSuffixAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             if (symbol.Type.Name.EndsWithNumber())
             {
-                if (symbol.Type.TypeKind == TypeKind.Struct && symbol.ContainingType.IsTestClass())
+                if (symbol.Type.TypeKind is TypeKind.Struct && symbol.ContainingType.IsTestClass())
                 {
                     // ignore only structs in tests
                     return false;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1087_CtorParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1087_CtorParameterNameAnalyzer.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var argumentsCount = arguments.Count;
 
-            if (argumentsCount == 0)
+            if (argumentsCount is 0)
             {
                 // no arguments to check for
                 yield break;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
@@ -55,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             if (name.EndsWith(Constants.Element, Comparison))
             {
-                var proposal = name == Constants.frameworkElement ? Constants.element : name.WithoutSuffix(Constants.Element);
+                var proposal = name is Constants.frameworkElement ? Constants.element : name.WithoutSuffix(Constants.Element);
 
                 return new[] { Issue(symbol, proposal, CreateBetterNameProposal(proposal)) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 }
                 else if (name.EndsWith(Constants.Element, Comparison))
                 {
-                    var proposal = name == Constants.frameworkElement ? Constants.element : name.WithoutSuffix(Constants.Element);
+                    var proposal = name is Constants.frameworkElement ? Constants.element : name.WithoutSuffix(Constants.Element);
 
                     yield return Issue(name, location, proposal, CreateBetterNameProposal(proposal));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1111_TestMethodsWithoutParametersNotSuffixedWithUnderscoreAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1111_TestMethodsWithoutParametersNotSuffixedWithUnderscoreAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Parameters.Length == 0 && symbol.IsTestMethod();
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Parameters.Length is 0 && symbol.IsTestMethod();
 
         protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => false; // do not consider local functions at all
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1200_ExceptionCatchBlockAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1200_ExceptionCatchBlockAnalyzer.cs
@@ -52,9 +52,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                     var expectedIdentifier = Constants.ExceptionIdentifier;
 
-                    if (node.Parent.AncestorsWithinMethods<CatchClauseSyntax>().Any(_ => _.Declaration?.Identifier.ValueText == Constants.ExceptionIdentifier))
+                    if (node.Parent.AncestorsWithinMethods<CatchClauseSyntax>().Any(_ => _.Declaration?.Identifier.ValueText is Constants.ExceptionIdentifier))
                     {
-                        if (name == Constants.InnerExceptionIdentifier)
+                        if (name is Constants.InnerExceptionIdentifier)
                         {
                             return null;
                         }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                 break;
                             }
 
-                            if (lambda is ParenthesizedLambdaExpressionSyntax parenthesized && parenthesized.ParameterList.Parameters.Count == 1)
+                            if (lambda is ParenthesizedLambdaExpressionSyntax parenthesized && parenthesized.ParameterList.Parameters.Count is 1)
                             {
                                 count++;
 
@@ -129,7 +129,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 {
                     var parameters = parenthesized.ParameterList.Parameters;
 
-                    if (parameters.Count == 1)
+                    if (parameters.Count is 1)
                     {
                         return AnalyzeParameter(parameters[0]);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
@@ -65,7 +65,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         internal static string FindBetterName(string name)
         {
-            if (name == "Model")
+            if (name is "Model")
             {
                 return Pluralizer.GetPluralName(Constants.Entity);
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
@@ -15,11 +15,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct && base.ShallAnalyze(symbol);
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ReturnType.TypeKind is TypeKind.Struct && base.ShallAnalyze(symbol);
 
-        protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct;
+        protected override bool ShallAnalyzeLocalFunctions(IMethodSymbol symbol) => symbol.ReturnType.TypeKind is TypeKind.Struct;
 
-        protected override bool ShallAnalyzeLocalFunction(IMethodSymbol symbol) => symbol.ReturnType.TypeKind == TypeKind.Struct;
+        protected override bool ShallAnalyzeLocalFunction(IMethodSymbol symbol) => symbol.ReturnType.TypeKind is TypeKind.Struct;
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IPropertySymbol symbol) => base.ShallAnalyze(symbol) && symbol.Type.TypeKind == TypeKind.Struct;
+        protected override bool ShallAnalyze(IPropertySymbol symbol) => base.ShallAnalyze(symbol) && symbol.Type.TypeKind is TypeKind.Struct;
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(IFieldSymbol symbol)
         {
-            if (symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
+            if (symbol.Type.TypeKind is TypeKind.Struct && symbol.Name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
             {
                 if (symbol.ContainingType.IsTestClass())
                 {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) && symbol.TypeKind == TypeKind.Struct;
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) && symbol.TypeKind is TypeKind.Struct;
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IParameterSymbol symbol) => symbol.Type.TypeKind == TypeKind.Struct && symbol.Name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase);
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => symbol.Type.TypeKind is TypeKind.Struct && symbol.Name.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -111,7 +111,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var localFunctions = symbol.GetLocalFunctions();
 
-            if (localFunctions.Count == 0)
+            if (localFunctions.Count is 0)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/DisposeOrderingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/DisposeOrderingCodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             {
                 var relatedDirectives = regionTrivia.GetRelatedDirectives();
 
-                if (relatedDirectives.Count == 2)
+                if (relatedDirectives.Count is 2)
                 {
                     var endRegionTrivia = relatedDirectives[1].ParentTrivia;
                     var parent = endRegionTrivia.Token.Parent;

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             var ordinaryMethods = GetMethodsOrderedByLocation(symbol);
             var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation);
 
-            var ordinaryDisposeMethods = ordinaryMethods.Where(_ => _.DeclaredAccessibility == Accessibility.Public && _.Parameters.None() && _.Name == nameof(IDisposable.Dispose)).ToList();
+            var ordinaryDisposeMethods = ordinaryMethods.Where(_ => _.DeclaredAccessibility is Accessibility.Public && _.Parameters.None() && _.Name == nameof(IDisposable.Dispose)).ToList();
             var interfaceDisposeMethods = interfaceImplementations.Where(_ => _.Parameters.None() && _.Name == nameof(System) + "." + nameof(IDisposable) + "." + nameof(IDisposable.Dispose)).ToList();
 
             var otherMethods = ordinaryMethods.Except(ordinaryDisposeMethods).Concat(interfaceImplementations.Except(interfaceDisposeMethods)).Select(_ => _.GetStartingLine()).ToList();

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_DisposeMethodsOrderedBeforeOtherMethodsAnalyzer.cs
@@ -44,13 +44,13 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
                 var methods = ordinaryMethods.Where(_ => _.DeclaredAccessibility == accessibility).ToList();
                 var disposeMethods = methods.Where(_ => _.Name == nameof(IDisposable.Dispose)).ToList();
 
-                if (accessibility == Accessibility.Public && disposeMethods.Count == 0)
+                if (accessibility is Accessibility.Public && disposeMethods.Count is 0)
                 {
                     var interfaceImplementations = GetMethodsOrderedByLocation(symbol, MethodKind.ExplicitInterfaceImplementation);
                     disposeMethods = interfaceImplementations.Where(_ => _.Parameters.None() && _.Name == nameof(System) + "." + nameof(IDisposable) + "." + nameof(IDisposable.Dispose)).ToList();
                 }
 
-                if (disposeMethods.Count == 0)
+                if (disposeMethods.Count is 0)
                 {
                     continue;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
             var types = new List<BaseTypeSyntax>();
 
-            if (type?.TypeKind == TypeKind.Class)
+            if (type?.TypeKind is TypeKind.Class)
             {
                 // the base type, if any
                 types.Add(baseType);

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_ImplementedInterfaceOrderedAfterClassAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_ImplementedInterfaceOrderedAfterClassAnalyzer.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             }
 
             // interface should be first after base type
-            return types.Contains(baseTypeName) && index == 1;
+            return types.Contains(baseTypeName) && index is 1;
         }
 
         private static BaseListSyntax GetBaseListSyntax(INamedTypeSymbol symbol)

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4008_GetHashCodeMethodsOrderedAfterEqualsMethodAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4008_GetHashCodeMethodsOrderedAfterEqualsMethodAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
         protected override IEnumerable<Diagnostic> AnalyzeType(INamedTypeSymbol symbol, Compilation compilation)
         {
-            var methods = GetMethodsOrderedByLocation(symbol).Where(_ => _.DeclaredAccessibility == Accessibility.Public).ToList();
+            var methods = GetMethodsOrderedByLocation(symbol).Where(_ => _.DeclaredAccessibility is Accessibility.Public).ToList();
             var methodNames = methods.ToHashSet(_ => _.Name);
 
             return methodNames.Contains(nameof(GetHashCode)) && methodNames.Contains(nameof(Equals))

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5001_CodeFixProvider.cs
@@ -94,7 +94,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             var position = children.IndexOf(insertedIf);
 
-            if (position == 0)
+            if (position is 0)
             {
                 // first node
                 if (childrenCount > 1)
@@ -165,7 +165,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                 {
                     statements.AddRange(block.Statements);
 
-                    if (position == MovePosition.Start)
+                    if (position is MovePosition.Start)
                     {
                         // statements have to be positioned after the already existing one, so insert the existing ones to the beginning
                         statements.InsertRange(0, statementsOfInsertedBlock);
@@ -181,7 +181,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                     // statement is no block, so add it as block
                     statements.AddRange(statementsOfInsertedBlock);
 
-                    if (position == MovePosition.Start)
+                    if (position is MovePosition.Start)
                     {
                         // statements have to be positioned before the already existing one, so add the existing one to the end
                         statements.Add(existingStatement);

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5002_DebugFormatInsteadDebugLogAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5002_DebugFormatInsteadDebugLogAnalyzer.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             }
         }
 
-        private Diagnostic AnalyzeInvocation(InvocationExpressionSyntax node, SemanticModel semanticModel) => node.Expression is MemberAccessExpressionSyntax methodCall && node.ArgumentList.Arguments.Count == 1
+        private Diagnostic AnalyzeInvocation(InvocationExpressionSyntax node, SemanticModel semanticModel) => node.Expression is MemberAccessExpressionSyntax methodCall && node.ArgumentList.Arguments.Count is 1
                                                                                                               ? Analyze(methodCall, semanticModel)
                                                                                                               : null;
 

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5003_LogExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5003_LogExceptionAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
         {
             var arguments = node.ArgumentList.Arguments;
 
-            if (arguments.Count == 0)
+            if (arguments.Count is 0)
             {
                 return null;
             }
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                     case Constants.ILog.Error:
                     case Constants.ILog.Fatal:
                     {
-                        return arguments.Count == 1
+                        return arguments.Count is 1
                                ? AnalyzeCall(methodCall, arguments, semanticModel, methodName)
                                : null;
                     }
@@ -78,7 +78,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             var type = methodCall.GetTypeSymbol(semanticModel);
 
             // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
-            if (type?.Name == Constants.ILog.TypeName && arguments.Any(_ => _.IsException(semanticModel)))
+            if (type?.Name is Constants.ILog.TypeName && arguments.Any(_ => _.IsException(semanticModel)))
             {
                 var enclosingMethod = methodCall.GetEnclosingMethod(semanticModel);
 

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
@@ -96,7 +96,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
                     var operand = Invocation(SimpleMemberAccess(left, nameof(Equals)), argument1);
 
-                    if (kind == SyntaxKind.NotEqualsExpression)
+                    if (kind is SyntaxKind.NotEqualsExpression)
                     {
                         return IsFalsePattern(operand);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
@@ -21,14 +21,14 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
 
-        private static bool IsObjectEqualsStaticMethod(IMethodSymbol method) => method.ContainingType.SpecialType == SpecialType.System_Object && method.IsStatic;
+        private static bool IsObjectEqualsStaticMethod(IMethodSymbol method) => method.ContainingType.SpecialType is SpecialType.System_Object && method.IsStatic;
 
         private static bool IsObjectEqualsOnStructMethod(IMethodSymbol method)
         {
             var parameters = method.Parameters;
 
             // find out whether it is the non-static 'Equals(object)' method
-            if (parameters.Length == 1 && parameters[0].Type.IsObject())
+            if (parameters.Length is 1 && parameters[0].Type.IsObject())
             {
                 return method.ContainingType.IsValueType;
             }
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         private static bool IsObjectEqualsInsideOwnOperator(ISymbol containingSymbol, SemanticModel semanticModel, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
-            if (arguments.Count == 2 && containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind == MethodKind.UserDefinedOperator)
+            if (arguments.Count is 2 && containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind is MethodKind.UserDefinedOperator)
             {
                 return IsSameType(arguments[0], semanticModel, enclosingMethod) || IsSameType(arguments[1], semanticModel, enclosingMethod);
             }
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         private static bool IsOwnEqualsInsideOwnOperator(ISymbol containingSymbol, SemanticModel semanticModel, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
-            if (arguments.Count == 1 && containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind == MethodKind.UserDefinedOperator)
+            if (arguments.Count is 1 && containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind is MethodKind.UserDefinedOperator)
             {
                 return IsSameType(arguments[0], semanticModel, enclosingMethod);
             }
@@ -69,9 +69,9 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                                                                                                                                                        }
                                                                                                                                                    });
 
-        private static bool IsEnumEqualsMethod(IMethodSymbol method) => method.ContainingType.SpecialType == SpecialType.System_Enum;
+        private static bool IsEnumEqualsMethod(IMethodSymbol method) => method.ContainingType.SpecialType is SpecialType.System_Enum;
 
-        private static bool IsStringEqualsMethod(IMethodSymbol method) => method.ContainingType.SpecialType == SpecialType.System_String && method.Parameters.All(_ => _.Type.SpecialType == SpecialType.System_String || _.Type.TypeKind == TypeKind.Enum);
+        private static bool IsStringEqualsMethod(IMethodSymbol method) => method.ContainingType.SpecialType is SpecialType.System_String && method.Parameters.All(_ => _.Type.SpecialType is SpecialType.System_String || _.Type.TypeKind is TypeKind.Enum);
 
         private static bool IsStruct(in SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel) => arguments.Any(_ => _.Expression.IsStruct(semanticModel));
 
@@ -172,7 +172,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                 if (IsStruct(arguments, semanticModel))
                 {
                     // let's see who this method is that invokes Equals
-                    if (containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind == MethodKind.UserDefinedOperator)
+                    if (containingSymbol is IMethodSymbol enclosingMethod && enclosingMethod.MethodKind is MethodKind.UserDefinedOperator)
                     {
                         return Issue(nodeSymbol.Name, node.Expression, "object.Equals", new[] { new Pair("dummy", "dummy") }); // marker to see that we have to handle an operator
                     }
@@ -203,7 +203,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             }
 
             // seems specific Equals, so let's see if it is the negative one
-            if (node.Parent.IsAnyKind(StrangeMarkers) && node.ArgumentList.Arguments.Count == 1)
+            if (node.Parent.IsAnyKind(StrangeMarkers) && node.ArgumentList.Arguments.Count is 1)
             {
                 if (node.Expression is MemberAccessExpressionSyntax syntax)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5012_RecursiveCallUsesYieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5012_RecursiveCallUsesYieldAnalyzer.cs
@@ -104,7 +104,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
         {
             var symbolInfo = semanticModel.GetSymbolInfo(identifier);
 
-            if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
+            if (symbolInfo.CandidateReason is CandidateReason.OverloadResolutionFailure)
             {
                 var arguments = invocation.ArgumentList.Arguments;
                 var argumentsCount = arguments.Count;

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5013_EmptyArrayAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5013_EmptyArrayAnalyzer.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             switch (size)
             {
-                case LiteralExpressionSyntax literal when literal.Token.ValueText == "0":
+                case LiteralExpressionSyntax literal when literal.Token.ValueText is "0":
                 case OmittedArraySizeExpressionSyntax _ when node.Initializer?.ChildNodes().Any() is false:
                 {
                     // it's an empty array
@@ -61,6 +61,6 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             }
         }
 
-        private static bool HasIssue(InitializerExpressionSyntax node) => node.Expressions.Count == 0; // seems we do not have any contents
+        private static bool HasIssue(InitializerExpressionSyntax node) => node.Expressions.Count is 0; // seems we do not have any contents
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5014_MethodReturnsEmptyListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5014_MethodReturnsEmptyListAnalyzer.cs
@@ -19,11 +19,11 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         protected override bool ShallAnalyze(IMethodSymbol symbol)
         {
-            if (symbol.ReturnsVoid is false && symbol.ContainingType.TypeKind == TypeKind.Class)
+            if (symbol.ReturnsVoid is false && symbol.ContainingType.TypeKind is TypeKind.Class)
             {
                 var returnType = symbol.ReturnType;
 
-                if (returnType.TypeKind == TypeKind.Interface)
+                if (returnType.TypeKind is TypeKind.Interface)
                 {
                     switch (returnType.SpecialType)
                     {
@@ -67,11 +67,11 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         private static bool HasIssue(ObjectCreationExpressionSyntax creation)
         {
-            if (creation.ArgumentList?.Arguments.Count == 0 || creation.Initializer?.Expressions.Count == 0)
+            if (creation.ArgumentList?.Arguments.Count is 0 || creation.Initializer?.Expressions.Count is 0)
             {
                 var name = creation.Type.GetNameOnlyPartWithoutGeneric();
 
-                return name == "List";
+                return name is "List";
             }
 
             return false;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6001_LogStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6001_LogStatementSurroundedByBlankLinesAnalyzer.cs
@@ -37,9 +37,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             switch (type?.Name)
             {
-                case Constants.ILog.TypeName when type.ContainingNamespace.Name == Constants.ILog.NamespaceName:
-                case Constants.SeriLog.TypeName when type.ContainingNamespace.Name == Constants.SeriLog.NamespaceName:
-                case Constants.MicrosoftLogging.TypeName when type.ContainingNamespace.FullyQualifiedName() == Constants.MicrosoftLogging.NamespaceName:
+                case Constants.ILog.TypeName when type.ContainingNamespace.Name is Constants.ILog.NamespaceName:
+                case Constants.SeriLog.TypeName when type.ContainingNamespace.Name is Constants.SeriLog.NamespaceName:
+                case Constants.MicrosoftLogging.TypeName when type.ContainingNamespace.FullyQualifiedName() is Constants.MicrosoftLogging.NamespaceName:
                     return true;
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6004_VariableAssignmentPrecededByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6004_VariableAssignmentPrecededByBlankLinesAnalyzer.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             var symbol = syntax.Identifier.GetSymbol(semanticModel);
 
-            return symbol?.Kind == SymbolKind.Local;
+            return symbol?.Kind is SymbolKind.Local;
         }
 
         private void Analyze(SyntaxNodeAnalysisContext context)

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6021_ArgumentNullExceptionThrowIfNullStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6021_ArgumentNullExceptionThrowIfNullStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name == nameof(ArgumentNullException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() == "ThrowIfNull" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIfNull" && base.IsCall(syntax, semanticModel);
 
         protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6022_ArgumentExceptionThrowIfNullOrEmptyStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6022_ArgumentExceptionThrowIfNullOrEmptyStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name == nameof(ArgumentException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() == "ThrowIfNullOrEmpty" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIfNullOrEmpty" && base.IsCall(syntax, semanticModel);
 
         protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6024_ObjectDisposedExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6024_ObjectDisposedExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name == nameof(ObjectDisposedException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() == "ThrowIf" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIf" && base.IsCall(syntax, semanticModel);
 
         protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             var arguments = invocation.ArgumentList.Arguments;
 
-            if (arguments.Count == 1)
+            if (arguments.Count is 1)
             {
                 AnalyzeArgument(context, arguments[0], invocation);
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
         {
-            if (syntax is CollectionExpressionSyntax expression && expression.Parent is ArgumentSyntax argument && argument.Parent is ArgumentListSyntax argumentList && argumentList.Arguments.IndexOf(argument) == 0)
+            if (syntax is CollectionExpressionSyntax expression && expression.Parent is ArgumentSyntax argument && argument.Parent is ArgumentListSyntax argumentList && argumentList.Arguments.IndexOf(argument) is 0)
             {
                 var updatedArgumentList = argumentList.ReplaceNode(argument, argument.WithoutLeadingTrivia());
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -186,7 +186,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected static SeparatedSyntaxList<TSyntaxNode> GetUpdatedSyntax<TSyntaxNode>(in SeparatedSyntaxList<TSyntaxNode> expressions, in int leadingSpaces) where TSyntaxNode : SyntaxNode
         {
-            if (expressions.Count == 0)
+            if (expressions.Count is 0)
             {
                 return SyntaxFactory.SeparatedList<TSyntaxNode>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
@@ -57,7 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             var differenceBefore = callLineSpan.StartLinePosition.Line - endingLine;
 
-            return differenceBefore == 1;
+            return differenceBefore is 1;
         }
 
         protected static bool HasNoBlankLinesBefore(SyntaxNode node, SyntaxNode other)
@@ -71,7 +71,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             var differenceAfter = startingLine - callLineSpan.EndLinePosition.Line;
 
-            return differenceAfter == 1;
+            return differenceAfter is 1;
         }
 
         protected static bool HasNoBlankLinesAfter(SyntaxNode node, SyntaxNode other)

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -241,7 +241,7 @@ namespace TestHelper
         /// </returns>
         private static Diagnostic[] SortDiagnostics(List<Diagnostic> diagnostics)
         {
-            if (diagnostics.Count == 0)
+            if (diagnostics.Count is 0)
             {
                 return [];
             }
@@ -299,7 +299,7 @@ namespace TestHelper
 
             var length = sources.Length;
 
-            if (length == 1)
+            if (length is 1)
             {
                 const string FileName = "Test.cs";
                 var documentId = DocumentId.CreateNewId(projectId, debugName: FileName);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [TearDown]
         public void TearDown()
         {
-            if (s_testNumber % 5000 == 0)
+            if (s_testNumber % 5000 is 0)
             {
                 GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
             }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -82,7 +82,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [TearDown]
         public void TearDown()
         {
-            if (s_testNumber % 5000 == 0)
+            if (s_testNumber % 5000 is 0)
             {
                 GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
             }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [TearDown]
         public void TearDown()
         {
-            if (s_testNumber % 5000 == 0)
+            if (s_testNumber % 5000 is 0)
             {
                 GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
             }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [TearDown]
         public void TearDown()
         {
-            if (s_testNumber % 5000 == 0)
+            if (s_testNumber % 5000 is 0)
             {
                 GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
             }

--- a/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/CodeFixVerifier.cs
@@ -154,7 +154,7 @@ namespace TestHelper
                     var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, _) => actions.Add(a), CancellationToken.None);
                     codeFixProvider.RegisterCodeFixesAsync(context).Wait();
 
-                    if (actions.Count == 0)
+                    if (actions.Count is 0)
                     {
                         break;
                     }
@@ -187,7 +187,7 @@ New document:
                     }
 
                     // check if there are analyzer diagnostics left after the code fix
-                    if (analyzerDiagnostics.Length == 0)
+                    if (analyzerDiagnostics.Length is 0)
                     {
                         break;
                     }

--- a/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/MiKo.Analyzer.Tests/Verifiers/DiagnosticVerifier.cs
@@ -122,7 +122,7 @@ namespace TestHelper
             {
                 var results = GetDiagnostics(File.ReadAllText(file), languageVersion);
 
-                if (results.Length != 0)
+                if (results.Length is not 0)
                 {
                     yield return file;
                 }


### PR DESCRIPTION
- Replace '==' with 'is' for literal comparisons  

- Modernize extension method conditional checks  

- Update analyzer rules and codefix providers  

- Improve readability via pattern matching
