### PR TITLE
Added NCrunch 'Isolated' attribute to AnalyzerTests

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -11,6 +11,8 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+using NCrunch.Framework;
+
 using NUnit.Framework;
 
 using TestHelper;
@@ -18,7 +20,7 @@ using TestHelper;
 //// ncrunch: rdi off
 namespace MiKoSolutions.Analyzers.Rules
 {
-    [TestFixture, Category("Always impacted")]
+    [TestFixture, Category("Always impacted"), Isolated]
     public static class AnalyzerTests
     {
         private static readonly Analyzer[] AllAnalyzers = CreateAllAnalyzers();
@@ -26,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         [Ignore("Shall be run manually")]
         [Explicit]
-        [TestCase("TODO"), Timeout(4 * 60 * 60 * 1000)] // 4h
+        [TestCase("TODO"), Timeout(1 * 60 * 60 * 1000)] // 1h
         public static void Performance_(string path)
         {
 //// ncrunch: no coverage start


### PR DESCRIPTION
Those tests now run in isolation as they take very long to finish (compared to other tests). In addition, changed the timeout value from 4h to 1h (which is reasonable as the tests may take only about 15min to run in total)