### PR TITLE
MiKo_6030 is now aware of initializers placed on same line

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -188,6 +188,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsLocatedAt(this in SyntaxToken value, Location location) => value.GetLocation().Equals(location);
 
+        internal static bool IsOnSameLineAs(this in SyntaxToken value, SyntaxNode other) => value.GetStartingLine() == other?.GetStartingLine();
+
+        internal static bool IsOnSameLineAs(this in SyntaxToken value, in SyntaxNodeOrToken other) => value.GetStartingLine() == other.GetStartingLine();
+
+        internal static bool IsOnSameLineAs(this in SyntaxToken value, in SyntaxToken other) => value.GetStartingLine() == other.GetStartingLine();
+
         internal static bool IsSpanningMultipleLines(this in SyntaxToken value)
         {
             var leadingTrivia = value.LeadingTrivia;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_CodeFixProvider.cs
@@ -19,16 +19,26 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 case InitializerExpressionSyntax initializer:
                 {
-                    return initializer.WithOpenBraceToken(initializer.OpenBraceToken.WithLeadingSpaces(spaces))
-                                      .WithExpressions(GetUpdatedSyntax(initializer.Expressions, spaces + Constants.Indentation))
-                                      .WithCloseBraceToken(initializer.CloseBraceToken.WithLeadingSpaces(spaces));
+                    var openBraceToken = initializer.OpenBraceToken;
+                    var closeBraceToken = initializer.CloseBraceToken;
+
+                    var closeBraceTokenSpaces = openBraceToken.IsOnSameLineAs(closeBraceToken) ? 0 : spaces;
+
+                    return initializer.WithOpenBraceToken(openBraceToken.WithLeadingSpaces(spaces))
+                                      .WithExpressions(GetUpdatedSyntax(initializer.Expressions, openBraceToken, spaces + Constants.Indentation))
+                                      .WithCloseBraceToken(closeBraceToken.WithLeadingSpaces(closeBraceTokenSpaces));
                 }
 
                 case AnonymousObjectCreationExpressionSyntax anonymous:
                 {
-                    return anonymous.WithOpenBraceToken(anonymous.OpenBraceToken.WithLeadingSpaces(spaces))
-                                    .WithInitializers(GetUpdatedSyntax(anonymous.Initializers, spaces + Constants.Indentation))
-                                    .WithCloseBraceToken(anonymous.CloseBraceToken.WithLeadingSpaces(spaces));
+                    var openBraceToken = anonymous.OpenBraceToken;
+                    var closeBraceToken = anonymous.CloseBraceToken;
+
+                    var closeBraceTokenSpaces = openBraceToken.IsOnSameLineAs(closeBraceToken) ? 0 : spaces;
+
+                    return anonymous.WithOpenBraceToken(openBraceToken.WithLeadingSpaces(spaces))
+                                    .WithInitializers(GetUpdatedSyntax(anonymous.Initializers, openBraceToken, spaces + Constants.Indentation))
+                                    .WithCloseBraceToken(closeBraceToken.WithLeadingSpaces(closeBraceTokenSpaces));
                 }
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6034_DotsAreOnSameLineAsInvokedMemberAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6034_DotsAreOnSameLineAsInvokedMemberAnalyzer.cs
@@ -19,13 +19,11 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var maes = (MemberAccessExpressionSyntax)context.Node;
+            var operatorToken = maes.OperatorToken;
 
-            var dotLine = maes.OperatorToken.GetStartingLine();
-            var memberLine = maes.Name.GetStartingLine();
-
-            if (dotLine != memberLine)
+            if (operatorToken.IsOnSameLineAs(maes.Name) is false)
             {
-                ReportDiagnostics(context, Issue(maes.OperatorToken));
+                ReportDiagnostics(context, Issue(operatorToken));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_OpenParenthesisAreOnSameLineAsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6035_OpenParenthesisAreOnSameLineAsInvocationAnalyzer.cs
@@ -36,10 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeNameSyntax(in SyntaxNodeAnalysisContext context, NameSyntax name, in SyntaxToken parenthesis)
         {
-            var parenthesisLine = parenthesis.GetStartingLine();
-            var memberLine = name.GetStartingLine();
-
-            if (parenthesisLine != memberLine)
+            if (parenthesis.IsOnSameLineAs(name) is false)
             {
                 ReportDiagnostics(context, Issue(parenthesis));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6038_CastsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6038_CastsAreOnSameLineAnalyzer.cs
@@ -20,10 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             var cast = (CastExpressionSyntax)context.Node;
 
-            var startLine = cast.OpenParenToken.GetStartingLine();
-            var expressionLine = cast.Expression.GetStartingLine();
-
-            if (startLine != expressionLine)
+            if (cast.OpenParenToken.IsOnSameLineAs(cast.Expression) is false)
             {
                 ReportDiagnostics(context, Issue(cast));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6039_ReturnStatementsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6039_ReturnStatementsAreOnSameLineAnalyzer.cs
@@ -22,15 +22,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             var returnValue = node.Expression;
 
-            if (returnValue != null)
+            if (returnValue is null)
             {
-                var startLine = node.ReturnKeyword.GetStartingLine();
-                var returnValueLine = returnValue.GetStartingLine();
+                return;
+            }
 
-                if (startLine != returnValueLine)
-                {
-                    ReportDiagnostics(context, Issue(node.ReturnKeyword));
-                }
+            var returnKeyword = node.ReturnKeyword;
+
+            if (returnKeyword.IsOnSameLineAs(returnValue) is false)
+            {
+                ReportDiagnostics(context, Issue(returnKeyword));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzer.cs
@@ -41,10 +41,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             switch (node)
             {
                 // arrays and collections spanning multiple lines are allowed
-                case InitializerExpressionSyntax initializer when initializer.OpenBraceToken.GetStartingLine() != initializer.CloseBraceToken.GetStartingLine():
+                case InitializerExpressionSyntax initializer when initializer.OpenBraceToken.IsOnSameLineAs(initializer.CloseBraceToken) is false:
                     return true;
 #if  VS2022
-                case CollectionExpressionSyntax expression when expression.OpenBracketToken.GetStartingLine() != expression.CloseBracketToken.GetStartingLine():
+                case CollectionExpressionSyntax expression when expression.OpenBracketToken.IsOnSameLineAs(expression.CloseBracketToken) is false:
                     return true;
 #endif
 
@@ -72,12 +72,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         private void AnalyzeAssignmentExpression(in SyntaxNodeAnalysisContext context, AssignmentExpressionSyntax node)
         {
             var operatorToken = node.OperatorToken;
+            var allOnSameLine = operatorToken.IsOnSameLineAs(node.Left) && operatorToken.IsOnSameLineAs(node.Right);
 
-            var startLine = operatorToken.GetStartingLine();
-            var leftLine = node.Left.GetStartingLine();
-            var rightLine = node.Right.GetStartingLine();
-
-            if (startLine != leftLine || startLine != rightLine)
+            if (allOnSameLine is false)
             {
                 ReportIssue(context, operatorToken);
             }
@@ -85,22 +82,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeEqualsValueClause(in SyntaxNodeAnalysisContext context, EqualsValueClauseSyntax node)
         {
-            var startLine = node.EqualsToken.GetStartingLine();
-            var expressionLine = node.Value.GetStartingLine();
+            var equalsToken = node.EqualsToken;
+            var allOnSameLine = equalsToken.IsOnSameLineAs(node.Value) && equalsToken.IsOnSameLineAs(node.PreviousSiblingNodeOrToken());
 
-            if (startLine != expressionLine)
+            if (allOnSameLine is false)
             {
                 ReportIssue(context, node);
-            }
-            else
-            {
-                var sibling = node.PreviousSiblingNodeOrToken();
-                var siblingStartLine = sibling.GetStartingLine();
-
-                if (startLine != siblingStartLine)
-                {
-                    ReportIssue(context, node);
-                }
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6042_CreationsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6042_CreationsAreOnSameLineAnalyzer.cs
@@ -21,10 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             var creation = (ObjectCreationExpressionSyntax)context.Node;
             var newKeyword = creation.NewKeyword;
 
-            var startLine = newKeyword.GetStartingLine();
-            var expressionLine = creation.Type.GetStartingLine();
-
-            if (startLine != expressionLine)
+            if (newKeyword.IsOnSameLineAs(creation.Type) is false)
             {
                 ReportDiagnostics(context, Issue(newKeyword));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6043_CodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                 .WithNewKeyword(aoces.NewKeyword.WithoutTrivia().WithTrailingSpace())
                                 .WithOpenBraceToken(aoces.OpenBraceToken.WithoutTrivia().WithLeadingSpace()) // remove the spaces or line breaks around the opening bracket
                                 .WithCloseBraceToken(aoces.CloseBraceToken.WithoutTrivia().WithLeadingSpace()) // remove the spaces or line breaks around the closing bracket
-                                .WithInitializers(GetUpdatedSyntax(aoces.Initializers, Constants.Indentation));
+                                .WithInitializers(GetUpdatedSyntax(aoces.Initializers, aoces.OpenBraceToken, Constants.Indentation));
 
                 case ConditionalAccessExpressionSyntax conditional:
                     return conditional.WithoutTrivia()

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
@@ -58,32 +59,31 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 case BinaryExpressionSyntax binary:
                 {
-                    var startLine = binary.OperatorToken.GetStartingLine();
-                    var rightPosition = binary.Right.GetStartPosition();
+                    var operatorToken = binary.OperatorToken;
+                    var expression = binary.Right;
 
-                    return startLine != rightPosition.Line
-                           ? Issue(binary.OperatorToken, CreateProposalForSpaces(rightPosition.Character))
-                           : null;
+                    if (operatorToken.IsOnSameLineAs(expression))
+                    {
+                        return null;
+                    }
+
+                    var spaces = expression.GetPositionWithinStartLine();
+
+                    return Issue(operatorToken, CreateProposalForSpaces(spaces));
                 }
 
                 case PrefixUnaryExpressionSyntax unary:
                 {
-                    var startLine = unary.Operand.GetStartingLine();
-                    var operatorLine = unary.OperatorToken.GetStartingLine();
+                    var operatorToken = unary.OperatorToken;
 
-                    return startLine != operatorLine
-                           ? Issue(unary.OperatorToken)
-                           : null;
+                    return operatorToken.IsOnSameLineAs(unary.Operand) ? null : Issue(operatorToken);
                 }
 
                 case PostfixUnaryExpressionSyntax unary:
                 {
-                    var startLine = unary.Operand.GetStartingLine();
-                    var operatorLine = unary.OperatorToken.GetStartingLine();
+                    var operatorToken = unary.OperatorToken;
 
-                    return startLine != operatorLine
-                           ? Issue(unary.OperatorToken)
-                           : null;
+                    return operatorToken.IsOnSameLineAs(unary.Operand) ? null : Issue(operatorToken);
                 }
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_CodeFixProvider.cs
@@ -54,9 +54,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             var operatorToken = binary.OperatorToken;
             var right = binary.Right;
 
-            var updatedLeft = left.GetStartingLine() != operatorToken.GetStartingLine() && left.HasTrailingComment()
-                              ? left // there is already a comment, so nothing to do here
-                              : left.WithTrailingTriviaFrom(operatorToken); // copy comment or line break
+            var updatedLeft = left;
+
+            if (operatorToken.IsOnSameLineAs(left) || left.HasTrailingComment() is false)
+            {
+                // copy comment or line break
+                updatedLeft = left.WithTrailingTriviaFrom(operatorToken);
+            }
 
             var updatedToken = operatorToken.WithLeadingSpaces(spaces).WithTrailingSpace();
             var updatedRight = right.WithoutLeadingTrivia();

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6045_ComparisonsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6045_ComparisonsAreOnSameLineAnalyzer.cs
@@ -30,14 +30,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = (BinaryExpressionSyntax)context.Node;
+            var operatorToken = node.OperatorToken;
 
-            var leftLine = node.Left.GetStartingLine();
-            var startLine = node.OperatorToken.GetStartingLine();
-            var rightLine = node.Right.GetStartingLine();
+            var allOnSameLine = operatorToken.IsOnSameLineAs(node.Left) && operatorToken.IsOnSameLineAs(node.Right);
 
-            if (leftLine != startLine || startLine != rightLine)
+            if (allOnSameLine is false)
             {
-                ReportDiagnostics(context, Issue(node.OperatorToken));
+                ReportDiagnostics(context, Issue(operatorToken));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6046_CalculationOperationsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6046_CalculationOperationsAreOnSameLineAnalyzer.cs
@@ -30,21 +30,20 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = (BinaryExpressionSyntax)context.Node;
+            var operatorToken = node.OperatorToken;
 
-            var leftLine = node.Left.GetStartingLine();
-            var startLine = node.OperatorToken.GetStartingLine();
-            var rightLine = node.Right.GetStartingLine();
-
-            if (leftLine != startLine || startLine != rightLine)
+            if (operatorToken.IsOnSameLineAs(node.Left) && operatorToken.IsOnSameLineAs(node.Right))
             {
-                if (node.IsStringConcatenation(context.SemanticModel))
-                {
-                    // ignore string concatenations
-                }
-                else
-                {
-                    ReportDiagnostics(context, Issue(node.OperatorToken));
-                }
+                return;
+            }
+
+            if (node.IsStringConcatenation(context.SemanticModel))
+            {
+                // ignore string concatenations
+            }
+            else
+            {
+                ReportDiagnostics(context, Issue(operatorToken));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6051_ConstructorOperatorsAreOnSameLineAsRightArgumentsAnalyzer.cs
@@ -28,10 +28,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             }
 
             var colonToken = node.ColonToken;
-            var startLine = colonToken.GetStartingLine();
-            var keywordLine = keyword.GetStartingLine();
 
-            if (startLine != keywordLine)
+            if (colonToken.IsOnSameLineAs(keyword) is false)
             {
                 ReportDiagnostics(context, Issue(colonToken));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6052_BaseListOperatorsAreOnSameLineAsBaseListTypeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6052_BaseListOperatorsAreOnSameLineAsBaseListTypeAnalyzer.cs
@@ -28,10 +28,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             }
 
             var colonToken = node.ColonToken;
-            var startLine = colonToken.GetStartingLine();
-            var baseTypeLine = firstBaseType.GetStartingLine();
 
-            if (startLine != baseTypeLine)
+            if (colonToken.IsOnSameLineAs(firstBaseType) is false)
             {
                 ReportDiagnostics(context, Issue(colonToken));
             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6053_SimpleMemberArgumentsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6053_SimpleMemberArgumentsAreOnSameLineAnalyzer.cs
@@ -36,12 +36,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             if (argument.Expression is MemberAccessExpressionSyntax maes && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression))
             {
                 var operatorToken = maes.OperatorToken;
+                var allOnSameLine = operatorToken.IsOnSameLineAs(maes.Expression) && operatorToken.IsOnSameLineAs(maes.Name);
 
-                var startingLine = maes.Expression.GetStartingLine();
-                var operatorLine = operatorToken.GetStartingLine();
-                var nameLine = maes.Name.GetStartingLine();
-
-                if (startingLine != operatorLine || operatorLine != nameLine)
+                if (allOnSameLine is false)
                 {
                     return new[] { Issue(argument) };
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6054_LambdaArrowsAreOnSameLineAsParameterListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6054_LambdaArrowsAreOnSameLineAsParameterListAnalyzer.cs
@@ -38,25 +38,20 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeLambda(in SyntaxNodeAnalysisContext context, SyntaxNode parameter, in SyntaxToken arrowToken, ExpressionSyntax expressionBody)
         {
-            var parametersStartingLine = parameter.GetStartingLine();
-            var tokenStartingLine = arrowToken.GetStartingLine();
-
-            if (parametersStartingLine != tokenStartingLine)
-            {
-                ReportDiagnostics(context, Issue(arrowToken));
-            }
-            else
+            if (arrowToken.IsOnSameLineAs(parameter))
             {
                 // only consider expression bodies to be placed on same line as arrow token
                 if (expressionBody != null)
                 {
-                    var bodyStartingLine = expressionBody.GetStartingLine();
-
-                    if (bodyStartingLine != tokenStartingLine)
+                    if (arrowToken.IsOnSameLineAs(expressionBody) is false)
                     {
                         ReportDiagnostics(context, Issue(arrowToken));
                     }
                 }
+            }
+            else
+            {
+                ReportDiagnostics(context, Issue(arrowToken));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 if (openBracketToken.IsLocatedAt(issueLocation))
                 {
                     return expression.WithOpenBracketToken(openBracketToken.WithLeadingSpaces(spaces))
-                                     .WithElements(GetUpdatedSyntax(elements, spaces + Constants.Indentation))
+                                     .WithElements(GetUpdatedSyntax(elements, openBracketToken, spaces + Constants.Indentation))
                                      .WithCloseBracketToken(closeBracketToken.WithLeadingSpaces(spaces));
                 }
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzer.cs
@@ -110,10 +110,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 {
                     var orientationToken = GetOutdentedOrientationToken(binary);
 
-                    var orientationStartingLine = orientationToken.GetStartingLine();
-                    var operatorTokenStartingLine = operatorToken.GetStartingLine();
-
-                    if (orientationStartingLine != operatorTokenStartingLine)
+                    if (orientationToken.IsOnSameLineAs(operatorToken) is false)
                     {
                         var spaces = GetOutdentedPosition(binary);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 {
                     var token = arms.GetSeparator(index);
 
-                    if (token.GetStartingLine() != arm.GetStartingLine())
+                    if (token.IsOnSameLineAs(arm) is false)
                     {
                         return true;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -184,14 +184,14 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                                                                               .WithWhenKeyword(clause.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
                                                                                               .WithCondition(PlacedOnSameLine(clause.Condition));
 
-        protected static SeparatedSyntaxList<TSyntaxNode> GetUpdatedSyntax<TSyntaxNode>(in SeparatedSyntaxList<TSyntaxNode> expressions, in int leadingSpaces) where TSyntaxNode : SyntaxNode
+        protected static SeparatedSyntaxList<TSyntaxNode> GetUpdatedSyntax<TSyntaxNode>(in SeparatedSyntaxList<TSyntaxNode> expressions, in SyntaxToken openBraceToken, in int leadingSpaces) where TSyntaxNode : SyntaxNode
         {
             if (expressions.Count is 0)
             {
                 return SyntaxFactory.SeparatedList<TSyntaxNode>();
             }
 
-            int? currentLine = null;
+            int? currentLine = openBraceToken.GetStartingLine();
 
             var updatedExpressions = new List<TSyntaxNode>(expressions.Count);
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzerTests.cs
@@ -1242,6 +1242,82 @@ public class TestMe : IList<int>
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_implicit_field_object_initializer_with_arguments_when_placed_outdented_below_type_and_space_between_braces()
+        {
+            const string OriginalCode = @"
+using System;
+
+public record Item
+{
+    public string Name { get; set; }
+    public string FullName { get; set; }
+    public string Information { get; set; }
+}
+
+public class TestMe
+{
+    private readonly Item _item = new()
+        { Name = ""test name"", FullName = ""complete test name"", Information = ""some information"" };
+}
+";
+            const string FixedCode = @"
+using System;
+
+public record Item
+{
+    public string Name { get; set; }
+    public string FullName { get; set; }
+    public string Information { get; set; }
+}
+
+public class TestMe
+{
+    private readonly Item _item = new()
+                                      { Name = ""test name"", FullName = ""complete test name"", Information = ""some information"" };
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_implicit_field_object_initializer_with_arguments_when_placed_outdented_below_type_and_no_space_between_braces()
+        {
+            const string OriginalCode = @"
+using System;
+
+public record Item
+{
+    public string Name { get; set; }
+    public string FullName { get; set; }
+    public string Information { get; set; }
+}
+
+public class TestMe
+{
+    private readonly Item _item = new()
+        {Name = ""test name"", FullName = ""complete test name"", Information = ""some information""};
+}
+";
+            const string FixedCode = @"
+using System;
+
+public record Item
+{
+    public string Name { get; set; }
+    public string FullName { get; set; }
+    public string Information { get; set; }
+}
+
+public class TestMe
+{
+    private readonly Item _item = new()
+                                      {Name = ""test name"", FullName = ""complete test name"", Information = ""some information""};
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer();


### PR DESCRIPTION
- Update code fixes for brace and operator indentation

- Add tests for implicit object initializer indent fix

- Add `IsOnSameLineAs` token extension methods

- Refactor spacing analyzers to use same-line checks

