### PR TITLE
'FirstWordHandling' renamed to 'FirstWordAdjustment'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/FirstWordAdjustmentExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/FirstWordAdjustmentExtensions.cs
@@ -8,9 +8,9 @@ using MiKoSolutions.Analyzers.Linguistics;
 #pragma warning disable IDE0130
 namespace System
 {
-    internal static class FirstWordHandlingExtensions
+    internal static class FirstWordAdjustmentExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool HasSet(this FirstWordHandling value, in FirstWordHandling flag) => (value & flag) == flag;
+        public static bool HasSet(this FirstWordAdjustment value, in FirstWordAdjustment flag) => (value & flag) == flag;
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Text
 
         private static readonly ArrayPool<char> SharedPool = ArrayPool<char>.Shared;
 
-        public static StringBuilder AdjustFirstWord(this StringBuilder value, in FirstWordHandling handling)
+        public static StringBuilder AdjustFirstWord(this StringBuilder value, in FirstWordAdjustment adjustment)
         {
             if (value.IsNullOrEmpty() || value[0] is '<')
             {
@@ -25,26 +25,26 @@ namespace System.Text
             }
 
             // only keep it if there is already a leading space (otherwise it may be on the same line without any leading space, and we would fix it in a wrong way)
-            value.TrimLeadingSpacesTo(handling.HasSet(FirstWordHandling.KeepSingleLeadingSpace) ? 1 : 0);
+            value.TrimLeadingSpacesTo(adjustment.HasSet(FirstWordAdjustment.KeepSingleLeadingSpace) ? 1 : 0);
 
-            if (handling.HasSet(FirstWordHandling.StartLowerCase))
+            if (adjustment.HasSet(FirstWordAdjustment.StartLowerCase))
             {
                 value.StartLowerCase();
             }
-            else if (handling.HasSet(FirstWordHandling.StartUpperCase))
+            else if (adjustment.HasSet(FirstWordAdjustment.StartUpperCase))
             {
                 value.StartUpperCase();
             }
 
-            if (handling.HasSet(FirstWordHandling.MakeInfinite))
+            if (adjustment.HasSet(FirstWordAdjustment.MakeInfinite))
             {
                 value.MakeInfinite();
             }
-            else if (handling.HasSet(FirstWordHandling.MakePlural))
+            else if (adjustment.HasSet(FirstWordAdjustment.MakePlural))
             {
                 value.MakePlural();
             }
-            else if (handling.HasSet(FirstWordHandling.MakeThirdPersonSingular))
+            else if (adjustment.HasSet(FirstWordAdjustment.MakeThirdPersonSingular))
             {
                 value.MakeThirdPersonSingular();
             }
@@ -52,7 +52,7 @@ namespace System.Text
             return value;
         }
 
-        public static StringBuilder AdjustWordAfter(this StringBuilder value, string phrase, in FirstWordHandling handling)
+        public static StringBuilder AdjustWordAfter(this StringBuilder value, string phrase, in FirstWordAdjustment adjustment)
         {
             if (phrase.IsNullOrEmpty())
             {
@@ -96,7 +96,7 @@ namespace System.Text
                         var nextWordLength = nextWordEndIndex - nextWordStartIndex + 1;
 
                         var nextWord = value.ToString(nextWordStartIndex, nextWordLength);
-                        var adjustedWord = nextWord.AdjustFirstWord(handling);
+                        var adjustedWord = nextWord.AdjustFirstWord(adjustment);
 
                         // cut it out
                         value.Remove(nextWordStartIndex, nextWordLength);
@@ -284,7 +284,7 @@ namespace System.Text
             return value.Replace(oldValue, newValue, replaceStartIndex, value.Length - replaceStartIndex);
         }
 
-        public static StringBuilder SeparateWords(this StringBuilder value, in char separator, in FirstWordHandling firstWordHandling = FirstWordHandling.None)
+        public static StringBuilder SeparateWords(this StringBuilder value, in char separator, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.None)
         {
             if (value.IsNullOrEmpty())
             {
@@ -385,7 +385,7 @@ namespace System.Text
                 }
             }
 
-            return value.AdjustFirstWord(firstWordHandling);
+            return value.AdjustFirstWord(firstWordAdjustment);
         }
 
         public static StringBuilder Trimmed(this StringBuilder value)

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -31,7 +31,7 @@ namespace System
 
         private static readonly Regex PascalCasingRegex = new Regex("[a-z]+[A-Z]+", RegexOptions.Compiled, 100.Milliseconds());
 
-        public static string AdjustFirstWord(this string value, in FirstWordHandling handling)
+        public static string AdjustFirstWord(this string value, in FirstWordAdjustment adjustment)
         {
             if (value.StartsWith('<'))
             {
@@ -42,7 +42,7 @@ namespace System
 
             string word;
 
-            if (handling.HasSet(FirstWordHandling.StartLowerCase))
+            if (adjustment.HasSet(FirstWordAdjustment.StartLowerCase))
             {
                 var firstWord = valueSpan.FirstWord();
 
@@ -55,7 +55,7 @@ namespace System
             {
                 var firstWord = valueSpan.FirstWord();
 
-                word = handling.HasSet(FirstWordHandling.StartUpperCase)
+                word = adjustment.HasSet(FirstWordAdjustment.StartUpperCase)
                        ? firstWord.ToUpperCaseAt(0)
                        : firstWord.ToString();
             }
@@ -63,20 +63,20 @@ namespace System
             // build continuation here because the word length may change based on the infinite term
             var continuation = valueSpan.TrimStart().Slice(word.Length);
 
-            if (handling.HasSet(FirstWordHandling.MakeInfinite))
+            if (adjustment.HasSet(FirstWordAdjustment.MakeInfinite))
             {
                 word = Verbalizer.MakeInfiniteVerb(word);
             }
-            else if (handling.HasSet(FirstWordHandling.MakePlural))
+            else if (adjustment.HasSet(FirstWordAdjustment.MakePlural))
             {
                 word = Pluralizer.MakePluralName(word);
             }
-            else if (handling.HasSet(FirstWordHandling.MakeThirdPersonSingular))
+            else if (adjustment.HasSet(FirstWordAdjustment.MakeThirdPersonSingular))
             {
                 word = Verbalizer.MakeThirdPersonSingularVerb(word);
             }
 
-            if (handling.HasSet(FirstWordHandling.KeepSingleLeadingSpace))
+            if (adjustment.HasSet(FirstWordAdjustment.KeepSingleLeadingSpace))
             {
                 // only keep it if there is already a leading space (otherwise it may be on the same line without any leading space, and we would fix it in a wrong way)
                 if (value.StartsWith(' '))

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3829,21 +3829,21 @@ namespace MiKoSolutions.Analyzers
             return value;
         }
 
-        internal static SyntaxList<XmlNodeSyntax> WithStartText(this XmlElementSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase) => value.Content.WithStartText(startText, firstWordHandling);
+        internal static SyntaxList<XmlNodeSyntax> WithStartText(this XmlElementSyntax value, string startText, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase) => value.Content.WithStartText(startText, firstWordAdjustment);
 
-        internal static SyntaxList<XmlNodeSyntax> WithStartText(this in SyntaxList<XmlNodeSyntax> values, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
+        internal static SyntaxList<XmlNodeSyntax> WithStartText(this in SyntaxList<XmlNodeSyntax> values, string startText, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase)
         {
             if (values.Count > 0)
             {
                 return values[0] is XmlTextSyntax textSyntax
-                       ? values.Replace(textSyntax, textSyntax.WithStartText(startText, firstWordHandling))
+                       ? values.Replace(textSyntax, textSyntax.WithStartText(startText, firstWordAdjustment))
                        : values.Insert(0, XmlText(startText));
             }
 
             return XmlText(startText).ToSyntaxList<XmlNodeSyntax>();
         }
 
-        internal static XmlTextSyntax WithStartText(this XmlTextSyntax value, string startText, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
+        internal static XmlTextSyntax WithStartText(this XmlTextSyntax value, string startText, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase)
         {
             var tokens = value.TextTokens;
 
@@ -3887,7 +3887,7 @@ namespace MiKoSolutions.Analyzers
                 var space = i is 0 ? string.Empty : " ";
 
                 // replace 3rd person word by infinite word if configured
-                var continuation = originalText.AdjustFirstWord(firstWordHandling);
+                var continuation = originalText.AdjustFirstWord(firstWordAdjustment);
 
                 var modifiedText = space + startText + continuation;
 

--- a/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/ArticleProvider.cs
@@ -4,9 +4,9 @@ namespace MiKoSolutions.Analyzers.Linguistics
 {
     internal static class ArticleProvider
     {
-        internal static string GetArticleFor(string text, in FirstWordHandling firstWordHandling = FirstWordHandling.None) => GetArticleFor(text.AsSpan(), firstWordHandling);
+        internal static string GetArticleFor(string text, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.None) => GetArticleFor(text.AsSpan(), firstWordAdjustment);
 
-        internal static string GetArticleFor(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling = FirstWordHandling.None)
+        internal static string GetArticleFor(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.None)
         {
             if (text.Length is 0)
             {
@@ -25,33 +25,33 @@ namespace MiKoSolutions.Analyzers.Linguistics
             // | H / h  | ~ 3.5           |
             if (text.StartsWithAny("AaIi"))
             {
-                return An(firstWordHandling);
+                return An(firstWordAdjustment);
             }
 
             if (text.StartsWithAny("Hh"))
             {
-                return ArticleForH(text, firstWordHandling);
+                return ArticleForH(text, firstWordAdjustment);
             }
 
             if (text.StartsWithAny("Oo"))
             {
-                return ArticleForO(text, firstWordHandling);
+                return ArticleForO(text, firstWordAdjustment);
             }
 
             if (text.StartsWithAny("Ee"))
             {
-                return ArticleForE(text, firstWordHandling);
+                return ArticleForE(text, firstWordAdjustment);
             }
 
             if (text.StartsWithAny("Uu"))
             {
-                return ArticleForU(text, firstWordHandling);
+                return ArticleForU(text, firstWordAdjustment);
             }
 
-            return A(firstWordHandling);
+            return A(firstWordAdjustment);
         }
 
-        private static string ArticleForU(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling)
+        private static string ArticleForU(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment)
         {
             if (text.StartsWith("uni", StringComparison.OrdinalIgnoreCase))
             {
@@ -63,61 +63,61 @@ namespace MiKoSolutions.Analyzers.Linguistics
                         case 'N':
                         {
                             // something like 'uninformed', so is a vowel sound
-                            return An(firstWordHandling);
+                            return An(firstWordAdjustment);
                         }
                     }
                 }
 
                 // uni is pronounced like 'yuni' where 'y' is a consonant and no vowel sound, hence we have to use 'A'
-                return A(firstWordHandling);
+                return A(firstWordAdjustment);
             }
 
             if (text.StartsWith("use", StringComparison.OrdinalIgnoreCase))
             {
                 // something like 'use case' or 'user'
-                return A(firstWordHandling);
+                return A(firstWordAdjustment);
             }
 
-            return An(firstWordHandling);
+            return An(firstWordAdjustment);
         }
 
-        private static string ArticleForE(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling)
+        private static string ArticleForE(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment)
         {
             if (text.StartsWith("eu", StringComparison.OrdinalIgnoreCase))
             {
                 // Words like 'european' start with a 'y' sound which is a consonant and no vowel sound, hence we have to use 'A'
-                return A(firstWordHandling);
+                return A(firstWordAdjustment);
             }
 
-            return An(firstWordHandling);
+            return An(firstWordAdjustment);
         }
 
-        private static string ArticleForO(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling)
+        private static string ArticleForO(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment)
         {
             if (text.StartsWith("on", StringComparison.OrdinalIgnoreCase))
             {
                 // in English, the words 'one' or 'once' begin with the letter 'o', but they are pronounced with an initial 'w' sound which is a consonant sound, not a vowel sound
-                return A(firstWordHandling);
+                return A(firstWordAdjustment);
             }
 
-            return An(firstWordHandling);
+            return An(firstWordAdjustment);
         }
 
-        private static string ArticleForH(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling)
+        private static string ArticleForH(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment)
         {
             if (text.StartsWith("herb", StringComparison.OrdinalIgnoreCase) // in American English, 'h' is silent in 'herb', so it starts with a vowel sound
              || text.StartsWith("heir", StringComparison.OrdinalIgnoreCase) // 'h' is silent in 'heir', so it starts with a vowel sound
              || text.StartsWith("hon", StringComparison.OrdinalIgnoreCase) // 'h' it is silent in 'honest', so it starts with a vowel sound
              || text.StartsWith("hou", StringComparison.OrdinalIgnoreCase)) // 'h' is silent in 'hour', so it starts with a vowel sound
             {
-                return An(firstWordHandling);
+                return An(firstWordAdjustment);
             }
 
-            return A(firstWordHandling);
+            return A(firstWordAdjustment);
         }
 
-        private static string A(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.StartLowerCase) ? "a " : "A ";
+        private static string A(in FirstWordAdjustment adjustment) => adjustment.HasSet(FirstWordAdjustment.StartLowerCase) ? "a " : "A ";
 
-        private static string An(in FirstWordHandling handling) => handling.HasSet(FirstWordHandling.StartLowerCase) ? "an " : "An ";
+        private static string An(in FirstWordAdjustment adjustment) => adjustment.HasSet(FirstWordAdjustment.StartLowerCase) ? "an " : "An ";
     }
 }

--- a/MiKo.Analyzer.Shared/Linguistics/FirstWordAdjustment.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/FirstWordAdjustment.cs
@@ -3,10 +3,10 @@
 namespace MiKoSolutions.Analyzers.Linguistics
 {
     /// <summary>
-    /// Defines values that specify how to handle the first word of a comment.
+    /// Defines values that specify how to handle the first word of a comment or name.
     /// </summary>
     [Flags]
-    public enum FirstWordHandling
+    public enum FirstWordAdjustment
     {
         /// <summary>
         /// Keep it, do NOT touch it.

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -527,17 +527,17 @@ namespace MiKoSolutions.Analyzers.Linguistics
             }
         }
 
-        public static string MakeFirstWordInfiniteVerb(string text, in FirstWordHandling handling = FirstWordHandling.None)
+        public static string MakeFirstWordInfiniteVerb(string text, in FirstWordAdjustment adjustment = FirstWordAdjustment.None)
         {
             if (text.IsNullOrWhiteSpace())
             {
                 return text;
             }
 
-            return MakeFirstWordInfiniteVerb(text.AsSpan(), handling);
+            return MakeFirstWordInfiniteVerb(text.AsSpan(), adjustment);
         }
 
-        public static string MakeFirstWordInfiniteVerb(in ReadOnlySpan<char> text, in FirstWordHandling firstWordHandling = FirstWordHandling.None)
+        public static string MakeFirstWordInfiniteVerb(in ReadOnlySpan<char> text, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.None)
         {
             if (text.IsNullOrWhiteSpace())
             {
@@ -554,7 +554,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
             }
 
             // first word
-            var firstWord = GetFirstWord(valueText, firstWordHandling);
+            var firstWord = GetFirstWord(valueText, firstWordAdjustment);
 
             var infiniteVerb = MakeInfiniteVerb(firstWord);
 
@@ -565,14 +565,14 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             return text.ToString();
 
-            string GetFirstWord(in ReadOnlySpan<char> span, in FirstWordHandling handling)
+            string GetFirstWord(in ReadOnlySpan<char> span, in FirstWordAdjustment adjustment)
             {
                 var word = span.FirstWord();
 
-                switch (handling)
+                switch (adjustment)
                 {
-                    case FirstWordHandling.StartLowerCase: return word.ToLowerCaseAt(0);
-                    case FirstWordHandling.StartUpperCase: return word.ToUpperCaseAt(0);
+                    case FirstWordAdjustment.StartLowerCase: return word.ToLowerCaseAt(0);
+                    case FirstWordAdjustment.StartUpperCase: return word.ToUpperCaseAt(0);
                     default:
                         return word.ToString();
                 }

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -13,7 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CommentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EnumerableExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensions\FirstWordHandlingExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\FirstWordAdjustmentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\LocationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ReadOnlySpanEnumeratorEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SplitReadOnlySpanEnumerator.cs" />
@@ -32,7 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\AbbreviationFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\ArticleProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\AscendingStringComparer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordHandling.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordAdjustment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -14,7 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CommentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EnumerableExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensions\FirstWordHandlingExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\FirstWordAdjustmentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\LocationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ReadOnlySpanEnumeratorEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SplitReadOnlySpanEnumerator.cs" />
@@ -32,7 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\AbbreviationFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\ArticleProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\AscendingStringComparer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordHandling.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Linguistics\FirstWordAdjustment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -99,18 +99,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlElementSyntax Comment(XmlElementSyntax comment, string text, string additionalComment = null) => Comment(comment, additionalComment is null ? XmlText(text) : XmlText(text + additionalComment));
 
-        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepSingleLeadingSpace)
+        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace)
         {
-            var result = Comment<XmlElementSyntax>(syntax, terms, replacementMap, firstWordHandling);
+            var result = Comment<XmlElementSyntax>(syntax, terms, replacementMap, firstWordAdjustment);
 
             return CombineTexts(result);
         }
 
-        protected static T Comment<T>(T syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordHandling firstWordHandling = FirstWordHandling.KeepSingleLeadingSpace) where T : SyntaxNode
+        protected static T Comment<T>(T syntax, in ReadOnlySpan<string> terms, in ReadOnlySpan<Pair> replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace) where T : SyntaxNode
         {
             var minimumLength = MinLength(terms);
 
-            var textMap = CreateReplacementTextMap(minimumLength, terms, replacementMap, firstWordHandling);
+            var textMap = CreateReplacementTextMap(minimumLength, terms, replacementMap, firstWordAdjustment);
 
             if (textMap is null)
             {
@@ -145,7 +145,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return minimum;
             }
 
-            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, in ReadOnlySpan<string> phrases, in ReadOnlySpan<Pair> map, in FirstWordHandling handling)
+            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, in ReadOnlySpan<string> phrases, in ReadOnlySpan<Pair> map, in FirstWordAdjustment adjustment)
             {
                 Dictionary<XmlTextSyntax, XmlTextSyntax> result = null;
 
@@ -178,7 +178,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         {
                             var replacedText = originalText.AsCachedBuilder()
                                                            .ReplaceAllWithProbe(map)
-                                                           .AdjustFirstWord(handling)
+                                                           .AdjustFirstWord(adjustment)
                                                            .ToStringAndRelease();
 
                             if (originalText.AsSpan().SequenceEqual(replacedText.AsSpan()))
@@ -364,19 +364,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, in ReadOnlySpan<string> phrases, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
+        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, in ReadOnlySpan<string> phrases, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase)
         {
-            return CommentStartingWith(comment, phrases[0], firstWordHandling);
+            return CommentStartingWith(comment, phrases[0], firstWordAdjustment);
         }
 
-        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
+        protected static XmlElementSyntax CommentStartingWith(XmlElementSyntax comment, string phrase, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase)
         {
-            var content = CommentStartingWith(comment.Content, phrase, firstWordHandling);
+            var content = CommentStartingWith(comment.Content, phrase, firstWordAdjustment);
 
             return CommentWithContent(comment, content);
         }
 
-        protected static SyntaxList<XmlNodeSyntax> CommentStartingWith(SyntaxList<XmlNodeSyntax> content, string phrase, in FirstWordHandling firstWordHandling = FirstWordHandling.StartLowerCase)
+        protected static SyntaxList<XmlNodeSyntax> CommentStartingWith(SyntaxList<XmlNodeSyntax> content, string phrase, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.StartLowerCase)
         {
             // when necessary adjust beginning text
             // Note: when on new line, then the text is not the 1st one but the 2nd one
@@ -397,7 +397,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     text = text.WithoutTrailingXmlComment();
                 }
 
-                var newText = text.WithStartText(phrase, firstWordHandling);
+                var newText = text.WithStartText(phrase, firstWordAdjustment);
 
                 return content.Insert(index, newText);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return fixedComment;
         }
 
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
+        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
 
 //// ncrunch: rdi off
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (text.StartsWithAny(EmptyReplacementsMapKeys, StringComparison.Ordinal))
             {
-                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordHandling.StartUpperCase | FirstWordHandling.MakeThirdPersonSingular | FirstWordHandling.KeepSingleLeadingSpace);
+                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
             }
 
             if (comment.GetEnclosing(Declarations) is MemberDeclarationSyntax member)
@@ -158,7 +158,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return GetUpdatedSyntax(comment, t);
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
+            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
         }
 
         private static XmlEmptyElementSyntax GetUpdatedSyntaxWithInheritdoc(in SyntaxList<XmlNodeSyntax> content)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -135,17 +135,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                    .Without("Kind")
                                                    .Without("Enum")
                                                    .WithoutAbbreviations()
-                                                   .AdjustFirstWord(FirstWordHandling.MakePlural)
-                                                   .SeparateWords(' ', FirstWordHandling.StartLowerCase);
+                                                   .AdjustFirstWord(FirstWordAdjustment.MakePlural)
+                                                   .SeparateWords(' ', FirstWordAdjustment.StartLowerCase);
                     }
                     else
                     {
-                        continuation = continuation.AdjustFirstWord(FirstWordHandling.StartLowerCase);
+                        continuation = continuation.AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
                     }
                 }
                 else
                 {
-                    continuation = continuation.AdjustFirstWord(FirstWordHandling.StartLowerCase);
+                    continuation = continuation.AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
                 }
 
                 var finalText = continuation.Insert(0, startingPhrase)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
@@ -18,6 +18,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override string Title => Resources.MiKo_2016_CodeFixTitle.FormatWith(Phrase);
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => CommentStartingWith((XmlElementSyntax)syntax, Phrase, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeThirdPersonSingular);
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => CommentStartingWith((XmlElementSyntax)syntax, Phrase, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -227,7 +227,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 commentContinuation.Append(ReplacementTo);
 
-                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(text, FirstWordHandling.StartLowerCase);
+                var continuation = Verbalizer.MakeFirstWordInfiniteVerb(text, FirstWordAdjustment.StartLowerCase);
 
                 commentContinuation.Append(continuation);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
@@ -39,8 +39,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             // TODO RKN: Update comment base on whether we have a Flags enum or not (defined as part of the properties of the reported issue)
             var updatedComment = isFlagged
-                                 ? Comment(comment, FlagsReplacementMapKeys, FlagsReplacementMap, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeThirdPersonSingular)
-                                 : Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartLowerCase);
+                                 ? Comment(comment, FlagsReplacementMapKeys, FlagsReplacementMap, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular)
+                                 : Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
 
             return CommentStartingWith(updatedComment, phrase);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
-                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordHandling.StartLowerCase);
+                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
                     var startText = switchedText.AsCachedBuilder().Insert(0, ' ').TrimmedEnd().ToStringAndRelease();
 
                     var updatedContents = contents.Remove(t);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -84,8 +84,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (WellKnownTypeNames.Contains(typeName) is false)
                 {
                     var text = typeName.AsCachedBuilder()
-                                       .AdjustFirstWord(FirstWordHandling.MakePlural)
-                                       .SeparateWords(' ', FirstWordHandling.StartLowerCase)
+                                       .AdjustFirstWord(FirstWordAdjustment.MakePlural)
+                                       .SeparateWords(' ', FirstWordAdjustment.StartLowerCase)
                                        .ToStringAndRelease();
 
                     if (text.Length > 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -50,9 +50,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (syntax is XmlElementSyntax element)
             {
-                var comment = Comment(element, CommandReplacementMapKeys, CommandReplacementMap, FirstWordHandling.StartLowerCase);
+                var comment = Comment(element, CommandReplacementMapKeys, CommandReplacementMap, FirstWordAdjustment.StartLowerCase);
 
-                return CommentStartingWith(comment, Constants.Comments.CommandSummaryStartingPhrase, FirstWordHandling.StartLowerCase | FirstWordHandling.MakeInfinite);
+                return CommentStartingWith(comment, Constants.Comments.CommandSummaryStartingPhrase, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeInfinite);
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             else
             {
                 var summary = summaries[0];
-                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordHandling.StartLowerCase);
+                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordAdjustment.StartLowerCase);
                 var newSummary = CommentStartingWith(preparedSummary, Phrase);
 
                 return comment.ReplaceNode(summary, newSummary);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -78,16 +78,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         }
                         else
                         {
-                            article = ArticleProvider.GetArticleFor(unsuffixedSpan, FirstWordHandling.StartLowerCase);
+                            article = ArticleProvider.GetArticleFor(unsuffixedSpan, FirstWordAdjustment.StartLowerCase);
                         }
 
                         unsuffixed = unsuffixed.ToLowerCaseAt(0);
 
-                        var firstWordHandling = FirstWordHandling.StartLowerCase;
+                        var firstWordHandling = FirstWordAdjustment.StartLowerCase;
 
                         if (isPlural)
                         {
-                            firstWordHandling |= FirstWordHandling.MakePlural;
+                            firstWordHandling |= FirstWordAdjustment.MakePlural;
                         }
 
                         var replacement = enumType.AsCachedBuilder()
@@ -106,7 +106,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordHandling.StartUpperCase | FirstWordHandling.KeepSingleLeadingSpace);
+            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var betterText = text.AsCachedBuilder()
                                  .ReplaceAllWithProbe(Replacements)
