### PR TITLE
Refactored usage of syntax factory

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -189,6 +189,8 @@ namespace System
 
         public static InterpolatedStringTextSyntax AsInterpolatedString(this string value) => SyntaxFactory.InterpolatedStringText(value.AsToken(SyntaxKind.InterpolatedStringTextToken));
 
+        public static TypeSyntax AsTypeSyntax(this string value) => SyntaxFactory.ParseTypeName(value);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ConcatenatedWith(this IEnumerable<string> values) => string.Concat(values.WhereNotNull());
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -239,7 +240,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSeeCrefTaskResult(this SyntaxNode value)
         {
-            var type = SyntaxFactory.ParseTypeName("Task<TResult>");
+            var type = "Task<TResult>".AsTypeSyntax();
             var member = SyntaxFactory.ParseName(nameof(Task<object>.Result));
 
             return value.IsSeeCref(type, member);
@@ -247,12 +248,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSeeCrefTask(this SyntaxNode value)
         {
-            if (value.IsSeeCref(SyntaxFactory.ParseTypeName("Task")))
+            if (value.IsSeeCref("Task".AsTypeSyntax()))
             {
                 return true;
             }
 
-            if (value.IsSeeCref(SyntaxFactory.ParseTypeName("Task<TResult>")))
+            if (value.IsSeeCref("Task<TResult>".AsTypeSyntax()))
             {
                 return true;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -462,7 +462,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlElementSyntax CommentWithContent(XmlElementSyntax value, in SyntaxList<XmlNodeSyntax> content) => SyntaxFactory.XmlElement(value.StartTag, content, value.EndTag).WithTagsOnSeparateLines();
 
-        protected static TypeCrefSyntax Cref(string typeName) => Cref(SyntaxFactory.ParseTypeName(typeName));
+        protected static TypeCrefSyntax Cref(string typeName) => Cref(typeName.AsTypeSyntax());
 
         protected static TypeCrefSyntax Cref(TypeSyntax type)
         {
@@ -590,7 +590,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                    : comment.ReplaceNode(text, modifiedText);
         }
 
-        protected static XmlEmptyElementSyntax SeeCref(string typeName) => Cref(Constants.XmlTag.See, SyntaxFactory.ParseTypeName(typeName));
+        protected static XmlEmptyElementSyntax SeeCref(string typeName) => Cref(Constants.XmlTag.See, typeName.AsTypeSyntax());
 
         protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2000_CodeFixProvider.cs
@@ -70,7 +70,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                          .AppendLine(endTagFullString)
                                          .ToStringAndRelease();
 
-            var newParent = SyntaxFactory.ParseTypeName("###").WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(text));
+            var newParent = "###".AsTypeSyntax().WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(text));
 
             return newParent.GetDocumentationCommentTriviaSyntax().FirstOrDefault() ?? syntax;
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -61,7 +61,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static DocumentationCommentTriviaSyntax FixCtorComment(ConstructorDeclarationSyntax ctor)
         {
             var typeDeclarationSyntax = ctor.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-            var type = SyntaxFactory.ParseTypeName(typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty);
+            var type = (typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty).AsTypeSyntax();
 
             // we have a ctor
             var parameters = ctor.ParameterList.Parameters;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2090_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -23,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var parameters = method.ParameterList.Parameters;
             var typeDeclarationSyntax = method.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-            var type = SyntaxFactory.ParseTypeName(typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty);
+            var type = (typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty).AsTypeSyntax();
 
             var summary = Comment(SyntaxFactory.XmlSummaryElement(), "Determines whether the specified ", SeeCref(type), " instances are considered equal.").WithTrailingXmlComment();
             var param1 = ParameterComment(parameters[0], "The first value to compare.").WithTrailingXmlComment();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2091_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -23,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var parameters = method.ParameterList.Parameters;
             var typeDeclarationSyntax = method.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-            var type = SyntaxFactory.ParseTypeName(typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty);
+            var type = (typeDeclarationSyntax?.Identifier.ValueText ?? string.Empty).AsTypeSyntax();
 
             var summary = Comment(SyntaxFactory.XmlSummaryElement(), "Determines whether the specified ", SeeCref(type), " instances are considered not equal.").WithTrailingXmlComment();
             var param1 = ParameterComment(parameters[0], "The first value to compare.").WithTrailingXmlComment();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static XmlEmptyElementSyntax SeeCrefTaskResult()
         {
-            var type = SyntaxFactory.ParseTypeName("Task<TResult>");
+            var type = "Task<TResult>".AsTypeSyntax();
             var member = SyntaxFactory.ParseName(nameof(Task<object>.Result));
 
             return Cref(Constants.XmlTag.See, type, member);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsSimplifierCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsSimplifierCodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     var argument1 = Argument(left.Left);
                     var argument2 = Argument(left.Right);
 
-                    var access = SimpleMemberAccess(PredefinedType(PredefinedTypeKind), nameof(Equals));
+                    var access = Member(PredefinedType(PredefinedTypeKind), nameof(Equals));
 
                     var updatedSyntax = arguments?.Count > 1
                                         ? Invocation(access, argument1, argument2, arguments.Value[1])

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -20,9 +20,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                                   { SyntaxKind.LessThanToken, SyntaxKind.GreaterThanEqualsToken },
                                                                                               };
 
-        protected static ArgumentSyntax Argument(string identifier) => Argument(SyntaxFactory.IdentifierName(identifier));
+        protected static ArgumentSyntax Argument(string identifier) => Argument(IdentifierName(identifier));
 
-        protected static ArgumentSyntax Argument(ParameterSyntax parameter) => Argument(SyntaxFactory.IdentifierName(parameter.GetName()));
+        protected static ArgumentSyntax Argument(ParameterSyntax parameter) => Argument(IdentifierName(parameter.GetName()));
 
         protected static ArgumentSyntax Argument(ExpressionSyntax expression) => SyntaxFactory.Argument(expression);
 
@@ -37,12 +37,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected static ArgumentSyntax Argument(string typeName, string methodName, params ArgumentSyntax[] arguments)
         {
-            return Argument(SimpleMemberAccess(typeName, methodName), arguments);
+            return Argument(Member(typeName, methodName), arguments);
         }
 
         protected static ArgumentSyntax ArgumentWithCast(in SyntaxKind kind, ParameterSyntax parameter) => ArgumentWithCast(PredefinedType(kind), parameter);
 
-        protected static ArgumentSyntax ArgumentWithCast(TypeSyntax type, ParameterSyntax parameter) => ArgumentWithCast(type, SyntaxFactory.IdentifierName(parameter.GetName()));
+        protected static ArgumentSyntax ArgumentWithCast(TypeSyntax type, ParameterSyntax parameter) => ArgumentWithCast(type, IdentifierName(parameter.GetName()));
 
         protected static ArgumentSyntax ArgumentWithCast(in SyntaxKind kind, IdentifierNameSyntax identifier) => ArgumentWithCast(PredefinedType(kind), identifier);
 
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected static InvocationExpressionSyntax Invocation(string typeName, string methodName, params ArgumentSyntax[] arguments)
         {
             // that's for the method call
-            var member = SimpleMemberAccess(typeName, methodName);
+            var member = Member(typeName, methodName);
 
             return Invocation(member, arguments);
         }
@@ -59,41 +59,41 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected static InvocationExpressionSyntax Invocation(string typeName, string propertyName, string methodName, params TypeSyntax[] items)
         {
             // that's for the method call
-            var member = SimpleMemberAccess(typeName, propertyName, methodName, items);
+            var member = Member(typeName, propertyName, methodName, items);
 
             return Invocation(member);
         }
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(PredefinedTypeSyntax type, string methodName)
+        protected static MemberAccessExpressionSyntax Member(PredefinedTypeSyntax type, string methodName)
         {
-            var method = SyntaxFactory.IdentifierName(methodName);
+            var method = IdentifierName(methodName);
 
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
+            return Member(type, method);
         }
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(string typeName, string methodName)
+        protected static MemberAccessExpressionSyntax Member(string typeName, string methodName)
         {
-            var type = SyntaxFactory.IdentifierName(typeName);
-            var method = SyntaxFactory.IdentifierName(methodName);
+            var type = IdentifierName(typeName);
+            var method = IdentifierName(methodName);
 
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
+            return Member(type, method);
         }
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(string typeName, string middlePart, string methodName, TypeSyntax[] items)
+        protected static MemberAccessExpressionSyntax Member(string typeName, string middlePart, string methodName, TypeSyntax[] items)
         {
-            var type = SyntaxFactory.IdentifierName(typeName);
-            var method = SyntaxFactory.GenericName(methodName).AddTypeArgumentListArguments(items);
+            var type = IdentifierName(typeName);
+            var method = GenericName(methodName, items);
 
-            var expression = SimpleMemberAccess(type, middlePart);
+            var expression = Member(type, middlePart);
 
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, method);
+            return Member(expression, method);
         }
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(string typeName, params string[] methodNames)
+        protected static MemberAccessExpressionSyntax Member(string typeName, params string[] methodNames)
         {
-            var start = SimpleMemberAccess(typeName, methodNames[0]);
+            var start = Member(typeName, methodNames[0]);
 
-            var result = methodNames.Skip(1).Aggregate(start, SimpleMemberAccess);
+            var result = methodNames.Skip(1).Aggregate(start, Member);
 
             return result;
         }
@@ -150,7 +150,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected static TypeOfExpressionSyntax TypeOf(in SyntaxKind kind) => TypeOf(PredefinedType(kind));
 
-        protected static TypeOfExpressionSyntax TypeOf(string typeName) => TypeOf(SyntaxFactory.ParseTypeName(typeName));
+        protected static TypeOfExpressionSyntax TypeOf(string typeName) => TypeOf(typeName.AsTypeSyntax());
 
         protected static TypeOfExpressionSyntax TypeOf(TypeSyntax type) => SyntaxFactory.TypeOfExpression(type);
 
@@ -163,14 +163,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected static InvocationExpressionSyntax NameOf(string identifierName)
         {
-            var syntax = SyntaxFactory.IdentifierName(identifierName);
+            var syntax = IdentifierName(identifierName);
 
             return NameOf(syntax);
         }
 
         protected static InvocationExpressionSyntax NameOf(string typeName, string identifierName)
         {
-            var syntax = SimpleMemberAccess(typeName, identifierName);
+            var syntax = Member(typeName, identifierName);
 
             return NameOf(syntax);
         }
@@ -195,9 +195,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             // nameof has a special RawContextualKind, hence we have to create it via its specific SyntaxKind
             // (see https://stackoverflow.com/questions/46259039/constructing-nameof-expression-via-syntaxfactory-roslyn)
-            var nameofSyntax = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(SyntaxFactory.TriviaList(), SyntaxKind.NameOfKeyword, "nameof", "nameof", SyntaxFactory.TriviaList()));
+            var nameofSyntax = SyntaxFactory.Identifier(SyntaxFactory.TriviaList(), SyntaxKind.NameOfKeyword, "nameof", "nameof", SyntaxFactory.TriviaList());
 
