### PR TITLE
Added new rule MiKo_2313 for comments that should be XML documentation instead

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -221,6 +221,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static class Comments
         {
+            internal const string CommentExterior = "//";
+            internal const string XmlCommentExterior = "///";
             internal const string AlternativeStringReturnTypeStartingPhraseTemplate = "An interned copy of the {0} {1} ";
             internal const string ArrayReturnTypeStartingPhraseA = "An array of ";
             internal const string ArrayReturnTypeStartingPhraseALowerCase = "an array of ";
@@ -1528,6 +1530,7 @@ namespace MiKoSolutions.Analyzers
             internal const string ParameterValue = nameof(ParameterValue);
 
             internal const string Marker = nameof(Marker);
+            internal const string CommentTags = nameof(CommentTags);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -236,5 +236,36 @@ namespace MiKoSolutions.Analyzers
 
             return Array.Empty<SyntaxTrivia>();
         }
+
+        internal static string ToTextOnlyString(this in SyntaxTrivia trivia)
+        {
+            if (trivia.IsComment() && trivia.SyntaxTree is SyntaxTree tree)
+            {
+                var sourceText = tree.GetText();
+
+                var span = trivia.Span;
+                var start = span.Start + 2; // the text '//' has 2 characters
+                var end = span.End;
+
+                while (sourceText[start].IsWhiteSpace())
+                {
+                    start++;
+                }
+
+                while (sourceText[end].IsWhiteSpace())
+                {
+                    end--;
+                }
+
+                if (start >= end)
+                {
+                    return string.Empty;
+                }
+
+                return sourceText.ToString(TextSpan.FromBounds(start, end + 1));
+            }
+
+            return trivia.ToString();
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -147,6 +147,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2309_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2311_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2312_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2313_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OverallDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ParameterDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ReturnTypeDocumentationCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -170,6 +170,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2310_CommentContainsIntentionallyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2311_CommentIsSeparatorAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2312_CommentShouldUseToAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2313_CommentShouldBeDocumentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MultiLineCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OperatorAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\OverallDocumentationAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -9416,6 +9416,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to XML documentation.
+        /// </summary>
+        internal static string MiKo_2313_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2313_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The API documentation for summaries should use &apos;/// &lt;summary&gt;&apos; instead of &apos;// Summary:&apos; because &apos;/// &lt;summary&gt;&apos; creates XML comments that the .NET compiler understands. These comments show up in IntelliSense, help generate external documentation, and follow a structured format..
+        /// </summary>
+        internal static string MiKo_2313_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2313_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use XML documentation instead.
+        /// </summary>
+        internal static string MiKo_2313_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2313_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Plain documentation comments should be XML documentation.
+        /// </summary>
+        internal static string MiKo_2313_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2313_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If #region directives are used, avoid any empty #region. They just clutter the code without adding any value. When regions are truly needed, keep them meaningful and populated to ensure the code remains clean and efficient. This approach maintains clarity and organization in the codebase..
         /// </summary>
         internal static string MiKo_3000_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3320,6 +3320,18 @@ Instead, comments should enhance understanding, giving context and reasoning for
   <data name="MiKo_2312_Title" xml:space="preserve">
     <value>Comments should use 'to' instead of 'that is to' or 'which is to'</value>
   </data>
+  <data name="MiKo_2313_CodeFixTitle" xml:space="preserve">
+    <value>Convert to XML documentation</value>
+  </data>
+  <data name="MiKo_2313_Description" xml:space="preserve">
+    <value>The API documentation for summaries should use '/// &lt;summary&gt;' instead of '// Summary:' because '/// &lt;summary&gt;' creates XML comments that the .NET compiler understands. These comments show up in IntelliSense, help generate external documentation, and follow a structured format.</value>
+  </data>
+  <data name="MiKo_2313_MessageFormat" xml:space="preserve">
+    <value>Use XML documentation instead</value>
+  </data>
+  <data name="MiKo_2313_Title" xml:space="preserve">
+    <value>Plain documentation comments should be XML documentation</value>
+  </data>
   <data name="MiKo_3000_Description" xml:space="preserve">
     <value>If #region directives are used, avoid any empty #region. They just clutter the code without adding any value. When regions are truly needed, keep them meaningful and populated to ensure the code remains clean and efficient. This approach maintains clarity and organization in the codebase.</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -105,6 +105,18 @@ namespace MiKoSolutions.Analyzers.Rules
             context.RegisterCompilationStartAction(CompilationStartAction);
         }
 
