### PR TITLE
MiKo_2230 is now aware of XML tags inside the comments to fix

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -784,6 +784,8 @@ namespace System
             return false;
         }
 
+        public static bool ContainsXml(this string value) => value.Contains('<') && value.Contains("/>");
+
         public static int CountLeadingWhitespaces(this string value, int start = 0)
         {
             var whitespaces = 0;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzer.cs
@@ -26,9 +26,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return Array.Empty<Diagnostic>();
             }
 
-            return xmlSyntax.SelectMany(_ => _.Content.OfType<XmlTextSyntax>())
-                            .Where(_ => _.GetTextTrimmed().Contains(Constants.Comments.ValueMeaningPhrase, StringComparison.Ordinal))
-                            .Select(_ => Issue(_))
+            return xmlSyntax.Where(_ => _.GetTextTrimmed().Contains(Constants.Comments.ValueMeaningPhrase, StringComparison.Ordinal))
+                            .Select(_ => Issue(_.GetContentsLocation()))
                             .ToArray();
         }
     }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
@@ -320,6 +320,38 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_problematic_text_in_comparer_on_separate_lines_with_paramref_texts()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A signed integer that indicates the relative values of <paramref name=""x""/> and <paramref name=""y""/>, as shown in the following table.Value Meaning Less than zero<paramref name=""x""/> is less than <paramref name=""y""/>.Zero<paramref name=""x""/> equals <paramref name=""y""/>.Greater than zero<paramref name=""x""/> is greater than <paramref name=""y""/>.
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <returns>
+    /// A signed integer that indicates the relative values of <paramref name=""x""/> and <paramref name=""y""/>, as shown in the following table.
+    /// <list type=""table"">
+    /// <listheader><term>Value</term><description>Meaning</description></listheader>
+    /// <item><term>Less than zero</term><description><paramref name=""x""/> is less than <paramref name=""y""/>.</description></item>
+    /// <item><term>Zero</term><description><paramref name=""x""/> equals <paramref name=""y""/>.</description></item>
+    /// <item><term>Greater than zero</term><description><paramref name=""x""/> is greater than <paramref name=""y""/>.</description></item>
+    /// </list>
+    /// </returns>
+    public int Compare(int x, int y) => 42;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2230_ReturnValueUsesListAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2230_ReturnValueUsesListAnalyzer();


### PR DESCRIPTION
- Add `ContainsXml` extension for XML detection

- Enhance code fix to split XML comments into lists

- Refactor XML node parsing and helper methods

- Add test for multiline XML comments fix