-            return SyntaxFactory.InvocationExpression(nameofSyntax, ArgumentList(SyntaxFactory.Argument(syntax)));
+            return Invocation(IdentifierName(nameofSyntax), Argument(syntax));
         }
 
         private static ExpressionSyntax InvertCondition(PrefixUnaryExpressionSyntax prefixed)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3012_CodeFixProvider.cs
@@ -80,7 +80,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     return ArgumentList(
                                     ParamName(identifier),
                                     ArgumentWithCast(SyntaxKind.IntKeyword, identifier),
-                                    Argument(Invocation(SimpleMemberAccess(identifier, nameof(GetType))))); // use .GetType() call as we are not sure which type the identifier has
+                                    Argument(Invocation(Member(identifier, nameof(GetType))))); // use .GetType() call as we are not sure which type the identifier has
             }
 
             return null;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => "MiKo_3013";
 
-        protected override TypeSyntax GetUpdatedSyntaxType(ObjectCreationExpressionSyntax syntax) => SyntaxFactory.ParseTypeName(nameof(ArgumentOutOfRangeException));
+        protected override TypeSyntax GetUpdatedSyntaxType(ObjectCreationExpressionSyntax syntax) => nameof(ArgumentOutOfRangeException).AsTypeSyntax();
 
         protected override ArgumentListSyntax GetUpdatedArgumentListSyntax(ObjectCreationExpressionSyntax syntax)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3015_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public override string FixableDiagnosticId => "MiKo_3015";
 
