### PR TITLE
Sealed classes and refactored Linq call

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -85,8 +85,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            foreach (var issue in emptyElements.Select(_ => AnalyzeEmptyXmlElement(_, lines)))
+            foreach (var element in emptyElements)
             {
+                var issue = AnalyzeEmptyXmlElement(element, lines);
+
+                if (issue is null)
+                {
+                    continue;
+                }
+
                 if (results is null)
                 {
                     results = new List<Diagnostic>(1);

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer : NamingAnalyzer
     {
         public const string Id = "MiKo_1117";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_1504_PropertiesWithCounterSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1504_PropertiesWithCounterSuffixAnalyzer : NamingAnalyzer
     {
         public const string Id = "MiKo_1504";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_1505_FieldsWithCounterSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1505_FieldsWithCounterSuffixAnalyzer : NamingAnalyzer
     {
         public const string Id = "MiKo_1505";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_1506_VariablesWithCounterSuffixAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1506_VariablesWithCounterSuffixAnalyzer : NamingLocalVariableAnalyzer
     {
         public const string Id = "MiKo_1506";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_1507_ParametersWithCounterSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1507_ParametersWithCounterSuffixAnalyzer : NamingAnalyzer
     {
         public const string Id = "MiKo_1507";
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6063_InvocationIsOnSameLineAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_6063_InvocationIsOnSameLineAnalyzer : SpacingAnalyzer
+    public sealed class MiKo_6063_InvocationIsOnSameLineAnalyzer : SpacingAnalyzer
     {
         public const string Id = "MiKo_6063";
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer : SpacingAnalyzer
+    public sealed class MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer : SpacingAnalyzer
     {
         public const string Id = "MiKo_6064";
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MiKo_6065_InvocationIsIndentedAnalyzer : SpacingAnalyzer
+    public sealed class MiKo_6065_InvocationIsIndentedAnalyzer : SpacingAnalyzer
     {
         public const string Id = "MiKo_6065";
 


### PR DESCRIPTION
- Seal analyzer classes for inheritance prevention

- Refactor Documentation analyzer's empty element iteration and add null check to skip `null` diagnostics
