### PR TITLE
Renamed 'diagnostic' parameters to 'issue'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -115,9 +115,9 @@ namespace MiKoSolutions.Analyzers
             return parameters.Length > 0 && parameters.Any(_ => _.Name == parameterName);
         }
 
-        internal static SyntaxToken FindToken<T>(this T value, Diagnostic diagnostic) where T : SyntaxNode
+        internal static SyntaxToken FindToken<T>(this T value, Diagnostic issue) where T : SyntaxNode
         {
-            var position = diagnostic.Location.SourceSpan.Start;
+            var position = issue.Location.SourceSpan.Start;
             var token = value.FindToken(position, true);
 
             return token;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -120,12 +120,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return comment;
         }
 
-        protected DocumentationCommentTriviaSyntax FixComment(SyntaxNode syntax, DocumentationCommentTriviaSyntax comment, Diagnostic diagnostic)
+        protected DocumentationCommentTriviaSyntax FixComment(SyntaxNode syntax, DocumentationCommentTriviaSyntax comment, Diagnostic issue)
         {
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var exception in comment.Content.OfType<XmlElementSyntax>().Where(_ => _.IsException()))
             {
-                var fixedException = FixExceptionComment(syntax, exception, comment, diagnostic);
+                var fixedException = FixExceptionComment(syntax, exception, comment, issue);
 
                 if (fixedException != null)
                 {
@@ -136,7 +136,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return null;
         }
 
-        protected virtual DocumentationCommentTriviaSyntax FixExceptionComment(SyntaxNode syntax, XmlElementSyntax exception, DocumentationCommentTriviaSyntax comment, Diagnostic diagnostic) => null;
+        protected virtual DocumentationCommentTriviaSyntax FixExceptionComment(SyntaxNode syntax, XmlElementSyntax exception, DocumentationCommentTriviaSyntax comment, Diagnostic issue) => null;
 
         private static IEnumerable<string> GetParameterReferences(string parameterName)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2056_CodeFixProvider.cs
@@ -30,11 +30,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return null;
         }
 
-        protected override DocumentationCommentTriviaSyntax FixExceptionComment(SyntaxNode syntax, XmlElementSyntax exception, DocumentationCommentTriviaSyntax comment, Diagnostic diagnostic)
+        protected override DocumentationCommentTriviaSyntax FixExceptionComment(SyntaxNode syntax, XmlElementSyntax exception, DocumentationCommentTriviaSyntax comment, Diagnostic issue)
         {
             if (exception.IsExceptionCommentFor<ObjectDisposedException>())
             {
-                var phrase = GetPhraseProposal(diagnostic);
+                var phrase = GetPhraseProposal(issue);
 
                 var exceptionComment = CommentEndingWith(exception, phrase);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_CodeFixProvider.cs
@@ -37,11 +37,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return syntax;
         }
 
-        private static InvocationExpressionSyntax NameOf(Diagnostic diagnostic)
+        private static InvocationExpressionSyntax NameOf(Diagnostic issue)
         {
-            diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.PropertyName, out var propertyName);
+            issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.PropertyName, out var propertyName);
 
-            if (diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.PropertyTypeName, out var propertyTypeName))
+            if (issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.PropertyTypeName, out var propertyTypeName))
             {
                 return NameOf(propertyTypeName, propertyName);
             }

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -157,16 +157,16 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected virtual SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue) => root.WithoutAnnotations(annotationOfSyntax);
 
-        protected virtual Task<Solution> ApplySolutionCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic diagnostic, CancellationToken cancellationToken) => Task.FromResult(document.Project.Solution);
+        protected virtual Task<Solution> ApplySolutionCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic issue, CancellationToken cancellationToken) => Task.FromResult(document.Project.Solution);
 
-        protected Task<Document> ApplyDocumentCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic diagnostic, CancellationToken cancellationToken)
+        protected Task<Document> ApplyDocumentCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic issue, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromResult(document);
             }
 