-        protected override TypeSyntax GetUpdatedSyntaxType(ObjectCreationExpressionSyntax syntax) => SyntaxFactory.ParseTypeName(nameof(InvalidOperationException));
+        protected override TypeSyntax GetUpdatedSyntaxType(ObjectCreationExpressionSyntax syntax) => nameof(InvalidOperationException).AsTypeSyntax();
 
         protected override ArgumentListSyntax GetUpdatedArgumentListSyntax(ObjectCreationExpressionSyntax syntax)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                 ? nameof(InvalidOperationException)
                                 : nameof(ArgumentException);
 
-            return SyntaxFactory.ParseTypeName(exceptionName);
+            return exceptionName.AsTypeSyntax();
         }
 
         protected override ArgumentListSyntax GetUpdatedArgumentListSyntax(ObjectCreationExpressionSyntax syntax)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3017_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3017_CodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     else
                     {
                         // seems like there is no exception inside the catch clause, so we have to add the missing ones
-                        var newCatchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.ParseTypeName(nameof(Exception)), newExceptionIdentifier);
+                        var newCatchDeclaration = SyntaxFactory.CatchDeclaration(nameof(Exception).AsTypeSyntax(), newExceptionIdentifier);
                         var newBlock = catchClause.Block.ReplaceNode(argumentList, newArgumentList);
 
                         result.Add(catchClause, SyntaxFactory.CatchClause(newCatchDeclaration, null, newBlock));

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CodeFixProvider.cs
@@ -16,6 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<InvocationExpressionSyntax>().FirstOrDefault();
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => SimpleMemberAccess(nameof(Task), nameof(Task.CompletedTask));
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => Member(nameof(Task), nameof(Task.CompletedTask));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3032_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Composition;
 using System.Linq;
