### PR TITLE
Moved check for expression trees inside check for potentially matching nodes to speed up check by avoiding unnecessary calls on non-matching nodes

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForBinaryExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingForBinaryExpressionAnalyzer.cs
@@ -17,15 +17,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var semanticModel = context.SemanticModel;
 
-                if (node.IsExpressionTree(semanticModel))
-                {
-                    // ignore expression trees
-                    return;
-                }
-
                 if (IsResponsibleNode(node.Right, semanticModel) || IsResponsibleNode(node.Left, semanticModel))
                 {
-                    ReportIssue(context, node.OperatorToken);
+                    // ignore expression trees
+                    if (node.IsExpressionTree(semanticModel) is false)
+                    {
+                        ReportIssue(context, node.OperatorToken);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Move expression tree check into responsible branch

- Only run `IsExpressionTree` when relevant nodes match

- Avoid semantic model calls on non-matching nodes

- Preserve ignoring expression trees behavior
