### PR TITLE
Added new rule MiKo_1510 that reports 'Info' suffix on types

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -486,6 +486,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1509_ParametersWithStructuralDesignPatternSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1510_TypesWithInfoSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5050,6 +5050,34 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;Info&apos; suffix is too generic and does not clearly convey the purpose or structure of a type.
+        ///Replacing it with more descriptive and intent-revealing names (such as &apos;Data&apos;, &apos;Descriptor&apos;, &apos;Details&apos;, &apos;Metadata&apos;, &apos;Overview&apos;, &apos;Profile&apos;, &apos;Settings&apos;, &apos;Snapshot&apos;, &apos;Status&apos; or &apos;Summary&apos;) improves code readability, simplifies maintenance, and enhances discoverability through better IntelliSense support. It also reduces confusion, so developers don’t have to guess what the type represents..
+        /// </summary>
+        internal static string MiKo_1510_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1510_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change suffix &apos;Info&apos; to a more intent-revealing name.
+        /// </summary>
+        internal static string MiKo_1510_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1510_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Types should not be suffixed with &apos;Info&apos;.
+        /// </summary>
+        internal static string MiKo_1510_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1510_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1830,6 +1830,16 @@ This improves code readability, avoids confusion with class names and helps deve
   <data name="MiKo_1509_Title" xml:space="preserve">
     <value>Parameters should not be suffixed with pattern names</value>
   </data>
+  <data name="MiKo_1510_Description" xml:space="preserve">
+    <value>The 'Info' suffix is too generic and does not clearly convey the purpose or structure of a type.
+Replacing it with more descriptive and intent-revealing names (such as 'Data', 'Descriptor', 'Details', 'Metadata', 'Overview', 'Profile', 'Settings', 'Snapshot', 'Status' or 'Summary') improves code readability, simplifies maintenance, and enhances discoverability through better IntelliSense support. It also reduces confusion, so developers don’t have to guess what the type represents.</value>
+  </data>
+  <data name="MiKo_1510_MessageFormat" xml:space="preserve">
+    <value>Change suffix 'Info' to a more intent-revealing name</value>
+  </data>
+  <data name="MiKo_1510_Title" xml:space="preserve">
+    <value>Types should not be suffixed with 'Info'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1510_TypesWithInfoSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1510";
+
+        public MiKo_1510_TypesWithInfoSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => symbol.Name.EndsWith("Info", StringComparison.Ordinal)
+                                                                                                                    ? new[] { Issue(symbol) }
+                                                                                                                    : Array.Empty<Diagnostic>();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzerTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1510_TypesWithInfoSuffixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] TypeKinds = ["interface", "class", "struct", "record", "enum"];
+
+        [Test]
+        public void No_issue_is_reported_for_type_without_suffix_Info_([ValueSource(nameof(TypeKinds))] string type) => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public " + type + @" TestMe
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_suffix_Info_([ValueSource(nameof(TypeKinds))] string type) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    public " + type + @" TestMeInfo
+    {
+    }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1510_TypesWithInfoSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1510_TypesWithInfoSuffixAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 508 rules that are currently provided by the analyzer.
+The following tables lists all the 509 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -169,6 +169,7 @@ The following tables lists all the 508 rules that are currently provided by the 
 |MiKo_1507|Parameters should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
 |MiKo_1508|Local variables should not be suffixed with pattern names|&#x2713;|&#x2713;|
 |MiKo_1509|Parameters should not be suffixed with pattern names|&#x2713;|&#x2713;|
+|MiKo_1510|Types should not be suffixed with 'Info'|&#x2713;|\-|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add naming analyzer for 'Info' suffix

- Include localization resources for rule

- Add unit tests for multiple type kinds

- Update project and README entries

(resolves #1423)