### PR TITLE
Refactored MiKo_3122 implementation to work on syntax and not symbols to improve performance

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3114_UseMockOfInsteadMockObjectAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3114_UseMockOfInsteadMockObjectAnalyzer.cs
@@ -20,12 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName(Constants.Moq.MockFullQualified) != null;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context)
-        {
-            base.InitializeCore(context);
-
-            context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
-        }
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
         private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3120_UseValueInsteadOfItIsConditionMatcherAnalyzer.cs
@@ -22,12 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsApplicable(CompilationStartAnalysisContext context) => context.Compilation.GetTypeByMetadataName(Constants.Moq.MockFullQualified) != null;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context)
-        {
-            base.InitializeCore(context);
-
-            context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
-        }
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
         private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3122_TestMethodsDoNotHaveMultipleParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3122_TestMethodsDoNotHaveMultipleParametersAnalyzer.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -17,15 +16,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsTestMethod();
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
 
-        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        private void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (symbol.Parameters.Length > 2)
+            if (context.Node is MethodDeclarationSyntax method && method.IsTestMethod())
             {
-                var syntax = symbol.GetSyntax<MethodDeclarationSyntax>();
+                var parameterList = method.ParameterList;
 
-                yield return Issue(syntax.ParameterList);
+                if (parameterList.Parameters.Count > 2)
+                {
+                    ReportDiagnostics(context, Issue(parameterList));
+                }
             }
         }
     }


### PR DESCRIPTION
- Simplify `InitializeCore` overrides, remove base calls

- Refactor analyzers to syntax-based registration

