### PR TITLE
MiKo_1054 is now able to fix 'HandleXyzHelper' into 'XyzHandler'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
@@ -14,6 +14,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private const string CorrectName = "Utilization";
 
+        private const string SpecialNameHandle = "Handle";
+        private const string SpecialNameHandler = "Handler";
+
         private static readonly string[] WrongNames = { "Helper", "Util", "Misc" };
 
         // sorted by intent so that the best match is found until a more generic is found
@@ -36,12 +39,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var wrongName = WrongNamesForConcreteLookup.First(_ => symbolName.Contains(_, StringComparison.OrdinalIgnoreCase));
 
-                var proposal = symbolName.WithoutSuffix(wrongName);
+                var proposal = FindBetterName(symbolName.AsSpan(), wrongName);
 
                 return new[] { Issue(symbol, wrongName, CreateBetterNameProposal(proposal)) };
             }
 
             return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(ReadOnlySpan<char> symbolName, string wrongName)
+        {
+            if (symbolName.Length > SpecialNameHandle.Length && symbolName.StartsWith(SpecialNameHandle, StringComparison.Ordinal))
+            {
+                return symbolName.WithoutSuffix(wrongName)
+                                 .Slice(SpecialNameHandle.Length)
+                                 .ConcatenatedWith(SpecialNameHandler);
+            }
+
+            return symbolName.WithoutSuffix(wrongName).ToString();
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
@@ -45,7 +45,7 @@ public class " + name + @"
 ");
 
         [Test]
-        public void Code_gets_fixed_for_wrong_name_([ValueSource(nameof(WrongSuffixes))] string wrongSuffix)
+        public void Code_gets_fixed_for_name_with_suffix_([ValueSource(nameof(WrongSuffixes))] string wrongSuffix)
         {
             var originalCode = @"
 public class TestMe" + wrongSuffix + @"
@@ -55,6 +55,24 @@ public class TestMe" + wrongSuffix + @"
 
             const string FixedCode = @"
 public class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Handle_type_name_with_suffix_([ValueSource(nameof(WrongSuffixes))] string wrongSuffix)
+        {
+            var originalCode = @"
+public class HandleTestMe" + wrongSuffix + @"
+{
+}
+";
+
+            const string FixedCode = @"
+public class TestMeHandler
 {
 }
 ";


### PR DESCRIPTION
- Enhance analyzer to handle `Handle` prefix

- Introduce `FindBetterName` for special cases

- Add `SpecialNameHandle/Handler` constants

- Add new test for `Handle`-prefixed classes
