### PR TITLE
Added new rules MiKo_1511 and MiKo_1512 to report 'proxy' variable or parameter names

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -329,6 +329,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1507_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1508_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1509_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -487,6 +487,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1509_ParametersWithStructuralDesignPatternSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1510_TypesWithInfoSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_ProxyVariablesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_ProxyParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5078,6 +5078,80 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;proxy&apos; from name.
+        /// </summary>
+        internal static string MiKo_1511_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1511_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The purpose of the Proxy Pattern is to control access to another object (e.g., for lazy loading, access control, logging), without directly exposing the real object. However, from the developer&apos;s perspective, the proxy is used *as if* it were the real object.
+        ///Therefore, names should reflect the intended role rather than the implementation detail, avoiding prefixes or suffixes like &apos;Proxy&apos;..
+        /// </summary>
+        internal static string MiKo_1511_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1511_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1511_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1511_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local variables should not be prefixed or suffixed with &apos;proxy&apos;.
+        /// </summary>
+        internal static string MiKo_1511_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1511_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;proxy&apos; from name.
+        /// </summary>
+        internal static string MiKo_1512_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1512_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The purpose of the Proxy Pattern is to control access to another object (e.g., for lazy loading, access control, logging), without directly exposing the real object. However, from the developer&apos;s perspective, the proxy is used *as if* it were the real object.
+        ///Therefore, names should reflect the intended role rather than the implementation detail, avoiding prefixes or suffixes like &apos;Proxy&apos;..
+        /// </summary>
+        internal static string MiKo_1512_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1512_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1512_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1512_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters should not be prefixed or suffixed with &apos;proxy&apos;.
+        /// </summary>
+        internal static string MiKo_1512_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1512_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1840,6 +1840,32 @@ Replacing it with more descriptive and intent-revealing names (such as 'Data', '
   <data name="MiKo_1510_Title" xml:space="preserve">
     <value>Types should not be suffixed with 'Info'</value>
   </data>
+  <data name="MiKo_1511_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'proxy' from name</value>
+  </data>
+  <data name="MiKo_1511_Description" xml:space="preserve">
+    <value>The purpose of the Proxy Pattern is to control access to another object (e.g., for lazy loading, access control, logging), without directly exposing the real object. However, from the developer's perspective, the proxy is used *as if* it were the real object.
+Therefore, names should reflect the intended role rather than the implementation detail, avoiding prefixes or suffixes like 'Proxy'.</value>
+  </data>
+  <data name="MiKo_1511_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1511_Title" xml:space="preserve">
+    <value>Local variables should not be prefixed or suffixed with 'proxy'</value>
+  </data>
+  <data name="MiKo_1512_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'proxy' from name</value>
+  </data>
+  <data name="MiKo_1512_Description" xml:space="preserve">
+    <value>The purpose of the Proxy Pattern is to control access to another object (e.g., for lazy loading, access control, logging), without directly exposing the real object. However, from the developer's perspective, the proxy is used *as if* it were the real object.
+Therefore, names should reflect the intended role rather than the implementation detail, avoiding prefixes or suffixes like 'Proxy'.</value>
+  </data>
+  <data name="MiKo_1512_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1512_Title" xml:space="preserve">
+    <value>Parameters should not be prefixed or suffixed with 'proxy'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1511_CodeFixProvider)), Shared]
+    public sealed class MiKo_1511_CodeFixProvider : LocalVariableNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1511";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1511_ProxyVariablesAnalyzer : LocalVariableNamingAnalyzer
+    {
+        public const string Id = "MiKo_1511";
+
+        public MiKo_1511_ProxyVariablesAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+
+                    if (name.Contains("Proxy", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var betterName = FindBetterName(name);
+
+                        if (betterName != name)
+                        {
+                            yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string FindBetterName(string name) => name.Length > 5
+                                                             ? name.Without("proxy").Without("Proxy").ToLowerCaseAt(0) // simply remove both as we need to check them anyway (so we save some calls)
+                                                             : name;
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1512_CodeFixProvider)), Shared]
+    public sealed class MiKo_1512_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1512";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1512_ProxyParametersAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1512";
+
+        public MiKo_1512_ProxyParametersAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+
+            if (name.Contains("Proxy", StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = FindBetterName(name);
+
+                if (betterName != name)
+                {
+                    return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string name) => name.Length > 5
+                                                             ? name.Without("proxy").Without("Proxy").ToLowerCaseAt(0) // simply remove both as we need to check them anyway (so we save some calls)
+                                                             : name;
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzerTests.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1511_ProxyVariablesAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_variable_without_proxy_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test] // currently, we do not know how to rename such variable 'proxy'
+        public void No_issue_is_reported_for_variable_named_proxy() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int proxy = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_named_([Values("proxySomething", "someProxy")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int " + name + @" = 42;
+        }
+    }
+}
+");
+
+        [TestCase("proxySomething", "something")]
+        [TestCase("someProxy", "some")]
+        [TestCase("someProxyStuff", "someStuff")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int ### = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1511_ProxyVariablesAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1511_ProxyVariablesAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1511_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1512_ProxyParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1512_ProxyParametersAnalyzerTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1512_ProxyParametersAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_parameter_without_proxy_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test] // currently, we do not know how to rename such parameter 'proxy'
+        public void No_issue_is_reported_for_parameter_named_proxy() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int proxy)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_named_([Values("proxySomething", "someProxy")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int " + name + @")
+        {
+        }
+    }
+}
+");
+
+        [TestCase("proxySomething", "something")]
+        [TestCase("someProxy", "some")]
+        [TestCase("someProxyStuff", "someStuff")]
+        public void Code_gets_fixed_for_parameter_with_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int ###)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1512_ProxyParametersAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1512_ProxyParametersAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1512_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 509 rules that are currently provided by the analyzer.
+The following tables lists all the 511 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -170,6 +170,8 @@ The following tables lists all the 509 rules that are currently provided by the 
 |MiKo_1508|Local variables should not be suffixed with pattern names|&#x2713;|&#x2713;|
 |MiKo_1509|Parameters should not be suffixed with pattern names|&#x2713;|&#x2713;|
 |MiKo_1510|Types should not be suffixed with 'Info'|&#x2713;|\-|
+|MiKo_1511|Local variables should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
+|MiKo_1512|Parameters should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add rule MiKo_1511 forbidding 'proxy' in local variables

- Add rule MiKo_1512 forbidding 'proxy' in parameters

- Provide code fixes that remove 'proxy' from names

- Update resources, project, README, and tests

(resolves #1422)