### PR TITLE
Added speculative check for uncompilable code for MiKo_6005

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -4253,10 +4253,10 @@ namespace MiKoSolutions.Analyzers
             foreach (var triviaGroup in triviaGroupedByLines)
             {
                 var trivia1 = triviaGroup.ElementAt(0);
-                var index1 = finalTrivia.IndexOf(trivia1);
 
                 if (trivia1.IsWhiteSpace())
                 {
+                    var index1 = finalTrivia.IndexOf(trivia1);
                     var spaces = count;
 
                     if (triviaGroup.MoreThan(1))

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -168,11 +168,10 @@ namespace MiKoSolutions.Analyzers.Rules
 
             if (issues is Diagnostic[] array)
             {
-                ReportDiagnostics(context, array);
-            }
-            else if (issues is IReadOnlyList<Diagnostic> list)
-            {
-                ReportDiagnostics(context, list);
+                if (array.Length > 0)
+                {
+                    ReportDiagnostics(context, array);
+                }
             }
             else
             {
@@ -182,31 +181,20 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, Diagnostic[] issues)
         {
-            var issuesLength = issues.Length;
-
-            switch (issuesLength)
+            for (int index = 0, length = issues.Length; index < length; index++)
             {
-                case 0: return;
-                case 1: ReportDiagnostics(context, issues[0]); return;
-            }
+                var issue = issues[index];
 
-            for (var index = 0; index < issuesLength; index++)
-            {
-                ReportDiagnostics(context, issues[index]);
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
             }
         }
 
         protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, IReadOnlyList<Diagnostic> issues)
         {
-            var issuesCount = issues.Count;
-
-            switch (issuesCount)
-            {
-                case 0: return;
-                case 1: ReportDiagnostics(context, issues[0]); return;
-            }
-
-            for (var index = 0; index < issuesCount; index++)
+            for (int index = 0, count = issues.Count; index < count; index++)
             {
                 ReportDiagnostics(context, issues[index]);
             }
@@ -228,14 +216,9 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected void InitializeCore(CompilationStartAnalysisContext context, params SymbolKind[] symbolKinds)
         {
-            var length = symbolKinds.Length;
-
-            if (length > 0)
+            for (int index = 0, length = symbolKinds.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
-                {
-                    InitializeCore(context, symbolKinds[index]);
-                }
+                InitializeCore(context, symbolKinds[index]);
             }
         }
 
@@ -404,58 +387,55 @@ namespace MiKoSolutions.Analyzers.Rules
                 return;
             }
 
-            if (issues is Diagnostic[] array)
+            switch (issues)
             {
-                ReportDiagnostics(context, array);
-            }
-            else if (issues is IReadOnlyList<Diagnostic> list)
-            {
-                ReportDiagnostics(context, list);
-            }
-            else
-            {
-                ReportDiagnosticsEnumerable(context, issues);
-            }
-        }
+                case Diagnostic[] array:
+                {
+                    if (array.Length > 0)
+                    {
+                        ReportDiagnostics(context, array);
+                    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ReportDiagnostics(in SymbolAnalysisContext context, Diagnostic issue)
-        {
-            if (issue != null)
-            {
-                context.ReportDiagnostic(issue);
+                    return;
+                }
+
+                case IReadOnlyList<Diagnostic> list:
+                {
+                    if (list.Count > 0)
+                    {
+                        ReportDiagnostics(context, list);
+                    }
+
+                    return;
+                }
             }
+
+            ReportDiagnosticsEnumerable(context, issues);
         }
 
         private static void ReportDiagnostics(in SymbolAnalysisContext context, Diagnostic[] array)
         {
-            var arrayLength = array.Length;
-
-            switch (arrayLength)
+            for (int index = 0, length = array.Length; index < length; index++)
             {
-                case 0: return;
-                case 1: ReportDiagnostics(context, array[0]); return;
-            }
+                var issue = array[index];
 
-            for (var index = 0; index < arrayLength; index++)
-            {
-                ReportDiagnostics(context, array[index]);
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
             }
         }
 
         private static void ReportDiagnostics(in SymbolAnalysisContext context, IReadOnlyList<Diagnostic> list)
         {
-            var listCount = list.Count;
-
-            switch (listCount)
+            for (int index = 0, count = list.Count; index < count; index++)
             {
-                case 0: return;
-                case 1: ReportDiagnostics(context, list[0]); return;
-            }
+                var issue = list[index];
 
-            for (var index = 0; index < listCount; index++)
-            {
-                ReportDiagnostics(context, list[index]);
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
             }
         }
 
@@ -469,7 +449,10 @@ namespace MiKoSolutions.Analyzers.Rules
                     return;
                 }
 
