### PR TITLE
Increased performance of 'IsWhiteSpace' extension method

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -1502,16 +1502,23 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsWhiteSpace(this in char value)
         {
+            if (value > ' ')
+            {
+                return value >= 127 && char.IsWhiteSpace(value);
+            }
+
             switch (value)
             {
                 case ' ':
                 case '\t':
                 case '\r':
                 case '\n':
+                case '\v':
+                case '\f':
                     return true;
 
                 default:
-                    return char.IsWhiteSpace(value);
+                    return false;
             }
         }
 
@@ -1528,7 +1535,11 @@ namespace System
         public static bool StartsWith(this in ReadOnlySpan<char> value, string characters) => characters.HasCharacters() && value.StartsWith(characters.AsSpan());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWith(this string value, in ReadOnlySpan<char> characters, in StringComparison comparison) => value.HasCharacters() && value.AsSpan().StartsWith(characters, comparison);
+        public static bool StartsWith(this string value, in ReadOnlySpan<char> characters, in StringComparison comparison)
+        {
+            // for the moment this does not need a different handling for 'StringComparison' as it is used too few times to have any benefit
+            return value.HasCharacters() && value.AsSpan().StartsWith(characters, comparison);
+        }
 
         public static bool StartsWith(this in ReadOnlySpan<char> value, string characters, in StringComparison comparison)
         {

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -10,7 +10,9 @@ namespace MiKoSolutions.Analyzers.Extensions
     {
         private const string LowerCaseCharacters = "abcdefghijklmnopqrstuvwxyz";
         private const string UpperCaseCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        private const string SpecialCases = " \t.?!;:,-1234567890";
+        private const string Numbers = "1234567890";
+        private const string SentenceParts = ".?!;:,-";
+        private const string SpecialCases = " \t" + SentenceParts + Numbers;
 
         [TestCase(null, ExpectedResult = null)]
         [TestCase("", ExpectedResult = "")]
@@ -250,5 +252,14 @@ namespace MiKoSolutions.Analyzers.Extensions
 
         [TestCaseSource(nameof(UpperCaseCharacters))]
         public static void ToLowerCase_for_upper_case_(in char c) => Assert.That(c.ToLowerCase(), Is.EqualTo(char.ToLowerInvariant(c)));
+
+        [TestCaseSource(nameof(UpperCaseCharacters))]
+        [TestCaseSource(nameof(LowerCaseCharacters))]
+        [TestCaseSource(nameof(Numbers))]
+        [TestCaseSource(nameof(SentenceParts))]
+        public static void IsWhiteSpace_for_letter_(in char c) => Assert.That(c.IsWhiteSpace(), Is.False);
+
+        [Test]
+        public static void IsWhiteSpace_for_whitespace_([Values(' ', '\t', '\r', '\n', '\v', '\f')] in char c) => Assert.That(c.IsWhiteSpace(), Is.True);
     }
 }


### PR DESCRIPTION
- Refactor and optimize `IsWhiteSpace` extension logic

- Extend whitespace cases to include `\v`, `\f`

- Add comprehensive `IsWhiteSpace` unit tests

- Add clarification comment to `StartsWith` string-span overload
