### PR TITLE
Enhanced MiKo_2230 to detect strange formatting of phrase and avoid multiple spaces in a row

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1240,6 +1240,26 @@ namespace MiKoSolutions.Analyzers
             return trimmed;
         }
 
+        internal static string GetTextTrimmed(this XmlTextSyntax value)
+        {
+            if (value is null)
+            {
+                return string.Empty;
+            }
+
+            var builder = StringBuilderCache.Acquire();
+
+            var trimmed = value.GetTextWithoutTrivia(builder)
+                               .WithoutParaTags()
+                               .WithoutNewLines()
+                               .WithoutMultipleWhiteSpaces()
+                               .Trim();
+
+            StringBuilderCache.Release(builder);
+
+            return trimmed;
+        }
+
         internal static string GetTextWithoutTrivia(this XmlTextAttributeSyntax value)
         {
             if (value is null)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         internal static SyntaxNode GetUpdatedSyntax(XmlElementSyntax comment, XmlTextSyntax textSyntax)
         {
-            var text = textSyntax.GetTextWithoutTrivia().AsSpan();
+            var text = textSyntax.GetTextTrimmed().AsSpan();
 
             if (text.StartsWith("Interaction logic for", StringComparison.Ordinal))
             {
@@ -174,7 +174,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // maybe it is a documentation that should be an inherit documentation instead
             if (content.FirstOrDefault() is XmlTextSyntax t)
             {
-                var text = t.GetTextWithoutTrivia();
+                var text = t.GetTextTrimmed();
 
                 if (text.IsNullOrWhiteSpace() && content.Count > 1 && content[1].IsSeeCref())
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (content.Count > 0 && content[0] is XmlTextSyntax textSyntax)
                 {
-                    var startText = textSyntax.GetTextWithoutTrivia();
+                    var startText = textSyntax.GetTextTrimmed();
 
                     if (startText.StartsWith("Given ", StringComparison.Ordinal))
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
@@ -78,7 +78,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         // we seem to have an issue here, so inspect the code
                         if (HasIssue(symbol, semanticModel, cref))
                         {
-                            var text = t.GetTextWithoutTrivia();
+                            var text = t.GetTextTrimmed();
 
                             if (text.IsNullOrWhiteSpace())
                             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 case 0:
                     return CommentStartingWith(preparedComment, phrase + Constants.TODO + ".");
 
-                case 1 when contents[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
+                case 1 when contents[0] is XmlTextSyntax text && text.GetTextTrimmed().IsNullOrEmpty():
                     return comment.ReplaceNode(text, XmlText(phrase + Constants.TODO + ".").WithLeadingXmlComment().WithTrailingXmlComment());
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -137,7 +137,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 case 1 when contents[0] is XmlTextSyntax t:
                 {
-                    var text = t.GetTextWithoutTrivia().AsSpan();
+                    var text = t.GetTextTrimmed().AsSpan();
 
                     if (text.IsEmpty)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
@@ -82,7 +82,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     if (contents[1].IsSeeCrefTask() && contents[2] is XmlTextSyntax continueText)
                     {
                         // might be an almost complete text
-                        var text = continueText.GetTextWithoutTrivia();
+                        var text = continueText.GetTextTrimmed();
 
                         if (text.StartsWithAny(ContinueTextParts))
                         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (contents.First() is XmlTextSyntax t)
             {
-                var text = t.GetTextWithoutTrivia();
+                var text = t.GetTextTrimmed();
 
                 if (text.StartsWith("If ", StringComparison.OrdinalIgnoreCase) && text.ContainsAny(UnwantedResultTexts))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (contents.Count is 1 && contents[0] is XmlTextSyntax txt)
             {
-                var text = txt.GetTextWithoutTrivia();
+                var text = txt.GetTextTrimmed();
 
                 if (text.StartsWith("Enum", StringComparison.Ordinal))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2225_CodeFixProvider.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (syntax is XmlElementSyntax element && element.Content.FirstOrDefault() is XmlTextSyntax text)
             {
-                var code = text.GetTextWithoutTrivia();
+                var code = text.GetTextTrimmed();
 
                 return element.WithContent(XmlText(code));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (token.Parent is XmlTextSyntax node)
             {
-                var text = node.GetTextWithoutTrivia();
+                var text = node.GetTextTrimmed();
 
                 return syntax.ReplaceNode(node, UpdateText(text.AsSpan()));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzer.cs
@@ -26,8 +26,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return Array.Empty<Diagnostic>();
             }
 
-            return xmlSyntax.GetXmlTextTokens()
-                            .Where(_ => _.ValueText.Contains(Constants.Comments.ValueMeaningPhrase, StringComparison.Ordinal))
+            return xmlSyntax.SelectMany(_ => _.Content.OfType<XmlTextSyntax>())
+                            .Where(_ => _.GetTextTrimmed().Contains(Constants.Comments.ValueMeaningPhrase, StringComparison.Ordinal))
                             .Select(_ => Issue(_))
                             .ToArray();
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_CodeFixProvider.cs
@@ -89,7 +89,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             void RemoveEmptyText(int i)
             {
-                if (content.Count > i && content[i] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty())
+                if (content.Count > i && content[i] is XmlTextSyntax text && text.GetTextTrimmed().IsNullOrEmpty())
                 {
                     content.RemoveAt(i);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2232_EmptySummaryAnalyzer.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 switch (content.Count)
                 {
                     case 0:
-                    case 1 when content[0] is XmlTextSyntax text && text.GetTextWithoutTrivia().IsNullOrEmpty():
+                    case 1 when content[0] is XmlTextSyntax text && text.GetTextTrimmed().IsNullOrEmpty():
                         return new[] { Issue(summary) };
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
@@ -49,7 +49,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (content.Count > 0 && content[0] is XmlTextSyntax node)
                     {
-                        var text = node.GetTextWithoutTrivia();
+                        var text = node.GetTextTrimmed();
 
                         if (text.StartsWithAny(WrongStartingPhrases, StringComparison.Ordinal))
                         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
@@ -249,6 +249,77 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_problematic_text_in_comparer_on_separate_lines_with_additional_spaces()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A value that indicates something being compared.
+    /// The return value has these meanings: Value Meaning Less than zero x is 
+    /// less than y. Zero x equals y. Greater than zero x is 
+    /// greater than y.
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A value that indicates something being compared. The return value has these meanings:
+    /// <list type=""table"">
+    /// <listheader><term>Value</term><description>Meaning</description></listheader>
+    /// <item><term>Less than zero</term><description>x is less than y.</description></item>
+    /// <item><term>Zero</term><description>x equals y.</description></item>
+    /// <item><term>Greater than zero</term><description>x is greater than y.</description></item>
+    /// </list>
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_problematic_text_in_comparer_on_separate_lines_with_additional_spaces_and_strange_text_split_of_Value_Meaning()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A value that indicates something being compared.
+    /// The return value has these meanings: Value
+    /// Meaning Less than zero x is 
+    /// less than y. Zero x equals y. Greater than zero x is 
+    /// greater than y.
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A value that indicates something being compared. The return value has these meanings:
+    /// <list type=""table"">
+    /// <listheader><term>Value</term><description>Meaning</description></listheader>
+    /// <item><term>Less than zero</term><description>x is less than y.</description></item>
+    /// <item><term>Zero</term><description>x equals y.</description></item>
+    /// <item><term>Greater than zero</term><description>x is greater than y.</description></item>
+    /// </list>
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2230_ReturnValueUsesListAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2230_ReturnValueUsesListAnalyzer();


### PR DESCRIPTION
- Add `GetTextTrimmed` extension for `XmlTextSyntax`

- Replace `GetTextWithoutTrivia` calls with trimmed method

- Update analyzers and code fixes for normalized whitespace

- Add tests for problematic spaced text