+        protected static Location CreateLocation(in SyntaxTriviaList trivia)
+        {
+            if (trivia.Count > 0)
+            {
+                var span = trivia.FullSpan;
+
+                return CreateLocation(trivia[0].SyntaxTree, span.Start, span.End);
+            }
+
+            return Location.None;
+        }
+
         protected static Location CreateLocation(SyntaxNode node, in int start, in int end) => CreateLocation(node.SyntaxTree, start, end);
 
         protected static Location CreateLocation(in SyntaxToken token, in int start, in int end) => CreateLocation(token.SyntaxTree, start, end);
@@ -328,6 +340,8 @@ namespace MiKoSolutions.Analyzers.Rules
         protected Diagnostic Issue(in SyntaxToken token, params Pair[] properties) => CreateIssue(token.GetLocation(), properties, token.ValueText);
 
         protected Diagnostic Issue(in SyntaxTrivia trivia, params Pair[] properties) => CreateIssue(trivia.GetLocation(), properties);
+
+        protected Diagnostic Issue(in SyntaxTriviaList trivia, params Pair[] properties) => CreateIssue(CreateLocation(trivia), properties);
 
         protected Diagnostic Issue(Location location, params Pair[] properties) => CreateIssue(location, properties, location.GetText());
 

--- a/MiKo.Analyzer.Shared/Rules/CodeDetector.cs
+++ b/MiKo.Analyzer.Shared/Rules/CodeDetector.cs
@@ -118,7 +118,7 @@ namespace MiKoSolutions.Analyzers.Rules
                 return true;
             }
 
-            if (line.Contains("//"))
+            if (line.Contains(Constants.Comments.CommentExterior))
             {
                 // comment in comment indicator
                 if (line.Contains("://"))
@@ -126,7 +126,7 @@ namespace MiKoSolutions.Analyzers.Rules
                     return false; // allow indicators such as http:// or ftp://
                 }
 
-                if (line.EndsWith("//", StringComparison.Ordinal))
+                if (line.EndsWith(Constants.Comments.CommentExterior, StringComparison.Ordinal))
                 {
                     return false; // ignore all framed comments
                 }
@@ -136,7 +136,7 @@ namespace MiKoSolutions.Analyzers.Rules
                     return false; // ignore '// ReSharper' comments
                 }
 
-                if (line.Contains("///"))
+                if (line.Contains(Constants.Comments.XmlCommentExterior))
                 {
                     return false; // allow triplets such as '///'
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -97,7 +97,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Comment(comment, end);
         }
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, string additionalComment = null) => Comment(comment, XmlText(text + additionalComment));
+        protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, string additionalComment = null) => Comment(comment, additionalComment is null ? XmlText(text) : XmlText(text + additionalComment));
 
         protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepSingleLeadingSpace)
         {
@@ -461,6 +461,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         }
 
         protected static XmlElementSyntax CommentWithContent(XmlElementSyntax value, in SyntaxList<XmlNodeSyntax> content) => SyntaxFactory.XmlElement(value.StartTag, content, value.EndTag).WithTagsOnSeparateLines();
+
+        protected static TypeCrefSyntax Cref(string typeName) => Cref(SyntaxFactory.ParseTypeName(typeName));
+
+        protected static TypeCrefSyntax Cref(TypeSyntax type)
+        {
+            // fix trivia, to avoid situation as reported in https://github.com/dotnet/roslyn/issues/47550
+            return SyntaxFactory.TypeCref(type.WithoutTrivia());
+        }
 
         protected static XmlEmptyElementSyntax Cref(string tag, TypeSyntax type)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
@@ -54,10 +54,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var contentFullString = element.Content.ToFullString();
             var endTagFullString = element.EndTag.ToFullString();
 
-            const string XmlCommentExterior = "///";
-
             var capacity = StringBuilderCache.DefaultCapacity // some buffer as we modify the contents
-                         + XmlCommentExterior.Length
+                         + Constants.Comments.XmlCommentExterior.Length
                          + someText.Length
                          + startTagFullString.Length
                          + contentFullString.Length
