### PR TITLE
Added new rule MiKo_6065 that reports outdented dots on invocations

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1042,6 +1042,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static int GetPositionWithinStartLine(this SyntaxNode value) => value.GetLocation().GetPositionWithinStartLine();
 
+        internal static int GetPositionWithinEndLine(this SyntaxNode value) => value.GetLocation().GetPositionWithinEndLine();
+
         internal static int GetStartingLine(this SyntaxNode value) => value.GetLocation().GetStartingLine();
 
         internal static int GetEndingLine(this SyntaxNode value) => value.GetLocation().GetEndingLine();

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -406,6 +406,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6062_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6063_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6064_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6065_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -569,6 +569,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6062_ComplexInitializerElementExpressionsAreIndentedBesideOpenBraceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6063_InvocationIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6065_InvocationIsIndentedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -16159,7 +16159,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consecutive invocations spaning multiple lines should be aligned by their dots.
+        ///   Looks up a localized string similar to Consecutive invocations spanning multiple lines should be aligned by their dots.
         /// </summary>
         internal static string MiKo_6040_Title {
             get {
@@ -17028,6 +17028,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_6064_Title {
             get {
                 return ResourceManager.GetString("MiKo_6064_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indent dot.
+        /// </summary>
+        internal static string MiKo_6065_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6065_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code readability improves when invocations spanning multiple lines are vertically indented. This makes the code clearer and easier to follow..
+        /// </summary>
+        internal static string MiKo_6065_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6065_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indent dot.
+        /// </summary>
+        internal static string MiKo_6065_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6065_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Consecutive invocations spanning multiple lines should be indented and not outdented.
+        /// </summary>
+        internal static string MiKo_6065_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6065_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5620,7 +5620,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Indent dots</value>
   </data>
   <data name="MiKo_6040_Title" xml:space="preserve">
-    <value>Consecutive invocations spaning multiple lines should be aligned by their dots</value>
+    <value>Consecutive invocations spanning multiple lines should be aligned by their dots</value>
   </data>
   <data name="MiKo_6041_CodeFixTitle" xml:space="preserve">
     <value>Place assignment on same line</value>
@@ -5909,6 +5909,18 @@ This organization ensures clarity and makes the code easier to find, understand 
   </data>
   <data name="MiKo_6064_Title" xml:space="preserve">
     <value>Identifier invocations should be placed on same line</value>
+  </data>
+  <data name="MiKo_6065_CodeFixTitle" xml:space="preserve">
+    <value>Indent dot</value>
+  </data>
+  <data name="MiKo_6065_Description" xml:space="preserve">
+    <value>Code readability improves when invocations spanning multiple lines are vertically indented. This makes the code clearer and easier to follow.</value>
+  </data>
+  <data name="MiKo_6065_MessageFormat" xml:space="preserve">
+    <value>Indent dot</value>
+  </data>
+  <data name="MiKo_6065_Title" xml:space="preserve">
+    <value>Consecutive invocations spanning multiple lines should be indented and not outdented</value>
   </data>
   <data name="MiKo_6070_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_CodeFixProvider.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6065_CodeFixProvider)), Shared]
+    public sealed class MiKo_6065_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6065";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            foreach (var node in syntaxNodes)
+            {
+                switch (node)
+                {
+                    case MemberAccessExpressionSyntax _:
+                        return node;
+
+                    case MemberBindingExpressionSyntax _:
+                        return node.Parent?.Parent; // we are interested in the ConditionalAccessExpressionSyntax that is the parent of the InvocationExpressionSyntax
+                }
+            }
+
+            return null;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            switch (syntax)
+            {
+                case MemberAccessExpressionSyntax a:
+                {
+                    var spaces = GetProposedSpaces(issue);
+
+                    return a.WithOperatorToken(a.OperatorToken.WithLeadingSpaces(spaces));
+                }
+
+                case ConditionalAccessExpressionSyntax c:
+                {
+                    var spaces = GetProposedSpaces(issue);
+
+                    return c.WithOperatorToken(c.OperatorToken.WithLeadingSpaces(spaces));
+                }
+
+                default:
+                    return syntax;
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class MiKo_6065_InvocationIsIndentedAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6065";
+
+        public MiKo_6065_InvocationIsIndentedAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.InvocationExpression);
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context) => ReportDiagnostics(context, FindIssue(context));
+
+        private Diagnostic FindIssue(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax invocation)
+            {
+                switch (invocation.Expression)
+                {
+                    case MemberAccessExpressionSyntax maes:
+                        return FindIssue(maes);
+
+                    case MemberBindingExpressionSyntax mbes:
+                        return FindIssue(mbes, invocation.Parent as ConditionalAccessExpressionSyntax);
+                }
+            }
+
+            return null;
+        }
+
+        private Diagnostic FindIssue(MemberAccessExpressionSyntax member)
+        {
+            if (member.IsKind(SyntaxKind.SimpleMemberAccessExpression) && member.Name is IdentifierNameSyntax)
+            {
+                var dot = member.OperatorToken;
+                var expression = member.Expression;
+
+                if (dot.GetPositionWithinStartLine() < expression.GetPositionWithinStartLine())
+                {
+                    switch (expression)
+                    {
+                        case IdentifierNameSyntax identifier:
+                            return FindIssue(dot, identifier);
+
+                        case InvocationExpressionSyntax invocation when invocation.Expression is IdentifierNameSyntax identifier:
+                            return FindIssue(dot, identifier);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private Diagnostic FindIssue(MemberBindingExpressionSyntax member, ConditionalAccessExpressionSyntax conditional)
+        {
+            var expression = conditional?.Expression;
+
+            if (expression is null)
+            {
+                return null;
+            }
+
+            var token = member.OperatorToken;
+
+            if (token.GetPositionWithinStartLine() < expression.GetPositionWithinStartLine())
+            {
+                switch (expression)
+                {
+                    case IdentifierNameSyntax identifier:
+                        return FindIssue(token, identifier);
+
+                    case InvocationExpressionSyntax invocation when invocation.Expression is IdentifierNameSyntax identifier:
+                        return FindIssue(token, identifier);
+                }
+            }
+
+            return null;
+        }
+
+        private Diagnostic FindIssue(SyntaxToken dot, IdentifierNameSyntax identifier)
+        {
+            var location = identifier.GetLocation();
+            var position = location.GetPositionWithinEndLine();
+
+            return Issue(dot, CreateProposalForSpaces(position - Constants.Indentation));
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzerTests.cs
@@ -1,0 +1,469 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6065_InvocationIsIndentedAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_object_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject.DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_object_is_indented_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+                    .DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_invocation_on_object_is_outdented_on_other_line() => An_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+            .DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_object_is_on_same_line_in_expression_body() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject) => await someObject.DoSomething(1, 2, 3);
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_object_is_indented_on_other_line_in_expression_body() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject) => await someObject
+                                                                    .DoSomething(1, 2, 3);
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_invocation_on_object_is_outdented_on_other_line_in_expression_body() => An_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject) => await someObject
+                                                            .DoSomething(1, 2, 3);
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_return_value_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42).DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_invocation_on_return_value_is_indented_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+                    .DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_invocation_on_return_value_is_outdented_on_other_line() => An_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+            .DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_conditional_invocation_on_object_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject?.DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_conditional_invocation_on_object_is_indented_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+                    ?.DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_conditional_invocation_on_object_is_outdented_on_other_line() => An_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+            ?.DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_conditional_invocation_on_return_value_is_on_same_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_conditional_invocation_on_return_value_is_indented_on_other_line() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+                    ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_if_conditional_invocation_on_return_value_is_outdented_on_other_line() => An_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+            ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_if_invocation_on_object_is_outdented_on_other_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+            .DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+                    .DoSomething(1, 2, 3);
+    }
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_invocation_on_object_is_outdented_on_other_line_in_expression_body()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject) => await someObject
+                                                            .DoSomething(1, 2, 3);
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject) => await someObject
+                                                                    .DoSomething(1, 2, 3);
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_invocation_on_return_value_is_outdented_on_other_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+            .DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+                  .DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_conditional_invocation_on_object_is_outdented_on_other_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+            ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething(TestMe someObject)
+    {
+        await someObject
+                    ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_if_conditional_invocation_on_return_value_is_outdented_on_other_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+            ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomething()
+    {
+        await CreateMe(42)
+                  ?.DoSomething(1, 2, 3);
+    }
+
+    private TestMe CreateMe(int unused) => new TestMe();
+
+    private Task DoSomething(int i, int j, int k) => Task.CompletedTask;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6065_InvocationIsIndentedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6065_InvocationIsIndentedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6065_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 496 rules that are currently provided by the analyzer.
+The following tables lists all the 497 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -536,5 +536,6 @@ The following tables lists all the 496 rules that are currently provided by the 
 |MiKo_6062|Expressions within complex initializer expressions should be placed beside open brace|&#x2713;|&#x2713;|
 |MiKo_6063|Invocations should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6064|Identifier invocations should be placed on same line|&#x2713;|&#x2713;|
+|MiKo_6065|Consecutive invocations spanning multiple lines should be indented and not outdented|&#x2713;|&#x2713;|
 |MiKo_6070|Console statements should be surrounded by blank lines|&#x2713;|&#x2713;|
 |MiKo_6071|Local using statements should be surrounded by blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add MiKo_6065 analyzer enforcing indented invocation dots

- Provide CodeFix provider for dot indentation

- Include unit tests for analyzer and code fixes

- Update resources, project files, and README

(resolves #1321)