-                ReportDiagnostics(context, issue);
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
             }
         }
 
@@ -483,7 +466,10 @@ namespace MiKoSolutions.Analyzers.Rules
                     return;
                 }
 
-                ReportDiagnostics(context, issue);
+                if (issue != null)
+                {
+                    context.ReportDiagnostic(issue);
+                }
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
@@ -23,9 +23,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2000";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
+            var token = syntax.FindToken(issue);
 
             if (token.IsKind(SyntaxKind.LessThanToken) && token.Parent is XmlElementStartTagSyntax startTag && startTag.Parent is XmlElementSyntax element)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2006";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var fieldDeclaration = syntax.FirstAncestorOrSelf<FieldDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2014_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2014";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var method = syntax.FirstAncestorOrSelf<MethodDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2015";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var text = syntax.ToString();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2017";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var fieldDeclaration = syntax.FirstAncestorOrSelf<FieldDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2020";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return syntax.WithoutTrivia()
                          .WithContent(Inheritdoc().WithEndOfLine())

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2029_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2029";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var wrongInheritDocs = syntax.DescendantNodes<XmlEmptyElementSyntax>(_ => _.GetName() is Constants.XmlTag.Inheritdoc && _.Attributes.OfType<XmlCrefAttributeSyntax>().Any());
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
@@ -10,12 +10,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2036";
 
