### PR TITLE
Refactored 'IntersectsWith' and fixed a bug if 2 texts do not overlap but are placed side by side

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -75,9 +75,7 @@ namespace MiKoSolutions.Analyzers
                 return null;
             }
 
-            var result = sourceText.ToString(TextSpan.FromBounds(lastIndexOfFirstSpace + 1, text.Length + firstIndexOfNextSpace));
-
-            return result;
+            return sourceText.ToString(TextSpan.FromBounds(lastIndexOfFirstSpace + 1, text.Length + firstIndexOfNextSpace));
         }
 
         internal static bool Contains(this Location value, Location other)
@@ -93,38 +91,7 @@ namespace MiKoSolutions.Analyzers
             var valueSpan = value.SourceSpan;
             var otherSpan = other.SourceSpan;
 
-            var a = valueSpan.Start;
-            var b = valueSpan.End;
-            var x = otherSpan.Start;
-            var y = otherSpan.End;
-
-            if (a <= x)
-            {
-                if (y <= b)
-                {
-                    return true; // axyb
-                }
-
-                if (b <= y)
-                {
-                    return x <= b; // axby
-                }
-            }
-
-            if (x <= a)
-            {
-                if (y <= b)
-                {
-                    return a <= y; // xayb
-                }
-
-                if (b <= y)
-                {
-                    return true; // xaby
-                }
-            }
-
-            return false;
+            return valueSpan.Start < otherSpan.End && otherSpan.Start < valueSpan.End;
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Extensions
             var location1 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(11, 22));
             var location2 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(13, 25));
             var location3 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(15, 17));
-            var location4 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(25, 28));
+            var location4 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(24, 28));
 
             Assert.Multiple(() =>
                                  {
@@ -48,6 +48,9 @@ namespace MiKoSolutions.Analyzers.Extensions
             var location2 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(22, 25));
             var location3 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(31, 37));
 
+            var location4 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(0, 5));
+            var location5 = Location.Create(result.SyntaxTree, TextSpan.FromBounds(5, 10));
+
             Assert.Multiple(() =>
                                  {
                                      Assert.That(location1.IntersectsWith(location2), Is.False);
@@ -58,6 +61,9 @@ namespace MiKoSolutions.Analyzers.Extensions
 
                                      Assert.That(location3.IntersectsWith(location1), Is.False);
                                      Assert.That(location3.IntersectsWith(location2), Is.False);
+
+                                     Assert.That(location4.IntersectsWith(location5), Is.False);
+                                     Assert.That(location5.IntersectsWith(location4), Is.False);
                                  });
         }
     }


### PR DESCRIPTION
- Simplify `IntersectsWith` with simple range condition

- Fix bug for side-by-side non-overlapping spans

- Refactor `GetSurroundingWord` single-line return

- Update tests with additional non-intersect cases
