### PR TITLE
MiKo_1115 is now also aware of 'Keep', 'DoesAlter', 'Remove' and 'Accepted'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -31,6 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private const string IsGiven = Is + Given;
         private const string Consumed = "Consumed";
         private const string Rejected = "Rejected";
+        private const string Accepted = "Accepted";
 
         private static readonly string[] ExpectedOutcomeMarkers =
                                                                   {
@@ -54,9 +55,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                       Rejected,
                                                                       Consumed,
                                                                       "Once",
-                                                                      "DoesNot",
+                                                                      "Does", // incl. 'DoesNot'
                                                                       "Create",
                                                                       "Append",
+                                                                      "Keep",
+                                                                      Accepted,
                                                                   };
 
         private static readonly string[] SpecialFirstPhrases =
@@ -324,6 +327,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             else if (original.StartsWith(Rejected, StringComparison.OrdinalIgnoreCase))
             {
                 builder.Append(original, Rejected.Length, original.Length - Rejected.Length).Append(Is).Append(Rejected);
+            }
+            else if (original.StartsWith(Accepted, StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Append(original, Accepted.Length, original.Length - Accepted.Length).Append(Is).Append(Accepted);
             }
             else
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -156,6 +156,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ReplaceWithProbe("NoThrow", "ThrowsNo")
                                    .ReplaceWithProbe("NoError", "HasNoError")
                                    .ReplaceWithProbe("Already", "IsAlready")
+                                   .ReplaceWithProbe("Keep", "Keeps")
+                                   .ReplaceWithProbe("Keepss", "Keeps") // fix typo
                                    .ReplaceWithProbe(nameof(ArgumentException) + "Thrown", "Throws" + nameof(ArgumentException))
                                    .ReplaceWithProbe(nameof(ArgumentNullException) + "Thrown", "Throws" + nameof(ArgumentNullException))
                                    .ReplaceWithProbe(nameof(ArgumentOutOfRangeException) + "Thrown", "Throws" + nameof(ArgumentOutOfRangeException))
@@ -204,6 +206,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    .ReplaceWithProbe("R_eference", "_reference")
                                    .ReplaceWithProbe("T_ype", "_type")
                                    .ReplaceWithProbe("_is_is_", "_is_")
+                                   .ReplaceWithProbe("_does_alter_", "_alters_")
+                                   .ReplaceWithProbe("_remove_", "_removes_")
+                                   .ReplaceWithProbe("_not_removes_", "_not_remove_")
+                                   .ReplaceWithProbe("_reject_", "_rejects_")
+                                   .ReplaceWithProbe("_not_rejects_", "_not_reject_")
                                    .ToStringAndRelease();
 
             return result;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -151,8 +151,16 @@ public class TestMe
         [TestCase("MethodName_NotThrows_NullReferenceException", "Method_name_throws_no_NullReferenceException")]
         [TestCase("MethodName_ConsumedMessage_Publish", "Method_name_publish_consumed_message")]
         [TestCase("MethodName_ConsumedMessage_Publishes", "Method_name_publishes_consumed_message")]
+        [TestCase("MethodName_AcceptedConsumedMessage_DoesNotRejectMessage", "Method_name_does_not_reject_message_if_consumed_message_is_accepted")]
         [TestCase("MethodName_RejectedConsumedMessage_LogsWhenAboveCriticalThreshold", "Method_name_logs_if_above_critical_threshold_if_consumed_message_is_rejected")]
         [TestCase("MethodName_RejectedConsumedMessage_RejectsMessage", "Method_name_rejects_message_if_consumed_message_is_rejected")]
+        [TestCase("MethodName_RejectedConsumedMessage_DoesNotRemoveMessage", "Method_name_does_not_remove_message_if_consumed_message_is_rejected")]
+        [TestCase("MethodName_RejectedConsumedMessage_RemoveMessage", "Method_name_removes_message_if_consumed_message_is_rejected")]
+        [TestCase("MethodName_RejectedConsumedMessage_RemovesMessage", "Method_name_removes_message_if_consumed_message_is_rejected")]
+        [TestCase("MethodName_SomeCondition_KeepValue", "Method_name_keeps_value_if_some_condition")]
+        [TestCase("MethodName_SomeCondition_KeepsValue", "Method_name_keeps_value_if_some_condition")]
+        [TestCase("MethodName_SomeCondition_DoesAlter", "Method_name_alters_if_some_condition")]
+        [TestCase("MethodName_SomeCondition_DoesNotAlter", "Method_name_does_not_alter_if_some_condition")]
         public void Code_gets_fixed_for_2_slashes_in_(string originalName, string fixedName) => VerifyCSharpFix(
                                                                                                             "class TestMe { [Test] public void " + originalName + "() { } }",
                                                                                                             "class TestMe { [Test] public void " + fixedName + "() { } }");


### PR DESCRIPTION
- Extend analyzer to support `Accepted` and `Keep` markers

- Add normalization rules for `DoesAlter`, `Remove`, `Reject` markers

- Update `FixPart` for `Accepted` prefix handling

- Add tests covering new naming scenarios