@@ -29,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (issue.Properties.ContainsKey(Constants.AnalyzerCodeFixSharedData.CreateArgs))
             {
                 var argument = Argument(expression);
-                var typeSyntax = SyntaxFactory.ParseTypeName(nameof(PropertyChangedEventArgs));
+                var typeSyntax = nameof(PropertyChangedEventArgs).AsTypeSyntax();
 
                 return SyntaxFactory.ObjectCreationExpression(typeSyntax, ArgumentList(argument), null);
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3054_CodeFixProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 
@@ -27,10 +28,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var prefix = ExtractFieldNamePrefix(declarator);
             var identifier = prefix + Constants.DependencyProperty.FieldSuffix;
 
-            var assignment = SimpleMemberAccess(declarator.Identifier.Text, Constants.DependencyProperty.TypeName);
+            var assignment = Member(declarator.Identifier.Text, Constants.DependencyProperty.TypeName);
             var variableDeclarator = SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(identifier), default, SyntaxFactory.EqualsValueClause(assignment));
 
-            var type = SyntaxFactory.ParseTypeName(Constants.DependencyProperty.TypeName);
+            var type = Constants.DependencyProperty.TypeName.AsTypeSyntax();
             var variableDeclaration = SyntaxFactory.VariableDeclaration(type, variableDeclarator.ToSeparatedSyntaxList());
 
             var field = SyntaxFactory.FieldDeclaration(default, PublicStaticReadOnly.ToTokenList(), variableDeclaration);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3065_CodeFixProvider.cs
@@ -105,7 +105,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return syntax.Expression;
             }
 
-            return Invocation(SimpleMemberAccess(syntax.Expression, nameof(ToString)), Argument(StringLiteral(clause.FormatStringToken.ValueText)));
+            return Invocation(Member(syntax.Expression, nameof(ToString)), Argument(StringLiteral(clause.FormatStringToken.ValueText)));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3077_CodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var type = typeSyntax.GetTypeSymbol(document);
 
