### PR TITLE
Replaced 'Array.Resize' with rented arrays to comsume less memory

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -1099,19 +1099,19 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount > 0)
+            if (sourceCount is 0)
             {
-                var target = new SyntaxToken[sourceCount];
-
-                for (var index = 0; index < sourceCount; index++)
-                {
-                    target[index] = source[index];
-                }
-
-                return target;
+                return Array.Empty<SyntaxToken>();
             }
 
-            return Array.Empty<SyntaxToken>();
+            var target = new SyntaxToken[sourceCount];
+
+            for (var index = 0; index < sourceCount; index++)
+            {
+                target[index] = source[index];
+            }
+
+            return target;
         }
 
         internal static T[] ToArray<T>(this in SyntaxList<T> source) where T : SyntaxNode
@@ -1119,19 +1119,19 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount > 0)
+            if (sourceCount is 0)
             {
-                var target = new T[sourceCount];
-
-                for (var index = 0; index < sourceCount; index++)
-                {
-                    target[index] = source[index];
-                }
-
-                return target;
+                return Array.Empty<T>();
             }
 
-            return Array.Empty<T>();
+            var target = new T[sourceCount];
+
+            for (var index = 0; index < sourceCount; index++)
+            {
+                target[index] = source[index];
+            }
+
+            return target;
         }
 
         internal static T[] ToArray<T>(this in SeparatedSyntaxList<T> source) where T : SyntaxNode
@@ -1139,79 +1139,79 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            if (sourceCount > 0)
+            if (sourceCount is 0)
             {
-                var target = new T[sourceCount];
-
-                for (var index = 0; index < sourceCount; index++)
-                {
-                    target[index] = source[index];
-                }
-
-                return target;
+                return Array.Empty<T>();
             }
 
-            return Array.Empty<T>();
+            var target = new T[sourceCount];
+
+            for (var index = 0; index < sourceCount; index++)
+            {
+                target[index] = source[index];
+            }
+
+            return target;
         }
 
         internal static T[] ToArray<T>(this IEnumerable<T> source, IComparer<T> comparer) => source.ToArray(_ => _, comparer);
 
         internal static TKey[] ToArray<TKey, TSource>(this in SeparatedSyntaxList<TSource> source, Func<TSource, TKey> keySelector) where TSource : SyntaxNode
         {
-            var length = source.Count;
+            var sourceCount = source.Count;
 
-            if (length > 0)
+            if (sourceCount is 0)
             {
-                var result = new TKey[length];
-
-                for (var index = 0; index < length; index++)
-                {
-                    result[index] = keySelector(source[index]);
-                }
-
-                return result;
+                return Array.Empty<TKey>();
             }
 
-            return Array.Empty<TKey>();
+            var result = new TKey[sourceCount];
+
+            for (var index = 0; index < sourceCount; index++)
+            {
+                result[index] = keySelector(source[index]);
+            }
+
+            return result;
         }
 
         internal static TKey[] ToArray<TKey, TSource>(this IReadOnlyList<TSource> source, Func<TSource, TKey> keySelector)
         {
-            var length = source.Count;
+            var sourceCount = source.Count;
 
-            if (length > 0)
+            if (sourceCount is 0)
             {
-                var result = new TKey[length];
-
-                for (var index = 0; index < length; index++)
-                {
-                    result[index] = keySelector(source[index]);
-                }
-
-                return result;
+                return Array.Empty<TKey>();
             }
 
-            return Array.Empty<TKey>();
+            var result = new TKey[sourceCount];
+
+            for (var index = 0; index < sourceCount; index++)
+            {
+                result[index] = keySelector(source[index]);
+            }
+
+            return result;
         }
 
         internal static TKey[] ToArray<TKey, TSource>(this IReadOnlyCollection<TSource> source, Func<TSource, TKey> keySelector)
         {
-            var length = source.Count;
+            var sourceCount = source.Count;
 
-            if (length > 0)
+            if (sourceCount is 0)
             {
-                var result = new TKey[length];
-                var index = 0;
-
-                foreach (var item in source)
-                {
-                    result[index++] = keySelector(item);
-                }
-
-                return result;
+                return Array.Empty<TKey>();
             }
 
-            return Array.Empty<TKey>();
+            var index = 0;
+            var result = new TKey[sourceCount];
+
+            foreach (var item in source)
+            {
+                result[index++] = keySelector(item);
+            }
+
+            return result;
         }
 
         internal static TKey[] ToArray<TKey, TSource>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -555,28 +555,26 @@ namespace System.Text
             var startChars = pool.Rent(lengthToCompare);
             var endChars = pool.Rent(lengthToCompare);
 
