### PR TITLE
added [in] modifiers, changed IReadOnlyList to List

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -375,7 +375,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static SyntaxToken WithLeadingXmlComment(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentStart);
 
-        internal static SyntaxToken WithLeadingXmlCommentExterior(this SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentExterior);
+        internal static SyntaxToken WithLeadingXmlCommentExterior(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentExterior);
 
         internal static SyntaxToken WithTriviaFrom(this in SyntaxToken value, SyntaxNode node) => value.WithLeadingTriviaFrom(node)
                                                                                                        .WithTrailingTriviaFrom(node);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -93,7 +93,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return names.ToHashSet(_ => _ + " ");
         }
 
-        private Diagnostic[] AnalyzeSummaryPhrases(ISymbol symbol, ReadOnlySpan<string> summaries, IEnumerable<string> phrases)
+        private Diagnostic[] AnalyzeSummaryPhrases(ISymbol symbol, in ReadOnlySpan<string> summaries, IEnumerable<string> phrases)
         {
             var summariesLength = summaries.Length;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -202,17 +202,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return bothFixed.WithTagsOnSeparateLines();
         }
 
-        private static XmlElementSyntax FixTextOnlyComment(XmlElementSyntax comment, XmlTextSyntax originalText, ReadOnlySpan<char> subText, string replacement, in ConcreteMapInfo info)
+        private static XmlElementSyntax FixTextOnlyComment(XmlElementSyntax comment, XmlTextSyntax originalText, in ReadOnlySpan<char> subText, string replacement, in ConcreteMapInfo info)
         {
-            subText = ModifyOrNotPart(subText);
+            var text = ModifyOrNotPart(subText);
 
             for (int index = 0, length = Conditionals.Length; index < length; index++)
             {
                 var conditional = Conditionals[index];
 
-                if (subText.StartsWith(conditional, StringComparison.OrdinalIgnoreCase))
+                if (text.StartsWith(conditional, StringComparison.OrdinalIgnoreCase))
                 {
-                    subText = subText.Slice(conditional.Length).TrimStart();
+                    text = text.Slice(conditional.Length).TrimStart();
 
                     replacement = ReplacementTo;
 
@@ -223,11 +223,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var commentContinuation = StringBuilderCache.Acquire();
 
             // be aware of a gerund verb
-            if (replacement == ReplacementTo || Verbalizer.IsGerundVerb(subText.FirstWord()))
+            if (replacement == ReplacementTo || Verbalizer.IsGerundVerb(text.FirstWord()))
             {
                 commentContinuation.Append(ReplacementTo);
 
-                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(subText, FirstWordHandling.StartLowerCase);
+                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(text, FirstWordHandling.StartLowerCase);
 
                 commentContinuation.Append(continuation);
             }
@@ -236,7 +236,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 commentContinuation.Append(replacement);
 
                 // do not try to make the first word a verb as it might not be one
-                var continuation = subText.TrimStart().ToLowerCaseAt(0);
+                var continuation = text.TrimStart().ToLowerCaseAt(0);
 
                 commentContinuation.Append(continuation);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzer.cs
@@ -115,9 +115,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<string>();
         }
 
-        private Diagnostic[] AnalyzeTypeSummary(INamedTypeSymbol symbol, ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment) => AnalyzeSummaryPhrase(symbol, summaries, comment, Constants.Comments.ExceptionTypeSummaryStartingPhrase);
+        private Diagnostic[] AnalyzeTypeSummary(INamedTypeSymbol symbol, in ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment) => AnalyzeSummaryPhrase(symbol, summaries, comment, Constants.Comments.ExceptionTypeSummaryStartingPhrase);
 
-        private Diagnostic[] AnalyzeMethodSummary(IMethodSymbol symbol, ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment)
+        private Diagnostic[] AnalyzeMethodSummary(IMethodSymbol symbol, in ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment)
         {
             var defaultPhrases = Constants.Comments.ExceptionCtorSummaryStartingPhrase.ToArray(_ => _.FormatWith(symbol.ContainingType));
 
@@ -180,7 +180,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return AnalyzeStartingPhrase(symbol, Constants.XmlTag.Remarks, comments, comment, defaultPhrases);
         }
 
-        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, string xmlTag, ReadOnlySpan<string> comments, DocumentationCommentTriviaSyntax comment, string[] phrases)
+        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, string xmlTag, in ReadOnlySpan<string> comments, DocumentationCommentTriviaSyntax comment, string[] phrases)
         {
             if (comments.None(_ => phrases.Exists(__ => _.StartsWith(__, StringComparison.Ordinal))))
             {
@@ -198,7 +198,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Array.Empty<Diagnostic>();
         }
 
-        private Diagnostic[] AnalyzeSummaryPhrase(ISymbol symbol, ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment, params string[] phrases) => AnalyzeStartingPhrase(symbol, Constants.XmlTag.Summary, summaries, comment, phrases);
+        private Diagnostic[] AnalyzeSummaryPhrase(ISymbol symbol, in ReadOnlySpan<string> summaries, DocumentationCommentTriviaSyntax comment, params string[] phrases) => AnalyzeStartingPhrase(symbol, Constants.XmlTag.Summary, summaries, comment, phrases);
 
         private Diagnostic[] AnalyzeParameter(IParameterSymbol symbol, string commentXml, DocumentationCommentTriviaSyntax comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                    : startingPhrases.Select(_ => _.FormatWith(argumentType));
         }
 
-        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, ReadOnlySpan<string> summaries, params string[] phrases)
+        private Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, IReadOnlyList<XmlElementSyntax> summaryXmls, in ReadOnlySpan<string> summaries, params string[] phrases)
         {
             if (summaries.None(_ => phrases.Exists(__ => _.StartsWith(__, StringComparison.Ordinal))))
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
@@ -128,7 +128,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private bool CanBeIgnored(SyntaxNodeAnalysisContext context)
+        private bool CanBeIgnored(in SyntaxNodeAnalysisContext context)
         {
             if (context.CancellationToken.IsCancellationRequested)
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
@@ -181,7 +181,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static InvocationExpressionSyntax AssertThatHasMatches(string match, Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax AssertThatHasMatches(string match, Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var argument = arguments[0];
 
@@ -209,7 +209,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return null;
         }
 
-        private static InvocationExpressionSyntax ConvertBe(ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertBe(ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var argument = arguments[0];
 
@@ -231,7 +231,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("EqualTo", arguments[0]), arguments, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertNotBe(ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertNotBe(ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var argument = arguments[0];
 
@@ -253,7 +253,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("Not", "EqualTo", argument), arguments, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertBeEmpty(Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertBeEmpty(Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var type = originalExpression.GetTypeSymbol(document);
 
@@ -265,7 +265,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("Empty"), arguments, 0, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertNotBeEmpty(Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertNotBeEmpty(Document document, ExpressionSyntax originalExpression, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var type = originalExpression.GetTypeSymbol(document);
 
@@ -277,7 +277,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("Not", "Empty"), arguments, 0, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertBeEquivalentTo(Document document, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertBeEquivalentTo(Document document, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var count = arguments.Count;
 
@@ -309,7 +309,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("EquivalentTo", GetAsArray(arguments)), arguments, count, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertNotBeEquivalentTo(Document document, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertNotBeEquivalentTo(Document document, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var count = arguments.Count;
 
@@ -341,7 +341,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return AssertThat(expression, Is("Not", "EquivalentTo", GetAsArray(arguments)), arguments, count, removeNameColon: true);
         }
 
-        private static InvocationExpressionSyntax ConvertContain(Document document, ExpressionSyntax expression, SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static InvocationExpressionSyntax ConvertContain(Document document, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             var argument = arguments[0];
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static ExpressionSyntax GetCondition(SyntaxNodeAnalysisContext context)
+        private static ExpressionSyntax GetCondition(in SyntaxNodeAnalysisContext context)
         {
             switch (context.Node)
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
@@ -46,7 +46,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private void Analyze(SyntaxNodeAnalysisContext context, PropertyDeclarationSyntax property)
+        private void Analyze(in SyntaxNodeAnalysisContext context, PropertyDeclarationSyntax property)
         {
             var type = property.Type;
 
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private void Analyze(SyntaxNodeAnalysisContext context, ParameterSyntax parameter)
+        private void Analyze(in SyntaxNodeAnalysisContext context, ParameterSyntax parameter)
         {
             var type = parameter.Type;
 

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MetricsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MetricsAnalyzer.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
         protected virtual Diagnostic AnalyzeExpressionBody(ArrowExpressionClauseSyntax body, ISymbol containingSymbol) => null;
 
-        private static BlockSyntax GetBody(SyntaxNodeAnalysisContext context)
+        private static BlockSyntax GetBody(in SyntaxNodeAnalysisContext context)
         {
             switch (context.Node)
             {
@@ -57,7 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
             }
         }
 
-        private static ArrowExpressionClauseSyntax GetExpressionBody(SyntaxNodeAnalysisContext context)
+        private static ArrowExpressionClauseSyntax GetExpressionBody(in SyntaxNodeAnalysisContext context)
         {
             switch (context.Node)
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
@@ -182,12 +182,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        private void AnalyzeIdentifiers(SyntaxNodeAnalysisContext context, ITypeSymbol type, VariableDeclarationSyntax syntax)
+        private void AnalyzeIdentifiers(in SyntaxNodeAnalysisContext context, ITypeSymbol type, VariableDeclarationSyntax syntax)
         {
             AnalyzeIdentifiers(context, type, syntax.Variables.ToArray(_ => _.Identifier));
         }
 
-        private void AnalyzeIdentifiers(SyntaxNodeAnalysisContext context, ITypeSymbol type, params SyntaxToken[] identifiers)
+        private void AnalyzeIdentifiers(in SyntaxNodeAnalysisContext context, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
             var issues = AnalyzeIdentifiers(context.SemanticModel, type, identifiers);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6065_InvocationIsIndentedAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context) => ReportDiagnostics(context, FindIssue(context));
 
-        private Diagnostic FindIssue(SyntaxNodeAnalysisContext context)
+        private Diagnostic FindIssue(in SyntaxNodeAnalysisContext context)
         {
             if (context.Node is InvocationExpressionSyntax invocation)
             {
@@ -84,7 +84,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return null;
         }
 
-        private Diagnostic FindIssue(SyntaxToken dot, IdentifierNameSyntax identifier)
+        private Diagnostic FindIssue(in SyntaxToken dot, IdentifierNameSyntax identifier)
         {
             var location = identifier.GetLocation();
             var position = location.GetPositionWithinEndLine();

--- a/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected virtual bool ShallAnalyzeOtherStatement(StatementSyntax node) => true;
 
-        private static bool HasNoBlankLinesAfter(IReadOnlyList<StatementSyntax> otherStatements, in FileLinePositionSpan afterPosition)
+        private static bool HasNoBlankLinesAfter(List<StatementSyntax> otherStatements, in FileLinePositionSpan afterPosition)
         {
             for (int index = 0, count = otherStatements.Count; index < count; index++)
             {
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return false;
         }
 
-        private static bool HasNoBlankLinesBefore(IReadOnlyList<StatementSyntax> otherStatements, in FileLinePositionSpan beforePosition)
+        private static bool HasNoBlankLinesBefore(List<StatementSyntax> otherStatements, in FileLinePositionSpan beforePosition)
         {
             for (int index = 0, count = otherStatements.Count; index < count; index++)
             {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(32, 64)] int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {


### PR DESCRIPTION
- Add 'in' modifiers to struct parameters for performance

- Refactor `subText` usages to `var text` in CodeFixProvider

- Update otherStatements type and 'in' usage in blank-lines analyzer

- Remove unnecessary 'in' modifier in test signature
