### PR TITLE
Performance improvements

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/EnumerableExtensions.cs
@@ -1104,14 +1104,14 @@ namespace System.Linq
                 return Array.Empty<SyntaxToken>();
             }
 
-            var target = new SyntaxToken[sourceCount];
+            var result = new SyntaxToken[sourceCount];
 
             for (var index = 0; index < sourceCount; index++)
             {
-                target[index] = source[index];
+                result[index] = source[index];
             }
 
-            return target;
+            return result;
         }
 
         internal static T[] ToArray<T>(this in SyntaxList<T> source) where T : SyntaxNode
@@ -1124,14 +1124,14 @@ namespace System.Linq
                 return Array.Empty<T>();
             }
 
-            var target = new T[sourceCount];
+            var result = new T[sourceCount];
 
             for (var index = 0; index < sourceCount; index++)
             {
-                target[index] = source[index];
+                result[index] = source[index];
             }
 
-            return target;
+            return result;
         }
 
         internal static T[] ToArray<T>(this in SeparatedSyntaxList<T> source) where T : SyntaxNode
@@ -1144,14 +1144,14 @@ namespace System.Linq
                 return Array.Empty<T>();
             }
 
-            var target = new T[sourceCount];
+            var result = new T[sourceCount];
 
             for (var index = 0; index < sourceCount; index++)
             {
-                target[index] = source[index];
+                result[index] = source[index];
             }
 
-            return target;
+            return result;
         }
 
         internal static T[] ToArray<T>(this IEnumerable<T> source, IComparer<T> comparer) => source.ToArray(_ => _, comparer);
@@ -1345,17 +1345,17 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            var target = new List<SyntaxToken>(sourceCount);
+            var result = new List<SyntaxToken>(sourceCount);
 
             if (sourceCount > 0)
             {
                 for (var index = 0; index < sourceCount; index++)
                 {
-                    target.Add(source[index]);
+                    result.Add(source[index]);
                 }
             }
 
-            return target;
+            return result;
         }
 
 //// ncrunch: no coverage end
@@ -1365,17 +1365,17 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            var target = new List<T>(sourceCount);
+            var result = new List<T>(sourceCount);
 
             if (sourceCount > 0)
             {
                 for (var index = 0; index < sourceCount; index++)
                 {
-                    target.Add(source[index]);
+                    result.Add(source[index]);
                 }
             }
 
-            return target;
+            return result;
         }
 
         internal static List<T> ToList<T>(this in SeparatedSyntaxList<T> source) where T : SyntaxNode
@@ -1383,17 +1383,17 @@ namespace System.Linq
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var sourceCount = source.Count;
 
-            var target = new List<T>(sourceCount);
+            var result = new List<T>(sourceCount);
 
             if (sourceCount > 0)
             {
                 for (var index = 0; index < sourceCount; index++)
                 {
-                    target.Add(source[index]);
+                    result.Add(source[index]);
                 }
             }
 
