### PR TITLE
MiKo_2100 is now aware of <example> documentation starting directly with <code> tags

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_CodeFixProvider.cs
@@ -11,11 +11,42 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2100_CodeFixProvider : ExampleDocumentationCodeFixProvider
     {
         private const string Phrase = Constants.Comments.ExampleDefaultPhrase;
+        private const string CompletePhrase = Phrase + "its usage.";
 
         public override string FixableDiagnosticId => "MiKo_2100";
 
         protected override string Title => Resources.MiKo_2100_CodeFixTitle.FormatWith(Phrase);
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => CommentStartingWith((XmlElementSyntax)syntax, Phrase);
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is XmlElementSyntax element)
+            {
+                var content = element.Content;
+
+                if (content.Count > 0)
+                {
+                    if (content[0].IsCode())
+                    {
+                        var xmlText = XmlText(CompletePhrase).WithLeadingXmlComment()
+                                                             .WithTrailingNewLine()
+                                                             .WithTrailingXmlComment();
+
+                        return element.WithContent(element.Content.Insert(0, xmlText));
+                    }
+
+                    if (content[0].IsWhiteSpaceOnlyText() && content.Count > 1 && content[1].IsCode())
+                    {
+                        var xmlText = XmlText(CompletePhrase).WithTrailingNewLine()
+                                                             .WithTrailingXmlComment();
+
+                        return element.WithContent(element.Content.Insert(1, xmlText));
+                    }
+
+                    return CommentStartingWith(element, Phrase);
+                }
+            }
+
+            return syntax;
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
@@ -184,6 +184,117 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_code_sample_with_introduction_text()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example>
+    /// Some example:
+    /// <code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example>
+    /// The following example demonstrates some example:
+    /// <code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_code_sample_without_introduction_text()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example>
+    /// The following example demonstrates its usage.
+    /// <code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_code_sample_without_introduction_text_and_placed_on_single_line()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example><code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary>
+    /// Some documentation.
+    /// </summary>
+    /// <example>
+    /// The following example demonstrates its usage.
+    /// <code>
+    /// some code here
+    /// </code>
+    /// </example>
+    public void DoSomething() { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2100_ExampleDefaultPhraseAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2100_ExampleDefaultPhraseAnalyzer();


### PR DESCRIPTION
- Introduce default `CompletePhrase` constant

- Extend `GetUpdatedSyntax` to handle direct `<code>` examples

- Insert XML intro before code or whitespace nodes

- Add tests for various example code placements
