### PR TITLE
MiKo_3051 now re-uses the trivia from the replaced text so that 'nameof()' is correctly placed

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3051_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3051_CodeFixProvider.cs
@@ -33,10 +33,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             switch (syntax)
             {
                 case LiteralExpressionSyntax literal:
-                    return NameOf(literal);
+                    return NameOf(literal).WithTriviaFrom(literal);
 
-                case TypeOfExpressionSyntax _ when issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.ParameterValue, out var value):
-                    return TypeOf(value);
+                case TypeOfExpressionSyntax expression when issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.ParameterValue, out var value):
+                    return TypeOf(value).WithTriviaFrom(expression);
 
                 default:
                     return null;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3051_DependencyPropertyRegisterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3051_DependencyPropertyRegisterAnalyzerTests.cs
@@ -248,6 +248,90 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_DependencyProperty_field_that_is_registered_with_StringLiteral_spanning_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System.Windows;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public int MyField { get; set; }
+        
+        private static readonly DependencyProperty m_fieldProperty = DependencyProperty.Register(
+                                                                                            ""MyField"",
+                                                                                            typeof(int),
+                                                                                            typeof(TestMe),
+                                                                                            new PropertyMetadata(default(int)));
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Windows;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public int MyField { get; set; }
+        
+        private static readonly DependencyProperty m_fieldProperty = DependencyProperty.Register(
+                                                                                            nameof(MyField),
+                                                                                            typeof(int),
+                                                                                            typeof(TestMe),
+                                                                                            new PropertyMetadata(default(int)));
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_DependencyProperty_field_that_is_registered_with_wrong_owning_type_spanning_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System.Windows;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public int MyField { get; set; }
+        
+        private static readonly DependencyProperty m_fieldProperty = DependencyProperty.Register(
+                                                                                            nameof(MyField),
+                                                                                            typeof(int),
+                                                                                            typeof(int),
+                                                                                            new PropertyMetadata(default(int)));
+    }
+}
+";
+
+            const string FixedCode = @"
+using System.Windows;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public int MyField { get; set; }
+        
+        private static readonly DependencyProperty m_fieldProperty = DependencyProperty.Register(
+                                                                                            nameof(MyField),
+                                                                                            typeof(int),
+                                                                                            typeof(TestMe),
+                                                                                            new PropertyMetadata(default(int)));
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_3051_DependencyPropertyRegisterAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3051_DependencyPropertyRegisterAnalyzer();


### PR DESCRIPTION
- Preserve original trivia in code fixes

- Add test for multiline string literal fix

- Add test for multiline wrong owning type fix