-            var updatedSyntax = GetUpdatedSyntax(document, syntax, diagnostic);
+            var updatedSyntax = GetUpdatedSyntax(document, syntax, issue);
 
             var newRoot = root;
 
@@ -197,21 +197,21 @@ namespace MiKoSolutions.Analyzers.Rules
                 return Task.FromResult(document);
             }
 
-            var finalRoot = GetUpdatedSyntaxRoot(document, newRoot, updatedSyntax, annotation, diagnostic) ?? newRoot;
+            var finalRoot = GetUpdatedSyntaxRoot(document, newRoot, updatedSyntax, annotation, issue) ?? newRoot;
             var newDocument = document.WithSyntaxRoot(finalRoot);
 
             return Task.FromResult(newDocument);
         }
 
-        protected Task<Document> ApplyDocumentCodeFixAsync(Document document, SyntaxNode root, SyntaxTrivia trivia, Diagnostic diagnostic, CancellationToken cancellationToken)
+        protected Task<Document> ApplyDocumentCodeFixAsync(Document document, SyntaxNode root, SyntaxTrivia trivia, Diagnostic issue, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromResult(document);
             }
 
-            var oldToken = GetToken(trivia, diagnostic);
-            var updatedToken = GetUpdatedToken(oldToken, diagnostic);
+            var oldToken = GetToken(trivia, issue);
+            var updatedToken = GetUpdatedToken(oldToken, issue);
 
             var newRoot = oldToken == updatedToken ? root : root.ReplaceToken(oldToken, updatedToken);
 
@@ -220,7 +220,7 @@ namespace MiKoSolutions.Analyzers.Rules
                 return Task.FromResult(document);
             }
 
-            var finalRoot = GetUpdatedSyntaxRoot(document, newRoot, trivia, diagnostic) ?? newRoot;
+            var finalRoot = GetUpdatedSyntaxRoot(document, newRoot, trivia, issue) ?? newRoot;
             var newDocument = document.WithSyntaxRoot(finalRoot);
 
             return Task.FromResult(newDocument);

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingCodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool IsSolutionWide => true;
 
-        protected sealed override async Task<Solution> ApplySolutionCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic diagnostic, CancellationToken cancellationToken)
+        protected sealed override async Task<Solution> ApplySolutionCodeFixAsync(Document document, SyntaxNode root, SyntaxNode syntax, Diagnostic issue, CancellationToken cancellationToken)
         {
             // Produce a new solution that has all references to that symbol renamed, including the declaration.
             var originalSolution = document.Project.Solution;
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return originalSolution;
             }
 
