### PR TITLE
Refactored analyzers from symbol-based to syntax-based

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2490,7 +2490,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsInsideTestClass(this SyntaxNode value) => value.Ancestors<ClassDeclarationSyntax>().Any(_ => _.IsTestClass());
 
-        internal static bool IsTestClass(this TypeDeclarationSyntax value) => value is ClassDeclarationSyntax declaration && IsTestClass(declaration);
+        internal static bool IsTestClass(this BaseTypeDeclarationSyntax value) => value is ClassDeclarationSyntax declaration && IsTestClass(declaration);
 
         internal static bool IsTestClass(this ClassDeclarationSyntax value) => value.HasAttributeName(Constants.Names.TestClassAttributeNames);
 
@@ -4105,27 +4105,7 @@ namespace MiKoSolutions.Analyzers
                        .FirstOrDefault();
         }
 
-        internal static bool HasAttributeName(this TypeDeclarationSyntax value, IEnumerable<string> names)
-        {
-            var attributeLists = value.AttributeLists;
-
-            for (int i = 0, count = attributeLists.Count; i < count; i++)
-            {
-                var attributes = attributeLists[i].Attributes;
-
-                for (int index = 0, attributesCount = attributes.Count; index < attributesCount; index++)
-                {
-                    if (names.Contains(attributes[index].GetName()))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        internal static bool HasAttributeName(this MethodDeclarationSyntax value, IEnumerable<string> names)
+        internal static bool HasAttributeName(this MemberDeclarationSyntax value, IEnumerable<string> names)
         {
             var attributeLists = value.AttributeLists;
 

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -496,6 +496,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\TypeSyntaxNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4003_DisposeMethodsOrderedAfterCtorsAndFinalizersAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -2094,7 +2094,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove &apos;Utility&apos; marker suffix.
+        ///   Looks up a localized string similar to Remove utility marker suffix.
         /// </summary>
         internal static string MiKo_1054_CodeFixTitle {
             get {
@@ -2103,7 +2103,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Names like &apos;helper&apos; or &apos;utility&apos; are too vague and do not follow the Single Responsibility Principle (SRP). These types often end up having too broad a scope and do not clearly define what they do.
+        ///   Looks up a localized string similar to Names like &apos;Helper&apos; or &apos;Utility&apos; are too vague and do not follow the Single Responsibility Principle (SRP). These types often end up having too broad a scope and do not clearly define what they do.
         ///Instead, use specific names that describe their exact purpose, making the code easier to understand and maintain..
         /// </summary>
         internal static string MiKo_1054_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -801,10 +801,10 @@ So, use meaningful names instead of vague ones like 'ret', 'retVal', or 'returnV
     <value>Do not suffix fields with delegate types</value>
   </data>
   <data name="MiKo_1054_CodeFixTitle" xml:space="preserve">
-    <value>Remove 'Utility' marker suffix</value>
+    <value>Remove utility marker suffix</value>
   </data>
   <data name="MiKo_1054_Description" xml:space="preserve">
-    <value>Names like 'helper' or 'utility' are too vague and do not follow the Single Responsibility Principle (SRP). These types often end up having too broad a scope and do not clearly define what they do.
+    <value>Names like 'Helper' or 'Utility' are too vague and do not follow the Single Responsibility Principle (SRP). These types often end up having too broad a scope and do not clearly define what they do.
 Instead, use specific names that describe their exact purpose, making the code easier to understand and maintain.</value>
   </data>
   <data name="MiKo_1054_MessageFormat" xml:space="preserve">

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1030_BaseTypePrefixSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1030_BaseTypePrefixSuffixAnalyzer.cs
@@ -2,32 +2,42 @@
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1030_BaseTypePrefixSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1030_BaseTypePrefixSuffixAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1030";
 
-        public MiKo_1030_BaseTypePrefixSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1030_BaseTypePrefixSuffixAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var symbolName = symbol.Name.Without("Abstraction").Replace("BasedOn", "#");
+            var symbolName = typeName.Without("Abstraction").Replace("BasedOn", "#");
+
+            List<Diagnostic> issues = null;
 
             foreach (var marker in Constants.Markers.BaseClasses)
             {
                 if (symbolName.Contains(marker))
                 {
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
                     var betterName = symbolName.Without(Constants.Markers.BaseClasses);
 
-                    yield return Issue(symbol, marker, CreateBetterNameProposal(betterName));
+                    issues.Add(Issue(typeNameIdentifier, betterName, marker));
                 }
             }
+
+            return issues?.ToArray() ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1054_HelperClassNameAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1054_HelperClassNameAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1054";
 
@@ -22,41 +22,39 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         // sorted by intent so that the best match is found until a more generic is found
         private static readonly string[] WrongNamesForConcreteLookup = { "Helpers", "Helper", "Miscellaneous", "Misc", "Utils", "Utility", "Utilities", "Util" };
 
-        public MiKo_1054_HelperClassNameAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1054_HelperClassNameAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var symbolName = symbol.Name;
-
-            if (symbolName.Contains(CorrectName))
+            if (typeName.Contains(CorrectName))
             {
                 return Array.Empty<Diagnostic>();
             }
 
-            if (symbolName.ContainsAny(WrongNames))
+            if (typeName.ContainsAny(WrongNames))
             {
-                var wrongName = WrongNamesForConcreteLookup.First(_ => symbolName.Contains(_, StringComparison.OrdinalIgnoreCase));
+                var wrongName = WrongNamesForConcreteLookup.First(_ => typeName.Contains(_, StringComparison.OrdinalIgnoreCase));
 
-                var proposal = FindBetterName(symbolName.AsSpan(), wrongName);
+                var proposal = FindBetterName(typeName.AsSpan(), wrongName);
 
-                return new[] { Issue(symbol, wrongName, CreateBetterNameProposal(proposal)) };
+                return new[] { Issue(typeNameIdentifier, proposal, wrongName) };
             }
 
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(in ReadOnlySpan<char> symbolName, string wrongName)
+        private static string FindBetterName(in ReadOnlySpan<char> typeName, string wrongName)
         {
-            if (symbolName.Length > SpecialNameHandle.Length && symbolName.StartsWith(SpecialNameHandle, StringComparison.Ordinal))
+            if (typeName.Length > SpecialNameHandle.Length && typeName.StartsWith(SpecialNameHandle, StringComparison.Ordinal))
             {
-                return symbolName.WithoutSuffix(wrongName)
-                                 .Slice(SpecialNameHandle.Length)
-                                 .ConcatenatedWith(SpecialNameHandler);
+                return typeName.WithoutSuffix(wrongName)
+                               .Slice(SpecialNameHandle.Length)
+                               .ConcatenatedWith(SpecialNameHandler);
             }
 
-            return symbolName.WithoutSuffix(wrongName).ToString();
+            return typeName.WithoutSuffix(wrongName).ToString();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_ImplClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1059_ImplClassNameAnalyzer.cs
@@ -1,33 +1,31 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1059_ImplClassNameAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1059_ImplClassNameAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1059";
 
         private static readonly string[] WrongSuffixes = { "Impl", "Implementation", "Imp" };
 
-        public MiKo_1059_ImplClassNameAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1059_ImplClassNameAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var symbolName = symbol.Name;
-
             foreach (var wrongSuffix in WrongSuffixes)
             {
-                if (symbolName.EndsWith(wrongSuffix, StringComparison.OrdinalIgnoreCase))
+                if (typeName.EndsWith(wrongSuffix, StringComparison.OrdinalIgnoreCase))
                 {
-                    var proposal = symbolName.WithoutSuffix(wrongSuffix);
+                    var proposal = typeName.WithoutSuffix(wrongSuffix);
 
-                    return new[] { Issue(symbol, wrongSuffix, CreateBetterNameProposal(proposal)) };
+                    return new[] { Issue(typeNameIdentifier, proposal, wrongSuffix) };
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1092_AbilityTypeWrongSuffixedAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1092_AbilityTypeWrongSuffixedAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1092";
 
@@ -22,21 +22,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "Information",
                                                         };
 
-        public MiKo_1092_AbilityTypeWrongSuffixedAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1092_AbilityTypeWrongSuffixedAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.Name.EndsWithAny(TypeSuffixes, Comparison);
+        protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => typeName.EndsWithAny(TypeSuffixes, Comparison);
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var name = symbol.Name;
-
-            if (name.Contains("able") && name.EndsWithAny(TypeSuffixes, Comparison))
+            if (typeName.Contains("able") && typeName.EndsWithAny(TypeSuffixes, Comparison))
             {
-                var proposedName = GetProposedName(name);
+                var proposedName = GetProposedName(typeName);
 
-                return new[] { Issue(symbol, proposedName, CreateBetterNameProposal(proposedName)) };
+                return new[] { Issue(typeNameIdentifier, proposedName) };
             }
 
             return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzer.cs
@@ -1,29 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1101_TestClassesSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1101_TestClassesSuffixAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1101";
 
-        private const string TestSuffix = "Test";
-
-        public MiKo_1101_TestClassesSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1101_TestClassesSuffixAnalyzer() : base(Id)
         {
         }
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.IsTestClass();
+        protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => declaration.IsTestClass();
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var className = symbol.Name;
+            var className = typeName.AsSpan();
 
             if (className.EndsWith(Constants.TestsSuffix, StringComparison.Ordinal))
             {
@@ -32,14 +30,27 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var name = FindBetterName(className);
 
-            return new[] { Issue(symbol, name, CreateBetterNameProposal(name)) };
+            return new[] { Issue(typeNameIdentifier, name) };
         }
 
-        private static string FindBetterName(string className)
+        private static string FindBetterName(in ReadOnlySpan<char> className)
         {
-            var suffix = className.EndsWith(TestSuffix, StringComparison.Ordinal) ? "s" : Constants.TestsSuffix;
+            if (className.EndsWith("Test", StringComparison.Ordinal))
+            {
+                return className.ConcatenatedWith('s');
+            }
 
-            return className + suffix;
+            if (className.EndsWith("TestBase", StringComparison.Ordinal))
+            {
+                return className.Slice(0, className.Length - 4).ConcatenatedWith('s');
+            }
+
+            if (className.EndsWith("TestsBase", StringComparison.Ordinal))
+            {
+                return className.Slice(0, className.Length - 4).ToString();
+            }
+
+            return className.ConcatenatedWith(Constants.TestsSuffix);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer.cs
@@ -1,34 +1,34 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1109";
 
         private const string Prefix = "Testable";
         private const string Suffix = "Ut";
 
-        public MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer() : base(Id)
         {
         }
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var symbolName = symbol.Name.AsSpan();
+            var className = typeName.AsSpan();
 
-            if (symbolName.EndsWith(Suffix, StringComparison.Ordinal))
+            if (className.EndsWith(Suffix, StringComparison.Ordinal))
             {
-                var betterName = FindBetterName(symbolName);
+                var betterName = FindBetterName(className);
 
-                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+                return new[] { Issue(typeNameIdentifier, betterName) };
             }
 
             return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
@@ -1,33 +1,33 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1513_TypesWithExtendedSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1513_TypesWithExtendedSuffixAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1513";
 
         private static readonly string[] WrongSuffixes = { "Advanced", "Complex", "Enhanced", "Extended", "Simple", "Simplified" };
 
-        public MiKo_1513_TypesWithExtendedSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1513_TypesWithExtendedSuffixAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
             foreach (var suffix in WrongSuffixes)
             {
-                var symbolName = symbol.Name.AsSpan();
+                var symbolName = typeName.AsSpan();
 
                 if (symbolName.EndsWith(suffix, StringComparison.Ordinal))
                 {
                     var proposal = suffix.ConcatenatedWith(symbolName.WithoutSuffix(suffix));
 
-                    return new[] { Issue(symbol, proposal, CreateBetterNameProposal(proposal)) };
+                    return new[] { Issue(typeNameIdentifier, proposal) };
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/TypeSyntaxNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/TypeSyntaxNamingAnalyzer.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    public abstract class TypeSyntaxNamingAnalyzer : NamingAnalyzer
+    {
+        private static readonly SyntaxKind[] TypeKinds =
+                                                         {
+                                                             SyntaxKind.ClassDeclaration,
+                                                             SyntaxKind.InterfaceDeclaration,
+                                                             SyntaxKind.StructDeclaration,
+                                                             SyntaxKind.RecordDeclaration,
+                                                             SyntaxKind.RecordStructDeclaration,
+                                                             SyntaxKind.EnumDeclaration,
+                                                         };
+
+        protected TypeSyntaxNamingAnalyzer(string diagnosticId) : base(diagnosticId)
+        {
+        }
+
+        protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSyntax, TypeKinds);
+
+        protected abstract Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration);
+
+        protected virtual bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => true;
+
+        protected Diagnostic Issue(in SyntaxToken typeNameIdentifier, string betterName)
+        {
+            var typeName = typeNameIdentifier.ValueText;
+
+            return Issue(typeName, typeNameIdentifier, betterName, CreateBetterNameProposal(betterName));
+        }
+
+        protected Diagnostic Issue(in SyntaxToken typeNameIdentifier, string betterName, string issue)
+        {
+            var typeName = typeNameIdentifier.ValueText;
+
+            return Issue(typeName, typeNameIdentifier, issue, CreateBetterNameProposal(betterName));
+        }
+
+        private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BaseTypeDeclarationSyntax declaration)
+            {
+                var typeNameIdentifier = declaration.Identifier;
+                var typeName = typeNameIdentifier.ValueText;
+
+                if (ShallAnalyze(typeName, declaration))
+                {
+                    var issues = AnalyzeName(typeName, typeNameIdentifier, declaration);
+
+                    if (issues.Length > 0)
+                    {
+                        ReportDiagnostics(context, issues);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzerTests.cs
@@ -38,6 +38,8 @@ public class TestMe
 
         [TestCase("[TestFixture] class TestMe { }", "[TestFixture] class TestMeTests { }")]
         [TestCase("[TestFixture] class TestMeTest { }", "[TestFixture] class TestMeTests { }")]
+        [TestCase("[TestFixture] class TestMeTestBase { }", "[TestFixture] class TestMeTests { }")]
+        [TestCase("[TestFixture] class TestMeTestsBase { }", "[TestFixture] class TestMeTests { }")]
         public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_1101_TestClassesSuffixAnalyzer.Id;


### PR DESCRIPTION
- Add `TypeSyntaxNamingAnalyzer` base for types

- Convert naming analyzers to syntax-based logic

- Generalize test and attribute extension methods

- Update resource strings and test cases

(resolves #1440)