@@ -68,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                          .Append(contentFullString)
                                          .ReplaceAllWithProbe(XmlEntities)
                                          .Insert(0, someText)
-                                         .Insert(0, XmlCommentExterior)
+                                         .Insert(0, Constants.Comments.XmlCommentExterior)
                                          .AppendLine(endTagFullString)
                                          .ToStringAndRelease();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzer.cs
@@ -110,7 +110,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static bool CommentHasIssue(string comment)
         {
-            if (comment.StartsWith("//", StringComparison.Ordinal))
+            if (comment.StartsWith(Constants.Comments.CommentExterior, StringComparison.Ordinal))
             {
                 return false; // ignore all comments that have the "double comment" marker
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2308_CommentPlacedAfterCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2308_CommentPlacedAfterCodeAnalyzer.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var comment = trivia.ToString().AsSpan().Trim();
 
-                if (comment.StartsWith("////"))
+                if (comment.StartsWith(Constants.Comments.CommentExterior + Constants.Comments.CommentExterior))
                 {
                     // that's a comment to ignore
                     return false;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2313_CodeFixProvider)), Shared]
+    public sealed class MiKo_2313_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        private static readonly Dictionary<string, string> CommentTagToXmlTagMapping = new Dictionary<string, string>
+                                                                                           {
+                                                                                               { "Summary:", Constants.XmlTag.Summary },
+                                                                                               { "Remark:", Constants.XmlTag.Remarks },
+                                                                                               { "Remarks:", Constants.XmlTag.Remarks },
+                                                                                               { "Return:", Constants.XmlTag.Returns },
+                                                                                               { "Returns:", Constants.XmlTag.Returns },
+                                                                                               { "Return value:", Constants.XmlTag.Returns },
+                                                                                               { "ReturnValue:", Constants.XmlTag.Returns },
+                                                                                               { "Value:", Constants.XmlTag.Value },
+                                                                                           };
+
+        private static readonly Dictionary<string, string> CommentTagToMultipleXmlTagMapping = new Dictionary<string, string>
+                                                                                                   {
+                                                                                                       { "Exception:", Constants.XmlTag.Exception },
+                                                                                                       { "Exceptions:", Constants.XmlTag.Exception },
+                                                                                                       { "Param:", Constants.XmlTag.Param },
+                                                                                                       { "Parameter:", Constants.XmlTag.Param },
+                                                                                                       { "Parameters:", Constants.XmlTag.Param },
+                                                                                                   };
+
+        private static readonly string[] XmlTagOrder =
+                                                       {
+                                                           Constants.XmlTag.Overloads,
+                                                           Constants.XmlTag.Summary,
+                                                           Constants.XmlTag.Remarks,
+                                                           Constants.XmlTag.Param,
+                                                           Constants.XmlTag.Returns,
+                                                           Constants.XmlTag.Value,
+                                                           Constants.XmlTag.Exception,
+                                                       };
+
+        public override string FixableDiagnosticId => "MiKo_2313";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<MemberDeclarationSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is MemberDeclarationSyntax member)
+            {
+                var foundCommentTags = issue.Properties[Constants.AnalyzerCodeFixSharedData.CommentTags].Split('|');
+
+                var spaces = member.GetPositionWithinStartLine();
+                var comment = CreateDocumentationComment(member, spaces, foundCommentTags);
+
+                var updatedMember = member.WithoutLeadingTrivia();
+
+                if (member.HasLeadingEmptyLine())
+                {
+                    updatedMember = updatedMember.WithLeadingEmptyLine();
+                }
+
+                updatedMember = updatedMember.WithLeadingSpaces(spaces)
+                                             .WithAdditionalLeadingTrivia(SyntaxFactory.Trivia(comment))
+                                             .WithAdditionalLeadingSpacesAtEnd(spaces);
+
+                return updatedMember;
+            }
+
+            return syntax;
+        }
+
+        private static DocumentationCommentTriviaSyntax CreateDocumentationComment(MemberDeclarationSyntax member, int spaces, string[] foundCommentTags)
+        {
+            var leadingComments = member.GetLeadingComments();
+            var comments = leadingComments.ToList();
+
+            var elements = new List<XmlElementSyntax>();
+
+            for (int i = 0, length = foundCommentTags.Length; i < length; i++)
+            {
+                var commentTag = foundCommentTags[i];
+
+                if (CommentTagToXmlTagMapping.TryGetValue(commentTag, out var xmlTag))
+                {
+                    elements.Add(Create(commentTag, xmlTag, comments, spaces, foundCommentTags));
+                }
+                else if (CommentTagToMultipleXmlTagMapping.TryGetValue(commentTag, out xmlTag))
+                {
+                    elements.AddRange(CreateMultiple(commentTag, xmlTag, comments, spaces, foundCommentTags));
+                }
+            }
+
+            var contents = elements.WhereNotNull()
+                                   .OrderBy(_ => XmlTagOrder.IndexOf(_.StartTag.GetName()));
+
+            return SyntaxFactory.DocumentationComment(contents.ToArray<XmlNodeSyntax>());
+        }
+
+        private static XmlElementSyntax Create(string commentTag, string xmlTag, List<string> comments, int spaces, string[] otherFoundCommentTags)
+        {
+            if (TryFindComments(comments, commentTag, otherFoundCommentTags, out var index, out var count))
+            {
+                var phrase = comments.Skip(index + 1).Take(count - 1).ConcatenatedWith(" ");
+
+                // remove the processed items as we do not need to re-process them
+                comments.RemoveRange(index, count);
+
+                var comment = Comment(XmlElement(xmlTag), phrase);
+
+                return comment.WithLeadingXmlCommentExterior()
+                              .WithLeadingSpaces(spaces)
+                              .WithEndOfLine();
+            }
+
+            return null;
+        }
+
+        private static XmlElementSyntax CreateTag(string xmlTag, in Pair pair)
+        {
+            switch (xmlTag)
+            {
+                case Constants.XmlTag.Param: return CreateParamTag(pair.Key, pair.Value);
+                case Constants.XmlTag.Exception: return CreateExceptionTag(pair.Key, pair.Value);
+
+                default:
+                    return null;
+            }
+        }
+
+        private static XmlElementSyntax CreateExceptionTag(string name, string text) => Comment(SyntaxFactory.XmlExceptionElement(Cref(name)), text);
+
+        private static XmlElementSyntax CreateParamTag(string name, string text) => Comment(SyntaxFactory.XmlParamElement(name), text);
+
+        private static XmlElementSyntax[] CreateMultiple(string xmlTag, int spaces, List<Pair> pairs)
+        {
+            var results = new XmlElementSyntax[pairs.Count];
+
+            for (int i = 0, pairsCount = pairs.Count; i < pairsCount; i++)
+            {
+                var comment = CreateTag(xmlTag, pairs[i]);
+
+                if (comment is null)
+                {
+                    continue;
+                }
+
+                results[i] = comment.WithLeadingXmlCommentExterior()
+                                    .WithLeadingSpaces(spaces)
+                                    .WithEndOfLine();
+            }
+
+            return results;
+        }
+
+        private static XmlElementSyntax[] CreateMultiple(string commentTag, string xmlTag, List<string> comments, int spaces, string[] otherFoundCommentTags)
+        {
+            if (TryFindComments(comments, commentTag, otherFoundCommentTags, out var index, out var count))
+            {
+                var parts = comments.Skip(index + 1).Take(count - 1).ToList();
+
+                // remove the processed items as we do not need to re-process them
+                comments.RemoveRange(index, count);
+
+                if (parts.Count > 0)
+                {
+                    var pairs = FindComments(parts.ToList());
+
+                    return CreateMultiple(xmlTag, spaces, pairs);
+                }
+            }
+
+            return Array.Empty<XmlElementSyntax>();
+        }
+
+        private static List<Pair> FindComments(List<string> comments)
+        {
+            int specificCount;
+
+            var pairs = new List<Pair>();
+
+            do
+            {
+                var pair = FindComments(comments, out specificCount);
+
+                pairs.Add(pair);
+
+                comments.RemoveRange(0, specificCount);
+            }
+            while (specificCount > 0 && comments.Count > 0);
+
+            return pairs;
+        }
+
+        private static Pair FindComments(List<string> comments, out int count)
+        {
+            var index = comments.FindIndex(0, _ => _.Contains(':'));
+            var nextIndex = comments.FindIndex(1, _ => _.Contains(':'));
+
+            if (nextIndex is -1)
+            {
+                nextIndex = comments.Count;
+            }
+
+            count = nextIndex - index;
+
+            var takes = count - 1;
+
+            if (takes <= 0)
+            {
+                var parts = comments[index].Split(':');
+
+                return new Pair(parts[0].Trim(), parts[1].Trim());
+            }
+            else
+            {
+                var parts = comments.Skip(index + 1).Take(takes).ConcatenatedWith(" ");
+
+                return new Pair(comments[index].TrimEnd(':'), parts);
+            }
+        }
+
+        private static bool TryFindComments(List<string> comments, string commentTag, string[] otherFoundCommentTags, out int index, out int count)
+        {
+            index = comments.IndexOf(commentTag);
+            count = 0;
+
+            if (index is -1)
+            {
+                return false;
+            }
+
+            var nextIndex = comments.FindIndex(index + 1, _ => _.ContainsAny(otherFoundCommentTags, StringComparison.Ordinal));
+
+            if (nextIndex is -1)
+            {
+                nextIndex = comments.Count;
+            }
+
+            count = nextIndex - index;
+
+            return true;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzer.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2313_CommentShouldBeDocumentationAnalyzer : DocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2313";
+
+        private static readonly string[] DocumentationCommentTags =
+                                                                    {
+                                                                        "Exception:",
+                                                                        "Exceptions:",
+                                                                        "Param:",
+                                                                        "Parameter:",
+                                                                        "Parameters:",
+                                                                        "Remark:",
+                                                                        "Remarks:",
+                                                                        "Return value:",
+                                                                        "Return:",
+                                                                        "Returns:",
+                                                                        "ReturnValue:",
+                                                                        "Summary:",
+                                                                        "Value:",
+                                                                    };
+
+        private static readonly SyntaxKind[] Declarations =
+                                                            {
+                                                                SyntaxKind.ClassDeclaration,
+                                                                SyntaxKind.InterfaceDeclaration,
+                                                                SyntaxKind.StructDeclaration,
+                                                                SyntaxKind.RecordDeclaration,
+                                                                SyntaxKind.EnumDeclaration,
+                                                                SyntaxKind.DelegateDeclaration,
+
+                                                                SyntaxKind.MethodDeclaration,
+                                                                SyntaxKind.ConstructorDeclaration,
+                                                                SyntaxKind.DestructorDeclaration,
+
+                                                                SyntaxKind.OperatorDeclaration,
+                                                                SyntaxKind.ConversionOperatorDeclaration,
+
+                                                                SyntaxKind.PropertyDeclaration,
+                                                                SyntaxKind.IndexerDeclaration,
+                                                                SyntaxKind.EnumMemberDeclaration,
+
+                                                                SyntaxKind.FieldDeclaration,
+                                                                SyntaxKind.EventFieldDeclaration,
+                                                            };
+
+        public MiKo_2313_CommentShouldBeDocumentationAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, Declarations);
+
+        private static IReadOnlyCollection<string> FindCommentTags(ReadOnlySpan<string> comments)
+        {
+            var length = DocumentationCommentTags.Length;
+            var commentsLength = comments.Length;
+
+            HashSet<string> foundCommentTags = null;
+
+            for (var i = 0; i < length; i++)
+            {
+                var marker = DocumentationCommentTags[i];
+
+                for (var index = 0; index < commentsLength; index++)
+                {
+                    if (comments[index].StartsWith(marker, StringComparison.Ordinal))
+                    {
+                        if (foundCommentTags is null)
+                        {
+                            foundCommentTags = new HashSet<string>();
+                        }
+
+                        foundCommentTags.Add(marker);
+                    }
+                }
+            }
+
+            return (IReadOnlyCollection<string>)foundCommentTags ?? Array.Empty<string>();
+        }
+
+        private void AnalyzeComment(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MemberDeclarationSyntax member)
+            {
+                var comments = member.GetLeadingComments();
+
+                if (comments.Length > 0)
+                {
+                    var commentTags = FindCommentTags(comments);
+
+                    if (commentTags.Count > 0)
+                    {
+                        var properties = new Pair(Constants.AnalyzerCodeFixSharedData.CommentTags, commentTags.ConcatenatedWith("|"));
+
+                        context.ReportDiagnostic(Issue(member.GetLeadingTrivia(), properties));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 
@@ -46,11 +47,14 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             // move comment to the end if it is a leading one
             if (syntax is StatementSyntax || syntax is MemberDeclarationSyntax)
             {
-                var leadingComment = clause.GetLeadingComment();
+                var leadingComment = clause.FindSyntaxNodeWithLeadingComment()
+                                           .GetLeadingComments();
 
-                if (leadingComment.IsComment())
+                if (leadingComment.Length > 0)
                 {
-                    updatedSyntax = updatedSyntax.WithTrailingTrivia(SyntaxFactory.Space, leadingComment, SyntaxFactory.CarriageReturnLineFeed);
+                    var comment = SyntaxFactory.Comment(Constants.Comments.CommentExterior + " " + leadingComment.ConcatenatedWith(" "));
+
+                    updatedSyntax = updatedSyntax.WithTrailingTrivia(SyntaxFactory.Space, comment, SyntaxFactory.CarriageReturnLineFeed);
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzerTests.cs
@@ -1,0 +1,675 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2313_CommentShouldBeDocumentationAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] DocumentationCommentMarkers = ["Summary:", "Remark:", "Remarks:", "Return:", "Returns:", "Parameter:", "Parameters:", "Param:", "Exception:", "Exceptions:", "Value:", "ReturnValue:", "Return value:"];
+
+        [Test]
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_comment_before_method() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        // some comment
+        public void DoSomething()
+        {
+        }
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_comment_within_method_([ValueSource(nameof(DocumentationCommentMarkers))] string comment) => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            // " + comment + @" some comment
+        }
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_comment_after_method_([ValueSource(nameof(DocumentationCommentMarkers))] string comment) => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public int DoSomething() => 42; // " + comment + @" some comment
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_comment_before_method_([ValueSource(nameof(DocumentationCommentMarkers))] string comment) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        // " + comment + @"
+        //     some comment
+        public void DoSomething()
+        {
+        }
+    }
+}");
+
+        [Test]
+        public void Code_gets_fixed_for_summary_comment_before_type()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    // Summary:
+    //     some comment
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    /// <summary>
+    /// some comment
+    /// </summary>
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_summary_comment_before_method()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     some comment
+        public void DoSomething()
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// some comment
+        /// </summary>
+        public void DoSomething()
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_summary_comment_before_enum_type()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    // Summary:
+    //     some comment
+    public enum TestMe
+    {
+        Something = 0,
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    /// <summary>
+    /// some comment
+    /// </summary>
+    public enum TestMe
+    {
+        Something = 0,
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_summary_comment_before_enum_member()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public enum TestMe
+    {
+        // Summary:
+        //     some comment
+        Something = 1,
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public enum TestMe
+    {
+        /// <summary>
+        /// some comment
+        /// </summary>
+        Something = 1,
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_summary_comment_before_every_enum_member()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public enum TestMe
+    {
+        // Summary:
+        //     this is nothing
+        Nothing = 0,
+
+        // Summary:
+        //     this is a something comment
+        Something = 1,
+
+        // Summary:
+        //     this is an anything comment
+        Anything = 2,
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public enum TestMe
+    {
+        /// <summary>
+        /// this is nothing
+        /// </summary>
+        Nothing = 0,
+
+        /// <summary>
+        /// this is a something comment
+        /// </summary>
+        Something = 1,
+
+        /// <summary>
+        /// this is an anything comment
+        /// </summary>
+        Anything = 2,
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_when_value_is_at_end()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Value:
+        //     The error message for the property. The default is an empty string ("""").
+        public string ErrorMessage { get; }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <value>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </value>
+        public string ErrorMessage { get; }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_when_remark_is_at_end_([Values("Remark", "Remarks")] string marker)
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // ###:
+        //     The error message for the property. The default is an empty string ("""").
+        public string ErrorMessage { get; }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <remarks>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </remarks>
+        public string ErrorMessage { get; }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", marker), FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_when_returns_is_at_end_([Values("Return", "Returns", "Return value", "ReturnValue")] string marker)
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // ###:
+        //     The error message for the property. The default is an empty string ("""").
+        public string GetErrorMessage()
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        public string GetErrorMessage()
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode.Replace("###", marker), FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_parameters_when_returns_is_at_end()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Parameters:
+        //   columnName:
+        //     The name of the property whose error message to get.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <param name=""columnName"">
+        /// The name of the property whose error message to get.
+        /// </param>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_parameters_when_parameters_comments_are_at_end()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        //
+        // Parameters:
+        //   columnName:
+        //     The name of the property whose error message to get.
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <param name=""columnName"">
+        /// The name of the property whose error message to get.
+        /// </param>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_parameters_when_parameters_comments_are_at_end_and_on_single_lines()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        //
+        // Parameters:
+        //   columnName1: The name of the property whose error message to get.
+        //   columnName2: Some other information to get.
+        public string GetErrorMessage(string columnName1, string columnName2)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <param name=""columnName1"">
+        /// The name of the property whose error message to get.
+        /// </param>
+        /// <param name=""columnName2"">
+        /// Some other information to get.
+        /// </param>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        public string GetErrorMessage(string columnName1, string columnName2)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_exceptions_when_exception_comments_are_at_end()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        //
+        // Exceptions:
+        //
+        //   System.ArgumentNullException:
+        //     The name parameter is null.
+        //
+        //   System.InvalidOperationException:
+        //     The value of the specified resource is not a string.
+        //
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        /// <exception cref=""System.ArgumentNullException"">
+        /// The name parameter is null.
+        /// </exception>
+        /// <exception cref=""System.InvalidOperationException"">
+        /// The value of the specified resource is not a string.
+        /// </exception>
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_exceptions_when_exception_comments_are_at_end_and_on_single_lines()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        //
+        // Exceptions:
+        //
+        //   System.ArgumentNullException: The name parameter is null.
+        //   System.InvalidOperationException: The value of the specified resource is not a string.
+        //
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        /// <exception cref=""System.ArgumentNullException"">
+        /// The name parameter is null.
+        /// </exception>
+        /// <exception cref=""System.InvalidOperationException"">
+        /// The value of the specified resource is not a string.
+        /// </exception>
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_complex_comment_with_exceptions_when_exception_comments_are_in_between()
+        {
+            const string OriginalCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        // Summary:
+        //     Gets the error message for the property with the given name.
+        //
+        // Exceptions:
+        //
+        //   System.ArgumentNullException:
+        //     The name parameter is null.
+        //
+        //   System.InvalidOperationException:
+        //     The value of the specified resource is not a string.
+        //
+        // Returns:
+        //     The error message for the property. The default is an empty string ("""").
+        //
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            const string FixedCode = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Gets the error message for the property with the given name.
+        /// </summary>
+        /// <returns>
+        /// The error message for the property. The default is an empty string ("""").
+        /// </returns>
+        /// <exception cref=""System.ArgumentNullException"">
+        /// The name parameter is null.
+        /// </exception>
+        /// <exception cref=""System.InvalidOperationException"">
+        /// The value of the specified resource is not a string.
+        /// </exception>
+        public string GetErrorMessage(string columnName)
+        {
+            return ""some value"";
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2313_CommentShouldBeDocumentationAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2313_CommentShouldBeDocumentationAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2313_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6041_AssignmentsAreOnSameLineAnalyzerTests.cs
@@ -420,6 +420,39 @@ public class TestMe
         }
 
         [Test]
+        public void Code_gets_fixed_if_assignment_with_multiple_comments_spans_different_lines()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        int i =
+                // this is
+                // some comment
+                0;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(object o)
+    {
+        int i = 0; // this is some comment
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_if_field_assignment_with_comment_spans_different_lines()
         {
             const string OriginalCode = @"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 500 rules that are currently provided by the analyzer.
+The following tables lists all the 501 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -296,6 +296,7 @@ The following tables lists all the 500 rules that are currently provided by the 
 |MiKo_2310|Comments should explain the 'Why' and not the 'That'|&#x2713;|\-|
 |MiKo_2311|Do not use separator comments|&#x2713;|&#x2713;|
 |MiKo_2312|Comments should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
+|MiKo_2313|Plain documentation comments should be XML documentation|&#x2713;|&#x2713;|
 
 ### Maintainability
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add analyzer MiKo_2313  for detecting plain comment tags and propose to convert to XML documentation

- Implement code fix

- Extend utilities, resources, and project configuration

(resolves #1347)