-            try
-            {
-                // Copy the start and end segments from the text
-                text.CopyTo(0, startChars, 0, lengthToCompare);
-                text.CopyTo(endIndex, endChars, 0, lengthToCompare);
+            // Copy the start and end segments from the text
+            text.CopyTo(0, startChars, 0, lengthToCompare);
+            text.CopyTo(endIndex, endChars, 0, lengthToCompare);
 
-                // Compare the segments
-                for (var position = 0; position < lengthToCompare; position++)
+            // Compare the segments
+            for (var position = 0; position < lengthToCompare; position++)
+            {
+                if (startChars[position] == startChar && endChars[position] == endChar)
                 {
-                    if (startChars[position] == startChar && endChars[position] == endChar)
-                    {
-                        return true;
-                    }
-                }
+                    pool.Return(startChars);
+                    pool.Return(endChars);
 
-                return false;
+                    return true;
+                }
             }
-            finally
-            {
-                pool.Return(startChars);
-                pool.Return(endChars);
-            }
+
+            pool.Return(startChars);
+            pool.Return(endChars);
+
+            return false;
         }
 
         private static int CountLeadingWhitespaces(this StringBuilder value, int start = 0)

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -559,22 +559,23 @@ namespace System.Text
             text.CopyTo(0, startChars, 0, lengthToCompare);
             text.CopyTo(endIndex, endChars, 0, lengthToCompare);
 
+            var found = false;
+
             // Compare the segments
             for (var position = 0; position < lengthToCompare; position++)
             {
                 if (startChars[position] == startChar && endChars[position] == endChar)
                 {
-                    pool.Return(startChars);
-                    pool.Return(endChars);
+                    found = true;
 
-                    return true;
+                    break;
                 }
             }
 
             pool.Return(startChars);
             pool.Return(endChars);
 
-            return false;
+            return found;
         }
 
         private static int CountLeadingWhitespaces(this StringBuilder value, int start = 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             Array.Copy(rentedArray, result, resultIndex);
 
-            pool.Return(rentedArray, true);
+            pool.Return(rentedArray);
 
             return result;
         }
@@ -194,7 +194,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                            .AdjustFirstWord(handling)
                                                            .ToStringAndRelease();
 
-                            if (originalText.Equals(replacedText, StringComparison.Ordinal))
+                            if (originalText.AsSpan().SequenceEqual(replacedText.AsSpan()))
                             {
                                 // replacement with itself does not make any sense
                                 continue;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -67,13 +67,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             return result;
         }
-        //// ncrunch: no coverage end
-        //// ncrunch: rdi default
 
-        protected static XmlElementSyntax C(string text)
-        {
-            return SyntaxFactory.XmlElement(Constants.XmlTag.C, XmlText(text).ToSyntaxList<XmlNodeSyntax>());
-        }
+//// ncrunch: no coverage end
+//// ncrunch: rdi default
+
+        protected static XmlElementSyntax C(string text) => SyntaxFactory.XmlElement(Constants.XmlTag.C, XmlText(text).ToSyntaxList<XmlNodeSyntax>());
 
         protected static XmlElementSyntax Comment(XmlElementSyntax comment, in SyntaxList<XmlNodeSyntax> content)
         {
@@ -86,17 +84,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlElementSyntax Comment(XmlElementSyntax comment, IEnumerable<XmlNodeSyntax> nodes) => Comment(comment, nodes.ToSyntaxList());
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, string additionalComment = null)
-        {
-            return Comment(comment, text[0], additionalComment);
-        }
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, string additionalComment = null) => Comment(comment, text[0], additionalComment);
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, in SyntaxList<XmlNodeSyntax> additionalComment)
-        {
-            return Comment(comment, text[0], additionalComment);
-        }
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, in ReadOnlySpan<string> text, in SyntaxList<XmlNodeSyntax> additionalComment) => Comment(comment, text[0], additionalComment);
 