-            var memberAccess = SimpleMemberAccess(type.Name, type.GetFields()[0].Name);
+            var memberAccess = Member(type.Name, type.GetFields()[0].Name);
 
             return SyntaxFactory.EqualsValueClause(memberAccess);
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
@@ -263,7 +263,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             var ifStatement = ConvertToIfStatement(conditional, trueCase => AssignmentStatement(declarator, trueCase), falseCase => AssignmentStatement(declarator, falseCase));
 
-            var identifier = SyntaxFactory.IdentifierName(variableName).WithTriviaFrom(expression);
+            var identifier = IdentifierName(variableName).WithTriviaFrom(expression);
             var updatedInitializer = initializer.ReplaceNode(expression, identifier);
 
             if (initializer.FirstAncestor<StatementSyntax>() is StatementSyntax statement)
@@ -362,7 +362,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ExpressionStatementSyntax AssignmentStatement(VariableDeclaratorSyntax declarator, ExpressionSyntax expression)
         {
-            return SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(declarator.Identifier), expression));
+            return SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName(declarator.Identifier), expression));
         }
 
         private static IfStatementSyntax ConvertToIfStatement(ConditionalExpressionSyntax conditional, Func<ExpressionSyntax, StatementSyntax> callback)
@@ -437,7 +437,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                        ? type.FullyQualifiedName().GetNameOnlyPart()
                        : type.Name;
 
-            return SyntaxFactory.ParseTypeName(name);
+            return name.AsTypeSyntax();
         }
 
         private static TypeSyntax GetTypeSyntax(VariableDeclarationSyntax declaration, Document document)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3089_CodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ExpressionSyntax GetUpdatedCondition(ExpressionSyntax expression, string name, in SyntaxKind expressionKind, LiteralExpressionSyntax literal)
         {
-            var operand = SimpleMemberAccess(expression, name);
+            var operand = Member(expression, name);
 
             switch (literal.Kind())
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3107_CodeFixProvider.cs
@@ -35,8 +35,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case SyntaxKind.BoolKeyword: return FalseLiteral();
                 case SyntaxKind.CharKeyword: return Literal(char.MinValue);
                 case SyntaxKind.DecimalKeyword: return Literal(decimal.Zero);
-                case SyntaxKind.DoubleKeyword: return SimpleMemberAccess(PredefinedType(kind), nameof(double.NaN));
-                case SyntaxKind.FloatKeyword: return SimpleMemberAccess(PredefinedType(kind), nameof(float.NaN));
+                case SyntaxKind.DoubleKeyword: return Member(PredefinedType(kind), nameof(double.NaN));
+                case SyntaxKind.FloatKeyword: return Member(PredefinedType(kind), nameof(float.NaN));
                 case SyntaxKind.ObjectKeyword: return NullLiteral();
                 case SyntaxKind.StringKeyword: return NullLiteral();
                 default: return Literal(0);
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 if (type.IsEnum())
                 {
                     // take the first value
-                    return SimpleMemberAccess(typeSyntax, type.GetFields()[0].Name);
+                    return Member(typeSyntax, type.GetFields()[0].Name);
                 }
 
                 // we have a struct

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_CodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     return MemberIs("Empty");
                 }
 
-                return SimpleMemberAccess(m.Expression, "Zero");
+                return Member(m.Expression, "Zero");
             }
 
             return node;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
@@ -198,7 +198,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         if (type.TryGetGenericArgumentType(out var genericType, i))
                         {
-                            types[i] = SyntaxFactory.ParseTypeName(genericType.FullyQualifiedName());
+                            types[i] = genericType.FullyQualifiedName().AsTypeSyntax();
                         }
                     }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3215_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3215_CodeFixProvider.cs
@@ -20,8 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             if (syntax is ParameterSyntax parameter && parameter.Type is GenericNameSyntax generic)
             {
-                return parameter.WithType(SyntaxFactory.GenericName("Func")
-                                                       .WithTypeArgumentList(generic.TypeArgumentList.AddArguments(PredefinedType(SyntaxKind.BoolKeyword))));
+                return parameter.WithType(GenericName("Func", generic.TypeArgumentList.AddArguments(PredefinedType(SyntaxKind.BoolKeyword))));
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var expression = InvocationIs(name, argument);
 
-            return Argument(SimpleMemberAccess(expression, name1));
+            return Argument(Member(expression, name1));
         }
 
         protected static ArgumentSyntax Is(string name, string name1, ExpressionSyntax expression) => Is(name, name1, Argument(expression));
