### PR TITLE
Added new rule MiKo_3230 that reports GUID properties or parameters suffixed with 'Id'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1705,7 +1705,7 @@ namespace MiKoSolutions.Analyzers
                 return predefined.Keyword.IsKind(SyntaxKind.BoolKeyword);
             }
 
-            switch (value.ToString())
+            switch (value?.ToString())
             {
                 case nameof(Boolean):
                 case nameof(System) + "." + nameof(Boolean):
@@ -1723,10 +1723,25 @@ namespace MiKoSolutions.Analyzers
                 return predefined.Keyword.IsKind(SyntaxKind.ByteKeyword);
             }
 
-            switch (value.ToString())
+            switch (value?.ToString())
             {
                 case nameof(Byte):
                 case nameof(System) + "." + nameof(Byte):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        internal static bool IsGuid(this TypeSyntax value)
+        {
+            switch (value?.ToString())
+            {
+                case nameof(Guid):
+                case nameof(Guid) + "?":
+                case nameof(System) + "." + nameof(Guid):
+                case nameof(System) + "." + nameof(Guid) + "?":
                     return true;
 
                 default:

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -322,6 +322,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13931,6 +13931,34 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using &apos;Guid&apos; directly as an identifier type is considered a form of primitive obsession, which is generally discouraged. Instead, you should define custom types (e.g., CustomerId, OrderId) to represent identifiers.
+        ///This approach improves type safety and makes it harder to accidentally mix up different kinds of IDs, since the compiler will catch mismatches between unrelated types..
+        /// </summary>
+        internal static string MiKo_3230_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3230_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use type &apos;Guid&apos; for identifier.
+        /// </summary>
+        internal static string MiKo_3230_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3230_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use &apos;Guid&apos; as type for identifiers.
+        /// </summary>
+        internal static string MiKo_3230_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3230_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4873,6 +4873,16 @@ Instead, use non-generic types as type arguments. This approach makes the code's
   <data name="MiKo_3228_Title" xml:space="preserve">
     <value>Prefer pattern matching for inequality checks</value>
   </data>
+  <data name="MiKo_3230_Description" xml:space="preserve">
+    <value>Using 'Guid' directly as an identifier type is considered a form of primitive obsession, which is generally discouraged. Instead, you should define custom types (e.g., CustomerId, OrderId) to represent identifiers.
+This approach improves type safety and makes it harder to accidentally mix up different kinds of IDs, since the compiler will catch mismatches between unrelated types.</value>
+  </data>
+  <data name="MiKo_3230_MessageFormat" xml:space="preserve">
+    <value>Do not use type 'Guid' for identifier</value>
+  </data>
+  <data name="MiKo_3230_Title" xml:space="preserve">
+    <value>Do not use 'Guid' as type for identifiers</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3230";
+
+        private const string WrongParameterName = "id";
+
+        private static readonly string[] WrongNameSuffixes =
+                                                             {
+                                                                 "Id",
+                                                                 "ID",
+                                                                 "dentifier", // ignore the starting 'I' to avoid ignore-case comparisons
+                                                                 "dentifer", // typo in name, ignore the starting 'I' to avoid ignore-case comparisons
+                                                             };
+
+        private static readonly SyntaxKind[] SyntaxKinds = { SyntaxKind.PropertyDeclaration, SyntaxKind.Parameter };
+
+        public MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(Analyze, SyntaxKinds);
+
+        private void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            switch (context.Node)
+            {
+                case PropertyDeclarationSyntax property:
+                    Analyze(context, property);
+                    break;
+
+                case ParameterSyntax parameter:
+                    Analyze(context, parameter);
+                    break;
+            }
+        }
+
+        private void Analyze(SyntaxNodeAnalysisContext context, PropertyDeclarationSyntax property)
+        {
+            var type = property.Type;
+
+            if (type.IsGuid() && property.GetName().EndsWithAny(WrongNameSuffixes, StringComparison.Ordinal))
+            {
+                context.ReportDiagnostic(Issue(type));
+            }
+        }
+
+        private void Analyze(SyntaxNodeAnalysisContext context, ParameterSyntax parameter)
+        {
+            var type = parameter.Type;
+
+            if (type.IsGuid())
+            {
+                var name = parameter.GetName();
+
+                if (name == WrongParameterName || name.EndsWithAny(WrongNameSuffixes, StringComparison.Ordinal))
+                {
+                    context.ReportDiagnostic(Issue(type));
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzerTests.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] WrongPropertyNames = ["SomeId", "SomeID", "ID", "Id", "SomeIdentifier", "Identifier", "SomeIdentifer", "Identifer"]; // contains typos to test for as well
+        private static readonly string[] WrongParameterNames = ["someId", "someID", "id", "someIdentifier", "identifier", "someIdentifer", "identifer"]; // contains typos to test for as well
+
+        [Test]
+        public void No_issue_is_reported_for_type_named_([ValueSource(nameof(WrongPropertyNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public class " + name + @"
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_field_named_([ValueSource(nameof(WrongParameterNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private Guid _" + name + @"
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Non_Guid_property_named_([ValueSource(nameof(WrongPropertyNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public record Identifier;
+
+public class TestMe
+{
+    public Identifier " + name + @" { get; set; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Non_Guid_parameter_named_([ValueSource(nameof(WrongParameterNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public record Identifier;
+
+public class TestMe
+{
+    public void DoSomething(Identifier " + name + @")
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Nullable_Non_Guid_property_named_([ValueSource(nameof(WrongPropertyNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public record Identifier;
+
+public class TestMe
+{
+    public Identifier? " + name + @" { get; set; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Nullable_Non_Guid_parameter_named_([ValueSource(nameof(WrongParameterNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public record Identifier;
+
+public class TestMe
+{
+    public void DoSomething(Identifier? " + name + @")
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Guid_property_named_([ValueSource(nameof(WrongPropertyNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public Guid " + name + @" { get; set; }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Guid_parameter_named_([ValueSource(nameof(WrongParameterNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(Guid " + name + @")
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Nullable_Guid_property_named_([ValueSource(nameof(WrongPropertyNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public Guid? " + name + @" { get; set; }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Nullable_Guid_parameter_named_([ValueSource(nameof(WrongParameterNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(Guid? " + name + @")
+    {
+    }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 498 rules that are currently provided by the analyzer.
+The following tables lists all the 499 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -437,6 +437,7 @@ The following tables lists all the 498 rules that are currently provided by the 
 |MiKo_3226|Read-only fields with initializers should be const|&#x2713;|&#x2713;|
 |MiKo_3227|Prefer pattern matching for equality checks|&#x2713;|&#x2713;|
 |MiKo_3228|Prefer pattern matching for inequality checks|&#x2713;|&#x2713;|
+|MiKo_3230|Do not use 'Guid' as type for identifiers|&#x2713;|\-|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduce MiKo_3230 rule forbidding `Guid` identifiers

- Extend `TypeSyntax` with `IsGuid` and `null` safety

- Add localized resources and update README

- Add unit tests covering new rule

(resolves #1333)