-                                 .AdjustFirstWord(FirstWordHandling.StartUpperCase)
+                                 .AdjustFirstWord(FirstWordAdjustment.StartUpperCase)
                                  .ToStringAndRelease();
 
             return betterText;

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -286,12 +286,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                            .ReplaceWithProbe("_will_be_", "_is_")
                            .ReplaceWithProbe("_will_", "_does_")
                            .Replace("__", "_")
-                           .AdjustWordAfter("_does_not_", FirstWordHandling.MakeInfinite)
+                           .AdjustWordAfter("_does_not_", FirstWordAdjustment.MakeInfinite)
                            .ReplaceWithProbe("_does_not_", "<4>")
-                           .AdjustWordAfter("_does_", FirstWordHandling.MakeThirdPersonSingular)
+                           .AdjustWordAfter("_does_", FirstWordAdjustment.MakeThirdPersonSingular)
                            .Replace("_does_", "_")
                            .ReplaceWithProbe("<4>", "_does_not_")
-                           .AdjustWordAfter("_to_", FirstWordHandling.MakeInfinite);
+                           .AdjustWordAfter("_to_", FirstWordAdjustment.MakeInfinite);
 
             return result.ToStringAndRelease();
         }
@@ -380,7 +380,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            var adjustedPart2 = part2.AdjustFirstWord(FirstWordHandling.MakeThirdPersonSingular);
+            var adjustedPart2 = part2.AdjustFirstWord(FirstWordAdjustment.MakeThirdPersonSingular);
 
             var addIf = IsIfRequired(part1, adjustedPart2);
             var ifToAdd = Verbalizer.IsThirdPersonSingularVerb(part1.AsSpan().FirstWord()) ? IfIt : If;

