### PR TITLE
Applied own rules to different types

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -1028,8 +1028,8 @@ namespace System
             var word = FirstSentence(span);
 
             return word != span
-                       ? word.ToString()
-                       : value;
+                   ? word.ToString()
+                   : value;
         }
 
         public static ReadOnlySpan<char> FirstSentence(this in ReadOnlySpan<char> value)

--- a/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
+++ b/MiKo.Analyzer.Shared/Extensions/WordsReadOnlySpanEnumerator.cs
@@ -16,8 +16,8 @@ namespace System
         public WordsReadOnlySpanEnumerator(in ReadOnlySpan<char> text)
         {
             m_text = text;
-            var textLength = text.Length;
 
+            var textLength = text.Length;
             var words = 1;
 
             // start at index 1 to skip first upper case character (and avoid return of empty word)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return SyntaxFactory.List<XmlNodeSyntax>().Add(XmlText(text).WithLeadingXmlComment());
         }
 
-        private static XmlElementSyntax XmlTable(ReadOnlySpan<char> text)
+        private static XmlElementSyntax XmlTable(in ReadOnlySpan<char> text)
         {
             // try to find all sentences by splitting the texts at the dots (that should indicate a sentence ending)
             var nodes = new List<XmlNodeSyntax>
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return XmlElement(Constants.XmlTag.ListType.Table, XmlText(Constants.TODO));
         }
 
-        private static bool TryCreateItems(ReadOnlySpan<char> text, List<XmlNodeSyntax> nodes)
+        private static bool TryCreateItems(in ReadOnlySpan<char> text, List<XmlNodeSyntax> nodes)
         {
             const string LessThanZero = Constants.Comments.LessThanZero;
             const string Zero = Constants.Comments.Zero;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return syntax;
         }
 
-        private static SyntaxList<XmlNodeSyntax> UpdateText(ReadOnlySpan<char> text)
+        private static SyntaxList<XmlNodeSyntax> UpdateText(in ReadOnlySpan<char> text)
         {
             const string ValueMeaning = Constants.Comments.ValueMeaningPhrase;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
@@ -102,7 +102,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return SyntaxFactory.DocumentationComment(contents.ToArray<XmlNodeSyntax>());
         }
 
-        private static XmlElementSyntax Create(string commentTag, string xmlTag, List<string> comments, int spaces, string[] otherFoundCommentTags)
+        private static XmlElementSyntax Create(string commentTag, string xmlTag, List<string> comments, in int spaces, string[] otherFoundCommentTags)
         {
             if (TryFindComments(comments, commentTag, otherFoundCommentTags, out var index, out var count))
             {
@@ -137,7 +137,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax CreateParamTag(string name, string text) => Comment(SyntaxFactory.XmlParamElement(name), text);
 
-        private static XmlElementSyntax[] CreateMultiple(string xmlTag, int spaces, List<Pair> pairs)
+        private static XmlElementSyntax[] CreateMultiple(string xmlTag, in int spaces, List<Pair> pairs)
         {
             var results = new XmlElementSyntax[pairs.Count];
 
@@ -158,7 +158,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return results;
         }
 
-        private static XmlElementSyntax[] CreateMultiple(string commentTag, string xmlTag, List<string> comments, int spaces, string[] otherFoundCommentTags)
+        private static XmlElementSyntax[] CreateMultiple(string commentTag, string xmlTag, List<string> comments, in int spaces, string[] otherFoundCommentTags)
         {
             if (TryFindComments(comments, commentTag, otherFoundCommentTags, out var index, out var count))
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return syntax;
         }
 
-        private static DocumentationCommentTriviaSyntax CreateDocumentationComment(MemberDeclarationSyntax member, int spaces, string[] foundCommentTags)
+        private static DocumentationCommentTriviaSyntax CreateDocumentationComment(MemberDeclarationSyntax member, in int spaces, string[] foundCommentTags)
         {
             var leadingComments = member.GetLeadingComments();
             var comments = leadingComments.ToList();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CommentShouldBeDocumentationAnalyzer.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, Declarations);
 
-        private static IReadOnlyCollection<string> FindCommentTags(ReadOnlySpan<string> comments)
+        private static IReadOnlyCollection<string> FindCommentTags(in ReadOnlySpan<string> comments)
         {
             var length = DocumentationCommentTags.Length;
             var commentsLength = comments.Length;

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -87,8 +87,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var name = symbolName.Replace("_Expect_", "_");
 
             var nameToImprove = TryGetInOrder(name, out var nameInOrder)
-                                    ? nameInOrder
-                                    : name;
+                                ? nameInOrder
+                                : name;
 
             return FindBetterTestName(nameToImprove, symbol);
         }

--- a/MiKo.Analyzer.Tests/PairTests.cs
+++ b/MiKo.Analyzer.Tests/PairTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 //// ncrunch: rdi off
 namespace MiKoSolutions.Analyzers

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(32, 64)] int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {


### PR DESCRIPTION
- Add `in` modifiers for span and integers

- Fix indentation and formatting consistency

- Remove unused `using` in PairTests

- Update NUnit test signature to `[in] int`
