### PR TITLE
Added new rule MiKo_5019 for [in] modifier

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -351,6 +351,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5014_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5015_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5017_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5019_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\PerformanceCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6001_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6002_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -514,6 +514,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5015_StringLiteralGetsInternedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\MiKo_5019_InParameterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Performance\PerformanceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\CallSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6001_LogStatementSurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15119,6 +15119,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add [in] modifier.
+        /// </summary>
+        internal static string MiKo_5019_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_5019_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using the [in] modifier for read-only struct parameters helps improve performance. It prevents the struct from being copied by value, which reduces the workload on the garbage collector..
+        /// </summary>
+        internal static string MiKo_5019_Description {
+            get {
+                return ResourceManager.GetString("MiKo_5019_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add [in] modifier.
+        /// </summary>
+        internal static string MiKo_5019_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_5019_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Read-only struct parameters should have the [in] modifier.
+        /// </summary>
+        internal static string MiKo_5019_Title {
+            get {
+                return ResourceManager.GetString("MiKo_5019_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
         internal static string MiKo_6001_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5275,6 +5275,18 @@ This organization ensures clarity and makes the code easier to find, understand 
   <data name="MiKo_5017_Title" xml:space="preserve">
     <value>Fields or variables assigned with string literals should be constant</value>
   </data>
+  <data name="MiKo_5019_CodeFixTitle" xml:space="preserve">
+    <value>Add [in] modifier</value>
+  </data>
+  <data name="MiKo_5019_Description" xml:space="preserve">
+    <value>Using the [in] modifier for read-only struct parameters helps improve performance. It prevents the struct from being copied by value, which reduces the workload on the garbage collector.</value>
+  </data>
+  <data name="MiKo_5019_MessageFormat" xml:space="preserve">
+    <value>Add [in] modifier</value>
+  </data>
+  <data name="MiKo_5019_Title" xml:space="preserve">
+    <value>Read-only struct parameters should have the [in] modifier</value>
+  </data>
   <data name="MiKo_6001_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_CodeFixProvider.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Performance
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_5019_CodeFixProvider)), Shared]
+    public sealed class MiKo_5019_CodeFixProvider : PerformanceCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_5019";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ParameterSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ParameterSyntax parameter)
+            {
+                return parameter.WithModifiers(parameter.Modifiers.Add(SyntaxKind.InKeyword.AsToken()));
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_InParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_InParameterAnalyzer.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Performance
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_5019_InParameterAnalyzer : PerformanceAnalyzer
+    {
+        public const string Id = "MiKo_5019";
+
+        private static readonly SyntaxKind[] PrefixedExpressions = { SyntaxKind.PreIncrementExpression, SyntaxKind.PreDecrementExpression };
+
+        private static readonly SyntaxKind[] PostfixedExpressions = { SyntaxKind.PostIncrementExpression, SyntaxKind.PostDecrementExpression };
+
+        public MiKo_5019_InParameterAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol)
+        {
+            var parameters = symbol.Parameters;
+
+            if (parameters.Length is 0)
+            {
+                return false;
+            }
+
+            if (parameters.Length is 1 && symbol.Name.StartsWith("Analyze", StringComparison.Ordinal) && parameters[0].Name is "context")
+            {
+                return false;
+            }
+
+            if (symbol.IsOverride)
+            {
+                return false;
+            }
+
+            if (symbol.IsAsync)
+            {
+                return false;
+            }
+
+            if (symbol.CanBeReferencedByName is false)
+            {
+                return false;
+            }
+
+            if (symbol.ReturnType.IsTask())
+            {
+                return false;
+            }
+
+            if (symbol.IsInterfaceImplementation())
+            {
+                return false;
+            }
+
+            return symbol.GetSyntax().DescendantNodes<YieldStatementSyntax>().None();
+        }
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation) => symbol.Parameters.SelectMany(_ => AnalyzeParameter(_, compilation));
+
+        protected override IEnumerable<Diagnostic> AnalyzeParameter(IParameterSymbol symbol, Compilation compilation)
+        {
+            var type = symbol.Type;
+
+            if (IsReadOnlyStruct(type))
+            {
+                if (symbol.RefKind == RefKind.None)
+                {
+                    if (symbol.HasAttribute("NUnit.Framework.RangeAttribute"))
+                    {
+                        // NUnit seems to have an issue here, so we cannot change the code
+                        return Array.Empty<Diagnostic>();
+                    }
+
+                    var parameterName = symbol.Name;
+                    var syntaxNode = symbol.ContainingSymbol.GetSyntax();
+
+                    foreach (var node in syntaxNode.AllDescendantNodes())
+                    {
+                        switch (node)
+                        {
+                            case LambdaExpressionSyntax lambda when lambda.DescendantNodes<IdentifierNameSyntax>().Any(_ => _.GetName() == parameterName):
+                            {
+                                // cannot fix lambdas
+                                return Array.Empty<Diagnostic>();
+                            }
+
+                            case AssignmentExpressionSyntax assignment when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) && assignment.Left is IdentifierNameSyntax identifier && identifier.GetName() == parameterName:
+                            {
+                                // cannot fix assignments
+                                return Array.Empty<Diagnostic>();
+                            }
+
+                            case PrefixUnaryExpressionSyntax prefix when prefix.IsAnyKind(PrefixedExpressions) && prefix.Operand is IdentifierNameSyntax identifier && identifier.GetName() == parameterName:
+                            {
+                                // cannot fix increments or decrements
+                                return Array.Empty<Diagnostic>();
+                            }
+
+                            case PostfixUnaryExpressionSyntax postfix when postfix.IsAnyKind(PostfixedExpressions) && postfix.Operand is IdentifierNameSyntax identifier && identifier.GetName() == parameterName:
+                            {
+                                // cannot fix increments or decrements
+                                return Array.Empty<Diagnostic>();
+                            }
+                        }
+                    }
+
+                    return new[] { Issue(symbol) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static bool IsReadOnlyStruct(ITypeSymbol type)
+        {
+            switch (type.SpecialType)
+            {
+                case SpecialType.System_Boolean:
+                case SpecialType.System_Char:
+                case SpecialType.System_SByte:
+                case SpecialType.System_Byte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                    return true;
+
+                default:
+                    switch (type.TypeKind)
+                    {
+                        case TypeKind.Struct when type.IsReadOnly:
+                        case TypeKind.Enum when type is INamedTypeSymbol namedType && namedType.EnumUnderlyingType?.IsReadOnly is true:
+                            return true;
+
+                        default:
+                            return false;
+                    }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5019_InParameterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5019_InParameterAnalyzerTests.cs
@@ -1,0 +1,334 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+namespace MiKoSolutions.Analyzers.Rules.Performance
+{
+    [TestFixture]
+    public sealed class MiKo_5019_InParameterAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_gets_reported_for_method_with_no_parameters() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething() { }
+}
+");
+
+        [Test] // this is the case for the Analyze methods of the MiKo analyzers that act as callbacks
+        public void No_issue_gets_reported_for_analyze_method_with_context_parameters() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void AnalyzeSomething(int context) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_reference_type_as_parameter() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(string value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_interface_as_parameter() => No_issue_is_reported_for(@"
+using System;
+
+public interface IMyInterface { }
+
+public class TestMe
+{
+    public void DoSomething(IMyInterface value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_record_as_parameter() => No_issue_is_reported_for(@"
+using System;
+
+public record MyRecord { }
+
+public class TestMe
+{
+    public void DoSomething(MyRecord value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_non_readonly_struct() => No_issue_is_reported_for(@"
+using System;
+
+public struct MyStruct { }
+
+public class TestMe
+{
+    public void DoSomething(MyStruct value)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_assigned() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        value = default;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_incremented_as_prefix() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        ++value;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_decremented_as_prefix() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        --value;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_incremented_as_postfix() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        value++;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_decremented_as_postfix() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        value--;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_gets_used_in_lambda() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int value)
+    {
+        DoSomethingCore(() => value);
+    }
+
+    public void DoSomethingCore(Func<int> callback) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_if_parameter_is_part_of_interface_implementation() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe : IEquatable<int>
+{
+    public bool Equals(int obj) => 42;
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_yield_returning_method() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public IEnumerable<int> DoSomething(int value)
+    {
+        yield return value;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_Task_returning_method() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public Task DoSomething(int value) => Task.CompletedTask;
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_async_method() => No_issue_is_reported_for(@"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    public async void DoSomethingAsync(int value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_overridden_method() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class TestMe : EqualityComparer<int>
+{
+    public override bool Equals(int x, int y) => true;
+
+    public override int GetHashCode(int obj) => 42;
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_readonly_struct_as_parameter_with_in_modifier() => No_issue_is_reported_for(@"
+using System;
+
+public readonly struct MyStruct { }
+
+public class TestMe
+{
+    public void DoSomething(in MyStruct value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_non_readonly_struct_as_parameter_without_in_modifier_but_Range_attribute() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+public class TestMe
+{
+    public void DoSomething([Range(1, 3)] int value) { }
+}
+");
+
+        [Test]
+        public void No_issue_gets_reported_for_enum_with_in_modifier_as_parameter() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(in StringComparison value) { }
+}
+");
+
+        [Test]
+        public void An_issue_gets_reported_for_readonly_struct_as_parameter() => An_issue_is_reported_for(@"
+using System;
+
+public readonly struct MyStruct { }
+
+public class TestMe
+{
+    public void DoSomething(MyStruct value) { }
+}
+");
+
+        [Test]
+        public void An_issue_gets_reported_for_enum_with_no_in_modifier_as_parameter() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(StringComparison value) { }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_readonly_struct_as_parameter()
+        {
+            const string OriginalCode = @"
+using System;
+
+public readonly struct MyStruct { }
+
+public class TestMe
+{
+    public void DoSomething(MyStruct value) { }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public readonly struct MyStruct { }
+
+public class TestMe
+{
+    public void DoSomething(in MyStruct value) { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_enum_as_parameter()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(StringComparison value) { }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(in StringComparison value) { }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_5019_InParameterAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_5019_InParameterAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_5019_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 504 rules that are currently provided by the analyzer.
+The following tables lists all the 505 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -479,6 +479,7 @@ The following tables lists all the 504 rules that are currently provided by the 
 |MiKo_5015|Do not intern string literals|&#x2713;|&#x2713;|
 |MiKo_5016|Use a HashSet for lookups in 'List.RemoveAll'|&#x2713;|\-|
 |MiKo_5017|Fields or variables assigned with string literals should be constant|&#x2713;|&#x2713;|
+|MiKo_5019|Read-only struct parameters should have the [in] modifier|&#x2713;|&#x2713;|
 
 ### Spacing
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Introduce MiKo_5019 analyzer for 'in' modifier

- Implement code fix to add `in` keyword

- Add unit tests for analyzer and code fixer

- Update resources and README rule count