@@ -71,13 +71,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var expression = MemberIs(name, name1);
             var invocation = Invocation(expression, argument);
 
-            return Argument(SimpleMemberAccess(invocation, name2));
+            return Argument(Member(invocation, name2));
         }
 
         protected static ArgumentSyntax Is(string name, ArgumentSyntax argument, string name1, ArgumentSyntax argument1)
         {
             var isCall = InvocationIs(name, argument);
-            var appendixCall = SimpleMemberAccess(isCall, name1);
+            var appendixCall = Member(isCall, name1);
 
             return Argument(appendixCall, argument1);
         }
@@ -86,7 +86,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var expression = MemberIs(name, name1);
             var isCall = Invocation(expression, argument);
-            var appendixCall = SimpleMemberAccess(isCall, name2);
+            var appendixCall = Member(isCall, name2);
 
             return Argument(appendixCall, argument1);
         }
@@ -101,7 +101,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected static ArgumentSyntax Does(string name, ArgumentSyntax argument, string name1)
         {
             var doesCall = Invocation(MemberDoes(name), argument);
-            var appendixCall = SimpleMemberAccess(doesCall, name1);
+            var appendixCall = Member(doesCall, name1);
 
             return Argument(appendixCall);
         }
@@ -111,7 +111,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected static ArgumentSyntax Does(string name, string name1, ArgumentSyntax argument, string name2)
         {
             var doesCall = Invocation(MemberDoes(name, name1), argument);
-            var appendixCall = SimpleMemberAccess(doesCall, name2);
+            var appendixCall = Member(doesCall, name2);
 
             return Argument(appendixCall);
         }
@@ -123,7 +123,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected static ArgumentSyntax Has(string name, ArgumentSyntax argument, string name1)
         {
             var hasCall = Invocation(MemberHas(name), argument);
-            var appendixCall = SimpleMemberAccess(hasCall, name1);
+            var appendixCall = Member(hasCall, name1);
 
             return Argument(appendixCall);
         }
@@ -134,13 +134,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected static ArgumentSyntax Has(string name, string name1, string name2, ExpressionSyntax expression) => Argument(MemberHas(name, name1, name2), Argument(expression));
 
-        protected static ArgumentSyntax Has(string name, string name1, ArgumentSyntax argument, params TypeSyntax[] types) => Argument(SimpleMemberAccess("Has", name, name1, types), argument);
+        protected static ArgumentSyntax Has(string name, string name1, ArgumentSyntax argument, params TypeSyntax[] types) => Argument(Member("Has", name, name1, types), argument);
 
-        protected static MemberAccessExpressionSyntax MemberDoes(params string[] names) => SimpleMemberAccess("Does", names);
+        protected static MemberAccessExpressionSyntax MemberDoes(params string[] names) => Member("Does", names);
 
-        protected static MemberAccessExpressionSyntax MemberHas(params string[] names) => SimpleMemberAccess("Has", names);
+        protected static MemberAccessExpressionSyntax MemberHas(params string[] names) => Member("Has", names);
 
-        protected static MemberAccessExpressionSyntax MemberIs(params string[] names) => SimpleMemberAccess("Is", names);
+        protected static MemberAccessExpressionSyntax MemberIs(params string[] names) => Member("Is", names);
 
         protected static ArgumentSyntax Throws(string name) => Argument("Throws", name);
 

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static ArgumentListSyntax ArgumentList(params ArgumentSyntax[] arguments) => SyntaxFactory.ArgumentList(arguments.ToSeparatedSyntaxList());
 
