### PR TITLE
Refactored 'SyntaxNodeExtensions.IsAnyKind' and extracted method 'IsNested' in MiKo_6040

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -52,7 +52,6 @@ namespace MiKoSolutions.Analyzers
 
         internal static IEnumerable<T> Ancestors<T>(this SyntaxNode value) where T : SyntaxNode => value.Ancestors().OfType<T>(); // value.AncestorsAndSelf().OfType<T>();
 
-        // TODO RKN: Use types, fields etc. as well?
         internal static IEnumerable<T> AncestorsWithinMethods<T>(this SyntaxNode value) where T : SyntaxNode
         {
             // ReSharper disable once LoopCanBePartlyConvertedToQuery
@@ -972,28 +971,13 @@ namespace MiKoSolutions.Analyzers
                 switch (ancestor)
                 {
                     case BaseMethodDeclarationSyntax method:
-                    {
-                        var parameters = method.ParameterList.Parameters;
-
-                        if (parameters.Count is 0)
-                        {
-                            return Array.Empty<ParameterSyntax>();
-                        }
-
-                        return parameters.ToArray();
-                    }
+                        return method.ParameterList.Parameters.ToArray();
 
                     case IndexerDeclarationSyntax indexer:
-                    {
-                        var parameters = indexer.ParameterList.Parameters;
+                        return indexer.ParameterList.Parameters.ToArray();
 
-                        if (parameters.Count is 0)
-                        {
-                            return Array.Empty<ParameterSyntax>();
-                        }
-
-                        return parameters.ToArray();
-                    }
+                    case BaseTypeDeclarationSyntax _:
+                        return Array.Empty<ParameterSyntax>();
                 }
             }
 
@@ -1007,33 +991,18 @@ namespace MiKoSolutions.Analyzers
                 switch (ancestor)
                 {
                     case BaseMethodDeclarationSyntax method:
-                    {
-                        var parameters = method.ParameterList.Parameters;
-
-                        if (parameters.Count is 0)
-                        {
-                            return Array.Empty<string>();
-                        }
-
-                        return parameters.ToArray(_ => _.GetName());
-                    }
+                        return method.ParameterList.Parameters.ToArray(_ => _.GetName());
 
                     case IndexerDeclarationSyntax indexer:
-                    {
-                        var parameters = indexer.ParameterList.Parameters;
-
-                        if (parameters.Count is 0)
-                        {
-                            return Array.Empty<string>();
-                        }
-
-                        return parameters.ToArray(_ => _.GetName());
-                    }
+                        return indexer.ParameterList.Parameters.ToArray(_ => _.GetName());
 
                     case BasePropertyDeclarationSyntax property:
                         return property.AccessorList?.Accessors.Any(_ => _.IsKind(SyntaxKind.SetAccessorDeclaration)) is true
                                ? Constants.Names.DefaultPropertyParameterNames
                                : Array.Empty<string>();
+
+                    case BaseTypeDeclarationSyntax _:
+                        return Array.Empty<string>();
                 }
             }
 
@@ -1679,16 +1648,16 @@ namespace MiKoSolutions.Analyzers
 
             if (kindsLength > 0)
             {
-                var valueKind = value.Kind();
+                var valueKind = value.RawKind;
 
                 if (kindsLength is 2)
                 {
-                    return valueKind == kinds[0] || valueKind == kinds[1];
+                    return valueKind == (int)kinds[0] || valueKind == (int)kinds[1];
                 }
 
                 for (var index = 0; index < kindsLength; index++)
                 {
-                    if (kinds[index] == valueKind)
+                    if (valueKind == (int)kinds[index])
                     {
                         return true;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.cs
@@ -74,11 +74,33 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             }
         }
 
+        private static bool IsNested(ExpressionSyntax node)
+        {
+            foreach (var ancestor in node.Ancestors())
+            {
+                switch (ancestor)
+                {
+                    case StatementSyntax _: return false;
+                    case EqualsValueClauseSyntax _: return false;
+                    case InitializerExpressionSyntax _: return false;
+                    case MemberDeclarationSyntax _: return false;
+                    case ArrowExpressionClauseSyntax _: return false;
+                }
+
+                if (ancestor.IsAnyKind(Expressions))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var node = (ExpressionSyntax)context.Node;
 
-            if (node.Ancestors().Any(_ => _.IsAnyKind(Expressions)))
+            if (IsNested(node))
             {
                 // we are a nested one, hence we do not need to calculate and report again
                 return;

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzerTests.cs
@@ -766,6 +766,70 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_if_multi_line_call_chain_is_long()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string DoSomething(object o)
+    {
+        return o.ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString()
+                   .ToString();
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string DoSomething(object o)
+    {
+        return o.ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString()
+                .ToString();
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer();


### PR DESCRIPTION
- Extract `IsNested` method in analyzer

- Add test for long multiline call chains

- Use `RawKind` and `int` in `IsAnyKind` for performance reasons

- Refactor `GetParameters` and `GetParameterNames` methods

