### PR TITLE
Fixed code so that tests that suddenly fail no longer fail

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzer.cs
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return false;
         }
 
-        private static bool IsStringFormatExtension(IMethodSymbol method) => method.ReturnType.SpecialType is SpecialType.System_String && method.Name.StartsWith("Format", StringComparison.Ordinal);
+        private static bool IsStringFormatExtension(IMethodSymbol method) => method.ReturnType.SpecialType is SpecialType.System_String && method.Name.StartsWith(nameof(string.Format), StringComparison.Ordinal);
 
         private static string FindBetterName(IParameterSymbol symbol)
         {
@@ -91,7 +91,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private Diagnostic[] AnalyzeName(IParameterSymbol parameter, params string[] names)
         {
-            if (names.Any(_ => _ == parameter.Name))
+            var parameterName = parameter.Name;
+
+            if (parameterName.IsNullOrEmpty() || names.Any(_ => _ == parameterName))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -554,8 +554,8 @@ namespace Bla
              @"public void Do(IEnumerable e, object o) => CollectionAssert.DoesNotContain(e, o, ""my message"");",
              @"public void Do(IEnumerable e, object o) => Assert.That(e, Does.Not.Contain(o), ""my message"");")]
         [TestCase(
-             @"public void Do(IEnumerable e, object o) => CollectionAssert.Contains(e, o, ""my message"");",
-             @"public void Do(IEnumerable e, object o) => Assert.That(e, Does.Contain(o), ""my message"");")]
+             @"public void Do(IEnumerable e, Object o) => CollectionAssert.Contains(e, o, ""my message"");",
+             @"public void Do(IEnumerable e, Object o) => Assert.That(e, Does.Contain(o), ""my message"");")]
         [TestCase(
              @"public void Do(string s) => StringAssert.StartsWith(""abc"", s, ""my message"");",
              @"public void Do(string s) => Assert.That(s, Does.StartWith(""abc""), ""my message"");")]


### PR DESCRIPTION
- Replace literal `"Format"` with `nameof(string.Format)`

- Add empty-name guard in parameter analyzer

- Adjust TestCase parameter type to `Object`

