### PR TITLE
MiKo_5017 no longer reports string variables to be constants in case they get re-assigned

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -36,6 +38,17 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                 {
                     case LocalDeclarationStatementSyntax localVariable when localVariable.IsConst is false:
                     {
+                        if (localVariable.Parent is BlockSyntax block)
+                        {
+                            var variableName = v.Identifier.ValueText;
+
+                            if (block.DescendantNodes<ExpressionStatementSyntax>().Any(_ => _.Expression is AssignmentExpressionSyntax a && a.Left is IdentifierNameSyntax i && i.GetName() == variableName))
+                            {
+                                // the variable gets reassigned, so we do not report an issue
+                                return null;
+                            }
+                        }
+
                         return Issue(localVariable);
                     }
 

--- a/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzerTests.cs
@@ -52,6 +52,24 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_string_literal_as_local_variable_that_gets_reassigned() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var value = ""test me"";
+
+        for (var i = 0; i < 10; i++)
+        {
+            value = ""test me"" + i;
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_string_literal_as_static_readonly_field() => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Skip reporting when string variable is reassigned

- Add new test for reassigned local string variable
