### PR TITLE
Moved 'Pair' from 'System' namespace into 'MiKoSolutions.Analyzers' namespace

### DIFF
--- a/MiKo.Analyzer.Shared/Pair.cs
+++ b/MiKo.Analyzer.Shared/Pair.cs
@@ -1,9 +1,9 @@
-﻿// for performance reasons we switch of RDI and NCrunch instrumentation
+﻿using System;
+
+// for performance reasons we switch of RDI and NCrunch instrumentation
 //// ncrunch: rdi off
 //// ncrunch: no coverage start
-// ReSharper disable once CheckNamespace
-#pragma warning disable IDE0130
-namespace System
+namespace MiKoSolutions.Analyzers
 {
     public readonly struct Pair : IEquatable<Pair>
     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3078_EnumMembersHaveValueAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3078_EnumMembersHaveValueAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_EqualsAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6040_MultiLineCallChainsAreOnSamePositionAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing


### PR DESCRIPTION
- Move `Pair` to `MiKoSolutions.Analyzers` namespace

- Remove unused `using` directives across analyzers

- Clean up formatting and reorder usings