--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -72,70 +72,70 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("    This is a test     ", ExpectedResult = "    This is a test")]
         public static string TrimEnd_trims_string_at_end_(string s) => new StringBuilder(s).TrimEnd();
 
-        [TestCase("", FirstWordHandling.KeepSingleLeadingSpace, "")]
-        [TestCase(" ", FirstWordHandling.KeepSingleLeadingSpace, " ")]
-        [TestCase("  ", FirstWordHandling.KeepSingleLeadingSpace, " ")]
-        [TestCase("   ", FirstWordHandling.KeepSingleLeadingSpace, " ")]
-        [TestCase("This is a test", FirstWordHandling.KeepSingleLeadingSpace, "This is a test")]
-        [TestCase(" This is a test", FirstWordHandling.KeepSingleLeadingSpace, " This is a test")]
-        [TestCase("   This is a test", FirstWordHandling.KeepSingleLeadingSpace, " This is a test")]
-        [TestCase("This is a test", FirstWordHandling.StartLowerCase, "this is a test")]
-        [TestCase("this is a test", FirstWordHandling.StartLowerCase, "this is a test")]
-        [TestCase(" THis is a Test", FirstWordHandling.StartLowerCase, "tHis is a Test")]
-        [TestCase("   THis is a Test", FirstWordHandling.StartLowerCase, "tHis is a Test")]
-        [TestCase(" THis is a Test", FirstWordHandling.StartLowerCase | FirstWordHandling.KeepSingleLeadingSpace, " tHis is a Test")]
-        [TestCase("   THis is a Test", FirstWordHandling.StartLowerCase | FirstWordHandling.KeepSingleLeadingSpace, " tHis is a Test")]
-        [TestCase("This is a test", FirstWordHandling.StartUpperCase, "This is a test")]
-        [TestCase("this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
-        [TestCase(" this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
-        [TestCase("   this is a test", FirstWordHandling.StartUpperCase, "This is a test")]
-        [TestCase("this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepSingleLeadingSpace, "This is a test")]
-        [TestCase(" this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepSingleLeadingSpace, " This is a test")]
-        [TestCase("   this is a test", FirstWordHandling.StartUpperCase | FirstWordHandling.KeepSingleLeadingSpace, " This is a test")]
-        [TestCase("represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase(" represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase("   represents someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase(" represents someone", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent someone")]
-        [TestCase("   represents someone", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent someone")]
-        [TestCase("represents", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase("represents", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, "represent")]
-        [TestCase(" represents", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase(" represents", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent")]
-        [TestCase("   represents", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase("   represents", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent")]
-        [TestCase("represent someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase(" represent someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase("   represent someone", FirstWordHandling.MakeInfinite, "represent someone")]
-        [TestCase(" represent someone", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent someone")]
-        [TestCase("   represent someone", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent someone")]
-        [TestCase("represent", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase("represent", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, "represent")]
-        [TestCase(" represent", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase(" represent", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent")]
-        [TestCase("   represent", FirstWordHandling.MakeInfinite, "represent")]
-        [TestCase("   represent", FirstWordHandling.MakeInfinite | FirstWordHandling.KeepSingleLeadingSpace, " represent")]
-        [TestCase("message", FirstWordHandling.MakePlural, "messages")]
-        [TestCase("message", FirstWordHandling.MakePlural | FirstWordHandling.KeepSingleLeadingSpace, "messages")]
-        [TestCase(" message", FirstWordHandling.MakePlural | FirstWordHandling.KeepSingleLeadingSpace, " messages")]
-        [TestCase("   message", FirstWordHandling.MakePlural | FirstWordHandling.KeepSingleLeadingSpace, " messages")]
+        [TestCase("", FirstWordAdjustment.KeepSingleLeadingSpace, "")]
+        [TestCase(" ", FirstWordAdjustment.KeepSingleLeadingSpace, " ")]
+        [TestCase("  ", FirstWordAdjustment.KeepSingleLeadingSpace, " ")]
+        [TestCase("   ", FirstWordAdjustment.KeepSingleLeadingSpace, " ")]
+        [TestCase("This is a test", FirstWordAdjustment.KeepSingleLeadingSpace, "This is a test")]
+        [TestCase(" This is a test", FirstWordAdjustment.KeepSingleLeadingSpace, " This is a test")]
+        [TestCase("   This is a test", FirstWordAdjustment.KeepSingleLeadingSpace, " This is a test")]
+        [TestCase("This is a test", FirstWordAdjustment.StartLowerCase, "this is a test")]
+        [TestCase("this is a test", FirstWordAdjustment.StartLowerCase, "this is a test")]
+        [TestCase(" THis is a Test", FirstWordAdjustment.StartLowerCase, "tHis is a Test")]
+        [TestCase("   THis is a Test", FirstWordAdjustment.StartLowerCase, "tHis is a Test")]
+        [TestCase(" THis is a Test", FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.KeepSingleLeadingSpace, " tHis is a Test")]
+        [TestCase("   THis is a Test", FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.KeepSingleLeadingSpace, " tHis is a Test")]
+        [TestCase("This is a test", FirstWordAdjustment.StartUpperCase, "This is a test")]
+        [TestCase("this is a test", FirstWordAdjustment.StartUpperCase, "This is a test")]
+        [TestCase(" this is a test", FirstWordAdjustment.StartUpperCase, "This is a test")]
+        [TestCase("   this is a test", FirstWordAdjustment.StartUpperCase, "This is a test")]
+        [TestCase("this is a test", FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace, "This is a test")]
+        [TestCase(" this is a test", FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace, " This is a test")]
+        [TestCase("   this is a test", FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace, " This is a test")]
+        [TestCase("represents someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase(" represents someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase("   represents someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase(" represents someone", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent someone")]
+        [TestCase("   represents someone", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent someone")]
+        [TestCase("represents", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase("represents", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, "represent")]
+        [TestCase(" represents", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase(" represents", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent")]
+        [TestCase("   represents", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase("   represents", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent")]
+        [TestCase("represent someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase(" represent someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase("   represent someone", FirstWordAdjustment.MakeInfinite, "represent someone")]
+        [TestCase(" represent someone", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent someone")]
+        [TestCase("   represent someone", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent someone")]
+        [TestCase("represent", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase("represent", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, "represent")]
+        [TestCase(" represent", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase(" represent", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent")]
+        [TestCase("   represent", FirstWordAdjustment.MakeInfinite, "represent")]
+        [TestCase("   represent", FirstWordAdjustment.MakeInfinite | FirstWordAdjustment.KeepSingleLeadingSpace, " represent")]
+        [TestCase("message", FirstWordAdjustment.MakePlural, "messages")]
+        [TestCase("message", FirstWordAdjustment.MakePlural | FirstWordAdjustment.KeepSingleLeadingSpace, "messages")]
+        [TestCase(" message", FirstWordAdjustment.MakePlural | FirstWordAdjustment.KeepSingleLeadingSpace, " messages")]
+        [TestCase("   message", FirstWordAdjustment.MakePlural | FirstWordAdjustment.KeepSingleLeadingSpace, " messages")]
 
-        [TestCase("Abc", FirstWordHandling.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
-        [TestCase("abc", FirstWordHandling.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
-        [TestCase("ABC", FirstWordHandling.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("aBC", FirstWordHandling.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("AbC", FirstWordHandling.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("abC", FirstWordHandling.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("Abc", FirstWordAdjustment.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abc", FirstWordAdjustment.StartLowerCase, "abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("ABC", FirstWordAdjustment.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("aBC", FirstWordAdjustment.StartLowerCase, "aBC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("AbC", FirstWordAdjustment.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abC", FirstWordAdjustment.StartLowerCase, "abC")] // just as clarification, situation is tested by other tests as well
 
-        [TestCase("Abc", FirstWordHandling.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
-        [TestCase("abc", FirstWordHandling.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
-        [TestCase("ABC", FirstWordHandling.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("aBC", FirstWordHandling.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("AbC", FirstWordHandling.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
-        [TestCase("abC", FirstWordHandling.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
-        public static void AdjustFirstWordHandling(string s, in FirstWordHandling handling, string expectedResult)
+        [TestCase("Abc", FirstWordAdjustment.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abc", FirstWordAdjustment.StartUpperCase, "Abc")] // just as clarification, situation is tested by other tests as well
+        [TestCase("ABC", FirstWordAdjustment.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("aBC", FirstWordAdjustment.StartUpperCase, "ABC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("AbC", FirstWordAdjustment.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
+        [TestCase("abC", FirstWordAdjustment.StartUpperCase, "AbC")] // just as clarification, situation is tested by other tests as well
+        public static void AdjustFirstWord_(string s, in FirstWordAdjustment adjustment, string expectedResult)
         {
-            var resultFromSB = new StringBuilder(s).AdjustFirstWord(handling).ToString();
-            var resultFromS = s.AdjustFirstWord(handling);
+            var resultFromSB = new StringBuilder(s).AdjustFirstWord(adjustment).ToString();
+            var resultFromS = s.AdjustFirstWord(adjustment);
 
             Assert.Multiple(() =>
                                  {
@@ -144,10 +144,10 @@ namespace MiKoSolutions.Analyzers.Extensions
                                  });
         }
 
-        [TestCase("The next word kill me.", " word ", FirstWordHandling.MakeThirdPersonSingular, ExpectedResult = "The next word kills me.")]
-        [TestCase("The next word kills me.", " word ", FirstWordHandling.MakeThirdPersonSingular, ExpectedResult = "The next word kills me.")]
-        [TestCase("Method_does_not_added_something", "_does_not_", FirstWordHandling.MakeInfinite, ExpectedResult = "Method_does_not_add_something")]
-        public static string AdjustWordAfter(string s, string phrase, in FirstWordHandling handling) => new StringBuilder(s).AdjustWordAfter(phrase, handling).ToString();
+        [TestCase("The next word kill me.", " word ", FirstWordAdjustment.MakeThirdPersonSingular, ExpectedResult = "The next word kills me.")]
+        [TestCase("The next word kills me.", " word ", FirstWordAdjustment.MakeThirdPersonSingular, ExpectedResult = "The next word kills me.")]
+        [TestCase("Method_does_not_added_something", "_does_not_", FirstWordAdjustment.MakeInfinite, ExpectedResult = "Method_does_not_add_something")]
+        public static string AdjustWordAfter_(string s, string phrase, in FirstWordAdjustment adjustment) => new StringBuilder(s).AdjustWordAfter(phrase, adjustment).ToString();
 
         [TestCase("", ExpectedResult = "")]
         [TestCase("SomeValue", ExpectedResult = "Some_value")]


### PR DESCRIPTION
- Rename `FirstWordHandling` enum to `FirstWordAdjustment`

- Update extension methods and parameters accordingly

- Adjust all documentation code fixes to new enum name

- Update tests and project includes for renamed type
