### PR TITLE
Added new rule MiKo_3124 that reports on asserts in 'finally' blocks

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2105,6 +2105,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsExpressionTree(this SyntaxNode value, SemanticModel semanticModel)
         {
+            // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var a in value.AncestorsWithinMethods<ArgumentSyntax>())
             {
                 var convertedType = semanticModel.GetTypeInfo(a.Expression).ConvertedType;
@@ -2233,6 +2234,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsWhiteSpaceOnlyText(this XmlTextSyntax value)
         {
+            // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var text in value.GetTextWithoutTriviaLazy())
             {
                 if (text.IsNullOrWhiteSpace() is false)
@@ -2917,10 +2919,10 @@ namespace MiKoSolutions.Analyzers
 
             if (parent is null)
             {
-                return default;
+                return null;
             }
 
-            SyntaxNode previousChild = default;
+            SyntaxNode previousChild = null;
 
             foreach (var child in parent.ChildNodes())
             {
@@ -2932,7 +2934,7 @@ namespace MiKoSolutions.Analyzers
                 previousChild = child;
             }
 
-            return default;
+            return null;
         }
 
         internal static SyntaxNodeOrToken PreviousSiblingNodeOrToken(this SyntaxNode value)
@@ -2965,7 +2967,7 @@ namespace MiKoSolutions.Analyzers
 
             if (parent is null)
             {
-                return default;
+                return null;
             }
 
             using (var enumerator = parent.ChildNodes().GetEnumerator())
@@ -2976,14 +2978,14 @@ namespace MiKoSolutions.Analyzers
                     {
                         var nextSibling = enumerator.MoveNext()
                                           ? enumerator.Current
-                                          : default;
+                                          : null;
 
                         return nextSibling;
                     }
                 }
             }
 
-            return default;
+            return null;
         }
 
         internal static IList<SyntaxNode> Siblings(this SyntaxNode value) => Siblings<SyntaxNode>(value);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -208,6 +208,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3119_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3120_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3123_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -303,6 +303,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3121_ObjectUnderTestIsNoInterfaceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3122_TestMethodsDoNotHaveMultipleParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -13516,6 +13516,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Move assertion outside finally block.
+        /// </summary>
+        internal static string MiKo_3124_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3124_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid asserting in finally blocks as failing assertions can hide the original test failures. Do the assertions after the finally blocks to ensure accurate and reliable test results..
+        /// </summary>
+        internal static string MiKo_3124_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3124_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not assert in finally block.
+        /// </summary>
+        internal static string MiKo_3124_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3124_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test methods should not assert in finally blocks.
+        /// </summary>
+        internal static string MiKo_3124_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3124_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
         internal static string MiKo_3201_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -4734,6 +4734,18 @@ This ensures precision in your tests and maintains clear expectations.</value>
   <data name="MiKo_3123_Title" xml:space="preserve">
     <value>Test methods should not catch exceptions</value>
   </data>
+  <data name="MiKo_3124_CodeFixTitle" xml:space="preserve">
+    <value>Move assertion outside finally block</value>
+  </data>
+  <data name="MiKo_3124_Description" xml:space="preserve">
+    <value>Avoid asserting in finally blocks as failing assertions can hide the original test failures. Do the assertions after the finally blocks to ensure accurate and reliable test results.</value>
+  </data>
+  <data name="MiKo_3124_MessageFormat" xml:space="preserve">
+    <value>Do not assert in finally block</value>
+  </data>
+  <data name="MiKo_3124_Title" xml:space="preserve">
+    <value>Test methods should not assert in finally blocks</value>
+  </data>
   <data name="MiKo_3201_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3123_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3123_CodeFixProvider.cs
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 }
             }
 
-            return syntax;
+            return root;
         }
 
         private static SyntaxNode GetUpdatedSyntaxRootForXunit(SyntaxNode root, TryStatementSyntax tryStatement)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3124_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3124_CodeFixProvider.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3124_CodeFixProvider)), Shared]