-//// ncrunch: rdi off
+        //// ncrunch: rdi off
 
         protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, in SyntaxList<XmlNodeSyntax> additionalComment)
         {
@@ -105,10 +97,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Comment(comment, end);
         }
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, string additionalComment = null)
-        {
-            return Comment(comment, XmlText(text + additionalComment));
-        }
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, string additionalComment = null) => Comment(comment, XmlText(text + additionalComment));
 
         protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepSingleLeadingSpace)
         {
@@ -714,8 +703,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected static XmlTextSyntax NewLineXmlText() => XmlText(string.Empty).WithLeadingXmlComment();
 
         protected static XmlTextSyntax TrailingNewLineXmlText() => XmlText(string.Empty).WithTrailingXmlComment();
-
-        protected static XmlTextSyntax XmlText(in ReadOnlySpan<char> text) => XmlText(text.ToString());
 
         protected static XmlTextSyntax XmlText(string text) => SyntaxFactory.XmlText(text);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -316,59 +316,59 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static ConcreteMapInfo FindMatchingReplacementMapKeys(in ReadOnlySpan<char> text)
         {
             // now get all data
-            var mappedDataValue = MappedData.Value;
+            var data = MappedData.Value;
 
             if (text.Length > 0)
             {
                 if (text.StartsWith(StartWithArticleA))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForA, mappedDataValue.ReplacementMapKeysForA, mappedDataValue.UniqueReplacementMapKeysForA);
+                    return new ConcreteMapInfo(data.ReplacementMapForA, data.ReplacementMapKeysForA, data.UniqueReplacementMapKeysForA);
                 }
 
                 if (text.StartsWith(StartWithArticleAn))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForAn, mappedDataValue.ReplacementMapKeysForAn, mappedDataValue.UniqueReplacementMapKeysForAn);
+                    return new ConcreteMapInfo(data.ReplacementMapForAn, data.ReplacementMapKeysForAn, data.UniqueReplacementMapKeysForAn);
                 }
 
                 if (text.StartsWith(StartWithArticleThe))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForThe, mappedDataValue.ReplacementMapKeysForThe, mappedDataValue.UniqueReplacementMapKeysForThe);
+                    return new ConcreteMapInfo(data.ReplacementMapForThe, data.ReplacementMapKeysForThe, data.UniqueReplacementMapKeysForThe);
                 }
 
                 if (text.StartsWith(StartWithParenthesis))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForParenthesis, mappedDataValue.ReplacementMapKeysForParenthesis, mappedDataValue.UniqueReplacementMapKeysForParenthesis);
+                    return new ConcreteMapInfo(data.ReplacementMapForParenthesis, data.ReplacementMapKeysForParenthesis, data.UniqueReplacementMapKeysForParenthesis);
                 }
 
                 if (text.StartsWith(StartWithArticleLowerCaseA))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseA, mappedDataValue.ReplacementMapKeysForLowerCaseA, mappedDataValue.UniqueReplacementMapKeysForA);
+                    return new ConcreteMapInfo(data.ReplacementMapForLowerCaseA, data.ReplacementMapKeysForLowerCaseA, data.UniqueReplacementMapKeysForA);
                 }
 
                 if (text.StartsWith(StartWithArticleLowerCaseAn))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseAn, mappedDataValue.ReplacementMapKeysForLowerCaseAn, mappedDataValue.UniqueReplacementMapKeysForAn);
+                    return new ConcreteMapInfo(data.ReplacementMapForLowerCaseAn, data.ReplacementMapKeysForLowerCaseAn, data.UniqueReplacementMapKeysForAn);
                 }
 
                 if (text.StartsWith(StartWithArticleLowerCaseThe))
                 {
-                    return new ConcreteMapInfo(mappedDataValue.ReplacementMapForLowerCaseThe, mappedDataValue.ReplacementMapKeysForLowerCaseThe, mappedDataValue.UniqueReplacementMapKeysForThe);
+                    return new ConcreteMapInfo(data.ReplacementMapForLowerCaseThe, data.ReplacementMapKeysForLowerCaseThe, data.UniqueReplacementMapKeysForThe);
                 }
             }
 
