### PR TITLE
Added rule MiKo_2239 that reports /** */

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1196,13 +1196,13 @@ namespace MiKoSolutions.Analyzers
             return token.HasStructuredTrivia && token.HasDocumentationCommentTriviaSyntax();
         }
 
-        internal static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(this SyntaxNode value)
+        internal static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(this SyntaxNode value, in SyntaxKind kind = SyntaxKind.SingleLineDocumentationCommentTrivia)
         {
             var token = value.FindStructuredTriviaToken();
 
             if (token.HasStructuredTrivia)
             {
-                var comment = token.GetDocumentationCommentTriviaSyntax();
+                var comment = token.GetDocumentationCommentTriviaSyntax(kind);
 
                 if (comment != null)
                 {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -111,7 +111,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        internal static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(this in SyntaxToken value)
+        internal static DocumentationCommentTriviaSyntax[] GetDocumentationCommentTriviaSyntax(this in SyntaxToken value, in SyntaxKind kind = SyntaxKind.SingleLineDocumentationCommentTrivia)
         {
             var leadingTrivia = value.LeadingTrivia;
             var count = leadingTrivia.Count;
@@ -121,7 +121,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var trivia = leadingTrivia[count is 4 ? 2 : 1];
 
-                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
+                if (trivia.IsKind(kind) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
                 {
                     return new[] { syntax };
                 }
@@ -134,7 +134,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var trivia = leadingTrivia[index];
 
-                if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
+                if (trivia.IsKind(kind) && trivia.GetStructure() is DocumentationCommentTriviaSyntax syntax)
                 {
                     if (results is null)
                     {
@@ -376,6 +376,8 @@ namespace MiKoSolutions.Analyzers
         }
 
         internal static SyntaxToken WithLeadingXmlComment(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentStart);
+
+        internal static SyntaxToken WithLeadingXmlCommentExterior(this SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentExterior);
 
         internal static SyntaxToken WithTriviaFrom(this in SyntaxToken value, SyntaxNode node) => value.WithLeadingTriviaFrom(node)
                                                                                                        .WithTrailingTriviaFrom(node);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -138,6 +138,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2235_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -156,6 +156,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_ExampleAbbreviationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_MultipleDocumentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2238_MakeSureToCallThisAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8948,6 +8948,43 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert into &apos;/// &lt;summary&gt;&apos; comment.
+        /// </summary>
+        internal static string MiKo_2239_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2239_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to API documentation should use &apos;///&apos; instead of &apos;/** */&apos; because &apos;///&apos; creates XML comments that the .NET compiler understands. These comments show up in IntelliSense, help generate external documentation, and follow a structured format.
+        ///&apos;/** */&apos; is just for general comments and will not be used by tools or IDEs to provide helpful info..
+        /// </summary>
+        internal static string MiKo_2239_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2239_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;///&apos; with XML tags instead of &apos;/** */&apos;.
+        /// </summary>
+        internal static string MiKo_2239_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2239_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should use &apos;///&apos; and not &apos;/** */&apos;.
+        /// </summary>
+        internal static string MiKo_2239_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2239_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3158,6 +3158,19 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
   <data name="MiKo_2238_Title" xml:space="preserve">
     <value>&lt;summary&gt; documentation shall not start with 'Make sure to call this'</value>
   </data>
+  <data name="MiKo_2239_CodeFixTitle" xml:space="preserve">
+    <value>Convert into '/// &lt;summary&gt;' comment</value>
+  </data>
+  <data name="MiKo_2239_Description" xml:space="preserve">
+    <value>API documentation should use '///' instead of '/** */' because '///' creates XML comments that the .NET compiler understands. These comments show up in IntelliSense, help generate external documentation, and follow a structured format.
+'/** */' is just for general comments and will not be used by tools or IDEs to provide helpful info.</value>
+  </data>
+  <data name="MiKo_2239_MessageFormat" xml:space="preserve">
+    <value>Use '///' with XML tags instead of '/** */'</value>
+  </data>
+  <data name="MiKo_2239_Title" xml:space="preserve">
+    <value>Documentation should use '///' and not '/** */'</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -487,11 +487,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlCrefAttributeSyntax GetSeeCref(SyntaxNode value) => value.GetCref(Constants.XmlTag.See);
 
-        protected static DocumentationCommentTriviaSyntax GetXmlSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        protected static DocumentationCommentTriviaSyntax GetXmlSyntax(IEnumerable<SyntaxNode> syntaxNodes, in SyntaxKind kind = SyntaxKind.SingleLineDocumentationCommentTrivia)
         {
             foreach (var node in syntaxNodes)
             {
-                var comments = node.GetDocumentationCommentTriviaSyntax();
+                var comments = node.GetDocumentationCommentTriviaSyntax(kind);
 
                 if (comments.Length > 0)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_CodeFixProvider.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2239_CodeFixProvider)), Shared]
+    public sealed class MiKo_2239_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2239";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes, SyntaxKind.MultiLineDocumentationCommentTrivia);
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            var comment = (DocumentationCommentTriviaSyntax)syntax;
+
+            var texts = comment.Content.OfType<XmlTextSyntax>()
+                                       .Select(CleanupText)
+                                       .ToSyntaxList<XmlNodeSyntax>();
+
+            var summary = Comment(SyntaxFactory.XmlSummaryElement(), texts).WithLeadingXmlCommentExterior();
+
+            return SyntaxFactory.DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, summary.ToSyntaxList<XmlNodeSyntax>());
+        }
+
+        private static XmlTextSyntax CleanupText(XmlTextSyntax text) => XmlText(CleanupTextTokens(text.TextTokens));
+
+        private static IEnumerable<SyntaxToken> CleanupTextTokens(SyntaxTokenList textTokens)
+        {
+            var last = textTokens.Count - 1;
+
+            for (var index = 0; index <= last; index++)
+            {
+                var textToken = textTokens[index];
+
+                if (textToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                {
+                    if (index > 0 && index < last)
+                    {
+                        yield return textToken.WithoutTrivia();
+                    }
+                }
+                else
+                {
+                    var token = textToken.WithoutTrivia()
+                                         .WithText(textToken.ValueText.Trim());
+
+                    if (index > 1)
+                    {
+                        yield return token.WithLeadingXmlCommentExterior();
+                    }
+                    else
+                    {
+                        yield return token;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer : DocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2239";
+
+        public MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, SyntaxKind.MultiLineDocumentationCommentTrivia);
+
+        private void AnalyzeComment(SyntaxNodeAnalysisContext context) => ReportDiagnostics(context, Issue(context.Node));
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzerTests.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
+public class TestMe
+{
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_SingleLineDocumentationComment_on_single_line() => No_issue_is_reported_for(@"
+/// <summary></summary>
+public class TestMe
+{
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_SingleLineDocumentationComment_on_separate_lines() => No_issue_is_reported_for(@"
+/// <summary>
+/// </summary>
+public class TestMe
+{
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_MultiLineDocumentationComment_on_single_line() => An_issue_is_reported_for(@"
+/** */
+public class TestMe
+{
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_MultiLineDocumentationComment_on_separate_lines() => An_issue_is_reported_for(@"
+/**
+*/
+public class TestMe
+{
+}");
+
+        [Test]
+        public void Code_gets_fixed_for_MultiLineDocumentationComment_on_single_line()
+        {
+            const string OriginalCode = @"
+/** Some comment */
+public class TestMe
+{
+}";
+
+            const string FixedCode = @"
+/// <summary>
+/// Some comment
+/// </summary>
+public class TestMe
+{
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_MultiLineDocumentationComment_on_separate_lines()
+        {
+            const string OriginalCode = @"
+/**
+* Some code
+* with some text
+*/
+public class TestMe
+{
+}";
+
+            const string FixedCode = @"
+/// <summary>
+/// Some code
+/// with some text
+/// </summary>
+public class TestMe
+{
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2239_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 497 rules that are currently provided by the analyzer.
+The following tables lists all the 498 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -282,6 +282,7 @@ The following tables lists all the 497 rules that are currently provided by the 
 |MiKo_2236|Documentation should use 'for example' instead of abbreviation 'e.g.'|&#x2713;|&#x2713;|
 |MiKo_2237|Documentation should not be separated by empty lines|&#x2713;|&#x2713;|
 |MiKo_2238|&lt;summary&gt; documentation shall not start with 'Make sure to call this'|&#x2713;|\-|
+|MiKo_2239|Documentation should use '///' and not '/** */'|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Add MiKo_2239 analyzer for `/** */` comments

- Implement code fix converting to `/// <summary>` XML comments

- Extend SyntaxNode/Token extension methods for comment kind

- Update resources, project files, README and tests

(resolves #1325)