### PR TITLE
Added test for RDI-off marker

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -216,6 +216,26 @@ namespace MiKoSolutions.Analyzers.Rules
                                  });
         }
 
+        [Ignore("Shall be run manually")]
+        [Explicit]
+        [TestCase(@"<TODO>\MiKo.Analyzer.Tests\", "*Tests.cs"), Timeout(60 * 1000)]
+        public static void Files_are_RDI_excluded_(string path, string searchPattern)
+        {
+            const string NcrunchRdiMarker = "//// ncrunch: rdi off";
+
+            var files = Directory.EnumerateFiles(path, searchPattern, SearchOption.AllDirectories);
+
+            Assert.Multiple(() =>
+                                 {
+                                     foreach (var file in files)
+                                     {
+                                         var hasMarker = File.ReadLines(file).Any(_ => _.AsSpan().Trim().Equals(NcrunchRdiMarker.AsSpan(), StringComparison.Ordinal));
+
+                                         Assert.That(hasMarker, Is.True, Path.GetFileName(file));
+                                     }
+                                 });
+        }
+
         [Test]
         public static void Analyzers_are_available() => Assert.That(AllAnalyzers.Length, Is.Not.Zero);
 


### PR DESCRIPTION
- Add manual test for RDI-off markers in test files

- Mark test as manual with [Ignore] and [Explicit]

- Parameterize scan with [TestCase] and Timeout

- Assert each file has RDI-off marker