-            return new ConcreteMapInfo(mappedDataValue.ReplacementMapForOthers, mappedDataValue.ReplacementMapKeysForOthers, mappedDataValue.UniqueReplacementMapKeysForOthers);
+            return new ConcreteMapInfo(data.ReplacementMapForOthers, data.ReplacementMapKeysForOthers, data.UniqueReplacementMapKeysForOthers);
         }
 
         private readonly ref struct ConcreteMapInfo
         {
-            public ConcreteMapInfo(in ReadOnlySpan<Pair> map, string[] keys, string[] uniqueKeys)
+            public ConcreteMapInfo(Pair[] map, string[] keys, string[] uniqueKeys)
             {
                 Map = map;
                 Keys = keys;
                 UniqueKeys = uniqueKeys;
             }
 
-            public ReadOnlySpan<Pair> Map { get; }
+            public Pair[] Map { get; }
 
             public string[] Keys { get; }
 
@@ -506,13 +506,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 ReplacementMapKeysForA = GetTermsForQuickLookup(UniqueReplacementMapKeysForA);
                 ReplacementMapKeysForAn = GetTermsForQuickLookup(UniqueReplacementMapKeysForAn);
                 ReplacementMapKeysForThe = GetTermsForQuickLookup(UniqueReplacementMapKeysForThe);
-                ReplacementMapKeysForLowerCaseA = ReplacementMapKeysForA;
-                ReplacementMapKeysForLowerCaseAn = ReplacementMapKeysForAn;
-                ReplacementMapKeysForLowerCaseThe = ReplacementMapKeysForThe;
                 ReplacementMapKeysForParenthesis = GetTermsForQuickLookup(UniqueReplacementMapKeysForParenthesis);
                 ReplacementMapKeysForOthers = GetTermsForQuickLookup(UniqueReplacementMapKeysForOthers);
 
-                string[] ToKeyArray(string[] keys, string text)
+                string[] ToKeyArray(ReadOnlySpan<string> keys, string text)
                 {
                     var length = keys.Length;
 
@@ -521,11 +518,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var pool = ArrayPool<string>.Shared;
                     var rentedArray = pool.Rent(length);
 
+                    var textSpan = text.AsSpan();
+
                     for (var index = 0; index < length; index++)
                     {
                         var key = keys[index];
 
-                        if (key.StartsWith(text, StringComparison.Ordinal))
+                        if (key.AsSpan().StartsWith(textSpan))
                         {
                             rentedArray[indexInResult++] = key;
                         }
@@ -535,7 +534,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     Array.Copy(rentedArray, results, indexInResult);
 
-                    pool.Return(rentedArray, true);
+                    pool.Return(rentedArray);
 
                     return results;
                 }
@@ -565,7 +564,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     Array.Copy(rentedArray, results, results.Length);
 
-                    pool.Return(rentedArray, true);
+                    pool.Return(rentedArray);
 
                     return results;
                 }
@@ -599,11 +598,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             public string[] ReplacementMapKeysForOthers { get; }
 
-            public string[] ReplacementMapKeysForLowerCaseA { get; }
+            public string[] ReplacementMapKeysForLowerCaseA => ReplacementMapKeysForA;
 
-            public string[] ReplacementMapKeysForLowerCaseAn { get; }
+            public string[] ReplacementMapKeysForLowerCaseAn => ReplacementMapKeysForAn;
 
-            public string[] ReplacementMapKeysForLowerCaseThe { get; }
+            public string[] ReplacementMapKeysForLowerCaseThe => ReplacementMapKeysForThe;
 
             public string[] UniqueReplacementMapKeysForA { get; }
 


### PR DESCRIPTION
- Replace `Array.Resize` with `ArrayPool` rentals and introduce `System.Buffers` imports for array pooling

- Rent and return arrays in key helper methods

- Remove try/finally and inline return logic in `QuickSubstringProbeAtIndicesWithRent`