-        protected static InvocationExpressionSyntax Invocation(MemberAccessExpressionSyntax member, params ArgumentSyntax[] arguments)
+        protected static InvocationExpressionSyntax Invocation(ExpressionSyntax member, params ArgumentSyntax[] arguments)
         {
             // that's for the argument
             var argumentList = ArgumentList(arguments);
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules
         protected static InvocationExpressionSyntax Invocation(string typeName, string methodName, params TypeSyntax[] items)
         {
             // that's for the method call
-            var member = SimpleMemberAccess(typeName, methodName, items);
+            var member = Member(typeName, methodName, items);
 
             return Invocation(member);
         }
@@ -93,20 +93,33 @@ namespace MiKoSolutions.Analyzers.Rules
 
         protected static PredefinedTypeSyntax PredefinedType(in SyntaxKind kind) => SyntaxFactory.PredefinedType(kind.AsToken());
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(ExpressionSyntax syntax, string name)
+        protected static MemberAccessExpressionSyntax Member(ExpressionSyntax expression, SimpleNameSyntax name)
         {
-            var identifierName = SyntaxFactory.IdentifierName(name);
-
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, syntax, identifierName);
+            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, name);
         }
 
-        protected static MemberAccessExpressionSyntax SimpleMemberAccess(string typeName, string methodName, TypeSyntax[] items)
+        protected static MemberAccessExpressionSyntax Member(ExpressionSyntax syntax, string name)
         {
-            var type = SyntaxFactory.IdentifierName(typeName);
-            var method = SyntaxFactory.GenericName(methodName).AddTypeArgumentListArguments(items);
+            var identifierName = IdentifierName(name);
 
-            return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, type, method);
+            return Member(syntax, identifierName);
         }
+
+        protected static MemberAccessExpressionSyntax Member(string typeName, string methodName, TypeSyntax[] items)
+        {
+            var type = IdentifierName(typeName);
+            var method = GenericName(methodName, items);
+
+            return Member(type, method);
+        }
+
+        protected static IdentifierNameSyntax IdentifierName(string name) => SyntaxFactory.IdentifierName(name);
+
+        protected static IdentifierNameSyntax IdentifierName(in SyntaxToken token) => SyntaxFactory.IdentifierName(token);
+
+        protected static GenericNameSyntax GenericName(string name, TypeSyntax[] items) => SyntaxFactory.GenericName(name).AddTypeArgumentListArguments(items);
+
+        protected static GenericNameSyntax GenericName(string name, TypeArgumentListSyntax types) => SyntaxFactory.GenericName(name).WithTypeArgumentList(types);
 
         protected static TSyntaxNode GetSyntaxWithLeadingSpaces<TSyntaxNode>(TSyntaxNode syntaxNode, in int spaces) where TSyntaxNode : SyntaxNode
         {

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5001_CodeFixProvider.cs
@@ -81,8 +81,8 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
         private static MemberAccessExpressionSyntax CreateCondition(MemberAccessExpressionSyntax expression)
         {
             var identifier = GetIdentifier(expression);
-            var method = SyntaxFactory.IdentifierName(Constants.ILog.IsDebugEnabled);
-            var condition = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, identifier, method);
+            var method = IdentifierName(Constants.ILog.IsDebugEnabled);
+            var condition = Member(identifier, method);
 
             return condition;
         }
@@ -293,7 +293,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
             switch (expression.Expression)
             {
                 case IdentifierNameSyntax i:
-                    return SyntaxFactory.IdentifierName(i.GetName());
+                    return IdentifierName(i.GetName());
 
                 case MemberAccessExpressionSyntax m:
                     return m.WithoutLeadingTrivia();

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5002_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5002_CodeFixProvider.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             var name = identifier.GetName().WithoutSuffix("Format");
 
-            return SyntaxFactory.IdentifierName(name);
+            return IdentifierName(name);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5010_CodeFixProvider.cs
@@ -94,7 +94,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                         return SyntaxFactory.BinaryExpression(kind, left, right).WithTriviaFrom(syntax);
                     }
 
-                    var operand = Invocation(SimpleMemberAccess(left, nameof(Equals)), argument1);
+                    var operand = Invocation(Member(left, nameof(Equals)), argument1);
 
                     if (kind is SyntaxKind.NotEqualsExpression)
                     {


### PR DESCRIPTION
- Add `string.AsTypeSyntax()` extension method

- Replace `ParseTypeName` calls with `.AsTypeSyntax()`

- Rename `SimpleMemberAccess` helper to `Member`

- Use new `IdentifierName` and `GenericName` wrappers
