### PR TITLE
Updated String builder cache default settings

### DIFF
--- a/MiKo.Analyzer.Shared/StringBuilderCache.cs
+++ b/MiKo.Analyzer.Shared/StringBuilderCache.cs
@@ -7,7 +7,7 @@ namespace MiKoSolutions.Analyzers
 {
     internal static class StringBuilderCache
     {
-        public const int DefaultCapacity = 32;
+        public const int DefaultCapacity = 64;
         private const int MaxBuilderSize = 1024;
 
         [ThreadStatic]
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            return new StringBuilder(capacity);
+            return new StringBuilder(Math.Max(capacity, DefaultCapacity));
         }
 
         public static void Release(StringBuilder builder)


### PR DESCRIPTION
- Increase `DefaultCapacity` to `64`

- Use maximum of acquired capacity and `DefaultCapacity` for string builder initial capacity