### PR TITLE
Refactored FindBetterName in analyzers

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1503_MethodsWithCounterSuffixAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             if (symbolName.EndsWith(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
             {
-                var betterName = FindBetterName(symbolName);
+                var betterName = FindBetterName(symbolName.AsSpan());
 
                 return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
             }
@@ -35,16 +35,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(string symbolName)
+        private static string FindBetterName(in ReadOnlySpan<char> symbolName)
         {
-            var nameSpan = symbolName.AsSpan();
+            var length = symbolName.Contains("Increment") || symbolName.Contains("Decrement")
+                         ? Constants.Names.Counter.Length
+                         : 2; // length of "er";
 
-            if (nameSpan.Contains("Increment") || nameSpan.Contains("Decrement"))
-            {
-                return symbolName.WithoutSuffix(Constants.Names.Counter);
-            }
-
-            return symbolName.WithoutSuffix("er");
+            return symbolName.Slice(0, symbolName.Length - length).ToString();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -33,14 +34,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(string symbolName)
+        private static string FindBetterName(string name)
         {
-            if (symbolName.Equals(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
+            if (name.Equals(Constants.Names.Counter, StringComparison.OrdinalIgnoreCase))
             {
                 return "Count";
             }
 
-            return "Counted" + Pluralizer.MakePluralName(symbolName.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
+            var length = Constants.Names.Counter.Length;
+
+            return "Counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToString());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1505_FieldsWithCounterSuffixAnalyzer.cs
@@ -35,16 +35,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
         {
-            var betterName = FindBetterName(symbol.Name);
+            var betterName = FindBetterName(symbol.Name.AsSpan());
 
             return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
         }
 
-        private static string FindBetterName(string symbolName)
+        private static string FindBetterName(in ReadOnlySpan<char> symbolName)
         {
             // be aware of field prefixes, such as 'm_'
             var prefix = GetFieldPrefix(symbolName);
-            var name = symbolName.AsSpan().Slice(prefix.Length, symbolName.Length - prefix.Length - Constants.Names.Counter.Length).ToUpperCaseAt(0);
+            var name = symbolName.Slice(prefix.Length, symbolName.Length - prefix.Length - Constants.Names.Counter.Length).ToUpperCaseAt(0);
 
             if (name.IsNullOrEmpty())
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -47,7 +48,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return "count";
             }
 
-            return "counted" + Pluralizer.MakePluralName(name.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
+            var length = Constants.Names.Counter.Length;
+
+            return "counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToString());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -33,7 +34,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return "count";
             }
 
-            return "counted" + Pluralizer.MakePluralName(symbolName.WithoutSuffix(Constants.Names.Counter).ToUpperCaseAt(0));
+            var length = Constants.Names.Counter.Length;
+
+            return "counted" + Pluralizer.MakePluralName(symbolName.AsCachedBuilder().Remove(symbolName.Length - length, length).ToUpperCaseAt(0).ToString());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -40,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         private static string FindBetterName(string name) => name.Length > 5
-                                                             ? name.Without("proxy").Without("Proxy").ToLowerCaseAt(0) // simply remove both as we need to check them anyway (so we save some calls)
+                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToString() // simply remove both as we need to check them anyway (so we save some calls)
                                                              : name;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -33,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         private static string FindBetterName(string name) => name.Length > 5
-                                                             ? name.Without("proxy").Without("Proxy").ToLowerCaseAt(0) // simply remove both as we need to check them anyway (so we save some calls)
+                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToString() // simply remove both as we need to check them anyway (so we save some calls)
                                                              : name;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -33,7 +33,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return expected;
         }
 
-        protected static string GetFieldPrefix(string fieldName)
+        protected static string GetFieldPrefix(string fieldName) => GetFieldPrefix(fieldName.AsSpan());
+
+        protected static string GetFieldPrefix(in ReadOnlySpan<char> fieldName)
         {
             var fieldPrefixes = Constants.Markers.FieldPrefixes;
 


### PR DESCRIPTION
- Refactor name handling to spans

- Reduce string allocations and copies

- Unify better-name generation logic

- Add overloads using `ReadOnlySpan<char>`

(resolves #1441)