### PR TITLE
MiKo_3123 is now able to fix more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MaintainabilityCodeFixProvider.cs
@@ -129,6 +129,24 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
+#pragma warning disable CA1021
+        protected static LocalDeclarationStatementSyntax LocalVariable(TypeSyntax type, string variableName, out VariableDeclaratorSyntax declarator)
+        {
+            declarator = SyntaxFactory.VariableDeclarator(variableName);
+            var declaration = SyntaxFactory.VariableDeclaration(type, declarator.ToSeparatedSyntaxList());
+
+            return SyntaxFactory.LocalDeclarationStatement(declaration);
+        }
+#pragma warning restore CA1021
+
+        protected static LocalDeclarationStatementSyntax LocalVariable(TypeSyntax type, string variableName, ExpressionSyntax value)
+        {
+            var declarator = SyntaxFactory.VariableDeclarator(variableName).WithInitializer(SyntaxFactory.EqualsValueClause(value));
+            var declaration = SyntaxFactory.VariableDeclaration(type, declarator.ToSeparatedSyntaxList());
+
+            return SyntaxFactory.LocalDeclarationStatement(declaration);
+        }
+
         protected static ExpressionSyntax LogicalNot(ExpressionSyntax expression) => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, SyntaxFactory.ParenthesizedExpression(expression));
 
         protected static IsPatternExpressionSyntax UnaryNot(IsPatternExpressionSyntax expression) => expression.WithPattern(UnaryNot(expression.Pattern));

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3085_CodeFixProvider.cs
@@ -72,8 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     var typeSyntax = GetTypeSyntax(parameterSymbol.Type);
                     var variableName = parameterSymbol.Name;
 
-                    var declarator = SyntaxFactory.VariableDeclarator(variableName);
-                    var declaration = SyntaxFactory.VariableDeclaration(typeSyntax, declarator.ToSeparatedSyntaxList());
+                    var localDeclaration = LocalVariable(typeSyntax, variableName, out var declarator);
 
                     var ifStatement = ConvertToIfStatement(conditional, trueCase => AssignmentStatement(declarator, trueCase), falseCase => AssignmentStatement(declarator, falseCase));
 
@@ -83,16 +82,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         case ReturnStatementSyntax returnStatement:
                         {
-                            var localDeclaration = SyntaxFactory.LocalDeclarationStatement(declaration).WithLeadingTriviaFrom(returnStatement);
                             var updatedReturnStatement = returnStatement.ReplaceNode(invocation, updatedInvocation);
 
-                            return root.ReplaceNode(returnStatement, new SyntaxNode[] { localDeclaration, ifStatement, updatedReturnStatement });
+                            return root.ReplaceNode(returnStatement, new SyntaxNode[] { localDeclaration.WithLeadingTriviaFrom(returnStatement), ifStatement, updatedReturnStatement });
                         }
 
                         case ArrowExpressionClauseSyntax arrowClause:
                         {
-                            var localDeclaration = SyntaxFactory.LocalDeclarationStatement(declaration);
-
                             var statement = arrowClause.HasReturnValue()
                                             ? (StatementSyntax)SyntaxFactory.ReturnStatement(updatedInvocation)
                                             : SyntaxFactory.ExpressionStatement(updatedInvocation);
@@ -257,9 +253,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var typeSyntax = GetTypeSyntax(expression.GetTypeSymbol(document));
             var variableName = assignment.Left.GetName().ToLowerCaseAt(0);
 
-            var declarator = SyntaxFactory.VariableDeclarator(variableName);
-            var declaration = SyntaxFactory.VariableDeclaration(typeSyntax, declarator.ToSeparatedSyntaxList());
-            var localDeclaration = SyntaxFactory.LocalDeclarationStatement(declaration).WithLeadingTriviaFrom(initializer).WithLeadingEmptyLine();
+            var localDeclaration = LocalVariable(typeSyntax, variableName, out var declarator).WithLeadingTriviaFrom(initializer).WithLeadingEmptyLine();
 
             var ifStatement = ConvertToIfStatement(conditional, trueCase => AssignmentStatement(declarator, trueCase), falseCase => AssignmentStatement(declarator, falseCase));
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzerTests.cs
@@ -947,6 +947,236 @@ namespace Bla
         }
 
         [Test]
+        public void Code_gets_fixed_for_NUnit_test_method_with_Assert_AreEqual_GetType_assertions_in_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            try
+            {
+                var a = 123;
+                var b = a.ToString();
+            }
+            catch (Exception ex)
+            {
+                // verify
+                Assert.AreEqual(typeof(DivideByZeroException), ex.GetType());
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            Assert.That(() =>
+            {
+                var a = 123;
+                var b = a.ToString();
+            }, Throws.TypeOf<DivideByZeroException>());
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_NUnit_test_method_with_Assert_AreEqual_Message_and_GetType_assertions_in_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            try
+            {
+                var a = 123;
+                var b = a.ToString();
+            }
+            catch (Exception ex)
+            {
+                // verify
+                Assert.AreEqual(""some message"", ex.Message);
+                Assert.AreEqual(typeof(DivideByZeroException), ex.GetType());
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            Assert.That(() =>
+            {
+                var a = 123;
+                var b = a.ToString();
+            }, Throws.TypeOf<DivideByZeroException>().With.Message.EqualTo(""some message""));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_NUnit_test_method_with_swapped_Assert_AreEqual_GetType_assertions_in_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            try
+            {
+                var a = 123;
+                var b = a.ToString();
+            }
+            catch (Exception ex)
+            {
+                // verify
+                Assert.AreEqual(ex.GetType(), typeof(DivideByZeroException));
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            Assert.That(() =>
+            {
+                var a = 123;
+                var b = a.ToString();
+            }, Throws.TypeOf<DivideByZeroException>());
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_NUnit_test_method_with_swapped_Assert_AreEqual_Message_and_GetType_assertions_in_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            try
+            {
+                var a = 123;
+                var b = a.ToString();
+            }
+            catch (Exception ex)
+            {
+                // verify
+                Assert.AreEqual(ex.Message, ""some message"");
+                Assert.AreEqual(ex.GetType(), typeof(DivideByZeroException));
+            }
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething(String s)
+        {
+            Assert.That(() =>
+            {
+                var a = 123;
+                var b = a.ToString();
+            }, Throws.TypeOf<DivideByZeroException>().With.Message.EqualTo(""some message""));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_NUnit_test_method_with_Assert_That_TypeOf_assertions_in_catch_block()
         {
             const string OriginalCode = @"


### PR DESCRIPTION
- Extend NUnit assertion code fix logic

- Add tests for new NUnit fix scenarios

- Add `LocalVariable` helper methods in code fixes

- Refactor MiKo_3085 and MiKo_3123 to use helper