-            var newName = GetNewName(diagnostic, symbol);
+            var newName = GetNewName(issue, symbol);
 
             if (newName.IsNullOrWhiteSpace() || newName.Equals(symbol.Name, StringComparison.Ordinal))
             {
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected sealed override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => throw new NotSupportedException("This code fix provider does not modify the syntax");
 
-        private static string GetNewName(Diagnostic diagnostic, ISymbol symbol) => diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.BetterName, out var betterName) ? betterName : symbol.Name;
+        private static string GetNewName(Diagnostic issue, ISymbol symbol) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.BetterName, out var betterName) ? betterName : symbol.Name;
 
         private static bool IsMethodKindCore(SyntaxNode node)
         {

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4001_CodeFixProvider.cs
@@ -14,9 +14,9 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4001";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
-            var method = diagnostic.Location.GetEnclosing<IMethodSymbol>(document.GetSemanticModel());
+            var method = issue.Location.GetEnclosing<IMethodSymbol>(document.GetSemanticModel());
             var methodName = method.Name;
 
             var methods = method.ContainingType.GetMethods(methodName);

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4002_CodeFixProvider.cs
@@ -13,9 +13,9 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4002";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
-            var method = diagnostic.Location.GetEnclosing<IMethodSymbol>(document.GetSemanticModel());
+            var method = issue.Location.GetEnclosing<IMethodSymbol>(document.GetSemanticModel());
             var methodName = method.Name;
             var accessibility = method.DeclaredAccessibility;
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4003_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4003";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var disposeMethod = (MethodDeclarationSyntax)syntax;
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4004_CodeFixProvider.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             return root.ReplaceNode(typeSyntax, updatedTypeSyntax);
         }
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var disposeMethod = (MethodDeclarationSyntax)syntax;
             var targetMethod = FindTargetMethod(document, typeSyntax, disposeMethod);

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4005_CodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4005";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             switch (typeSyntax)
             {

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4007_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4007_CodeFixProvider.cs
@@ -11,6 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4007";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax); // place before all other methods
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax); // place before all other methods
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4008_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4008_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4008";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var modifiedType = typeSyntax.RemoveNodeAndAdjustOpenCloseBraces(syntax);
             var method = modifiedType.ChildNodes<MethodDeclarationSyntax>().Last(_ => _.GetName() == nameof(Equals) && _.Modifiers.Any(SyntaxKind.PublicKeyword));

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4101_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4101_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4101";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var method = (MethodDeclarationSyntax)syntax;
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4102_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4102_CodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4102";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var method = (MethodDeclarationSyntax)syntax;
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4103_CodeFixProvider.cs
@@ -11,6 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4103";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax);
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue) => PlaceFirst<MethodDeclarationSyntax>(syntax, typeSyntax);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4104_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4104_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
     {
         public override string FixableDiagnosticId => "MiKo_4104";
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic)
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue)
         {
             var method = (MethodDeclarationSyntax)syntax;
 

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_CodeFixProvider.cs
@@ -15,6 +15,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
         protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<FieldDeclarationSyntax>().FirstOrDefault();
 
-        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic) => PlaceFirst<FieldDeclarationSyntax>(syntax, typeSyntax);
+        protected override SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue) => PlaceFirst<FieldDeclarationSyntax>(syntax, typeSyntax);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/OrderingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/OrderingCodeFixProvider.cs
@@ -30,6 +30,6 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
             return root.ReplaceNode(typeSyntax, updatedTypeSyntax);
         }
 
-        protected abstract SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic diagnostic);
+        protected abstract SyntaxNode GetUpdatedTypeSyntax(Document document, BaseTypeDeclarationSyntax typeSyntax, SyntaxNode syntax, Diagnostic issue);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -11,9 +11,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
     public abstract class SpacingCodeFixProvider : MiKoCodeFixProvider
     {
-        protected static LinePosition GetProposedLinePosition(Diagnostic diagnostic)
+        protected static LinePosition GetProposedLinePosition(Diagnostic issue)
         {
-            var properties = diagnostic.Properties;
+            var properties = issue.Properties;
 
             if (properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.LineNumber, out var lineNumber)
              && properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.CharacterPosition, out var characterPosition))
@@ -24,13 +24,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return LinePosition.Zero;
         }
 
-        protected static int GetProposedSpaces(Diagnostic diagnostic) => diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.Spaces, out var s)
-                                                                         ? int.Parse(s)
-                                                                         : 0;
+        protected static int GetProposedSpaces(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.Spaces, out var s)
+                                                                    ? int.Parse(s)
+                                                                    : 0;
 
-        protected static int GetProposedAdditionalSpaces(Diagnostic diagnostic) => diagnostic.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.AdditionalSpaces, out var s)
-                                                                                   ? int.Parse(s)
-                                                                                   : 0;
+        protected static int GetProposedAdditionalSpaces(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.AdditionalSpaces, out var s)
+                                                                              ? int.Parse(s)
+                                                                              : 0;
 
 #pragma warning disable CA1002
         protected static List<SyntaxNodeOrToken> SelfAndDescendantsOnSeparateLines(SyntaxNode syntax)


### PR DESCRIPTION
- Rename `diagnostic` parameter to `issue` across providers

- Update parameter usages in method signatures

- Adjust syntax extensions and code fix implementations

- Applies to documentation, naming, ordering, spacing providers