-        protected override bool IsApplicable(in ImmutableArray<Diagnostic> diagnostics)
+        protected override bool IsApplicable(in ImmutableArray<Diagnostic> issues)
         {
-            for (int index = 0, diagnosticsLength = diagnostics.Length; index < diagnosticsLength; index++)
+            for (int index = 0, length = issues.Length; index < length; index++)
             {
-                var diagnostic = diagnostics[index];
-                var properties = diagnostic.Properties;
+                var properties = issues[index].Properties;
 
                 if (properties.Count > 0 && properties.ContainsKey(Constants.AnalyzerCodeFixSharedData.IsBoolean))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         protected override string Title => Resources.MiKo_2036_CodeFixTitle_Enum;
 
-        protected override bool IsApplicable(in ImmutableArray<Diagnostic> diagnostics) => base.IsApplicable(diagnostics) is false;
+        protected override bool IsApplicable(in ImmutableArray<Diagnostic> issues) => base.IsApplicable(issues) is false;
 
         protected override IEnumerable<XmlNodeSyntax> GetDefaultComment(Document document, TypeSyntax returnType)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_NoDefault_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_NoDefault_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         protected override string Title => Resources.MiKo_2036_CodeFixTitle_NoDefault;
 
-        protected override bool IsApplicable(in ImmutableArray<Diagnostic> diagnostics) => diagnostics.Any();
+        protected override bool IsApplicable(in ImmutableArray<Diagnostic> issues) => issues.Any();
 
         protected override IEnumerable<XmlNodeSyntax> GetDefaultComment(Document document, TypeSyntax returnType)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2040";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var comment = syntax;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2041_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2041_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2041";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var syntaxNodes = syntax.GetSummaryXmls(Constants.Comments.InvalidSummaryCrefXmlTags).ToList();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2042_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2042";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             foreach (var node in syntax.DescendantNodes())
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
@@ -21,10 +21,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2049";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var location = diagnostic.Location;
-            var properties = diagnostic.Properties;
+            var location = issue.Location;
+            var properties = issue.Properties;
             var textToReplace = properties[Constants.AnalyzerCodeFixSharedData.TextKey];
             var textToReplaceWith = properties[Constants.AnalyzerCodeFixSharedData.TextReplacementKey];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2050";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var ctor = syntax.FirstAncestorOrSelf<ConstructorDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2051_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2051_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2051";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var updatedSyntax = syntax.ReplaceNodes(
                                                 syntax.GetExceptionXmls(),

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2052_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2052_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2052";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var updatedSyntax = syntax.ReplaceNodes(
                                                 syntax.GetExceptionXmls().Where(_ => _.IsExceptionCommentFor<ArgumentNullException>()),

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2054_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2054_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2054";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var updatedSyntax = syntax.ReplaceNodes(
                                                 syntax.GetExceptionXmls().Where(_ => _.IsExceptionCommentFor<ArgumentException>()),

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2055_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2055_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2055";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var updatedSyntax = syntax.ReplaceNodes(
                                                 syntax.GetExceptionXmls().Where(_ => _.IsExceptionCommentFor<ArgumentOutOfRangeException>()),

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2056";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             foreach (var ancestor in syntax.AncestorsAndSelf())
             {
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     case PropertyDeclarationSyntax _:
                     case MethodDeclarationSyntax _:
                     {
-                        return FixComment(ancestor, syntax, diagnostic);
+                        return FixComment(ancestor, syntax, issue);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2057_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2057_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2057";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var children = syntax.ChildNodes().ToList();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2059_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2059";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var exceptionComments = syntax.GetExceptionXmls();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
@@ -19,6 +19,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override string Title => Resources.MiKo_2075_CodeFixTitle.FormatWith(Constants.Comments.CallbackTerm);
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2090";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var method = syntax.FirstAncestorOrSelf<OperatorDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2091";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var method = syntax.FirstAncestorOrSelf<OperatorDeclarationSyntax>();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2202";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return Comment(syntax, Constants.Comments.IdTerms, ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2203";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return Comment(syntax, Constants.Comments.GuidTermsWithDelimiters, ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2204";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var list = syntax.DescendantNodes<XmlTextSyntax>(_ => _.TextTokens.Any(__ => __.ValueText.AsSpan().TrimStart().StartsWithAny(Markers)));
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
@@ -20,9 +20,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2208";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
+            var token = syntax.FindToken(issue);
 
             return syntax.ReplaceToken(token, token.WithText(ReplaceText(token.Text)));
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_CodeFixProvider.cs
@@ -11,9 +11,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2209";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
+            var token = syntax.FindToken(issue);
 
             return syntax.ReplaceToken(token, token.WithText(token.ValueText.Replace("..", ".")));
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2210";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return Comment(syntax, Constants.Comments.InfoTerms, ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2211";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var remarks = syntax.GetXmlSyntax(Constants.XmlTag.Remarks)[0];
             var summaries = syntax.GetXmlSyntax(Constants.XmlTag.Summary);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_CodeFixProvider.cs
@@ -11,9 +11,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2212";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
+            var token = syntax.FindToken(issue);
 
             return syntax.ReplaceToken(token, token.WithText(token.ValueText.Replace(Constants.Comments.WasNotSuccessfulPhrase, "failed")));
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
@@ -13,9 +13,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2213";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
+            var token = syntax.FindToken(issue);
             var text = token.ValueText.AsCachedBuilder().ReplaceAllWithProbe(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToStringAndRelease();
 
             return syntax.ReplaceToken(token, token.WithText(text));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2214";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var texts = syntax.DescendantNodes<XmlTextSyntax>(HasIssue);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2216_CodeFixProvider.cs
@@ -12,12 +12,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2216";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var issue = syntax.FindNode(diagnostic.Location.SourceSpan, true, true);
+            var node = syntax.FindNode(issue.Location.SourceSpan, true, true);
 
             // TODO RKN: use this for bulk replace: return syntax.ReplaceNodes(elements, (original, rewritten) => GetUpdatedSyntax(rewritten));
-            return syntax.ReplaceNode(issue, GetUpdatedSyntax(issue));
+            return syntax.ReplaceNode(node, GetUpdatedSyntax(node));
         }
 
         private static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2217_CodeFixProvider.cs
@@ -14,9 +14,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2217";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            if (syntax.FindNode(diagnostic.Location.SourceSpan) is XmlElementSyntax node)
+            if (syntax.FindNode(issue.Location.SourceSpan) is XmlElementSyntax node)
             {
                 var attribute = GetListElement(node).GetListType();
                 var listType = attribute.GetListType();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_CodeFixProvider.cs
@@ -14,10 +14,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2218";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var location = diagnostic.Location;
-            var properties = diagnostic.Properties;
+            var location = issue.Location;
+            var properties = issue.Properties;
             var textToReplace = properties[Constants.AnalyzerCodeFixSharedData.TextKey];
             var textToReplaceWith = properties[Constants.AnalyzerCodeFixSharedData.TextReplacementKey];
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
@@ -20,6 +20,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2220";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_CodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2222";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return Comment(syntax, Constants.Comments.IdentTerms, ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
@@ -12,10 +12,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2229";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(diagnostic);
-            var fragment = diagnostic.Location.GetText();
+            var token = syntax.FindToken(issue);
+            var fragment = issue.Location.GetText();
 
             return syntax.ReplaceToken(token, token.WithText(token.ValueText.Without(fragment)));
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2231_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2231";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             var updatedSyntax = syntax.WithContent(Inheritdoc().WithLeadingXmlCommentExterior().WithEndOfLine());
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
@@ -14,26 +14,21 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2232";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var node = syntax.FindNode(diagnostic.Location.SourceSpan, true, true);
+            var node = syntax.FindNode(issue.Location.SourceSpan, true, true);
 
-            if (node is XmlElementSyntax issue)
+            if (node is XmlElementSyntax element && element.Parent == syntax)
             {
-                if (issue.Parent == syntax)
+                // we are directly within the DocumentationCommentTriviaSyntax
+                var updatedContent = GetUpdatedXmlContent(syntax.Content, element);
+
+                if (updatedContent.Count is 0)
                 {
-                    // we are directly within the DocumentationCommentTriviaSyntax
-                    var updatedContent = GetUpdatedXmlContent(syntax.Content, issue);
-
-                    if (updatedContent.Count != 0)
-                    {
-                        var updatedSyntax = syntax.WithContent(updatedContent.WithoutFirstXmlNewLine().WithLeadingXmlComment().WithIndentation());
-
-                        return updatedSyntax;
-                    }
-
                     return null;
                 }
+
+                return syntax.WithContent(updatedContent.WithoutFirstXmlNewLine().WithLeadingXmlComment().WithIndentation());
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2234";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
             return Comment(syntax, Constants.Comments.WhichIsToTerms, ReplacementMap);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
@@ -29,6 +29,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2235";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
@@ -31,6 +31,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2236";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationCodeFixProvider.cs
@@ -9,13 +9,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => GetXmlSyntax(syntaxNodes);
 
-        protected sealed override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
-        {
-            var comment = (DocumentationCommentTriviaSyntax)syntax;
+        protected sealed override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => GetUpdatedSyntax(document, (DocumentationCommentTriviaSyntax)syntax, issue);
 
-            return GetUpdatedSyntax(document, comment, issue);
-        }
-
-        protected abstract DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic diagnostic);
+        protected abstract DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
             var diagnostics = context.Diagnostics;
 
-            if (IsApplicable(diagnostics))
+            if (diagnostics.Length > 0 && IsApplicable(diagnostics))
             {
                 var diagnostic = diagnostics[0];
 
@@ -112,8 +112,6 @@ namespace MiKoSolutions.Analyzers.Rules
         {
             var syntax = syntaxNode.WithLeadingSpaces(spaces);
 
-            var additionalSpaces = syntax.GetPositionWithinStartLine() - syntaxNode.GetPositionWithinStartLine();
-
             // collect all descendant nodes that are the first ones starting on a new line, then adjust leading space for each of those
             var startingNodes = GetNodesAndTokensStartingOnSeparateLines(syntax).ToList();
 
@@ -121,6 +119,8 @@ namespace MiKoSolutions.Analyzers.Rules
             {
                 return syntax;
             }
+
+            var additionalSpaces = syntax.GetPositionWithinStartLine() - syntaxNode.GetPositionWithinStartLine();
 
             return syntax.WithAdditionalLeadingSpacesOnDescendants(startingNodes, additionalSpaces);
         }
@@ -143,7 +143,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
 //// ncrunch: rdi off
 
-        protected virtual bool IsApplicable(in ImmutableArray<Diagnostic> diagnostics) => diagnostics.Any();
+        protected virtual bool IsApplicable(in ImmutableArray<Diagnostic> issues) => issues.Any();
 
         protected virtual SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.FirstOrDefault();
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer.cs
@@ -71,6 +71,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeStatements(in SyntaxList<StatementSyntax> statements, SyntaxNode returnStatement)
         {
+            if (returnStatement.ContainsDiagnostics)
+            {
+                // might be uncompilable code, so ignore it
+                return null;
+            }
+
             var callLineSpan = returnStatement.GetLocation().GetLineSpan();
 
             var noBlankLinesBefore = statements.Where(_ => _.IsKind(SyntaxKind.YieldReturnStatement) is false)

--- a/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
@@ -97,13 +97,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeStatement(BlockSyntax block, T node)
         {
-            var beforePosition = GetLocationOfNodeOrLeadingComment(node).GetLineSpan();
-            var afterPosition = GetLocationOfNodeOrTrailingComment(node).GetLineSpan();
-
             var otherStatements = block.Statements.Except(node).Where(ShallAnalyzeOtherStatement).ToList();
 
             if (otherStatements.Count > 0)
             {
+                var beforePosition = GetLocationOfNodeOrLeadingComment(node).GetLineSpan();
+                var afterPosition = GetLocationOfNodeOrTrailingComment(node).GetLineSpan();
+
                 var noBlankLinesBefore = HasNoBlankLinesBefore(otherStatements, beforePosition);
                 var noBlankLinesAfter = HasNoBlankLinesAfter(otherStatements, afterPosition);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
@@ -17,8 +17,6 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         protected static Location GetLocationOfNodeOrLeadingComment(SyntaxNode node)
         {
             var list = node.GetLeadingTrivia();
-
-            // keep in local variable to avoid multiple requests (see Roslyn implementation)
             var listCount = list.Count;
 
             if (listCount > 0)
@@ -40,14 +38,18 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         protected static Location GetLocationOfNodeOrTrailingComment(SyntaxNode node)
         {
             var list = node.GetTrailingTrivia();
+            var listCount = list.Count;
 
-            for (var index = list.Count - 1; index > -1; index--)
+            if (listCount > 0)
             {
-                var trivia = list[index];
-
-                if (trivia.IsComment())
+                for (var index = listCount - 1; index > -1; index--)
                 {
-                    return trivia.GetLocation();
+                    var trivia = list[index];
+
+                    if (trivia.IsComment())
+                    {
+                        return trivia.GetLocation();
+                    }
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzerTests.cs
@@ -658,6 +658,63 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void No_issue_is_reported_for_incomplete_code_with_return_statement_that_is_preceded_by_blank_line() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public int DoSomething(bool something)
+        {
+            return DoSomethingCore(something);
+
+            int DoSomethingCore(bool something)
+            {
+                var x = 0;
+
+                return x;
+
+                return x
+
+                return 
+
+                return
+
+                return 42
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incomplete_code_with_return_statement_that_is_preceded_by_no_blank_line() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public int DoSomething(bool something)
+        {
+            return DoSomethingCore(something);
+
+            int DoSomethingCore(bool something)
+            {
+                var x = 0;
+                return x;
+
+                return x
+
+                return 
+
+                return
+
+                return 42
+            }
+        }
+    }
+}
+");
+
         protected override string GetDiagnosticId() => MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer();


### PR DESCRIPTION
- Skip diagnostics on uncompilable return statements

- Refactor `ReportDiagnostics` to skip empty/null issues

- Rename CodeFix `GetUpdatedSyntax` parameter to `issue`

- Add unit tests for incomplete return statements
