### PR TITLE
Introduced new rule MiKo_1513 incl. codefix that reports types suffixed with "Advanced", "Complex", "Enhanced", "Extended", "Simple" and "Simplified"

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -333,9 +333,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1509_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1513_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\TypeNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\DisposeOrderingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4001_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4002_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -491,6 +491,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1510_TypesWithInfoSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_ProxyVariablesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_ProxyParametersAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamesFinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5152,6 +5152,43 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change suffix into prefix.
+        /// </summary>
+        internal static string MiKo_1513_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1513_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer prefixing type names with descriptive modifiers like &apos;Advanced&apos; or &apos;Simplified&apos; instead of suffixing them.
+        ///Prefixes improve IntelliSense grouping and readability, while also making related types easier to discover and maintain across large codebases..
+        /// </summary>
+        internal static string MiKo_1513_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1513_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1513_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1513_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Types should not be suffixed with &apos;Advanced&apos;, &apos;Complex&apos;, &apos;Enhanced&apos;, &apos;Extended&apos;, &apos;Simple&apos; or &apos;Simplified&apos;.
+        /// </summary>
+        internal static string MiKo_1513_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1513_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1866,6 +1866,19 @@ Therefore, names should reflect the intended role rather than the implementation
   <data name="MiKo_1512_Title" xml:space="preserve">
     <value>Parameters should not be prefixed or suffixed with 'proxy'</value>
   </data>
+  <data name="MiKo_1513_CodeFixTitle" xml:space="preserve">
+    <value>Change suffix into prefix</value>
+  </data>
+  <data name="MiKo_1513_Description" xml:space="preserve">
+    <value>Prefer prefixing type names with descriptive modifiers like 'Advanced' or 'Simplified' instead of suffixing them.
+Prefixes improve IntelliSense grouping and readability, while also making related types easier to discover and maintain across large codebases.</value>
+  </data>
+  <data name="MiKo_1513_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1513_Title" xml:space="preserve">
+    <value>Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1030_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1030_CodeFixProvider)), Shared]
-    public sealed class MiKo_1030_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1030_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1030";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1031_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1031_CodeFixProvider)), Shared]
-    public sealed class MiKo_1031_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1031_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1031";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1037_CodeFixProvider)), Shared]
-    public sealed class MiKo_1037_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1037_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1037";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1038_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1038_CodeFixProvider)), Shared]
-    public sealed class MiKo_1038_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1038_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1038";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1048_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1048_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1048_CodeFixProvider)), Shared]
-    public sealed class MiKo_1048_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1048_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1048";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1054_CodeFixProvider)), Shared]
-    public sealed class MiKo_1054_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1054_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1054";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1059_CodeFixProvider)), Shared]
-    public sealed class MiKo_1059_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1059_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1059";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1092_CodeFixProvider)), Shared]
-    public sealed class MiKo_1092_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1092_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1092";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1101_CodeFixProvider)), Shared]
-    public sealed class MiKo_1101_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1101_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1101";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_CodeFixProvider.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1109_CodeFixProvider)), Shared]
-    public sealed class MiKo_1109_CodeFixProvider : NamingCodeFixProvider
+    public sealed class MiKo_1109_CodeFixProvider : TypeNamingCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_1109";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<TypeDeclarationSyntax>().FirstOrDefault();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1513_CodeFixProvider)), Shared]
+    public sealed class MiKo_1513_CodeFixProvider : TypeNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1513";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1513_TypesWithExtendedSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1513";
+
+        private static readonly string[] WrongSuffixes = { "Advanced", "Complex", "Enhanced", "Extended", "Simple", "Simplified" };
+
+        public MiKo_1513_TypesWithExtendedSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        {
+            foreach (var suffix in WrongSuffixes)
+            {
+                var symbolName = symbol.Name.AsSpan();
+
+                if (symbolName.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    var proposal = suffix.ConcatenatedWith(symbolName.WithoutSuffix(suffix));
+
+                    return new[] { Issue(symbol, proposal, CreateBetterNameProposal(proposal)) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/TypeNamingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/TypeNamingCodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    public abstract class TypeNamingCodeFixProvider : NamingCodeFixProvider
+    {
+        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzerTests.cs
@@ -24,8 +24,6 @@ namespace Bla
 
         [Test]
         public void An_issue_is_reported_for_type_with_suffix_Info_([ValueSource(nameof(TypeKinds))] string type) => An_issue_is_reported_for(@"
-using NUnit.Framework;
-
 namespace Bla
 {
     public " + type + @" TestMeInfo

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzerTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1513_TypesWithExtendedSuffixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] TypeKinds = ["interface", "class", "struct", "record", "enum"];
+
+        private static readonly string[] WrongSuffixes = ["Advanced", "Complex", "Enhanced", "Extended", "Simple", "Simplified"];
+
+        [Test]
+        public void No_issue_is_reported_for_type_without_suffix_([ValueSource(nameof(WrongSuffixes))] string suffix, [ValueSource(nameof(TypeKinds))] string type) => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public " + type + @" TestMe
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_type_with_suffix_([ValueSource(nameof(WrongSuffixes))] string suffix, [ValueSource(nameof(TypeKinds))] string type) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public " + type + @" TestMe" + suffix + @"
+    {
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_type_with_suffix_([ValueSource(nameof(WrongSuffixes))] string suffix, [ValueSource(nameof(TypeKinds))] string type)
+        {
+            var originalCode = @"
+namespace Bla
+{
+    public " + type + @" TestMe" + suffix + @"
+    {
+    }
+}
+";
+
+            var fixedCode = @"
+namespace Bla
+{
+    public " + type + " " + suffix + @"TestMe
+    {
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1513_TypesWithExtendedSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1513_TypesWithExtendedSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1513_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 513 rules that are currently provided by the analyzer.
+The following tables lists all the 514 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -172,6 +172,7 @@ The following tables lists all the 513 rules that are currently provided by the 
 |MiKo_1510|Types should not be suffixed with 'Info'|&#x2713;|\-|
 |MiKo_1511|Local variables should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
 |MiKo_1512|Parameters should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
+|MiKo_1513|Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add rule MiKo_1513 to flag forbidden type suffixes

- Provide code fix to move suffix into prefix

- Refactor existing type codefixes to use new base class

- Add localization, tests and update README

(resolves #1436)