### PR TITLE
Refactored analyzers from symbol-based to syntax-based

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using MiKoSolutions.Analyzers.Linguistics;
@@ -9,24 +9,22 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1079_RepositorySuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1079_RepositorySuffixAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1079";
 
         private const string Repository = nameof(Repository);
 
-        public MiKo_1079_RepositorySuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1079_RepositorySuffixAnalyzer() : base(Id)
         {
         }
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.Length > Repository.Length;
+        protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => typeName.Length > Repository.Length;
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            var symbolName = symbol.Name;
-
-            return symbolName.EndsWith(Repository, StringComparison.Ordinal)
-                   ? new[] { Issue(symbol, CreateBetterNameProposal(FindBetterName(symbolName))) }
+            return typeName.EndsWith(Repository, StringComparison.Ordinal)
+                   ? new[] { Issue(typeNameIdentifier, FindBetterName(typeName)) }
                    : Array.Empty<Diagnostic>();
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1510_TypesWithInfoSuffixAnalyzer.cs
@@ -1,22 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1510_TypesWithInfoSuffixAnalyzer : NamingAnalyzer
+    public sealed class MiKo_1510_TypesWithInfoSuffixAnalyzer : TypeSyntaxNamingAnalyzer
     {
         public const string Id = "MiKo_1510";
 
-        public MiKo_1510_TypesWithInfoSuffixAnalyzer() : base(Id, SymbolKind.NamedType)
+        public MiKo_1510_TypesWithInfoSuffixAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => symbol.Name.EndsWith("Info", StringComparison.Ordinal)
-                                                                                                                    ? new[] { Issue(symbol) }
-                                                                                                                    : Array.Empty<Diagnostic>();
+        protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration) => typeName.EndsWith("Info", StringComparison.Ordinal)
+                                                                                                                                                  ? new[] { Issue(typeNameIdentifier) }
+                                                                                                                                                  : Array.Empty<Diagnostic>();
     }
 }


### PR DESCRIPTION
- Refactor analyzers to syntax-based processing

- Replace symbol checks with type name tokens

- Adjust analysis predicates to syntax nodes

- Preserve diagnostics, update issue reporting

(resolves #1440)