### PR TITLE
Added new rule MiKo_2240 that reports on <response> starting with 'Return' and provides a codefix

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2236_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2303_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2305_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -157,6 +157,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_MultipleDocumentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2238_MakeSureToCallThisAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_TestArrangeActAssertCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2302_CommentedOutCodeAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8985,6 +8985,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix response documentation.
+        /// </summary>
+        internal static string MiKo_2240_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2240_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation for a response value should start with a default phrase that provides a detailed description of what the response is. This approach helps clarify the purpose and use of the response value for developers..
+        /// </summary>
+        internal static string MiKo_2240_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2240_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Start &lt;response&gt; with: &apos;{0}&apos;.
+        /// </summary>
+        internal static string MiKo_2240_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2240_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;response&gt; documentation should not start with &apos;Returns&apos;.
+        /// </summary>
+        internal static string MiKo_2240_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2240_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
         ///This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation..
         /// </summary>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3171,6 +3171,18 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
   <data name="MiKo_2239_Title" xml:space="preserve">
     <value>Documentation should use '///' and not '/** */'</value>
   </data>
+  <data name="MiKo_2240_CodeFixTitle" xml:space="preserve">
+    <value>Fix response documentation</value>
+  </data>
+  <data name="MiKo_2240_Description" xml:space="preserve">
+    <value>Documentation for a response value should start with a default phrase that provides a detailed description of what the response is. This approach helps clarify the purpose and use of the response value for developers.</value>
+  </data>
+  <data name="MiKo_2240_MessageFormat" xml:space="preserve">
+    <value>Start &lt;response&gt; with: '{0}'</value>
+  </data>
+  <data name="MiKo_2240_Title" xml:space="preserve">
+    <value>&lt;response&gt; documentation should not start with 'Returns'</value>
+  </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
 This approach ensures comments are insightful and add real value by giving context and rationale, helping developers understand the reasoning behind the implementation.</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_CodeFixProvider.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2240_CodeFixProvider)), Shared]
+    public sealed class MiKo_2240_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2240";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<XmlElementSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is XmlElementSyntax element)
+            {
+                var phrase = GetPhraseProposal(issue);
+
+                return Comment(element, phrase);
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2240_ResponseTypeDefaultPhraseAnalyzer : DocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2240";
+
+        private static readonly string[] WrongStartingPhrases = { "Return", "Is return" };
+
+        private static readonly Pair[] Replacements =
+                                                      {
+                                                          new Pair("Is returned when "),
+                                                          new Pair("Is returned if "),
+                                                          new Pair("Returned when "),
+                                                          new Pair("Returned if "),
+                                                          new Pair("Returned "),
+                                                          new Pair("Returns when "),
+                                                          new Pair("Returns if "),
+                                                          new Pair("Returns "),
+                                                          new Pair("Return when "),
+                                                          new Pair("Return if "),
+                                                          new Pair("Return "),
+                                                      };
+
+        public MiKo_2240_ResponseTypeDefaultPhraseAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            var responseXmls = comment.GetXmlSyntax(Constants.XmlTag.Response);
+            var responseXmlsCount = responseXmls.Count;
+
+            if (responseXmlsCount > 0)
+            {
+                for (var index = 0; index < responseXmlsCount; index++)
+                {
+                    var content = responseXmls[index].Content;
+
+                    if (content.Count > 0 && content[0] is XmlTextSyntax node)
+                    {
+                        var text = node.GetTextWithoutTrivia();
+
+                        if (text.StartsWithAny(WrongStartingPhrases, StringComparison.Ordinal))
+                        {
+                            var betterText = FindBetterText(text);
+
+                            return new[] { Issue(node, betterText.AsSpan().HumanizedTakeFirst(50), CreatePhraseProposal(betterText)) };
+                        }
+                    }
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterText(string text)
+        {
+            var betterText = text.AsCachedBuilder()
+                                 .ReplaceAllWithProbe(Replacements)
+                                 .AdjustFirstWord(FirstWordHandling.StartUpperCase)
+                                 .ToStringAndRelease();
+
+            return betterText;
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzerTests.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2240_ResponseTypeDefaultPhraseAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public object DoSomething(object o) => null;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_uncommented_property() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public object DoSomething { get; set; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_void_method() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    public void DoSomething(object o) { }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_method_that_describes_response_as_([Values("A whatever", "An whatever", "The whatever")] string comment) => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <response code=""1234"">
+    /// " + comment + @"
+    /// </response>
+    public Task DoSomething(object o) => throw new NotSupportedException();
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_that_describes_response_as_([Values("Return whatever", "Returns whatever", "Is returned when the whatever", "Is returned if whatever")] string comment)
+            => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <response code=""1234"">
+    /// " + comment + @"
+    /// </response>
+    public object DoSomething(object o) => null;
+}
+");
+
+        [TestCase("Return whatever", "Whatever")]
+        [TestCase("Returns whatever", "Whatever")]
+        [TestCase("Returned whatever", "Whatever")]
+        [TestCase("Returned when whatever", "Whatever")]
+        [TestCase("Returned when the whatever", "The whatever")]
+        [TestCase("Returned if whatever", "Whatever")]
+        [TestCase("Returned if the whatever", "The whatever")]
+        [TestCase("Is returned when whatever", "Whatever")]
+        [TestCase("Is returned when the whatever", "The whatever")]
+        [TestCase("Is returned if whatever", "Whatever")]
+        [TestCase("Is returned if the whatever", "The whatever")]
+        public void Code_gets_fixed_for_method_that_describes_response_as_(string originalComment, string fixedComment)
+        {
+            const string Template = @"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <response code=""1234"">
+    /// ###.
+    /// </response>
+    public object DoSomething(object o) => null;
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2240_ResponseTypeDefaultPhraseAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2240_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 501 rules that are currently provided by the analyzer.
+The following tables lists all the 502 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -283,6 +283,7 @@ The following tables lists all the 501 rules that are currently provided by the 
 |MiKo_2237|Documentation should not be separated by empty lines|&#x2713;|&#x2713;|
 |MiKo_2238|&lt;summary&gt; documentation shall not start with 'Make sure to call this'|&#x2713;|\-|
 |MiKo_2239|Documentation should use '///' and not '/** */'|&#x2713;|&#x2713;|
+|MiKo_2240|&lt;response&gt; documentation should not start with 'Returns'|&#x2713;|&#x2713;|
 |MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
 |MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|


### PR DESCRIPTION
- Add MiKo_2240 analyzer for `<response>` docs

- Provide code fix for default phrase replacements

- Include unit tests for analyzer and code fix

- Update resources, project files, and README

(resolves #1397)