### PR TITLE
Renamed analyzers and codefixes base classes

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -233,6 +233,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UsePatternMatchingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\MiKoCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\FieldNamingCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\LocalVariableNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1000_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1001_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1002_CodeFixProvider.cs" />
@@ -326,7 +327,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1506_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLocalVariableCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\DisposeOrderingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -147,8 +147,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2228_DocumentationIsNotNegativeAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2230_ReturnValueUsesListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_XmlFragmentAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2230_ReturnValueUsesListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2231_InheritdocGetHashCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2232_EmptySummaryAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2233_EmptyXmlTagIsOnSameLineAnalyzer.cs" />
@@ -344,6 +344,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Metrics\MiKo_0005_LocalFunctionLinesOfCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Metrics\MiKo_0006_LocalFunctionCyclomaticComplexityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Metrics\MiKo_0007_LocalFunctionParameterCountAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\LocalVariableNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1000_EventArgsTypeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1001_EventArgsParameterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1002_EventHandlingMethodParametersAnalyzer.cs" />
@@ -483,10 +484,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLocalVariableAnalyzer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingNamespaceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
@@ -4,9 +4,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
-    public abstract class NamingLocalVariableAnalyzer : NamingAnalyzer
+    public abstract class LocalVariableNamingAnalyzer : NamingAnalyzer
     {
-        protected NamingLocalVariableAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
+        protected LocalVariableNamingAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
         {
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingCodeFixProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
-    public abstract class NamingLocalVariableCodeFixProvider : NamingCodeFixProvider
+    public abstract class LocalVariableNamingCodeFixProvider : NamingCodeFixProvider
     {
         protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1005_CodeFixProvider)), Shared]
-    public sealed class MiKo_1005_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1005_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1005";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1005_EventArgsLocalVariableAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1005_EventArgsLocalVariableAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1005";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1009_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1009_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1009_CodeFixProvider)), Shared]
-    public sealed class MiKo_1009_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1009_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1009";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1009_EventHandlerLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1009_EventHandlerLocalVariableAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1009_EventHandlerLocalVariableAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1009_EventHandlerLocalVariableAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1009";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1043_CancellationTokenLocalVariableAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1043_CancellationTokenLocalVariableAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1043";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1043_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1043_CodeFixProvider)), Shared]
-    public sealed class MiKo_1043_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1043_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1043";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1050_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1050_CodeFixProvider)), Shared]
-    public sealed class MiKo_1050_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1050_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1050";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1050_ReturnValueLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1050_ReturnValueLocalVariableAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1050_ReturnValueLocalVariableAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1050_ReturnValueLocalVariableAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1050";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1052_CodeFixProvider)), Shared]
-    public sealed class MiKo_1052_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1052_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1052";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1052";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -10,7 +10,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1063_AbbreviationsInNameAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1063_AbbreviationsInNameAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1063";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1070_CodeFixProvider)), Shared]
-    public sealed class MiKo_1070_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1070_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1070";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -11,7 +11,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1070_CollectionLocalVariableAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1070_CollectionLocalVariableAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1070";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1071";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1080_UseNumbersInsteadOfWordingAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1080_UseNumbersInsteadOfWordingAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1080";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1084_CodeFixProvider)), Shared]
-    public sealed class MiKo_1084_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1084_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1084";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1084_VariablesWithNumberSuffixAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1084_VariablesWithNumberSuffixAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1084";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1091_CodeFixProvider)), Shared]
-    public sealed class MiKo_1091_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1091_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1091";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1091_VariableWrongSuffixedAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1091_VariableWrongSuffixedAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1091";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_CodeFixProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1108_CodeFixProvider)), Shared]
-    public sealed class MiKo_1108_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1108_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1108";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1112_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1112_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1112_CodeFixProvider)), Shared]
-    public sealed class MiKo_1112_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1112_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1112";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1112";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
@@ -10,7 +10,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1400_NamespacesInPluralAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1400_NamespacesInPluralAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1400";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1401_TechnicalNamespacesAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1401_TechnicalNamespacesAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1401";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1402_WpfTechnicalNamespacesAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1402_WpfTechnicalNamespacesAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1402";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1403_RedundantNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1403_RedundantNamespaceAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1403_RedundantNamespaceAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1403_RedundantNamespaceAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1403";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1404_NonsenseNamespacesAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1404_NonsenseNamespacesAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1404";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1405_LibraryNamespacesAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1405_LibraryNamespacesAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1405";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1407_TestNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1407_TestNamespaceAnalyzer.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1407_TestNamespaceAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1407_TestNamespaceAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1407";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer : NamingNamespaceAnalyzer
+    public sealed class MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1409";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_CodeFixProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1506_CodeFixProvider)), Shared]
-    public sealed class MiKo_1506_CodeFixProvider : NamingLocalVariableCodeFixProvider
+    public sealed class MiKo_1506_CodeFixProvider : LocalVariableNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1506";
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1506_VariablesWithCounterSuffixAnalyzer : NamingLocalVariableAnalyzer
+    public sealed class MiKo_1506_VariablesWithCounterSuffixAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1506";
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
@@ -8,9 +8,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
-    public abstract class NamingNamespaceAnalyzer : NamingAnalyzer
+    public abstract class NamespaceNamingAnalyzer : NamingAnalyzer
     {
-        protected NamingNamespaceAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
+        protected NamespaceNamingAnalyzer(string diagnosticId) : base(diagnosticId, (SymbolKind)(-1))
         {
         }
 


### PR DESCRIPTION
- Rename `NamingLocalVariableAnalyzer` base class

- Rename `NamingLocalVariableCodeFixProvider` base class

- Update analyzers to use new base classes

- Adjust project files for renamed classes
