### PR TITLE
Refactored 'QuickSubstringProbe' and 'Replace(All)WithProbe'

### DIFF
--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -162,6 +162,7 @@ namespace MiKoSolutions.Analyzers.Extensions
 
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "DoEvents", "##Events", ExpectedResult = "CallsDownloadWorkflowForMultipleParameterDownloadDevices")]
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "Download", "My", ExpectedResult = "CallsMyWorkflowForMultipleParameterMyDevices")]
+        [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "Workflow", "#", ExpectedResult = "CallsDownload#ForMultipleParameterDownloadDevices")]
         public static string ReplaceWithProbe_above_threshold_uses_arrays_properly_to_adjust_(string start, string name, string other) => new StringBuilder(start).ReplaceWithProbe(name, other).ToString();
     }
 }


### PR DESCRIPTION
- Introduce pooling for `StringBuilder` span probing

- Refactor `ReplaceAllWithProbe`/`ReplaceWithProbe` logic

- Consolidate `QuickSubstringProbe` to span-based method

- Add test for pooling scenario in `ReplaceWithProbe`

