### PR TITLE
Changed the default values for the 'StringBuilderCache'

### DIFF
--- a/MiKo.Analyzer.Shared/StringBuilderCache.cs
+++ b/MiKo.Analyzer.Shared/StringBuilderCache.cs
@@ -7,8 +7,8 @@ namespace MiKoSolutions.Analyzers
 {
     internal static class StringBuilderCache
     {
-        public const int DefaultCapacity = 16;
-        private const int MaxBuilderSize = 1000;
+        public const int DefaultCapacity = 32;
+        private const int MaxBuilderSize = 1024;
 
         [ThreadStatic]
         private static StringBuilder s_cachedInstance;


### PR DESCRIPTION
- Increase `DefaultCapacity` from 16 to 32

- Raise `MaxBuilderSize` from 1000 to 1024