-            return target;
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -541,9 +541,7 @@ namespace System.Text
 
         private static int QuickSubstringProbe(in ReadOnlySpan<char> current, in ReadOnlySpan<char> other)
         {
-            var delta = current.Length - other.Length;
-
-            if (delta < 0)
+            if (current.Length < other.Length)
             {
                 // cannot be part in the replacement as other value is too long and cannot fit current value
                 return -1;
@@ -560,6 +558,7 @@ namespace System.Text
             var lastIndex = other.Length - 1;
             var startChar = other[0];
             var endChar = other[lastIndex];
+            var delta = current.Length - other.Length;
 
             for (var position = 0; position <= delta; position++)
             {

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -81,15 +81,13 @@ namespace System.Text
                 return string.Empty;
             }
 
-            var length = value.Length;
-
             // 1. Find word begin
             whitespacesBefore = value.CountLeadingWhitespaces();
 
             // 2. Find word end
             var wordLength = 0;
 
-            for (var i = whitespacesBefore; i < length; i++)
+            for (int i = whitespacesBefore, length = value.Length; i < length; i++)
             {
                 var c = value[i];
 
@@ -112,9 +110,7 @@ namespace System.Text
                 return false;
             }
 
-            var valueLength = value.Length;
-
-            for (; start < valueLength; start++)
+            for (var length = value.Length; start < length; start++)
             {
                 if (value[start].IsWhiteSpace())
                 {
@@ -134,12 +130,10 @@ namespace System.Text
 
         public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<Pair> replacementPairs)
         {
-            var count = replacementPairs.Length;
-
             char[] text = null;
             var textSpan = GetTextAsRentedArray(value, ref text, SharedPool);
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = replacementPairs.Length; index < count; index++)
             {
                 var pair = replacementPairs[index];
                 var oldValue = pair.Key;
@@ -166,12 +160,10 @@ namespace System.Text
 
         public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<string> texts, string replacement)
         {
-            var length = texts.Length;
-
             char[] text = null;
             var textSpan = GetTextAsRentedArray(value, ref text, SharedPool);
 
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = texts.Length; index < length; index++)
             {
                 var oldValue = texts[index];
 
@@ -397,9 +389,7 @@ namespace System.Text
 
         public static StringBuilder TrimStart(this StringBuilder value, char[] characters)
         {
-            var charactersLength = characters.Length;
-
-            for (var index = 0; index < charactersLength; index++)
+            for (int index = 0, length = characters.Length; index < length; index++)
             {
                 if (value.Length > 0 && value[0] == characters[index])
                 {
@@ -426,9 +416,7 @@ namespace System.Text
 
         public static StringBuilder TrimEnd(this StringBuilder value, char[] characters)
         {
-            var charactersLength = characters.Length;
-
-            for (var index = 0; index < charactersLength; index++)
+            for (int index = 0, length = characters.Length; index < length; index++)
             {
                 var i = value.Length - 1;
 
@@ -558,9 +546,8 @@ namespace System.Text
             var lastIndex = other.Length - 1;
             var startChar = other[0];
             var endChar = other[lastIndex];
-            var delta = current.Length - other.Length;
 
-            for (var position = 0; position <= delta; position++)
+            for (int position = 0, delta = current.Length - other.Length; position <= delta; position++)
             {
                 // Performance-Note:
                 // - do not split or re-calculate last index position each time as this gets invoked millions of time and re-calculation is too costly in such situation
@@ -577,9 +564,8 @@ namespace System.Text
         private static int CountLeadingWhitespaces(this StringBuilder value, int start = 0)
         {
             var whitespaces = 0;
-            var valueLength = value.Length;
 
-            for (; start < valueLength; start++)
+            for (var valueLength = value.Length; start < valueLength; start++)
             {
                 if (value[start].IsWhiteSpace())
                 {
@@ -615,9 +601,7 @@ namespace System.Text
 
         private static void StartLowerCase(this StringBuilder value)
         {
-            var valueLength = value.Length;
-
-            for (var i = 0; i < valueLength; i++)
+            for (int i = 0, length = value.Length; i < length; i++)
             {
                 var c = value[i];
 
@@ -638,9 +622,7 @@ namespace System.Text
 
         private static void StartUpperCase(this StringBuilder value)
         {
-            var valueLength = value.Length;
-
-            for (var i = 0; i < valueLength; i++)
+            for (int i = 0, length = value.Length; i < length; i++)
             {
                 var c = value[i];
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -2047,23 +2047,20 @@ namespace System
 
         private static bool QuickSubstringProbe(in ReadOnlySpan<char> value, in ReadOnlySpan<char> other, in StringComparison comparison)
         {
-            var valueLength = value.Length;
-            var otherLength = other.Length;
-
-            if (valueLength > otherLength)
+            if (value.Length > other.Length)
             {
                 // continue to check
                 return true;
             }
 
-            if (valueLength < otherLength)
+            if (value.Length < other.Length)
             {
                 // cannot match
                 return false;
             }
 
             // both are same length, so perform a quick compare first
-            if (valueLength > QuickSubstringProbeLengthThreshold)
+            if (value.Length > QuickSubstringProbeLengthThreshold)
             {
                 switch (comparison)
                 {

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -390,8 +390,9 @@ namespace System
                 var buffer = stackalloc char[length];
                 var bufferSpan = new Span<char>(buffer, length);
 
-                value.CopyTo(bufferSpan);
                 buffer[valueLength] = arg0;
+
+                value.CopyTo(bufferSpan);
                 arg1.AsSpan().CopyTo(bufferSpan.Slice(valueLength + 1));
 
                 return new string(buffer, 0, length);
@@ -716,10 +717,9 @@ namespace System
             if (value.HasCharacters())
             {
                 var valueSpan = value.AsSpan();
-                var phrasesLength = phrases.Length;
                 var ordinalComparison = comparison is StringComparison.Ordinal;
 
-                for (var index = 0; index < phrasesLength; index++)
+                for (int index = 0, length = phrases.Length; index < length; index++)
                 {
                     var phrase = phrases[index];
                     var phraseSpan = phrase.AsSpan();
@@ -751,9 +751,8 @@ namespace System
         public static int CountLeadingWhitespaces(this string value, int start = 0)
         {
             var whitespaces = 0;
-            var valueLength = value.Length;
 
-            for (; start < valueLength; start++)
+            for (var length = value.Length; start < length; start++)
             {
                 if (value[start].IsWhiteSpace())
                 {
@@ -812,9 +811,7 @@ namespace System
             {
                 var lastChar = value[value.Length - 1];
 
-                var length = suffixCharacters.Length;
-
-                for (var index = 0; index < length; index++)
+                for (int index = 0, length = suffixCharacters.Length; index < length; index++)
                 {
                     if (lastChar == suffixCharacters[index])
                     {
@@ -834,9 +831,8 @@ namespace System
             if (value.HasCharacters())
             {
                 var valueLength = value.Length;
-                var suffixesLength = suffixes.Length;
 
-                for (var index = 0; index < suffixesLength; index++)
+                for (int index = 0, length = suffixes.Length; index < length; index++)
                 {
                     var suffix = suffixes[index];
 
@@ -860,9 +856,8 @@ namespace System
             if (value.HasCharacters())
             {
                 var valueLength = value.Length;
-                var suffixesLength = suffixes.Count;
 
-                for (var index = 0; index < suffixesLength; index++)
+                for (int index = 0, count = suffixes.Count; index < count; index++)
                 {
                     var suffix = suffixes[index];
 
@@ -931,9 +926,7 @@ namespace System
         {
             if (value.HasCharacters())
             {
-                var phrasesLength = phrases.Length;
-
-                for (var index = 0; index < phrasesLength; index++)
+                for (int index = 0, length = phrases.Length; index < length; index++)
                 {
                     var phrase = phrases[index];
 
@@ -972,9 +965,7 @@ namespace System
         {
             if (value.Length > 0)
             {
-                var phrasesLength = phrases.Length;
-
-                for (var index = 0; index < phrasesLength; index++)
+                for (int index = 0, length = phrases.Length; index < length; index++)
                 {
                     var phrase = phrases[index];
 
@@ -1169,9 +1160,8 @@ namespace System
         public static bool HasUpperCaseLettersAbove(this in ReadOnlySpan<char> value, in ushort limit)
         {
             var count = 0;
-            var length = value.Length;
 
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = value.Length; index < length; index++)
             {
                 if (value[index].IsUpperCase())
                 {
@@ -1281,13 +1271,9 @@ namespace System
                 // performance optimization to avoid unnecessary 'ToString' calls on 'ReadOnlySpan' (see implementation inside MemoryExtensions)
                 if (comparison is StringComparison.Ordinal)
                 {
-                    var phrasesLength = phrases.Length;
-
-                    for (var i = 0; i < phrasesLength; i++)
+                    for (int i = 0, length = phrases.Length; i < length; i++)
                     {
-                        var phrase = phrases[i];
-
-                        var index = value.IndexOf(phrase.AsSpan()); // performs ordinal comparison
+                        var index = value.IndexOf(phrases[i].AsSpan()); // performs ordinal comparison
 
                         if (index > -1)
                         {
@@ -1314,13 +1300,9 @@ namespace System
                     return IndexOfAny(value.AsSpan(), phrases, comparison);
                 }
 
-                var phrasesLength = phrases.Length;
-
-                for (var i = 0; i < phrasesLength; i++)
+                for (int i = 0, length = phrases.Length; i < length; i++)
                 {
-                    var phrase = phrases[i];
-
-                    var index = value.IndexOf(phrase, comparison);
+                    var index = value.IndexOf(phrases[i], comparison);
 
                     if (index > -1)
                     {
@@ -1341,13 +1323,9 @@ namespace System
 
             if (value.Length > 0)
             {
-                var phrasesLength = phrases.Length;
-
-                for (var i = 0; i < phrasesLength; i++)
+                for (int i = 0, length = phrases.Length; i < length; i++)
                 {
-                    var phrase = phrases[i];
-
-                    var index = value.LastIndexOf(phrase, comparison);
+                    var index = value.LastIndexOf(phrases[i], comparison);
 
                     if (index > -1)
                     {
@@ -1571,9 +1549,8 @@ namespace System
             if (value.HasCharacters())
             {
                 var valueSpan = value.AsSpan();
-                var prefixesCount = prefixes.Length;
 
-                for (var index = 0; index < prefixesCount; index++)
+                for (int index = 0, length = prefixes.Length; index < length; index++)
                 {
                     var prefix = prefixes[index];
 
@@ -1594,13 +1571,9 @@ namespace System
         {
             if (value.Length > 0)
             {
-                var prefixesLength = prefixes.Length;
-
-                for (var index = 0; index < prefixesLength; index++)
+                for (int index = 0, length = prefixes.Length; index < length; index++)
                 {
-                    var prefix = prefixes[index];
-
-                    if (value.StartsWith(prefix, comparison))
+                    if (value.StartsWith(prefixes[index], comparison))
                     {
                         return true;
                     }
@@ -1827,9 +1800,7 @@ namespace System
         {
             var text = value.TrimStart();
 
-            var wordsLength = words.Length;
-
-            for (var index = 0; index < wordsLength; index++)
+            for (int index = 0, length = words.Length; index < length; index++)
             {
                 var word = words[index];
 
@@ -1973,10 +1944,8 @@ namespace System
             }
 
             var slice = value;
-            var suffixesLength = suffixes.Length;
 
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (var index = 0; index < suffixesLength; index++)
+            for (int index = 0, suffixesLength = suffixes.Length; index < suffixesLength; index++)
             {
                 var suffix = suffixes[index].AsSpan();
 
@@ -1998,9 +1967,7 @@ namespace System
 
         private static bool HasWhitespaces(this in ReadOnlySpan<char> value, int start = 0)
         {
-            var valueLength = value.Length;
-
-            for (; start < valueLength; start++)
+            for (var valueLength = value.Length; start < valueLength; start++)
             {
                 if (value[start].IsWhiteSpace())
                 {
@@ -2182,11 +2149,9 @@ namespace System
 
         private static int[] AllIndicesOrdinal(in ReadOnlySpan<char> span, in ReadOnlySpan<char> other)
         {
-            var otherLength = other.Length;
-
             int[] indices = null;
 
-            for (var index = 0; ; index += otherLength)
+            for (int index = 0, otherLength = other.Length; ; index += otherLength)
             {
                 var newIndex = span.Slice(index).IndexOf(other); // performs ordinal comparison
 
@@ -2215,11 +2180,9 @@ namespace System
 
         private static int[] AllIndicesNonOrdinal(string value, string finding, in StringComparison comparison)
         {
-            var findingLength = finding.Length;
-
             int[] indices = null;
 
-            for (var index = 0; ; index += findingLength)
+            for (int index = 0, findingLength = finding.Length; ; index += findingLength)
             {
                 index = value.IndexOf(finding, index, comparison);
 

--- a/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringSplitExtensions.cs
@@ -21,9 +21,7 @@ namespace System
 
             var tuples = new List<(int, string)>();
 
-            var findingsLength = findings.Length;
-
-            for (var findingsIndex = 0; findingsIndex < findingsLength; findingsIndex++)
+            for (int findingsIndex = 0, length = findings.Length; findingsIndex < length; findingsIndex++)
             {
                 var finding = findings[findingsIndex];
 

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -1272,12 +1272,12 @@ namespace MiKoSolutions.Analyzers
 
                 default:
                 {
-                    if (IsEnumerable(specialType))
+                    if (value.TypeKind is TypeKind.Array)
                     {
                         return true;
                     }
 
-                    if (value.TypeKind is TypeKind.Array)
+                    if (IsEnumerable(specialType))
                     {
                         return true;
                     }

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -422,9 +422,8 @@ namespace MiKoSolutions.Analyzers
                             sb.Append('<');
 
                             var typeParameters = method.TypeParameters;
-                            var count = typeParameters.Length - 1;
 
-                            for (var i = 0; i <= count; i++)
+                            for (int i = 0, count = typeParameters.Length - 1; i <= count; i++)
                             {
                                 sb.Append(typeParameters[i].MinimalTypeName());
 
@@ -446,9 +445,7 @@ namespace MiKoSolutions.Analyzers
             {
                 sb.Append('(');
 
-                var count = parameters.Length - 1;
-
-                for (var i = 0; i <= count; i++)
+                for (int i = 0, count = parameters.Length - 1; i <= count; i++)
                 {
                     AppendParameterSignature(parameters[i], sb);
 
@@ -644,11 +641,14 @@ namespace MiKoSolutions.Analyzers
             {
                 var count = symbols.Count;
 
-                for (var index = 0; index < count; index++)
+                if (count > 0)
                 {
-                    if (symbols[index] is IMethodSymbol method && method.IsTypeUnderTestCreationMethod())
+                    for (var index = 0; index < count; index++)
                     {
-                        yield return method;
+                        if (symbols[index] is IMethodSymbol method && method.IsTypeUnderTestCreationMethod())
+                        {
+                            yield return method;
+                        }
                     }
                 }
             }
@@ -786,8 +786,7 @@ namespace MiKoSolutions.Analyzers
             {
                 for (var index = 0; index < length; index++)
                 {
-                    var implementedInterface = interfaces[index];
-                    var fullInterfaceName = implementedInterface.ToString();
+                    var fullInterfaceName = interfaces[index].ToString();
 
                     if (fullInterfaceName == interfaceTypeName)
                     {
@@ -1700,9 +1699,11 @@ namespace MiKoSolutions.Analyzers
                     var parameterName = value.Name;
 
                     var prefixes = Constants.Markers.FieldPrefixes;
-                    fieldNames = new string[prefixes.Length];
+                    var prefixesLength = prefixes.Length;
 
-                    for (var index = 0; index < prefixes.Length; index++)
+                    fieldNames = new string[prefixesLength];
+
+                    for (var index = 0; index < prefixesLength; index++)
                     {
                         fieldNames[index] = prefixes[index] + parameterName;
                     }
@@ -1828,10 +1829,9 @@ namespace MiKoSolutions.Analyzers
         private static bool IsInterfaceImplementation<TSymbol>(this TSymbol value, ITypeSymbol typeSymbol, in ImmutableArray<INamedTypeSymbol> implementedInterfaces) where TSymbol : ISymbol
         {
             var name = value.Name;
-            var length = implementedInterfaces.Length;
 
             // Perf: do not use enumerable
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = implementedInterfaces.Length; index < length; index++)
             {
                 var members = implementedInterfaces[index].GetMembers(name);
                 var membersLength = members.Length;

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -217,10 +217,8 @@ namespace MiKoSolutions.Analyzers
             {
                 XmlNodeSyntax first = null;
 
-                var listCount = list.Count;
-
                 // try to find the first syntax that is not only an XmlCommentExterior
-                for (var index = 0; index < listCount; index++)
+                for (int index = 0, listCount = list.Count; index < listCount; index++)
                 {
                     first = list[index];
 
@@ -2619,16 +2617,16 @@ namespace MiKoSolutions.Analyzers
 
         internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, in ReadOnlySpan<string> phrases, string replacement)
         {
-            var resultLength = source.Count;
+            var sourceCount = source.Count;
 
-            if (resultLength is 0)
+            if (sourceCount is 0)
             {
                 return source;
             }
 
             var result = source.ToArray();
 
-            for (var index = 0; index < resultLength; index++)
+            for (var index = 0; index < sourceCount; index++)
             {
                 var value = result[index];
 
@@ -3134,9 +3132,7 @@ namespace MiKoSolutions.Analyzers
 
             var resetFinalTrivia = false;
 
-            var length = finalTrivia.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = finalTrivia.Length; index < length; index++)
             {
                 var trivia = finalTrivia[index];
 
@@ -3524,9 +3520,7 @@ namespace MiKoSolutions.Analyzers
                     continue;
                 }
 
-                var textsLength = texts.Length;
-
-                for (var textIndex = 0; textIndex < textsLength; textIndex++)
+                for (int textIndex = 0, textsLength = texts.Length; textIndex < textsLength; textIndex++)
                 {
                     var text = texts[textIndex];
 
@@ -3731,9 +3725,8 @@ namespace MiKoSolutions.Analyzers
             }
 
             var textTokens = tokens.ToList();
-            var textTokensCount = textTokens.Count;
 
-            for (var i = 0; i < textTokensCount; i++)
+            for (int i = 0, textTokensCount = textTokens.Count; i < textTokensCount; i++)
             {
                 var token = textTokens[i];
 
@@ -3804,7 +3797,7 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            for (var i = 0; i < textTokens.Count; i++)
+            for (int i = 0, count = textTokens.Count; i < count; i++)
             {
                 var token = textTokens[i];
 
@@ -3982,22 +3975,13 @@ namespace MiKoSolutions.Analyzers
         {
             var attributeLists = value.AttributeLists;
 
-            // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var attributeListsCount = attributeLists.Count;
-
-            for (var i = 0; i < attributeListsCount; i++)
+            for (int i = 0, count = attributeLists.Count; i < count; i++)
             {
                 var attributes = attributeLists[i].Attributes;
 
-                // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var attributesCount = attributes.Count;
-
-                for (var index = 0; index < attributesCount; index++)
+                for (int index = 0, attributesCount = attributes.Count; index < attributesCount; index++)
                 {
-                    var attribute = attributes[index];
-                    var name = attribute.GetName();
-
-                    if (names.Contains(name))
+                    if (names.Contains(attributes[index].GetName()))
                     {
                         return true;
                     }
@@ -4011,22 +3995,13 @@ namespace MiKoSolutions.Analyzers
         {
             var attributeLists = value.AttributeLists;
 
-            // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var attributeListsCount = attributeLists.Count;
-
-            for (var i = 0; i < attributeListsCount; i++)
+            for (int i = 0, count = attributeLists.Count; i < count; i++)
             {
                 var attributes = attributeLists[i].Attributes;
 
-                // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var attributesCount = attributes.Count;
-
-                for (var index = 0; index < attributesCount; index++)
+                for (int index = 0, attributesCount = attributes.Count; index < attributesCount; index++)
                 {
-                    var attribute = attributes[index];
-                    var name = attribute.GetName();
-
-                    if (names.Contains(name))
+                    if (names.Contains(attributes[index].GetName()))
                     {
                         return true;
                     }
@@ -4091,9 +4066,7 @@ namespace MiKoSolutions.Analyzers
         private static XmlCrefAttributeSyntax GetCref(in SyntaxList<XmlAttributeSyntax> syntax)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var syntaxCount = syntax.Count;
-
-            for (var index = 0; index < syntaxCount; index++)
+            for (int index = 0, count = syntax.Count; index < count; index++)
             {
                 if (syntax[index] is XmlCrefAttributeSyntax a)
                 {
@@ -4106,9 +4079,7 @@ namespace MiKoSolutions.Analyzers
 
         private static IEnumerable<XmlNodeSyntax> GetSummaryXmlsCore(IReadOnlyList<XmlElementSyntax> summaryXmls, ISet<string> tags)
         {
-            var count = summaryXmls.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var summary = summaryXmls[index];
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -128,9 +128,8 @@ namespace MiKoSolutions.Analyzers
             }
 
             DocumentationCommentTriviaSyntax[] results = null;
-            var resultsIndex = 0;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, resultsIndex = 0; index < count; index++)
             {
                 var trivia = leadingTrivia[index];
 
@@ -173,9 +172,7 @@ namespace MiKoSolutions.Analyzers
         {
             var valueKind = value.Kind();
 
-            var length = kinds.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = kinds.Length; index < length; index++)
             {
                 if (kinds[index] == valueKind)
                 {
@@ -277,13 +274,9 @@ namespace MiKoSolutions.Analyzers
             // remove existing empty lines
             var indicesToRemove = new Stack<int>();
 
-            var count = trivia.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = trivia.Count; index < count; index++)
             {
-                var t = trivia[index];
-
-                if (t.IsEndOfLine())
+                if (trivia[index].IsEndOfLine())
                 {
                     indicesToRemove.Push(index);
                 }
@@ -339,12 +332,11 @@ namespace MiKoSolutions.Analyzers
                 var additionalSpaces = count - value.GetPositionWithinStartLine();
 
                 var leadingTrivia = value.LeadingTrivia.ToList();
-                var triviaCount = leadingTrivia.Count;
 
                 // first collect all indices of the comments, for later reference
                 var indices = new List<int>(1);
 
-                for (var index = 0; index < triviaCount; index++)
+                for (int index = 0, triviaCount = leadingTrivia.Count; index < triviaCount; index++)
                 {
                     var trivia = leadingTrivia[index];
 

--- a/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
@@ -16,11 +16,12 @@ namespace System
         public WordsReadOnlySpanEnumerator(in ReadOnlySpan<char> text)
         {
             m_text = text;
+            var textLength = text.Length;
 
             var words = 1;
 
             // start at index 1 to skip first upper case character (and avoid return of empty word)
-            for (var index = 1; index < text.Length; index++)
+            for (var index = 1; index < textLength; index++)
             {
                 if (text[index].IsUpperCase())
                 {
@@ -31,10 +32,8 @@ namespace System
             m_wordStartingPositions = new int[words];
             m_wordStartingPositions[0] = 0;
 
-            var i = 1;
-
             // start at index 1 to skip first upper case character (and avoid return of empty word)
-            for (var index = 1; index < text.Length; index++)
+            for (int index = 1, i = 1; index < textLength; index++)
             {
                 if (text[index].IsUpperCase())
                 {

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationDetector.cs
@@ -401,14 +401,12 @@ namespace MiKoSolutions.Analyzers.Linguistics
             return ReplaceAllAbbreviations(value, findings);
         }
 
-        //// ncrunch: rdi off
+//// ncrunch: rdi off
         private static ReadOnlySpan<Pair> FindCore(in ReadOnlySpan<char> valueSpan)
         {
             var result = new HashSet<Pair>(KeyEqualityComparer.Instance);
 
-            var prefixesLength = Prefixes.Length;
-
-            for (var index = 0; index < prefixesLength; index++)
+            for (int index = 0, prefixesLength = Prefixes.Length; index < prefixesLength; index++)
             {
                 var pair = Prefixes[index];
 
@@ -427,9 +425,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             //// TODO RKN: replace prefixes to not find them again as middle terms or whatever?
 
-            var postfixesLength = Postfixes.Length;
-
-            for (var index = 0; index < postfixesLength; index++)
+            for (int index = 0, postfixesLength = Postfixes.Length; index < postfixesLength; index++)
             {
                 var pair = Postfixes[index];
 
@@ -439,9 +435,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 }
             }
 
-            var midTermsLength = MidTerms.Length;
-
-            for (var index = 0; index < midTermsLength; index++)
+            for (int index = 0, midTermsLength = MidTerms.Length; index < midTermsLength; index++)
             {
                 var pair = MidTerms[index];
 

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -305,9 +305,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     return false;
                 }
 
-                var length = NounsWithGerundEnding.Length;
-
-                for (var index = 0; index < length; index++)
+                for (int index = 0, length = NounsWithGerundEnding.Length; index < length; index++)
                 {
                     var noun = NounsWithGerundEnding[index];
 
@@ -688,9 +686,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return false;
             }
 
-            var length = Endings.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = Endings.Length; index < length; index++)
             {
                 var pair = Endings[index];
                 var key = pair.Key;
@@ -708,9 +704,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static bool HasAcceptableStartingPhrase(in ReadOnlySpan<char> value)
         {
-            var length = StartingPhrases.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = StartingPhrases.Length; index < length; index++)
             {
                 var phrase = StartingPhrases[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -85,9 +85,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var textTokens = text.TextTokens;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var textTokensCount = textTokens.Count;
-
-                for (var index = 0; index < textTokensCount; index++)
+                for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
                 {
                     var token = textTokens[index];
 
@@ -237,11 +235,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static IReadOnlyList<Location> GetAllLocationsWithLoop(SyntaxTree syntaxTree, in int spanStart, string value, in int startOffset, in int endOffset, in ReadOnlySpan<int> allIndices)
         {
             List<Location> alreadyReportedLocations = null;
-            var length = allIndices.Length;
-
             List<Location> results = null;
 
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = allIndices.Length; index < length; index++)
             {
                 var position = allIndices[index];
 
@@ -281,11 +277,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static IReadOnlyList<Location> GetAllLocationsWithLoop(string text, SyntaxTree syntaxTree, in int spanStart, in ReadOnlySpan<string> values, in StringComparison comparison, in int startOffset, in int endOffset, in int textLength)
         {
             List<Location> alreadyReportedLocations = null;
-            var valuesCount = values.Length;
-
             List<Location> results = null;
 
-            for (var valueIndex = 0; valueIndex < valuesCount; valueIndex++)
+            for (int valueIndex = 0, valuesCount = values.Length; valueIndex < valuesCount; valueIndex++)
             {
                 var value = values[valueIndex];
 
@@ -303,9 +297,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     continue;
                 }
 
-                var length = allIndices.Length;
-
-                for (var index = 0; index < length; index++)
+                for (int index = 0, length = allIndices.Length; index < length; index++)
                 {
                     var position = allIndices[index];
 
@@ -348,11 +340,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var lastPosition = textLength - 1;
 
             List<Location> alreadyReportedLocations = null;
-            var length = allIndices.Length;
-
             List<Location> results = null;
 
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = allIndices.Length; index < length; index++)
             {
                 var position = allIndices[index];
                 var afterPosition = position + value.Length;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -157,9 +157,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var textTokens = text.TextTokens;
 
                     // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                    var textTokensCount = textTokens.Count;
-
-                    for (var index = 0; index < textTokensCount; index++)
+                    for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
                     {
                         var token = textTokens[index];
 
@@ -521,9 +519,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected static XmlTextSyntax MakeFirstWordInfiniteVerb(XmlTextSyntax text)
         {
             var textTokens = text.TextTokens;
-            var textTokensCount = textTokens.Count;
 
-            for (var index = 0; index < textTokensCount; index++)
+            for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
             {
                 var token = textTokens[index];
 
@@ -612,18 +609,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var partsForOtherSentences = new List<XmlNodeSyntax>();
 
             var commentContents = comment.Content;
-            var commentContentsCount = commentContents.Count;
 
-            for (var index = 0; index < commentContentsCount; index++)
+            for (int index = 0, commentContentsCount = commentContents.Count; index < commentContentsCount; index++)
             {
                 var node = commentContents[index];
 
                 if (node is XmlTextSyntax text)
                 {
                     var textTokens = text.TextTokens;
-                    var textTokensCount = textTokens.Count;
 
-                    for (var tokenIndex = 0; tokenIndex < textTokensCount; tokenIndex++)
+                    for (int tokenIndex = 0, textTokensCount = textTokens.Count; tokenIndex < textTokensCount; tokenIndex++)
                     {
                         var token = textTokens[tokenIndex];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -154,7 +154,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static IEnumerable<XmlNodeSyntax> ParameterIsNull(params string[] parameters)
         {
-            for (var i = 0; i < parameters.Length; i++)
+            for (int i = 0, parametersLength = parameters.Length; i < parametersLength; i++)
             {
                 var parameter = parameters[i];
 
@@ -163,7 +163,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 yield return SeeLangword_Null();
                 yield return XmlText(".").WithTrailingXmlComment();
 
-                if (i < parameters.Length - 1)
+                if (i < parametersLength - 1)
                 {
                     yield return ParaOr();
                 }
@@ -195,10 +195,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             // split into parts, so that we can easily detect which part is a parameter and which is some normal text
             var parts = comment.SplitBy(parametersAsTextReferences).ToArray();
-            var partsLength = parts.Length;
 
             // now correct the parameters back
-            for (var i = 0; i < partsLength; i++)
+            for (int i = 0, last = parts.Length - 1; i <= last; i++)
             {
                 var part = parts[i];
 
@@ -212,7 +211,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             parts[i - 1] = parts[i - 1].ConcatenatedWith(part.First());
                         }
 
-                        if (i < partsLength - 1)
+                        if (i < last)
                         {
                             // that's text after the parameter, so add the missing character before
                             parts[i + 1] = part.Last().ConcatenatedWith(parts[i + 1]);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzer.cs
@@ -32,9 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             List<Diagnostic> issues = null;
 
-            var summariesCount = summaryXmls.Count;
-
-            for (var index = 0; index < summariesCount; index++)
+            for (int index = 0, summariesCount = summaryXmls.Count; index < summariesCount; index++)
             {
                 if (IsEqual(summaryXmls[index], SummaryPhrase) is false)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_ChecksSummaryAnalyzer.cs
@@ -50,11 +50,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            var count = summaryXmls.Count;
-
             List<Diagnostic> issues = null;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var summaryXml = summaryXmls[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -151,10 +151,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var data = FindMatchingReplacementMapKeys(text);
                     var uniqueKeys = data.UniqueKeys;
-                    var length = uniqueKeys.Length;
 
 //// ncrunch: no coverage start
-                    for (var index = 0; index < length; index++)
+                    for (int index = 0, length = uniqueKeys.Length; index < length; index++)
                     {
                         var key = uniqueKeys[index];
 
@@ -207,9 +206,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             subText = ModifyOrNotPart(subText);
 
-            var length = Conditionals.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = Conditionals.Length; index < length; index++)
             {
                 var conditional = Conditionals[index];
 
@@ -377,6 +374,27 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class MapData
         {
+#pragma warning disable SA1401 // Fields should be private
+            public readonly Pair[] ReplacementMapForA;
+            public readonly Pair[] ReplacementMapForAn;
+            public readonly Pair[] ReplacementMapForThe;
+            public readonly Pair[] ReplacementMapForParenthesis;
+            public readonly Pair[] ReplacementMapForOthers;
+            public readonly Pair[] ReplacementMapForLowerCaseA;
+            public readonly Pair[] ReplacementMapForLowerCaseAn;
+            public readonly Pair[] ReplacementMapForLowerCaseThe;
+            public readonly string[] ReplacementMapKeysForA;
+            public readonly string[] ReplacementMapKeysForAn;
+            public readonly string[] ReplacementMapKeysForThe;
+            public readonly string[] ReplacementMapKeysForParenthesis;
+            public readonly string[] ReplacementMapKeysForOthers;
+            public readonly string[] UniqueReplacementMapKeysForA;
+            public readonly string[] UniqueReplacementMapKeysForAn;
+            public readonly string[] UniqueReplacementMapKeysForThe;
+            public readonly string[] UniqueReplacementMapKeysForParenthesis;
+            public readonly string[] UniqueReplacementMapKeysForOthers;
+#pragma warning restore SA1401 // Fields should be private
+
             public MapData()
             {
                 var replacementMapCommon = new[]
@@ -546,9 +564,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var pool = ArrayPool<Pair>.Shared;
                     var rentedArray = pool.Rent(keys.Count + others.Length);
 
-                    var count = map.Length;
-
-                    for (var index = 0; index < count; index++)
+                    for (int index = 0, count = map.Length; index < count; index++)
                     {
                         var key = map[index];
 
@@ -572,47 +588,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 string[] ToUnique(IEnumerable<string> strings) => new HashSet<string>(strings, StringComparer.OrdinalIgnoreCase).ToArray();
             }
 
-            public Pair[] ReplacementMapForA { get; }
-
-            public Pair[] ReplacementMapForAn { get; }
-
-            public Pair[] ReplacementMapForThe { get; }
-
-            public Pair[] ReplacementMapForParenthesis { get; }
-
-            public Pair[] ReplacementMapForOthers { get; }
-
-            public Pair[] ReplacementMapForLowerCaseA { get; }
-
-            public Pair[] ReplacementMapForLowerCaseAn { get; }
-
-            public Pair[] ReplacementMapForLowerCaseThe { get; }
-
-            public string[] ReplacementMapKeysForA { get; }
-
-            public string[] ReplacementMapKeysForAn { get; }
-
-            public string[] ReplacementMapKeysForThe { get; }
-
-            public string[] ReplacementMapKeysForParenthesis { get; }
-
-            public string[] ReplacementMapKeysForOthers { get; }
-
             public string[] ReplacementMapKeysForLowerCaseA => ReplacementMapKeysForA;
 
             public string[] ReplacementMapKeysForLowerCaseAn => ReplacementMapKeysForAn;
 
             public string[] ReplacementMapKeysForLowerCaseThe => ReplacementMapKeysForThe;
-
-            public string[] UniqueReplacementMapKeysForA { get; }
-
-            public string[] UniqueReplacementMapKeysForAn { get; }
-
-            public string[] UniqueReplacementMapKeysForThe { get; }
-
-            public string[] UniqueReplacementMapKeysForParenthesis { get; }
-
-            public string[] UniqueReplacementMapKeysForOthers { get; }
 
             private static Pair[] CreateReplacementMap()
             {
@@ -825,9 +805,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             private static int GetOrder(in ReadOnlySpan<char> text, in ReadOnlySpan<string> orders)
             {
-                var length = orders.Length;
-
-                for (var i = 0; i < length; i++)
+                for (int i = 0, length = orders.Length; i < length; i++)
                 {
                     if (text.StartsWith(orders[i].AsSpan()))
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
@@ -30,15 +30,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static string[] GetPhrases(string parameterName)
         {
             var startingPhrases = Constants.Comments.ParameterStartingPhrase;
+            var startingPhrasesLength = startingPhrases.Length;
 
-            var phrases = new string[2 * (startingPhrases.Length + 1)];
+            var phrases = new string[2 * (startingPhrasesLength + 1)];
 
-            for (var i = 0; i < startingPhrases.Length; i++)
+            for (var i = 0; i < startingPhrasesLength; i++)
             {
                 var phraseWithName = startingPhrases[i] + parameterName;
 
                 phrases[i] = phraseWithName;
-                phrases[i + startingPhrases.Length] = phraseWithName + ".";
+                phrases[i + startingPhrasesLength] = phraseWithName + ".";
             }
 
             phrases[phrases.Length - 2] = parameterName;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -179,6 +179,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class MapData
         {
+#pragma warning disable SA1401 // Fields should be private
+            public readonly Pair[] ReplacementMap;
+            public readonly string[] ReplacementMapKeys;
+            public readonly Pair[] ByteArrayReplacementMap;
+            public readonly string[] ByteArrayReplacementMapKeys;
+            public readonly string[] ByteArrayContinueTexts;
+#pragma warning restore SA1401 // Fields should be private
+
 #pragma warning disable CA1861
             public MapData()
             {
@@ -246,16 +254,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                              };
             }
 #pragma warning restore CA1861
-
-            public Pair[] ReplacementMap { get; }
-
-            public string[] ReplacementMapKeys { get; }
-
-            public Pair[] ByteArrayReplacementMap { get; }
-
-            public string[] ByteArrayReplacementMapKeys { get; }
-
-            public string[] ByteArrayContinueTexts { get; }
 
             private static IEnumerable<string> CreatePhrases()
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
@@ -12,9 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool IsApplicable(in ImmutableArray<Diagnostic> diagnostics)
         {
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (var index = 0; index < diagnostics.Length; index++)
+            for (int index = 0, diagnosticsLength = diagnostics.Length; index < diagnosticsLength; index++)
             {
                 var diagnostic = diagnostics[index];
                 var properties = diagnostic.Properties;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -194,9 +194,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = textNode.TextTokens;
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var textTokensCount = textTokens.Count;
-
-            for (var index = 0; index < textTokensCount; index++)
+            for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
             {
                 var textToken = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
@@ -40,9 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = node.TextTokens;
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var textTokensCount = textTokens.Count;
-
-            for (var index = 0; index < textTokensCount; index++)
+            for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
             {
                 var token = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -173,6 +173,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class MapData
         {
+#pragma warning disable SA1401 // Fields should be private
+            public readonly Pair[] TypeReplacementMapA;
+            public readonly string[] TypeReplacementMapKeysA;
+            public readonly Pair[] TypeReplacementMapCD;
+            public readonly string[] TypeReplacementMapKeysCD;
+            public readonly Pair[] TypeReplacementMapThe;
+            public readonly string[] TypeReplacementMapKeysThe;
+            public readonly Pair[] TypeReplacementMapThis;
+            public readonly string[] TypeReplacementMapKeysThis;
+            public readonly Pair[] TypeReplacementMapOthers;
+            public readonly string[] TypeReplacementMapKeysOthers;
+            public readonly Pair[] MethodReplacementMap;
+            public readonly string[] MethodReplacementMapKeys;
+            public readonly Pair[] InstancesReplacementMap;
+            public readonly string[] InstancesReplacementMapKeys;
+            public readonly Pair[] CleanupReplacementMap;
+            public readonly string[] CleanupReplacementMapKeys;
+#pragma warning restore SA1401 // Fields should be private
+
             public MapData()
             {
                 var typeKeys = CreateTypeReplacementMapKeys();
@@ -287,38 +306,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return pairs;
                 }
             }
-
-            public Pair[] TypeReplacementMapA { get; }
-
-            public string[] TypeReplacementMapKeysA { get; }
-
-            public Pair[] TypeReplacementMapCD { get; }
-
-            public string[] TypeReplacementMapKeysCD { get; }
-
-            public Pair[] TypeReplacementMapThe { get; }
-
-            public string[] TypeReplacementMapKeysThe { get; }
-
-            public Pair[] TypeReplacementMapThis { get; }
-
-            public string[] TypeReplacementMapKeysThis { get; }
-
-            public Pair[] TypeReplacementMapOthers { get; }
-
-            public string[] TypeReplacementMapKeysOthers { get; }
-
-            public Pair[] MethodReplacementMap { get; }
-
-            public string[] MethodReplacementMapKeys { get; }
-
-            public Pair[] InstancesReplacementMap { get; }
-
-            public string[] InstancesReplacementMapKeys { get; }
-
-            public Pair[] CleanupReplacementMap { get; }
-
-            public string[] CleanupReplacementMapKeys { get; }
 
             private static string[] CreateTypeReplacementMapKeys()
             {
@@ -626,9 +613,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                   };
 
                 var results = new HashSet<string>(phrases);
-                var phrasesLength = phrases.Length;
 
-                for (var index = 0; index < phrasesLength; index++)
+                for (int index = 0, phrasesLength = phrases.Length; index < phrasesLength; index++)
                 {
                     results.Add(phrases[index].Replace("actory", "actory class"));
                 }
@@ -662,9 +648,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                             "the new instances of the ",
                                         };
 
-                var continuationsLength = continuations.Length;
-
-                for (var index = 0; index < continuationsLength; index++)
+                for (int index = 0, continuationsLength = continuations.Length; index < continuationsLength; index++)
                 {
                     var continuation = continuations[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -78,9 +78,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var textTokens = text.TextTokens;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var textTokensCount = textTokens.Count;
-
-                for (var index = 0; index < textTokensCount; index++)
+                for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
                 {
                     var token = textTokens[index];
                     var valueText = token.ValueText.Without(Constants.Comments.AsynchronouslyStartingPhrase).AsSpan().Trim();
@@ -141,9 +139,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 contents = summary.Content;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var count = contents.Count - 1;
-
-                for (var i = 0; i < count; i++)
+                for (int i = 0, count = contents.Count - 1; i < count; i++)
                 {
                     if (contents[i] is XmlTextSyntax t1 && contents[i + 1] is XmlTextSyntax t2)
                     {
@@ -191,9 +187,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var textTokens = sentenceEnding.TextTokens;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var textTokensCount = textTokens.Count;
-
-                for (var index = 0; index < textTokensCount; index++)
+                for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
                 {
                     var token = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2077_SummaryShouldNotUseCodeTagAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2077_SummaryShouldNotUseCodeTagAnalyzer.cs
@@ -38,11 +38,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            var count = summaryXmls.Count;
-
             List<Diagnostic> issues = null;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var summaryXml = summaryXmls[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
@@ -50,11 +50,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var symbolName = symbol.Name;
             var obviousComments = GetObviousComments(symbolName);
 
-            var count = summaryXmls.Count;
-
             List<Diagnostic> issues = null;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var summary = summaryXmls[index];
                 var trimmed = summary.GetTextTrimmed();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -45,6 +45,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private sealed class MapData
         {
+#pragma warning disable SA1401 // Fields should be private
+            public readonly Pair[] ReplacementMap;
+            public readonly string[] ReplacementMapKeys;
+            public readonly string[] TypeGuidReplacementMapKeys;
+            public readonly Pair[] TypeGuidReplacementMap;
+            public readonly string[] PreparationMapKeys;
+            public readonly Pair[] PreparationMap;
+            public readonly string[] CleanupMapKeys;
+            public readonly Pair[] CleanupMap;
+#pragma warning restore SA1401 // Fields should be private
+
 #pragma warning disable CA1861
             public MapData()
             {
@@ -114,22 +125,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);
             }
 #pragma warning restore CA1861
-
-            public Pair[] ReplacementMap { get; }
-
-            public string[] ReplacementMapKeys { get; }
-
-            public string[] TypeGuidReplacementMapKeys { get; }
-
-            public Pair[] TypeGuidReplacementMap { get; }
-
-            public string[] PreparationMapKeys { get; }
-
-            public Pair[] PreparationMap { get; }
-
-            public string[] CleanupMapKeys { get; }
-
-            public Pair[] CleanupMap { get; }
 
             private static HashSet<string> CreateReplacementMapKeys()
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2101_CodeFixProvider.cs
@@ -24,9 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var contents = example.Content;
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var contentsCount = contents.Count;
-
-            for (var index = 0; index < contentsCount; index++)
+            for (int index = 0, count = contents.Count; index < count; index++)
             {
                 var node = contents[index];
 
@@ -57,9 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = text.TextTokens;
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var textTokensCount = textTokens.Count;
-
-            for (var index = 0; index < textTokensCount; index++)
+            for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
             {
                 var token = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
@@ -95,10 +95,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static bool CommentHasIssue(in ReadOnlySpan<char> comment)
         {
-            var commentLength = comment.Length;
-            var last = commentLength - 1;
-
-            for (var i = 0; i < commentLength; i++)
+            for (int i = 0, last = comment.Length - 1; i <= last; i++)
             {
                 var c = comment[i];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
@@ -52,11 +52,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            var count = summaryXmls.Count;
-
             List<Diagnostic> issues = null;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var xml = summaryXmls[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -430,9 +430,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private void AddIssues(List<Diagnostic> issues, string replacement, IReadOnlyList<Location> locations)
         {
-            var count = locations.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = locations.Count; index < count; index++)
             {
                 issues.Add(Issue(locations[index], replacement));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -102,8 +102,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static bool TryFindCompoundWord(string text, ref int startIndex, ref int endIndex)
         {
+            var textLength = text.Length;
+
             // jump over white-spaces at the beginning
-            for (; startIndex < text.Length; startIndex++)
+            for (; startIndex < textLength; startIndex++)
             {
                 var c = text[startIndex];
 
@@ -119,7 +121,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var findings = 0;
 
             // now find next white-space and count upper cases in between
-            for (; endIndex < text.Length; endIndex++)
+            for (; endIndex < textLength; endIndex++)
             {
                 var c = text[endIndex];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -110,9 +110,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var textTokens = text.TextTokens;
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var textTokensCount = textTokens.Count;
-
-            for (var index = 0; index < textTokensCount; index++)
+            for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
             {
                 var token = textTokens[index];
 
@@ -137,9 +135,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static bool IsOnSameLine(in SyntaxList<XmlNodeSyntax> contents, params int[] lines)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var contentsCount = contents.Count;
-
-            for (var index = 0; index < contentsCount; index++)
+            for (int index = 0, contentsCount = contents.Count; index < contentsCount; index++)
             {
                 var content = contents[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
@@ -39,9 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            var count = summaryXmls.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var summary = summaryXmls[index];
                 var content = summary.Content;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2239_CodeFixProvider.cs
@@ -21,8 +21,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var comment = (DocumentationCommentTriviaSyntax)syntax;
 
             var texts = comment.Content.OfType<XmlTextSyntax>()
-                                       .Select(CleanupText)
-                                       .ToSyntaxList<XmlNodeSyntax>();
+                               .Select(CleanupText)
+                               .ToSyntaxList<XmlNodeSyntax>();
 
             var summary = Comment(SyntaxFactory.XmlSummaryElement(), texts).WithLeadingXmlCommentExterior();
 
@@ -33,9 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static IEnumerable<SyntaxToken> CleanupTextTokens(SyntaxTokenList textTokens)
         {
-            var last = textTokens.Count - 1;
-
-            for (var index = 0; index <= last; index++)
+            for (int index = 0, last = textTokens.Count - 1; index <= last; index++)
             {
                 var textToken = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SummaryStartDocumentationAnalyzer.cs
@@ -27,11 +27,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            var count = summaryXmls.Count;
-
             List<Diagnostic> issues = null;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = summaryXmls.Count; index < count; index++)
             {
                 var issue = AnalyzeTextStart(symbol, summaryXmls[index]);
 
@@ -105,10 +103,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         // report the location of the first word(s) via the corresponding text token
                         var textTokens = text.TextTokens;
 
-                        // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                        var textTokensCount = textTokens.Count;
-
-                        for (var index = 0; index < textTokensCount; index++)
+                        for (int index = 0, textTokensCount = textTokens.Count; index < textTokensCount; index++)
                         {
                             var token = textTokens[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3006_CancellationTokenParameterPositionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3006_CancellationTokenParameterPositionAnalyzer.cs
@@ -18,9 +18,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {
             var methodParameters = symbol.Parameters;
-            var last = methodParameters.Length - 1;
 
-            for (var i = 0; i < methodParameters.Length; i++)
+            for (int i = 0, last = methodParameters.Length - 1; i <= last; i++)
             {
                 var parameter = methodParameters[i];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3026_UnusedParameterAnalyzer.cs
@@ -145,9 +145,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var used = methodBody.GetAllUsedVariables(semanticModel);
 
-            var count = parameters.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = parameters.Count; index < count; index++)
             {
                 var parameter = parameters[index];
                 var parameterName = parameter.GetName();

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3027_FutureUsedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3027_FutureUsedParameterAnalyzer.cs
@@ -33,9 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private IEnumerable<Diagnostic> Analyze(ImmutableArray<IParameterSymbol> parameters, string commentXml)
         {
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var parametersLength = parameters.Length;
-
-            for (var index = 0; index < parametersLength; index++)
+            for (int index = 0, parametersLength = parameters.Length; index < parametersLength; index++)
             {
                 var parameter = parameters[index];
                 var comment = parameter.GetComment(commentXml);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3040_BooleanMethodParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3040_BooleanMethodParametersAnalyzer.cs
@@ -40,9 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private IEnumerable<Diagnostic> Analyze(ImmutableArray<IParameterSymbol> parameters)
         {
-            var length = parameters.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = parameters.Length; index < length; index++)
             {
                 var parameter = parameters[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3042_EventArgsInterfaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3042_EventArgsInterfaceAnalyzer.cs
@@ -35,9 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         var baseTypes = baseList.Types;
 
                         // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                        var baseTypesCount = baseTypes.Count;
-
-                        for (var index = 0; index < baseTypesCount; index++)
+                        for (int index = 0, baseTypesCount = baseTypes.Count; index < baseTypesCount; index++)
                         {
                             var type = baseTypes[index];
                             var typeName = type.Type.GetName();

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_LogMessagesContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3064_LogMessagesContainsNtContractionAnalyzer.cs
@@ -125,15 +125,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var text = token.Text; // use 'Text' and not 'ValueText' here because otherwise the indices do not match (as 'Text' still contains the " )
 
-                    for (var i = 0; i < phrasesLength; i++)
+                    for (var phraseIndex = 0; phraseIndex < phrasesLength; phraseIndex++)
                     {
-                        var value = phrases[i];
+                        var value = phrases[phraseIndex];
 
-                        foreach (var index in text.AllIndicesOf(value))
+                        var allIndices = text.AllIndicesOf(value);
+                        var allIndicesLength = allIndices.Length;
+
+                        if (allIndicesLength > 0)
                         {
-                            var location = CreateLocation(value, syntaxTree, token.SpanStart, index);
-
-                            yield return Issue(location);
+                            for (var i = 0; i < allIndicesLength; i++)
+                            {
+                                yield return Issue(CreateLocation(value, syntaxTree, token.SpanStart, allIndices[i]));
+                            }
                         }
                     }
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
@@ -94,8 +94,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             var localDeclaration = SyntaxFactory.LocalDeclarationStatement(declaration);
 
                             var statement = arrowClause.HasReturnValue()
-                                                ? (StatementSyntax)SyntaxFactory.ReturnStatement(updatedInvocation)
-                                                : SyntaxFactory.ExpressionStatement(updatedInvocation);
+                                            ? (StatementSyntax)SyntaxFactory.ReturnStatement(updatedInvocation)
+                                            : SyntaxFactory.ExpressionStatement(updatedInvocation);
 
                             return UpdateArrowExpressionClause(root, arrowClause, SyntaxFactory.Block(localDeclaration, ifStatement, statement));
                         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3087_AvoidComplexNegativeConditionsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3087_AvoidComplexNegativeConditionsAnalyzer.cs
@@ -77,9 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     var arguments = invocation.ArgumentList.Arguments;
 
                     // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                    var argumentsCount = arguments.Count;
-
-                    for (var index = 0; index < argumentsCount; index++)
+                    for (int index = 0, argumentsCount = arguments.Count; index < argumentsCount; index++)
                     {
                         if (arguments[index].Expression is InvocationExpressionSyntax)
                         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -88,12 +88,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var arguments = methodCall.ArgumentList.Arguments;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
-                var argumentsCount = arguments.Count;
-
-                for (var index = 0; index < argumentsCount; index++)
+                for (int index = 0, argumentsCount = arguments.Count; index < argumentsCount; index++)
                 {
-                    var argument = arguments[index];
-                    var issue = AnalyzeArgument(node, argument, arguments);
+                    var issue = AnalyzeArgument(node, arguments[index], arguments);
 
                     if (issue != null)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseZeroInsteadOfEqualToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseZeroInsteadOfEqualToAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 if (arguments.Count is 1 && arguments[0].Expression is LiteralExpressionSyntax literal && literal.Token.ValueText is "0")
                 {
-                    var location = CreateLocation(node, maes.Name.Span.Start, argumentList.Span.End);
+                    var location = CreateLocation(node, maes.Name.SpanStart, argumentList.Span.End);
 
                     return new[] { Issue(location) };
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3219_PublicMembersAreNotVirtualAnalyzer.cs
@@ -45,9 +45,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation)
         {
             var members = symbol.GetMembers();
-            var count = members.Length;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = members.Length; index < count; index++)
             {
                 var member = members[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
@@ -36,10 +36,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 case PropertyDeclarationSyntax property:
                     Analyze(context, property);
+
                     break;
 
                 case ParameterSyntax parameter:
                     Analyze(context, parameter);
+
                     break;
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0003_LinesOfCodeInClassAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0003_LinesOfCodeInClassAnalyzer.cs
@@ -48,9 +48,8 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
             var loc = 0;
 
             var members = declaration.Members;
-            var count = members.Count;
 
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = members.Count; index < count; index++)
             {
                 var member = members[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzer.cs
@@ -73,9 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var parameters = GetParameters(symbol);
 
-            var count = parameters.Count;
-
-            for (var index = 0; index < count; index++)
+            for (int index = 0, count = parameters.Count; index < count; index++)
             {
                 var parameter = parameters[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzer.cs
@@ -22,9 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var identifiersLength = identifiers.Length;
-
-            for (var index = 0; index < identifiersLength; index++)
+            for (int index = 0, identifiersLength = identifiers.Length; index < identifiersLength; index++)
             {
                 var identifier = identifiers[index];
                 var name = identifier.ValueText;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
@@ -106,9 +106,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             List<string> findings = null;
 
             var requirements = Constants.Markers.Requirements;
-            var requirementsLength = requirements.Length;
 
-            for (var index = 0; index < requirementsLength; index++)
+            for (int index = 0, requirementsLength = requirements.Length; index < requirementsLength; index++)
             {
                 var requirement = requirements[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1097_ParameterNameFollowsFieldNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1097_ParameterNameFollowsFieldNameSchemeAnalyzer.cs
@@ -27,8 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             if (symbolName.Length >= MinimalPrefixLength)
             {
-                // ReSharper disable once ForCanBeConvertedToForeach
-                for (var index = 0; index < WrongPrefixes.Length; index++)
+                for (int index = 0, length = WrongPrefixes.Length; index < length; index++)
                 {
                     var wrongPrefix = WrongPrefixes[index];
 
@@ -42,8 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 if (prefix[1].IsUpperCase())
                 {
-                    // ReSharper disable once ForCanBeConvertedToForeach
-                    for (var index = 0; index < WrongPrefixChars.Length; index++)
+                    for (int index = 0, length = WrongPrefixChars.Length; index < length; index++)
                     {
                         var wrongPrefixChar = WrongPrefixChars[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
@@ -38,9 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var names = new List<string>();
 
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
-            var length = directlyImplementedInterfaces.Length;
-
-            for (var index = 0; index < length; index++)
+            for (int index = 0, length = directlyImplementedInterfaces.Length; index < length; index++)
             {
                 var implementedInterface = directlyImplementedInterfaces[index];
                 var name = implementedInterface.Name

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -36,9 +36,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         protected static string GetFieldPrefix(string fieldName)
         {
             var fieldPrefixes = Constants.Markers.FieldPrefixes;
-            var prefixesLength = fieldPrefixes.Length;
 
-            for (var index = 0; index < prefixesLength; index++)
+            for (int index = 0, prefixesLength = fieldPrefixes.Length; index < prefixesLength; index++)
             {
                 var prefix = fieldPrefixes[index];
 
@@ -348,9 +347,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     var index = 0;
 
                     var fieldPrefixes = Constants.Markers.FieldPrefixes;
-                    var length = fieldPrefixes.Length;
 
-                    for (var i = 0; i < length; i++)
+                    for (int i = 0, length = fieldPrefixes.Length; i < length; i++)
                     {
                         var prefix = fieldPrefixes[i];
 

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5012_RecursiveCallUsesYieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5012_RecursiveCallUsesYieldAnalyzer.cs
@@ -123,9 +123,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
         private static bool ParametersHaveSameTypes(in ImmutableArray<IParameterSymbol> candidateParameters, in SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel)
         {
-            var candidateParametersLength = candidateParameters.Length;
-
-            for (var index = 0; index < candidateParametersLength; index++)
+            for (int index = 0, length = candidateParameters.Length; index < length; index++)
             {
                 var c = candidateParameters[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6055_SimpleAssignmentInBlockSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6055_SimpleAssignmentInBlockSurroundedByBlankLinesAnalyzer.cs
@@ -131,9 +131,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private IEnumerable<Diagnostic> AnalyzeStatements(SyntaxList<StatementSyntax> statements)
         {
-            var statementsCount = statements.Count;
-
-            for (var index = 0; index < statementsCount; index++)
+            for (int index = 0, statementsCount = statements.Count; index < statementsCount; index++)
             {
                 var current = statements[index];
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -190,40 +190,6 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                                                                               .WithWhenKeyword(syntax.WhenKeyword.WithLeadingSpace().WithoutTrailingTrivia())
                                                                                               .WithCondition(PlacedOnSameLine(syntax.Condition));
 
-        protected SeparatedSyntaxList<TSyntaxNode> GetUpdatedSyntax<TSyntaxNode>(in SeparatedSyntaxList<TSyntaxNode> nodes, in SyntaxToken openBraceToken, in int leadingSpaces) where TSyntaxNode : SyntaxNode
-        {
-            if (nodes.Count is 0)
-            {
-                return SyntaxFactory.SeparatedList<TSyntaxNode>();
-            }
-
-            int? currentLine = openBraceToken.GetStartingLine();
-
-            var updatedNodes = new List<TSyntaxNode>(nodes.Count);
-
-            foreach (var node in nodes)
-            {
-                var startingLine = node.GetStartingLine();
-
-                if (currentLine == startingLine)
-                {
-                    // it is on same line, so do not add any additional space
-                    updatedNodes.Add(node);
-                }
-                else
-                {
-                    currentLine = startingLine;
-
-                    // it seems to be on a different line, so add with spaces
-                    var updatedExpression = GetUpdatedSyntax(node, leadingSpaces);
-
-                    updatedNodes.Add(updatedExpression);
-                }
-            }
-
-            return SyntaxFactory.SeparatedList(updatedNodes, nodes.GetSeparators());
-        }
-
         protected virtual TSyntaxNode GetUpdatedSyntax<TSyntaxNode>(TSyntaxNode syntax, in int leadingSpaces) where TSyntaxNode : SyntaxNode => syntax.WithLeadingSpaces(leadingSpaces);
 
         protected AnonymousObjectCreationExpressionSyntax GetUpdatedSyntax(AnonymousObjectCreationExpressionSyntax syntax, in int spaces)
@@ -352,5 +318,39 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                                                                                                    .WithLeadingSpaces(spaces);
 
 #endif
+
+        protected SeparatedSyntaxList<TSyntaxNode> GetUpdatedSyntax<TSyntaxNode>(in SeparatedSyntaxList<TSyntaxNode> nodes, in SyntaxToken openBraceToken, in int leadingSpaces) where TSyntaxNode : SyntaxNode
+        {
+            if (nodes.Count is 0)
+            {
+                return SyntaxFactory.SeparatedList<TSyntaxNode>();
+            }
+
+            int? currentLine = openBraceToken.GetStartingLine();
+
+            var updatedNodes = new List<TSyntaxNode>(nodes.Count);
+
+            foreach (var node in nodes)
+            {
+                var startingLine = node.GetStartingLine();
+
+                if (currentLine == startingLine)
+                {
+                    // it is on same line, so do not add any additional space
+                    updatedNodes.Add(node);
+                }
+                else
+                {
+                    currentLine = startingLine;
+
+                    // it seems to be on a different line, so add with spaces
+                    var updatedExpression = GetUpdatedSyntax(node, leadingSpaces);
+
+                    updatedNodes.Add(updatedExpression);
+                }
+            }
+
+            return SyntaxFactory.SeparatedList(updatedNodes, nodes.GetSeparators());
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
@@ -21,13 +21,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var listCount = list.Count;
 
-            for (var index = 0; index < listCount; index++)
+            if (listCount > 0)
             {
-                var trivia = list[index];
-
-                if (trivia.IsComment())
+                for (var index = 0; index < listCount; index++)
                 {
-                    return trivia.GetLocation();
+                    var trivia = list[index];
+
+                    if (trivia.IsComment())
+                    {
+                        return trivia.GetLocation();
+                    }
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1049_RequirementTermAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1049_RequirementTermAnalyzerTests.cs
@@ -160,8 +160,8 @@ public class TestMe
         [TestCase("Something_ShouldHandleStuff", "Something_HandlesStuff")]
         [TestCase("Something_Should_HandleStuff", "Something_HandlesStuff")]
         public void Code_gets_fixed_for_method_(string method, string wanted) => VerifyCSharpFix(
-                                                                                                 "using System; class TestMe { void " + method + "() { } }",
-                                                                                                 "using System; class TestMe { void " + wanted + "() { } }");
+                                                                                             "using System; class TestMe { void " + method + "() { } }",
+                                                                                             "using System; class TestMe { void " + wanted + "() { } }");
 
         [TestCase("SomethingShouldFail", "SomethingFails")]
         [TestCase("SomethingShouldHaveAnything", "SomethingHaveAnything")]


### PR DESCRIPTION
- Rename `target` to `result` in array/list conversions

- Inline loop counters and lengths into `for` statements

- Cache collection lengths to avoid repeated property calls

- Apply loop optimizations in various analyzers and extensions