+    public sealed class MiKo_3124_CodeFixProvider : UnitTestCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3124";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ExpressionStatementSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => syntax;
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (syntax is ExpressionStatementSyntax statement && statement.FirstAncestor<TryStatementSyntax>() is TryStatementSyntax tryStatement && tryStatement.Parent is BlockSyntax outerBlock)
+            {
+                var nodeToRemove = statement.Parent is BlockSyntax block && block.Parent.IsKind(SyntaxKind.FinallyClause) is false && block.Statements.Count is 1
+                                   ? (SyntaxNode)block
+                                   : statement;
+
+                var nodeToAdjust = nodeToRemove.NextSibling();
+
+                BlockSyntax updatedBlock;
+
+                if (nodeToAdjust != null)
+                {
+                    // adjust the leading trivia of the node to adjust
+                    updatedBlock = outerBlock.ReplaceNodes(new[] { nodeToRemove, nodeToAdjust }, (original, rewritten) => original == nodeToAdjust ? rewritten.WithoutLeadingEndOfLine() : null);
+                }
+                else
+                {
+                    updatedBlock = outerBlock.Without(nodeToRemove);
+                }
+
+                return root.ReplaceNode(outerBlock, updatedBlock.AddStatements(statement.WithLeadingSpaces(tryStatement.GetPositionWithinStartLine()).WithLeadingEmptyLine()));
+            }
+
+            return root;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3124";
+
+        public MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeFinallyClause, SyntaxKind.FinallyClause);
+
+        private static bool IsAssert(ExpressionStatementSyntax statement) => statement.Expression is InvocationExpressionSyntax i && i.GetIdentifierName().EndsWith("Assert", StringComparison.Ordinal);
+
+        private void AnalyzeFinallyClause(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is FinallyClauseSyntax clause)
+            {
+                var method = clause.FirstAncestor<MethodDeclarationSyntax>();
+
+                if (method != null)
+                {
+                    var issues = clause.DescendantNodes<ExpressionStatementSyntax>()
+                                       .Where(IsAssert)
+                                       .Select(_ => Issue(_))
+                                       .ToList();
+
+                    if (issues.Count > 0)
+                    {
+                        ReportDiagnostics(context, issues);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzerTests.cs
@@ -149,7 +149,7 @@ namespace Bla
 ");
 
         [Test]
-        public void Ano_issue_is_reported_for_test_method_with_catch_exception_block() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_method_with_catch_exception_block() => An_issue_is_reported_for(@"
 using System;
 
 using NUnit.Framework;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzerTests.cs
@@ -1,0 +1,754 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_non_test_method_with_empty_finally_block() => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            try
+            {
+            }
+            finally
+            {
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_method_with_empty_finally_block_and_assertion_in_try_block() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            try
+            {
+                Assert.Fail(""for reasons"");
+            }
+            finally
+            {
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_non_test_method_with_code_in_finally_block_and_assertion_in_try_block() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable = null;
+
+            try
+            {
+                Assert.Fail(""for reasons"");
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_empty_finally_block() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            try
+            {
+            }
+            finally
+            {
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_empty_finally_block_and_assertion_in_try_block() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            try
+            {
+                Assert.Fail(""for reasons"");
+            }
+            finally
+            {
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_code_in_finally_block_and_assertion_in_try_block() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable = null;
+
+            try
+            {
+                Assert.Fail(""for reasons"");
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_test_method_with_code_and_assertion_at_start_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                Assert.Fail(""for reasons"");
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_test_method_with_code_and_assertion_in_the_middle_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                Assert.Fail(""for reasons"");
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_non_test_method_with_code_and_assertion_at_end_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                Assert.Fail(""for reasons"");
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_code_and_assertion_at_start_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                Assert.Fail(""for reasons"");
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_code_and_assertion_in_the_middle_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                Assert.Fail(""for reasons"");
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_code_and_assertion_at_end_of_finally_block() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                Assert.Fail(""for reasons"");
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_as_only_statement_in_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            try
+            {
+                // do something
+            }
+            finally
+            {
+                Assert.Fail(""for reasons"");
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            try
+            {
+                // do something
+            }
+            finally
+            {
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_at_start_of_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                Assert.Fail(""for reasons"");
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_in_the_middle_of_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable1, disposable2;
+
+            try
+            {
+                disposable1 = disposable2 = null;
+            }
+            finally
+            {
+                disposable1?.Dispose();
+
+                Assert.Fail(""for reasons"");
+
+                disposable2?.Dispose();
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable1, disposable2;
+
+            try
+            {
+                disposable1 = disposable2 = null;
+            }
+            finally
+            {
+                disposable1?.Dispose();
+                disposable2?.Dispose();
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_at_end_of_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                Assert.Fail(""for reasons"");
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_in_nested_block_at_end_of_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+
+                {
+                    Assert.Fail(""for reasons"");
+                }
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_assertion_in_nested_block_at_start_of_finally_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                {
+                    Assert.Fail(""for reasons"");
+                }
+
+                disposable?.Dispose();
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            IDisposable disposable;
+
+            try
+            {
+                disposable = null;
+            }
+            finally
+            {
+                disposable?.Dispose();
+            }
+
+            Assert.Fail(""for reasons"");
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3124_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 512 rules that are currently provided by the analyzer.
+The following tables lists all the 513 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -424,6 +424,7 @@ The following tables lists all the 512 rules that are currently provided by the 
 |MiKo_3121|Tests should test concrete implementations and no interfaces|&#x2713;|\-|
 |MiKo_3122|Test methods should not use more than 2 parameters|&#x2713;|\-|
 |MiKo_3123|Test methods should not catch exceptions|&#x2713;|\-|
+|MiKo_3124|Test methods should not assert in finally blocks|&#x2713;|\-|
 |MiKo_3201|If statements can be inverted in short methods|&#x2713;|&#x2713;|
 |MiKo_3202|Use positive conditions when returning in all paths|&#x2713;|&#x2713;|
 |MiKo_3203|If-continue statements can be inverted when followed by single line|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add MiKo_3124 analyzer to forbid asserts in finally blocks
  - Refactor `SyntaxNodeExtensions` to return `null` instead of `default`

- Implement code fix to move asserts outside finally blocks

- Add unit tests for analyzer and code fix

- Update project, localization resources and README with new rule

(resolves #1432)
