### PR TITLE
Refactored usage of string comparison for 'StartsWith', 'EndsWith', '…

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -108,7 +108,7 @@ namespace System
                 return AllIndicesOrdinal(value.AsSpan(), finding.AsSpan());
             }
 
-            return AllIndicesNonOrdinal(value, finding, comparison);
+            return AllIndicesNonOrdinal(value, finding);
         }
 
         public static int[] AllIndicesOf(this in ReadOnlySpan<char> value, string finding, in StringComparison comparison = StringComparison.OrdinalIgnoreCase)
@@ -129,7 +129,7 @@ namespace System
                 return AllIndicesOrdinal(value, finding.AsSpan());
             }
 
-            return AllIndicesNonOrdinal(value.ToString(), finding, comparison);
+            return AllIndicesNonOrdinal(value.ToString(), finding);
         }
 
         public static bool AllUpper(this in ReadOnlySpan<char> value)
@@ -641,7 +641,7 @@ namespace System
             return value.Contains(finding.AsSpan());
         }
 
-        public static bool Contains(this string value, string finding, in StringComparison comparison)
+        public static bool Contains(this string value, string finding, in StringComparison comparison) // TODO RKN: Use default value 'StringComparison.Ordinal'
         {
             if (finding.Length < value.Length)
             {
@@ -690,9 +690,9 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Contains(this in ReadOnlySpan<char> value, string finding, Func<char, bool> nextCharValidationCallback, in StringComparison comparison) => value.Contains(finding.AsSpan(), nextCharValidationCallback, comparison);
+        public static bool Contains(this in ReadOnlySpan<char> value, string finding, Func<char, bool> nextCharValidationCallback, in StringComparison comparison = StringComparison.Ordinal) => value.Contains(finding.AsSpan(), nextCharValidationCallback, comparison);
 
-        public static bool Contains(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> finding, Func<char, bool> nextCharValidationCallback, in StringComparison comparison)
+        public static bool Contains(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> finding, Func<char, bool> nextCharValidationCallback, in StringComparison comparison = StringComparison.Ordinal)
         {
             var index = 0;
             var valueLength = value.Length;
@@ -745,10 +745,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ContainsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> characters) => value.Length > 0 && value.IndexOfAny(characters) >= 0;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases) => value.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
-
-        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -830,7 +827,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool EndsWith(this in ReadOnlySpan<char> value, in char character) => value.Length > 0 && value[value.Length - 1] == character;
 
-        public static bool EndsWith(this in ReadOnlySpan<char> value, string characters, in StringComparison comparison)
+        public static bool EndsWith(this in ReadOnlySpan<char> value, string characters, in StringComparison comparison = StringComparison.Ordinal)
         {
             var span = characters.AsSpan();
 
@@ -839,9 +836,6 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool EndsWithAny(this string value, in ReadOnlySpan<char> suffixCharacters) => value.HasCharacters() && suffixCharacters.Contains(value[value.Length - 1]);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWithAny(this string value, in ReadOnlySpan<string> suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
 
         public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> suffixCharacters)
         {
@@ -861,10 +855,7 @@ namespace System
             return false;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes) => value.EndsWithAny(suffixes, StringComparison.OrdinalIgnoreCase);
-
-        public static bool EndsWithAny(this string value, in ReadOnlySpan<string> suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this string value, in ReadOnlySpan<string> suffixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -889,7 +880,7 @@ namespace System
             return false;
         }
 
-        public static bool EndsWithAny(this string value, Dictionary<string, string>.KeyCollection suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this string value, Dictionary<string, string>.KeyCollection suffixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -912,7 +903,7 @@ namespace System
             return false;
         }
 
-        public static bool EndsWithAny(this string value, List<string> suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this string value, List<string> suffixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -937,7 +928,7 @@ namespace System
             return false;
         }
 
-        public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes, in StringComparison comparison)
+        public static bool EndsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> suffixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             var valueLength = value.Length;
             var suffixesLength = suffixes.Length;
@@ -963,27 +954,21 @@ namespace System
             return false;
         }
 
-        public static bool EndsWithCommonNumber(this string value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers) is false;
+        public static bool EndsWithCommonNumber(this string value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers, StringComparison.OrdinalIgnoreCase) is false;
 
-        public static bool EndsWithCommonNumber(this in ReadOnlySpan<char> value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers) is false;
+        public static bool EndsWithCommonNumber(this in ReadOnlySpan<char> value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers, StringComparison.OrdinalIgnoreCase) is false;
 
         public static bool EndsWithNumber(this string value) => value.HasCharacters() && value[value.Length - 1].IsNumber();
 
         public static bool EndsWithNumber(this in ReadOnlySpan<char> value) => value.Length > 0 && value[value.Length - 1].IsNumber();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this string value, in ReadOnlySpan<char> other, in StringComparison comparison) => value != null && value.AsSpan().Equals(other, comparison);
+        public static bool Equals(this string value, in ReadOnlySpan<char> other, in StringComparison comparison = StringComparison.Ordinal) => value != null && value.AsSpan().Equals(other, comparison);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this in ReadOnlySpan<char> value, string other, in StringComparison comparison) => other != null && value.Equals(other.AsSpan(), comparison);
+        public static bool Equals(this in ReadOnlySpan<char> value, string other, in StringComparison comparison = StringComparison.Ordinal) => other != null && value.Equals(other.AsSpan(), comparison);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EqualsAny(this string value, IEnumerable<string> phrases) => EqualsAny(value, phrases, StringComparison.OrdinalIgnoreCase);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EqualsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases) => EqualsAny(value, phrases, StringComparison.OrdinalIgnoreCase);
-
-        public static bool EqualsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static bool EqualsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -1001,7 +986,7 @@ namespace System
             return false;
         }
 
-        public static bool EqualsAny(this string value, IEnumerable<string> phrases, in StringComparison comparison)
+        public static bool EqualsAny(this string value, IEnumerable<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (phrases is string[] array)
             {
@@ -1022,7 +1007,7 @@ namespace System
             return false;
         }
 
-        public static bool EqualsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static bool EqualsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.Length > 0)
             {
@@ -1227,7 +1212,7 @@ namespace System
         public static ReadOnlySpan<char> GetPartAfterLastDot(this in ReadOnlySpan<char> value) => value.Slice(value.LastIndexOf('.') + 1);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool HasCollectionMarker(this string value) => value.EndsWithAny(Constants.Markers.Collections);
+        public static bool HasCollectionMarker(this string value) => value.EndsWithAny(Constants.Markers.Collections, StringComparison.OrdinalIgnoreCase);
 
         public static bool HasEntityMarker(this string value)
         {
@@ -1362,7 +1347,7 @@ namespace System
             }
         }
 
-        public static int IndexOfAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static int IndexOfAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.Length > 0)
             {
@@ -1389,7 +1374,7 @@ namespace System
             return -1;
         }
 
-        public static int IndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static int IndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -1412,7 +1397,7 @@ namespace System
             return -1;
         }
 
-        public static int LastIndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison)
+        public static int LastIndexOfAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value is null)
             {
@@ -1631,13 +1616,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWithAny(this in ReadOnlySpan<char> value, IEnumerable<char> characters) => value.Length > 0 && characters.Contains(value[0]);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWithAny(this string value, in ReadOnlySpan<string> prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> prefixes) => value.StartsWithAny(prefixes, StringComparison.OrdinalIgnoreCase);
-
-        public static bool StartsWithAny(this string value, in ReadOnlySpan<string> prefixes, in StringComparison comparison)
+        public static bool StartsWithAny(this string value, in ReadOnlySpan<string> prefixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {
@@ -1660,7 +1639,7 @@ namespace System
             return false;
         }
 
-        public static bool StartsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> prefixes, in StringComparison comparison)
+        public static bool StartsWithAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> prefixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.Length > 0)
             {
@@ -2271,13 +2250,13 @@ namespace System
             return indices ?? Array.Empty<int>();
         }
 
-        private static int[] AllIndicesNonOrdinal(string value, string finding, in StringComparison comparison)
+        private static int[] AllIndicesNonOrdinal(string value, string finding)
         {
             int[] indices = null;
 
             for (int index = 0, findingLength = finding.Length; ; index += findingLength)
             {
-                index = value.IndexOf(finding, index, comparison);
+                index = value.IndexOf(finding, index, StringComparison.OrdinalIgnoreCase);
 
                 if (index is -1)
                 {

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -540,7 +540,7 @@ namespace MiKoSolutions.Analyzers
                             // Perf: quick catch find another dot, as we do not need to check for additional extensions in case we do not have any other dot here
                             if (span.LastIndexOfAny('.', Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) >= 0)
                             {
-                                if (filePathSpan.EndsWithAny(Constants.GeneratedCSharpFileExtensions, StringComparison.Ordinal))
+                                if (filePathSpan.EndsWithAny(Constants.GeneratedCSharpFileExtensions))
                                 {
                                     // ignore generated code (might be part of partial classes)
                                     continue;
@@ -1378,7 +1378,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var valueName = value.Name.AsSpan();
 
-                    return valueName.EndsWith(Constants.Names.Factory, StringComparison.Ordinal) && valueName.EndsWith(nameof(TaskFactory), StringComparison.Ordinal) is false;
+                    return valueName.EndsWith(Constants.Names.Factory) && valueName.EndsWith(nameof(TaskFactory)) is false;
                 }
 
                 default:
@@ -1726,7 +1726,7 @@ namespace MiKoSolutions.Analyzers
                     }
                 }
 
-                if (field.Name.EqualsAny(fieldNames))
+                if (StringExtensions.EqualsAny(field.Name, fieldNames, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3879,7 +3879,7 @@ namespace MiKoSolutions.Analyzers
 
                 foreach (var startText in startTexts)
                 {
-                    if (originalText.StartsWith(startText, StringComparison.Ordinal))
+                    if (originalText.StartsWith(startText))
                     {
                         var modifiedText = originalText.Slice(startText.Length);
 
@@ -4222,7 +4222,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var content = syntax.Content.ToString().AsSpan().Trim();
 
-                return content.EqualsAny(contents);
+                return StringExtensions.EqualsAny(content, contents, StringComparison.OrdinalIgnoreCase);
             }
 
             return false;

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
@@ -366,7 +366,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return ReadOnlySpan<Pair>.Empty;
             }
 
-            if (value.EqualsAny(AllowedNames))
+            if (StringExtensions.EqualsAny(value, AllowedNames, StringComparison.OrdinalIgnoreCase))
             {
                 return ReadOnlySpan<Pair>.Empty;
             }
@@ -481,7 +481,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool PostFixHasIssue(in ReadOnlySpan<char> key, in ReadOnlySpan<char> value) => value.EndsWith(key, StringComparison.Ordinal) && value.EndsWithAny(AllowedPostFixTerms, StringComparison.Ordinal) is false;
+        private static bool PostFixHasIssue(in ReadOnlySpan<char> key, in ReadOnlySpan<char> value) => value.EndsWith(key, StringComparison.Ordinal) && value.EndsWithAny(AllowedPostFixTerms) is false;
 
         private static bool MidTermHasIssue(in ReadOnlySpan<char> key, in ReadOnlySpan<char> value)
         {

--- a/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Pluralizer.cs
@@ -83,7 +83,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         private static readonly string[] SingularOrPluralEndings = { "data", "heep", "moose", "trivia", "ircraft", "nformation", "nested" };
         private static readonly string[] SpecialPluralEndingsWithoutS = new[] { "cti", "men", "ngi", "dren", "eeth", "feet", "mena", "mice", "eople", "teria" }.Concat(SingularOrPluralEndings).ToArray();
 
-        public static bool IsSingularAndPlural(in ReadOnlySpan<char> value) => value.EqualsAny(UncountableNouns) || (IsPlural(value) && value.EndsWithAny(SingularOrPluralEndings));
+        public static bool IsSingularAndPlural(in ReadOnlySpan<char> value) => StringExtensions.EqualsAny(value, UncountableNouns, StringComparison.OrdinalIgnoreCase) || (IsPlural(value) && value.EndsWithAny(SingularOrPluralEndings, StringComparison.OrdinalIgnoreCase));
 
         public static bool IsPlural(in ReadOnlySpan<char> value)
         {
@@ -106,15 +106,15 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
                 if (CharsForTwoCharacterEndingsWithS.Contains(value[value.Length - 2]))
                 {
-                    return value.EndsWithAny(SpecialPluralEndingsWithS) || value.EqualsAny(UncountableNouns);
+                    return value.EndsWithAny(SpecialPluralEndingsWithS, StringComparison.OrdinalIgnoreCase) || StringExtensions.EqualsAny(value, UncountableNouns, StringComparison.OrdinalIgnoreCase);
                 }
 
-                if (value.EndsWithAny(PluralEndings))
+                if (value.EndsWithAny(PluralEndings, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
 
-                if (value.EndsWithAny(NonPluralEndings))
+                if (value.EndsWithAny(NonPluralEndings, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
@@ -122,7 +122,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return true;
             }
 
-            return value.EndsWithAny(SpecialPluralEndingsWithoutS) || value.EqualsAny(UncountableNouns);
+            return value.EndsWithAny(SpecialPluralEndingsWithoutS, StringComparison.OrdinalIgnoreCase) || StringExtensions.EqualsAny(value, UncountableNouns, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             var proposedName = name.AsSpan().WithoutSuffixes(suffixes);
 
-            if (proposedName.EndsWithAny(Constants.Markers.Models) && proposedName.EndsWithAny(Constants.Markers.ViewModels) is false)
+            if (proposedName.EndsWithAny(Constants.Markers.Models, StringComparison.OrdinalIgnoreCase) && proposedName.EndsWithAny(Constants.Markers.ViewModels, StringComparison.OrdinalIgnoreCase) is false)
             {
                 proposedName = proposedName.WithoutSuffixes(Constants.Markers.Models);
             }

--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -302,7 +302,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
             if (Pluralizer.IsPlural(value))
             {
-                if (value.EndsWithAny(NonThirdPersonSingularEndingsWithS))
+                if (value.EndsWithAny(NonThirdPersonSingularEndingsWithS, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
@@ -327,7 +327,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         public static bool IsPastTense(string value) => value != null && IsPastTense(value.AsSpan());
 
-        public static bool IsPastTense(in ReadOnlySpan<char> value) => value.EndsWithAny(PastEndings, StringComparison.Ordinal);
+        public static bool IsPastTense(in ReadOnlySpan<char> value) => value.EndsWithAny(PastEndings);
 
         public static bool IsGerundVerb(string value) => value != null && IsGerundVerb(value.AsSpan());
 
@@ -338,7 +338,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return false;
             }
 
-            if (value.EndsWith("ing", StringComparison.Ordinal))
+            if (value.EndsWith("ing"))
             {
                 if (value.EndsWith("ling", StringComparison.OrdinalIgnoreCase))
                 {
@@ -521,7 +521,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     return word;
                 }
 
-                if (word.EndsWithAny(SpecialPastEndings, StringComparison.Ordinal))
+                if (word.EndsWithAny(SpecialPastEndings))
                 {
                     return word.AsSpan(0, word.Length - 1).ToString();
                 }
@@ -589,7 +589,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 return value;
             }
 
-            if (value.EqualsAny(ThirdPersonalSingularVerbExceptions))
+            if (StringExtensions.EqualsAny(value, ThirdPersonalSingularVerbExceptions, StringComparison.OrdinalIgnoreCase))
             {
                 return value;
             }
@@ -706,7 +706,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     return word.AsSpan().ConcatenatedWith('s');
                 }
 
-                if (word.EndsWithAny(SpecialPastEndings, StringComparison.Ordinal))
+                if (word.EndsWithAny(SpecialPastEndings))
                 {
                     return word.AsSpan(0, word.Length - 1).ConcatenatedWith('s');
                 }
@@ -771,7 +771,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 var pair = Endings[index];
                 var key = pair.Key;
 
-                if (span.EndsWith(key, StringComparison.Ordinal))
+                if (span.EndsWith(key))
                 {
                     result = span.Slice(0, span.Length - key.Length).ConcatenatedWith(pair.Value);
 
@@ -788,7 +788,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
             {
                 var phrase = StartingPhrases[index];
 
-                if (value.StartsWith(phrase, StringComparison.Ordinal))
+                if (value.StartsWith(phrase))
                 {
                     var remaining = value.Slice(phrase.Length);
 
@@ -799,8 +799,8 @@ namespace MiKoSolutions.Analyzers.Linguistics
             return false;
         }
 
-        private static bool HasAcceptableMiddlePhrase(string value) => value.ContainsAny(MiddlePhrases, StringComparison.Ordinal);
+        private static bool HasAcceptableMiddlePhrase(string value) => value.ContainsAny(MiddlePhrases);
 
-        private static bool HasAcceptableEndingPhrase(in ReadOnlySpan<char> value) => value.EndsWithAny(EndingPhrases, StringComparison.Ordinal);
+        private static bool HasAcceptableEndingPhrase(in ReadOnlySpan<char> value) => value.EndsWithAny(EndingPhrases);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/CodeDetector.cs
+++ b/MiKo.Analyzer.Shared/Rules/CodeDetector.cs
@@ -106,14 +106,14 @@ namespace MiKoSolutions.Analyzers.Rules
                 return true;
             }
 
-            if (line.StartsWithAny(CodeStartMarkers, StringComparison.Ordinal))
+            if (line.StartsWithAny(CodeStartMarkers))
             {
                 return true;
             }
 
             var lineString = line.ToString();
 
-            if (lineString.ContainsAny(CodeConditionMarkers, StringComparison.Ordinal))
+            if (lineString.ContainsAny(CodeConditionMarkers))
             {
                 return true;
             }
@@ -126,12 +126,12 @@ namespace MiKoSolutions.Analyzers.Rules
                     return false; // allow indicators such as http:// or ftp://
                 }
 
-                if (line.EndsWith(Constants.Comments.CommentExterior, StringComparison.Ordinal))
+                if (line.EndsWith(Constants.Comments.CommentExterior))
                 {
                     return false; // ignore all framed comments
                 }
 
-                if (lineString.ContainsAny(Constants.Markers.ReSharper))
+                if (lineString.ContainsAny(Constants.Markers.ReSharper, StringComparison.OrdinalIgnoreCase))
                 {
                     return false; // ignore '// ReSharper' comments
                 }
@@ -159,7 +159,7 @@ namespace MiKoSolutions.Analyzers.Rules
                 return true; // found a construction or initialization
             }
 
-            if (lineString.ContainsAny(FrameMarkers))
+            if (lineString.ContainsAny(FrameMarkers, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -176,7 +176,7 @@ namespace MiKoSolutions.Analyzers.Rules
                     return true;
                 }
 
-                if (lineString.ContainsAny(Operators))
+                if (lineString.ContainsAny(Operators, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
@@ -204,7 +204,7 @@ var convertedType = semanticModel.GetTypeInfo(node).ConvertedType;
                 return true;
             }
 
-            if (lineString.ContainsAny(LockStatements))
+            if (lineString.ContainsAny(LockStatements, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ArgumentExceptionPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ArgumentExceptionPhraseAnalyzer.cs
@@ -44,11 +44,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var parameterIndicators = parameters.ToDictionary<IParameterSymbol, IParameterSymbol, string>(_ => _, _ => Constants.Comments.ParamRefBeginningPhrase.FormatWith(_.Name), SymbolEqualityComparer.Default);
             var allParameterIndicatorPhrases = parameterIndicators.Values.ToArray();
 
-            const StringComparison Comparison = StringComparison.Ordinal;
-
             var results = new List<Diagnostic>(1);
 
-            if (comment.ContainsAny(allParameterIndicatorPhrases, Comparison))
+            if (comment.ContainsAny(allParameterIndicatorPhrases))
             {
                 foreach (var parameter in parameters)
                 {
@@ -61,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         {
                             var trimmed = part.AsSpan().Trim();
 
-                            if (trimmed.StartsWithAny(phrases, Comparison) is false && trimmed.StartsWithAny(allParameterIndicatorPhrases, Comparison) is false)
+                            if (trimmed.StartsWithAny(phrases) is false && trimmed.StartsWithAny(allParameterIndicatorPhrases) is false)
                             {
                                 results.Add(ExceptionIssue(exceptionComment, proposal));
                             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
@@ -13,11 +13,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                  };
 
         internal static bool EndsWithPeriod(in ReadOnlySpan<char> comment) => comment.EndsWith('.')
-                                                                        && comment.EndsWith("...", StringComparison.Ordinal) is false
+                                                                        && comment.EndsWith("...") is false
                                                                         && comment.EndsWith("etc.", StringComparison.OrdinalIgnoreCase) is false;
 
-        internal static bool ContainsDoublePeriod(in ReadOnlySpan<char> comment) => comment.Contains("..", _ => AllowedChars.Contains(_) is false, StringComparison.Ordinal)
-                                                                                 && comment.EndsWith("...", StringComparison.Ordinal) is false;
+        internal static bool ContainsDoublePeriod(in ReadOnlySpan<char> comment) => comment.Contains("..", _ => AllowedChars.Contains(_) is false)
+                                                                                 && comment.EndsWith("...") is false;
 
         internal static bool ContainsPhrase(string phrase, in ReadOnlySpan<char> comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var comment = exceptionComment.ToString();
 
-                var ps = parameters.Where(_ => comment.ContainsAny(GetParameterReferences(_).ToArray())).ToArray();
+                var ps = parameters.Where(_ => comment.ContainsAny(GetParameterReferences(_).ToArray(), StringComparison.OrdinalIgnoreCase)).ToArray();
 
                 if (ps.Length != 0)
                 {
@@ -78,7 +78,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var parametersAsTextReferences = parameters.SelectMany(GetParameterAsTextReference).ToArray();
 
             // seems we found the reference in text, so we have to split the text into 2 separate ones and place a <paramref/> between
-            var textNodes = exceptionComment.DescendantNodes<XmlTextSyntax>(_ => _.GetTextWithoutTriviaLazy().Any(__ => __.ContainsAny(parametersAsTextReferences))).ToList();
+            var textNodes = exceptionComment.DescendantNodes<XmlTextSyntax>(_ => _.GetTextWithoutTriviaLazy().Any(__ => __.ContainsAny(parametersAsTextReferences, StringComparison.OrdinalIgnoreCase))).ToList();
 
             if (textNodes.Count != 0)
             {
@@ -176,7 +176,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var part in parts)
             {
-                if (part.ContainsAny(parametersAsTextReferences))
+                if (part.ContainsAny(parametersAsTextReferences, StringComparison.OrdinalIgnoreCase))
                 {
                     var parameterName = part.Substring(1, part.Length - 2);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_EventSummaryAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = valueText.AsSpan().TrimStart();
 
-            if (text.StartsWith(StartingPhrase, comparison))
+            if (text.StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzer.cs
@@ -18,8 +18,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private const string StartingPhraseConcrete = StartingPhrase + "the <see cref=\"";
         private const string EndingPhraseConcrete = "/> event.";
 
-        private const StringComparison Comparison = StringComparison.Ordinal;
-
         public MiKo_2002_EventArgsSummaryAnalyzer() : base(Id)
         {
         }
@@ -50,13 +48,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var trimmedSummary = summary.Without(Constants.Comments.SealedClassPhrase).AsSpan().Trim();
 
-                    if (trimmedSummary.StartsWith(StartingPhrase, Comparison))
+                    if (trimmedSummary.StartsWith(StartingPhrase))
                     {
-                        var phrase = trimmedSummary.StartsWith(StartingPhraseConcrete, Comparison)
+                        var phrase = trimmedSummary.StartsWith(StartingPhraseConcrete)
                                      ? EndingPhraseConcrete
                                      : EndingPhraseMultiple;
 
-                        return trimmedSummary.EndsWith(phrase, Comparison);
+                        return trimmedSummary.EndsWith(phrase);
                     }
                 }
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -69,13 +69,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var text = textSyntax.GetTextTrimmed().AsSpan();
 
-            if (text.StartsWith("Interaction logic for", StringComparison.Ordinal))
+            if (text.StartsWith("Interaction logic for"))
             {
                 // seems like this is the default comment for WPF controls
                 return Comment(comment, XmlText("Represents a TODO"));
             }
 
-            if (text.StartsWithAny(EmptyReplacementsMapKeys, StringComparison.Ordinal))
+            if (text.StartsWithAny(EmptyReplacementsMapKeys))
             {
                 return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
             }
@@ -99,14 +99,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return MiKo_2002_CodeFixProvider.GetUpdatedSyntax(comment);
                 }
 
-                if (text.StartsWithAny(ReplacementMapKeys, StringComparison.Ordinal))
+                if (text.StartsWithAny(ReplacementMapKeys))
                 {
                     return Comment(comment, ReplacementMapKeys, ReplacementMap);
                 }
 
                 foreach (var phrase in UsedToPhrases)
                 {
-                    if (text.StartsWith(phrase, StringComparison.Ordinal))
+                    if (text.StartsWith(phrase))
                     {
                         var remainingText = text.Slice(phrase.Length);
 
@@ -125,7 +125,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
                 }
 
-                if (text.StartsWithAny(Constants.Comments.AAnThePhraseWithSpaces, StringComparison.Ordinal))
+                if (text.StartsWithAny(Constants.Comments.AAnThePhraseWithSpaces))
                 {
                     switch (member)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -98,7 +98,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var existingText = textTokens[0].ValueText.AsSpan();
                 var firstWord = existingText.FirstWord();
 
-                if (firstWord.EqualsAny(WrongStartingWords))
+                if (StringExtensions.EqualsAny(firstWord, WrongStartingWords, StringComparison.OrdinalIgnoreCase))
                 {
                     existingText = existingText.WithoutFirstWord();
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = valueText.AsSpan().TrimStart();
 
-            if (text.StartsWith(StartingPhrase, comparison))
+            if (text.StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            if (valueText.AsSpan().TrimStart().StartsWith(Phrase, comparison))
+            if (valueText.AsSpan().TrimStart().StartsWith(Phrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         return syntax;
                     }
 
-                    if (startText.StartsWithAny(RepresentsCandidates, StringComparison.Ordinal))
+                    if (startText.StartsWithAny(RepresentsCandidates))
                     {
                         return CommentStartingWith(summary, "Represents a ");
                     }
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     // only adjust in case there is no single letter
                     if (firstWord.Length > 1)
                     {
-                        if (firstWord.EndsWith("alled", StringComparison.Ordinal))
+                        if (firstWord.EndsWith("alled"))
                         {
                             // currently we cannot adjust "Called" text properly
                         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
@@ -35,11 +35,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static bool CommentHasIssue(string comment)
         {
-            const StringComparison Comparison = StringComparison.Ordinal;
-
-            if (comment.StartsWithAny(StartingPhrases, Comparison) && comment.ContainsAny(EndingPhrases, Comparison))
+            if (comment.StartsWithAny(StartingPhrases) && comment.ContainsAny(EndingPhrases))
             {
-                return comment.Contains("to value indicating", Comparison);
+                return comment.Contains("to value indicating", StringComparison.Ordinal);
             }
 
             return true;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
@@ -145,7 +145,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             continue;
                         }
 
-                        if (parameterComment.GetTextTrimmed().EqualsAny(Phrases))
+                        if (StringExtensions.EqualsAny(parameterComment.GetTextTrimmed(), Phrases, StringComparison.OrdinalIgnoreCase))
                         {
                             yield return Issue(parameterName, parameterComment.GetContentsLocation());
                         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private Diagnostic[] AnalyzeParameterComment(string parameterName, XmlElementSyntax parameterComment, string comment, in ReadOnlySpan<string> phrases)
         {
-            if (comment.AsSpan().EqualsAny(phrases))
+            if (StringExtensions.EqualsAny(comment.AsSpan(), phrases, StringComparison.OrdinalIgnoreCase))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -19,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrases = GetPhrases(parameter.Name);
 
-            if (parameterComment.GetTextTrimmed().EqualsAny(phrases))
+            if (StringExtensions.EqualsAny(parameterComment.GetTextTrimmed(), phrases, StringComparison.OrdinalIgnoreCase))
             {
                 return new[] { Issue(parameter.Name, parameterComment.GetContentsLocation()) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
@@ -84,7 +84,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         // might be an almost complete text
                         var text = continueText.GetTextTrimmed();
 
-                        if (text.StartsWithAny(ContinueTextParts))
+                        if (text.StartsWithAny(ContinueTextParts, StringComparison.OrdinalIgnoreCase))
                         {
                             var newText = text.Without(ContinueTextParts);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzer.cs
@@ -20,9 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var startingPhrases = GetStartingPhrases(owningSymbol, returnType);
             var endingPhrases = GetEndingPhrases(returnType);
 
-            const StringComparison Comparison = StringComparison.Ordinal;
-
-            if (commentXml.StartsWithAny(startingPhrases, Comparison) && commentXml.ContainsAny(endingPhrases, Comparison))
+            if (commentXml.StartsWithAny(startingPhrases) && commentXml.ContainsAny(endingPhrases))
             {
                 // nothing to do here
                 return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var text = t.GetTextTrimmed();
 
-                if (text.StartsWith("If ", StringComparison.OrdinalIgnoreCase) && text.ContainsAny(UnwantedResultTexts))
+                if (text.StartsWith("If ", StringComparison.OrdinalIgnoreCase) && text.ContainsAny(UnwantedResultTexts, StringComparison.OrdinalIgnoreCase))
                 {
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -158,7 +158,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var token = continueText.TextTokens.First();
                     var text = token.ValueText;
 
-                    if (text.StartsWithAny(MappedData.Value.ByteArrayContinueTexts))
+                    if (text.StartsWithAny(MappedData.Value.ByteArrayContinueTexts, StringComparison.OrdinalIgnoreCase))
                     {
                         var fixedText = text.AsCachedBuilder().Without(MappedData.Value.ByteArrayContinueTexts).ToStringAndRelease();
                         var newContinueText = continueText.ReplaceToken(token, token.WithText(fixedText));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                             .SelectMany(_ => Constants.Comments.DefaultCrefPhrases, (symbol, phrase) => phrase.FormatWith(symbol))
                                             .ToArray();
 
-            if (commentXml.EndsWithAny(endingPhrases, StringComparison.Ordinal))
+            if (commentXml.EndsWithAny(endingPhrases))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrases = GetStartingPhrase((IPropertySymbol)symbol);
 
-            if (summaries.Value.None(_ => _.StartsWithAny(phrases, StringComparison.Ordinal)))
+            if (summaries.Value.None(_ => _.StartsWithAny(phrases)))
             {
                 return new[] { Issue(symbol, Constants.XmlTag.Summary, phrases[0]) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrases = Constants.Comments.ExtensionMethodClassStartingPhrase;
 
-            if (summaries.Value.None(_ => _.StartsWithAny(phrases, StringComparison.Ordinal)))
+            if (summaries.Value.None(_ => _.StartsWithAny(phrases)))
             {
                 return new[] { Issue(symbol, Constants.XmlTag.Summary, phrases[0]) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -213,7 +213,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 // loop over text to see if we have to report at all
                 // (might be done a second time in case of report, but in case of no report we do not need to do all the other loops)
-                if (text.ContainsAny(Phrases) is false)
+                if (text.ContainsAny(Phrases, StringComparison.OrdinalIgnoreCase) is false)
                 {
                     // no need to loop further
                     continue;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             problematicText = null;
             comparison = StringComparison.Ordinal;
 
-            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_ValueConverterSummaryDefaultPhraseAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             problematicText = string.Empty;
             comparison = StringComparison.Ordinal;
 
-            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase, comparison))
+            if (valueText.AsSpan().TrimStart().StartsWith(StartingPhrase))
             {
                 return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -160,7 +160,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var text = issue.Location.GetText().ToLowerCase();
 
-                    if (text.Contains(AcceptedPhrase) is false && text.ContainsAny(PhrasesMapKeys) is false)
+                    if (text.Contains(AcceptedPhrase) is false && text.ContainsAny(PhrasesMapKeys, StringComparison.OrdinalIgnoreCase) is false)
                     {
                         issues.Add(issue);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -341,7 +341,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                            "roviding provid", "rovides provid", "rovide provid",
                                        };
 
-                results.RemoveWhere(_ => _.ContainsAny(strangeTexts, StringComparison.Ordinal));
+                results.RemoveWhere(_ => _.ContainsAny(strangeTexts));
 
                 return results.ToArray();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -83,7 +83,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var token = textTokens[index];
                     var valueText = token.ValueText.Without(Constants.Comments.AsynchronouslyStartingPhrase).AsSpan().Trim();
 
-                    if (valueText.StartsWithAny(Constants.Comments.ReturnWords))
+                    if (valueText.StartsWithAny(Constants.Comments.ReturnWords, StringComparison.OrdinalIgnoreCase))
                     {
                         var startText = GetCorrectStartText(summary);
                         var remainingText = valueText.WithoutFirstWord().WithoutFirstWords(BeginningConditions).ToString(); // TODO RKN: Use Span and create a ConcatenatedWith

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -54,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var firstWord = valueText.Without(Constants.Comments.AsynchronouslyStartingPhrase) // skip over async starting phrase
                                      .FirstWord();
 
-            if (firstWord.EqualsAny(Constants.Comments.ReturnWords))
+            if (StringExtensions.EqualsAny(firstWord, Constants.Comments.ReturnWords, StringComparison.OrdinalIgnoreCase))
             {
                 problematicText = valueText.FirstWord();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzer.cs
@@ -55,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
-            if (text.ContainsAny(BooleanPhrases, StringComparison.Ordinal) is false)
+            if (text.ContainsAny(BooleanPhrases) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_TrySummaryAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
@@ -34,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             StringBuilderCache.Release(builder);
 
-            if (firstWord.EqualsAny(Constants.Comments.TryWords))
+            if (StringExtensions.EqualsAny(firstWord, Constants.Comments.TryWords, StringComparison.OrdinalIgnoreCase))
             {
                 problematicText = firstWord;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
-            if (parameterComment.GetTextTrimmed().EndsWithAny(Phrases, StringComparison.Ordinal))
+            if (parameterComment.GetTextTrimmed().EndsWithAny(Phrases))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_ActionFunctionParameterPhraseAnalyzer.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
-            if (text.ContainsAny(Constants.Comments.ActionTerms, StringComparison.Ordinal) is false)
+            if (text.ContainsAny(Constants.Comments.ActionTerms) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs
@@ -15,8 +15,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private const string StartingBooleanDefaultPhrase = "Indicates whether ";
         private const string StartingGuidDefaultPhrase = "The unique identifier for ";
 
-        private const StringComparison Comparison = StringComparison.OrdinalIgnoreCase;
-
         public MiKo_2080_FieldSummaryDefaultPhraseAnalyzer() : base(Id)
         {
         }
@@ -55,14 +53,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool AnalyzeTextStart(ISymbol symbol, string valueText, out string problematicText, out StringComparison comparison)
         {
-            comparison = Comparison;
+            comparison = StringComparison.OrdinalIgnoreCase;
 
             var comment = valueText.AsSpan().TrimStart();
 
             var fieldSymbol = (IFieldSymbol)symbol;
             var phrase = GetStartingPhrase(fieldSymbol);
 
-            if (comment.StartsWith(phrase, Comparison))
+            if (comment.StartsWith(phrase, comparison))
             {
                 // no issue
                 problematicText = string.Empty;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
@@ -13,8 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2081";
 
-        private const StringComparison Comparison = StringComparison.Ordinal;
-
         public MiKo_2081_ReadOnlyFieldAnalyzer() : base(Id)
         {
         }
@@ -41,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            if (summaries.Value.None(_ => _.EndsWith(Constants.Comments.FieldIsReadOnly, Comparison)))
+            if (summaries.Value.None(_ => _.EndsWith(Constants.Comments.FieldIsReadOnly, StringComparison.Ordinal)))
             {
                 return new[] { Issue(symbol, Constants.Comments.FieldIsReadOnly) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var isPlural = Pluralizer.IsPlural(unsuffixedSpan) && Pluralizer.IsSingularAndPlural(unsuffixedSpan) is false;
 
                         if (isPlural
-                         || unsuffixed.EqualsAny(WordsThatPreventArticle)
+                         || StringExtensions.EqualsAny(unsuffixed, WordsThatPreventArticle, StringComparison.OrdinalIgnoreCase)
                          || Verbalizer.IsGerundVerb(unsuffixedSpan)
                          || Verbalizer.IsAdjectiveOrAdverb(unsuffixedSpan)
                          || Verbalizer.IsPastTense(unsuffixedSpan))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var tokens = example.GetXmlTextTokens();
 
-                if (tokens.None(_ => _.ValueText.AsSpan().TrimStart().StartsWith(Phrase, StringComparison.Ordinal)))
+                if (tokens.None(_ => _.ValueText.AsSpan().TrimStart().StartsWith(Phrase)))
                 {
                     if (results is null)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2201_DocumentationUsesCapitalizedSentencesAnalyzer.cs
@@ -151,6 +151,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static bool IsWellknownFileExtension(in ReadOnlySpan<char> comment, in int startIndex) => comment.Slice(startIndex).StartsWithAny(Constants.WellknownFileExtensions);
+        private static bool IsWellknownFileExtension(in ReadOnlySpan<char> comment, in int startIndex) => comment.Slice(startIndex).StartsWithAny(Constants.WellknownFileExtensions, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
-            if (trimmed.ContainsAny(Constants.Comments.Guids, StringComparison.Ordinal) is false)
+            if (trimmed.ContainsAny(Constants.Comments.Guids) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_CodeFixProvider.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
         {
-            var list = syntax.DescendantNodes<XmlTextSyntax>(_ => _.TextTokens.Any(__ => __.ValueText.AsSpan().TrimStart().StartsWithAny(Markers)));
+            var list = syntax.DescendantNodes<XmlTextSyntax>(_ => _.TextTokens.Any(__ => __.ValueText.AsSpan().TrimStart().StartsWithAny(Markers, StringComparison.OrdinalIgnoreCase)));
 
             return syntax.ReplaceNodes(list, GetReplacements);
         }
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 var adjustedToken = token.WithText(valueText).WithLeadingXmlComment();
 
-                if (valueText.StartsWithAny(Markers))
+                if (valueText.StartsWithAny(Markers, StringComparison.OrdinalIgnoreCase))
                 {
                     // we already have some text
                     AddXmlText(result, normalText);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var commentXml = textTokens.GetTextTrimmedWithParaTags();
 
-            if (commentXml.ContainsAny(Triggers, StringComparison.Ordinal) is false)
+            if (commentXml.ContainsAny(Triggers) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = textTokens.GetTextTrimmedWithParaTags();
 
-            if (text.ContainsAny(Phrases, StringComparison.Ordinal) is false)
+            if (text.ContainsAny(Phrases) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -168,7 +168,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
-            if (trimmed.Length > 3 && trimmed[2].IsNumber() && trimmed.StartsWithAny(CompilerWarningIndicators, StringComparison.Ordinal))
+            if (trimmed.Length > 3 && trimmed[2].IsNumber() && trimmed.StartsWithAny(CompilerWarningIndicators))
             {
                 return false;
             }
@@ -213,7 +213,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (trimmed.EndsWith('s'))
             {
-                var characters = trimmed.EndsWith("'s", StringComparison.Ordinal) ? 2 : 1;
+                var characters = trimmed.EndsWith("'s") ? 2 : 1;
 
                 var part = trimmed.Slice(0, trimmed.Length - characters);
 
@@ -225,7 +225,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
             else if (trimmed.EndsWith('d'))
             {
-                var characters = trimmed.EndsWith("ed", StringComparison.Ordinal) ? 2 : 1;
+                var characters = trimmed.EndsWith("ed") ? 2 : 1;
 
                 var part = trimmed.Slice(0, trimmed.Length - characters);
 
@@ -275,7 +275,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var compoundWord = IsCompoundWord(trimmed);
 
-                    if (compoundWord && trimmed.StartsWith("default(", StringComparison.Ordinal) && trimmed.EndsWith(')') is false)
+                    if (compoundWord && trimmed.StartsWith("default(") && trimmed.EndsWith(')') is false)
                     {
                         // adjust the default to include the brace as it had been trimmed above
                         var i = text.IndexOf(')');

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     continue;
                 }
 
-                if (text.ContainsAny(Constants.Comments.ReasoningPhrases))
+                if (text.ContainsAny(Constants.Comments.ReasoningPhrases, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var trimmed = textTokens.GetTextTrimmedWithParaTags();
 
-            if (trimmed.ContainsAny(Phrases, StringComparison.Ordinal) is false)
+            if (trimmed.ContainsAny(Phrases) is false)
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2238_MakeSureToCallThisAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2238_MakeSureToCallThisAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var text = valueText.AsSpan().TrimStart();
 
-            if (text.StartsWith(Phrase, comparison))
+            if (text.StartsWith(Phrase))
             {
                 problematicText = Phrase;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         var text = node.GetTextTrimmed();
 
-                        if (text.StartsWithAny(WrongStartingPhrases, StringComparison.Ordinal))
+                        if (text.StartsWithAny(WrongStartingPhrases))
                         {
                             var betterText = FindBetterText(text);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzer.cs
@@ -105,7 +105,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // perform 'ToString' here to avoid multiple calls later on
             var commentString = comment.ToString();
 
-            return CommentHasIssue(commentString) && commentString.ContainsAny(ReasoningMarkers) is false;
+            return CommentHasIssue(commentString) && commentString.ContainsAny(ReasoningMarkers, StringComparison.OrdinalIgnoreCase) is false;
         }
 
         private static bool CommentHasIssue(string comment)
@@ -127,7 +127,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var commentSpan = comment.AsSpan();
 
-            if (commentSpan.StartsWithAny(MeaninglessPhrases) && commentSpan.StartsWithAny(AllowedMarkers) is false)
+            if (commentSpan.StartsWithAny(MeaninglessPhrases, StringComparison.OrdinalIgnoreCase) && commentSpan.StartsWithAny(AllowedMarkers, StringComparison.OrdinalIgnoreCase) is false)
             {
                 return true;
             }
@@ -150,7 +150,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (spaces < 3)
             {
                 // 3 or fewer words
-                if (comment.ContainsAny(AllowedMarkers))
+                if (comment.ContainsAny(AllowedMarkers, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2304_CommentDoesNotContainQuestionMarkAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2304_CommentDoesNotContainQuestionMarkAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
-            if (comment.ToString().ContainsAny(TODOs))
+            if (comment.ToString().ContainsAny(TODOs, StringComparison.OrdinalIgnoreCase))
             {
                 // allow TODOs
                 return false;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        internal static bool CommentContainsSeparator(string comment) => comment.ContainsAny(Separators);
+        internal static bool CommentContainsSeparator(string comment) => comment.ContainsAny(Separators, StringComparison.OrdinalIgnoreCase);
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeComment, SyntaxKind.CompilationUnit);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
@@ -235,7 +235,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return false;
             }
 
-            var nextIndex = comments.FindIndex(index + 1, _ => _.ContainsAny(otherFoundCommentTags, StringComparison.Ordinal));
+            var nextIndex = comments.FindIndex(index + 1, _ => _.ContainsAny(otherFoundCommentTags));
 
             if (nextIndex is -1)
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
@@ -73,7 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var phrases = GetSummaryPhrases(symbol);
 
-            if (summaries.None(_ => _.AsSpan().Trim().EqualsAny(phrases)))
+            if (summaries.None(_ => StringExtensions.EqualsAny(_.AsSpan().Trim(), phrases, StringComparison.OrdinalIgnoreCase)))
             {
                 return new[] { Issue(symbol, Constants.XmlTag.Summary, phrases[0]) };
             }
@@ -86,7 +86,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var phrases = GetReturnsPhrases(symbol);
             var comments = CommentExtensions.GetReturns(commentXml);
 
-            if (comments.None(_ => _.AsSpan().Trim().EqualsAny(phrases)))
+            if (comments.None(_ => StringExtensions.EqualsAny(_.AsSpan().Trim(), phrases, StringComparison.OrdinalIgnoreCase)))
             {
                 return new[] { Issue(symbol, Constants.XmlTag.Returns, phrases[0]) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ParamDocumentationAnalyzer.cs
@@ -98,7 +98,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         continue;
                     }
 
-                    if (parameterCommentXml.EqualsAny(Constants.Comments.UnusedPhrase))
+                    if (StringExtensions.EqualsAny(parameterCommentXml, Constants.Comments.UnusedPhrase, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnsValueDocumentationAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected Diagnostic[] AnalyzeStartingPhrase(ISymbol symbol, DocumentationCommentTriviaSyntax comment, string commentXml, string xmlTag, in ReadOnlySpan<string> phrases)
         {
-            if (commentXml.StartsWithAny(phrases, StringComparison.Ordinal) is false)
+            if (commentXml.StartsWithAny(phrases) is false)
             {
                 var nodes = comment.GetXmlSyntax(xmlTag);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_ArgumentNullExceptionThrownAtWrongPlaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_ArgumentNullExceptionThrownAtWrongPlaceAnalyzer.cs
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     case BinaryExpressionSyntax binary when binary.Left is IdentifierNameSyntax || binary.Right is IdentifierNameSyntax:
                     case IsPatternExpressionSyntax pattern when pattern.Expression is IdentifierNameSyntax:
-                    case InvocationExpressionSyntax invocation when invocation.GetName().EqualsAny(EqualsMethods):
+                    case InvocationExpressionSyntax invocation when StringExtensions.EqualsAny(invocation.GetName(), EqualsMethods, StringComparison.OrdinalIgnoreCase):
                     {
                         // seems like a correct usage
                         return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3027_FutureUsedParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3027_FutureUsedParameterAnalyzer.cs
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     continue;
                 }
 
-                if (comment.ContainsAny(Constants.Comments.FuturePhrase))
+                if (comment.ContainsAny(Constants.Comments.FuturePhrase, StringComparison.OrdinalIgnoreCase))
                 {
                     yield return Issue(parameter);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3055_ViewModelImplementsINotifyPropertyChangedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3055_ViewModelImplementsINotifyPropertyChangedAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool ShallAnalyze(INamedTypeSymbol symbol) => symbol.TypeKind is TypeKind.Class
                                                                       && symbol.IsRecord is false
-                                                                      && symbol.Name.EndsWithAny(Constants.Markers.ViewModels, StringComparison.Ordinal)
+                                                                      && symbol.Name.EndsWithAny(Constants.Markers.ViewModels)
                                                                       && symbol.IsTestClass() is false;
 
         protected override IEnumerable<Diagnostic> Analyze(INamedTypeSymbol symbol, Compilation compilation) => symbol.Implements<INotifyPropertyChanged>()

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_CodeFixProvider.cs
@@ -536,14 +536,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var name = syntax.Expression.GetName();
 
-            return name.ContainsAny(ActualMarkers);
+            return name.ContainsAny(ActualMarkers, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsExpected(ArgumentSyntax syntax)
         {
             var name = syntax.Expression.GetName();
 
-            return name.ContainsAny(ExpectedMarkers);
+            return name.ContainsAny(ExpectedMarkers, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var invocation = shouldNode.FirstAncestor<InvocationExpressionSyntax>();
             var arguments = invocation.ArgumentList.Arguments;
 
-            return AssertThat(expression, Is("EquivalentTo", arguments[0]), arguments, 1, removeNameColon: true);
+            return AssertThat(expression, Is("EquivalentTo", arguments[0]), arguments, removeNameColon: true);
         }
 
         private static InvocationExpressionSyntax ConvertShould(Document document, MemberAccessExpressionSyntax shouldNode)
@@ -166,7 +166,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case "NotBeApproximately": return AssertThat(expression, Is("Not", "EqualTo", arguments[0], "Within", arguments[1]), arguments, 2, removeNameColon: true);
 
                 case "BeOfType" when constraintNode.Name is GenericNameSyntax g: return AssertThat(expression, Is("TypeOf", g.TypeArgumentList.Arguments.ToArray()), arguments, 0, removeNameColon: true);
-                case "BeOfType": return AssertThat(expression, Is("TypeOf", arguments[0]), arguments, 1, removeNameColon: true);
+                case "BeOfType": return AssertThat(expression, Is("TypeOf", arguments[0]), arguments, removeNameColon: true);
 
                 case "BeXmlSerializable": return AssertThat(expression, Is("XmlSerializable"), arguments, 0, removeNameColon: true);
                 case "BeBinarySerializable": return AssertThat(expression, Is("BinarySerializable"), arguments, 0, removeNameColon: true);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var type = property.Type;
 
-            if (type.IsGuid() && property.GetName().EndsWithAny(WrongNameSuffixes, StringComparison.Ordinal))
+            if (type.IsGuid() && property.GetName().EndsWithAny(WrongNameSuffixes))
             {
                 context.ReportDiagnostic(Issue(type));
             }
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var name = parameter.GetName();
 
-                if (name == WrongParameterName || name.EndsWithAny(WrongNameSuffixes, StringComparison.Ordinal))
+                if (name == WrongParameterName || name.EndsWithAny(WrongNameSuffixes))
                 {
                     context.ReportDiagnostic(Issue(type));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UnitTestCodeFixProvider.cs
@@ -198,7 +198,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var formatMessage = literal.Token.ValueText;
 
-                if (formatMessage.ContainsAny(FormatIdentifiers))
+                if (formatMessage.ContainsAny(FormatIdentifiers, StringComparison.OrdinalIgnoreCase))
                 {
                     return Argument(ConvertToInterpolatedString(formatMessage.AsSpan(), otherArguments));
                 }
@@ -213,7 +213,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             int index;
 
-            while ((index = formatMessage.IndexOfAny(FormatIdentifiers, StringComparison.Ordinal)) > -1)
+            while ((index = formatMessage.IndexOfAny(FormatIdentifiers)) > -1)
             {
                 if (index > 0)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1000_EventArgsTypeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1000_EventArgsTypeAnalyzer.cs
@@ -52,17 +52,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static ReadOnlySpan<char> GetNameWithoutSuffix(in ReadOnlySpan<char> name)
         {
-            if (name.EndsWith(Arg, StringComparison.Ordinal))
+            if (name.EndsWith(Arg))
             {
                 return GetNameWithoutSuffixes(name, EventArg, EventsArg, EventBaseArg, EventsBaseArg, BaseArg, Arg);
             }
 
-            if (name.EndsWith(Args, StringComparison.Ordinal))
+            if (name.EndsWith(Args))
             {
                 return GetNameWithoutSuffixes(name, EventsArgs, EventBaseArgs, EventsBaseArgs, BaseArgs, Args);
             }
 
-            if (name.EndsWith(Base, StringComparison.Ordinal))
+            if (name.EndsWith(Base))
             {
                 return GetNameWithoutSuffixes(name, EventArgBase, EventsArgBase, EventArgsBase, EventsArgsBase, Base);
             }
@@ -74,7 +74,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             foreach (var phrase in phrases)
             {
-                if (name.EndsWith(phrase, StringComparison.Ordinal))
+                if (name.EndsWith(phrase))
                 {
                     return name.WithoutSuffix(phrase);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
@@ -60,11 +60,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    ? methodName.AsSpan(Prefix.Length)
                                    : methodName.AsSpan();
 
-                if (adjustedName.EndsWith(OnCanExecuteSuffix, StringComparison.Ordinal))
+                if (adjustedName.EndsWith(OnCanExecuteSuffix))
                 {
                     name = "CanExecute".ConcatenatedWith(adjustedName.Slice(0, adjustedName.Length - OnCanExecuteSuffix.Length));
                 }
-                else if (adjustedName.EndsWith(OnExecutedSuffix, StringComparison.Ordinal))
+                else if (adjustedName.EndsWith(OnExecutedSuffix))
                 {
                     name = "Executed".ConcatenatedWith(adjustedName.Slice(0, adjustedName.Length - OnExecutedSuffix.Length));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1012_FireMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1012_FireMethodsAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var methodName = symbol.Name;
 
-            if (methodName.ContainsAny(FirePhrases) && methodName.ContainsAny(FirewallPhrases) is false)
+            if (methodName.ContainsAny(FirePhrases, StringComparison.OrdinalIgnoreCase) && methodName.ContainsAny(FirewallPhrases, StringComparison.OrdinalIgnoreCase) is false)
             {
                 var proposal = FindBetterName(symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var symbolName = symbol.Name;
 
-            if (symbolName.StartsWithAny(StartingPhrases))
+            if (symbolName.StartsWithAny(StartingPhrases, StringComparison.OrdinalIgnoreCase))
             {
                 // avoid situation that method has no name
                 if (symbolName.Without(StartingPhrase).Length != 0)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1014_CheckMethodsAnalyzer.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var methodName = symbol.Name;
 
-            if (methodName.StartsWith(Phrase, StringComparison.Ordinal) && methodName.StartsWithAny(StartingPhrases, StringComparison.Ordinal) is false)
+            if (methodName.StartsWith(Phrase, StringComparison.Ordinal) && methodName.StartsWithAny(StartingPhrases) is false)
             {
                 var betterName = FindBetterName(symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_TypeSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1037_TypeSuffixAnalyzer.cs
@@ -33,12 +33,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration)
         {
-            if (declaration is EnumDeclarationSyntax && typeName.EndsWithAny(AllowedEnumSuffixes, StringComparison.Ordinal))
+            if (declaration is EnumDeclarationSyntax && typeName.EndsWithAny(AllowedEnumSuffixes))
             {
                 return false;
             }
 
-            return typeName.EndsWithAny(WrongSuffixes);
+            return typeName.EndsWithAny(WrongSuffixes, StringComparison.OrdinalIgnoreCase);
         }
 
         protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzer.cs
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                             return name.Slice(IsPrefix.Length);
                         }
 
-                        if (nameLength > HasPrefix.Length && name[HasPrefix.Length].IsUpperCaseLetter() && name.Slice(0, HasPrefix.Length).EqualsAny(HasArePrefix))
+                        if (nameLength > HasPrefix.Length && name[HasPrefix.Length].IsUpperCaseLetter() && StringExtensions.EqualsAny(name.Slice(0, HasPrefix.Length), HasArePrefix, StringComparison.OrdinalIgnoreCase))
                         {
                             return name.Slice(HasPrefix.Length);
                         }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1047_NonAsyncMethodsButAsyncSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1047_NonAsyncMethodsButAsyncSuffixAnalyzer.cs
@@ -35,12 +35,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static string FindBetterName(in ReadOnlySpan<char> symbolName)
         {
-            if (symbolName.EndsWith(Constants.AsyncSuffix, StringComparison.Ordinal))
+            if (symbolName.EndsWith(Constants.AsyncSuffix))
             {
                 return symbolName.WithoutSuffix(Constants.AsyncSuffix).ToString();
             }
 
-            if (symbolName.EndsWith(Constants.AsyncCoreSuffix, StringComparison.Ordinal))
+            if (symbolName.EndsWith(Constants.AsyncCoreSuffix))
             {
                 return symbolName.WithoutSuffix(Constants.AsyncCoreSuffix).ConcatenatedWith(Constants.Core);
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1051_DelegateParameterNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1051_DelegateParameterNameSuffixAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation) => symbol.Name.EndsWithAny(WrongNames)
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation) => symbol.Name.EndsWithAny(WrongNames, StringComparison.OrdinalIgnoreCase)
                                                                                                                     ? new[] { Issue(symbol, CreateBetterNameProposal("callback")) }
                                                                                                                     : Array.Empty<Diagnostic>();
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => AnalyzeIdentifiers(identifiers);
 
-        private IEnumerable<Diagnostic> AnalyzeIdentifiers(IEnumerable<SyntaxToken> identifiers) => identifiers.Where(_ => _.ValueText.EndsWithAny(WrongNames) && _.ValueText.EndsWith("ransaction", StringComparison.OrdinalIgnoreCase) is false)
+        private IEnumerable<Diagnostic> AnalyzeIdentifiers(IEnumerable<SyntaxToken> identifiers) => identifiers.Where(_ => _.ValueText.EndsWithAny(WrongNames, StringComparison.OrdinalIgnoreCase) && _.ValueText.EndsWith("ransaction", StringComparison.OrdinalIgnoreCase) is false)
                                                                                                                .Select(_ => Issue(_, CreateBetterNameProposal("callback")));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 case TypeKind.Delegate:
                 case TypeKind.Class when symbolType.IsRecord is false && symbolType.ToString() == TypeNames.Delegate:
                 {
-                    if (symbol.Name.EndsWithAny(WrongNames))
+                    if (symbol.Name.EndsWithAny(WrongNames, StringComparison.OrdinalIgnoreCase))
                     {
                         var betterName = FindBetterName(symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            if (typeName.ContainsAny(WrongNames))
+            if (typeName.ContainsAny(WrongNames, StringComparison.OrdinalIgnoreCase))
             {
                 var wrongName = WrongNamesForConcreteLookup.First(_ => typeName.Contains(_, StringComparison.OrdinalIgnoreCase));
 
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static string FindBetterName(in ReadOnlySpan<char> typeName, string wrongName)
         {
-            if (typeName.Length > SpecialNameHandle.Length && typeName.StartsWith(SpecialNameHandle, StringComparison.Ordinal))
+            if (typeName.Length > SpecialNameHandle.Length && typeName.StartsWith(SpecialNameHandle))
             {
                 return typeName.WithoutSuffix(wrongName)
                                .Slice(SpecialNameHandle.Length)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     continue;
                 }
 
-                if (originalName.EqualsAny(SpecialNames, StringComparison.Ordinal))
+                if (originalName.EqualsAny(SpecialNames))
                 {
                     continue;
                 }
@@ -188,7 +188,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Pluralizer.GetPluralName(name, StringComparison.Ordinal);
             }
 
-            var index = originalName.IndexOfAny(Splitters, StringComparison.Ordinal);
+            var index = originalName.IndexOfAny(Splitters);
 
             if (index > 0)
             {
@@ -209,7 +209,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 name = pluralName.ToString();
 
-                if (pluralName.EndsWithAny(Constants.Markers.Collections))
+                if (pluralName.EndsWithAny(Constants.Markers.Collections, StringComparison.OrdinalIgnoreCase))
                 {
                     return Pluralizer.GetPluralName(name, StringComparison.OrdinalIgnoreCase, Constants.Markers.Collections);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     continue;
                 }
 
-                if (name.StartsWithAny(Prefixes, StringComparison.Ordinal) && name.HasUpperCaseLettersAbove(1) && name.StartsWith("isInDesign", StringComparison.Ordinal) is false)
+                if (name.StartsWithAny(Prefixes) && name.HasUpperCaseLettersAbove(1) && name.StartsWith("isInDesign", StringComparison.Ordinal) is false)
                 {
                     yield return Issue(name, identifier);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzer.cs
@@ -88,9 +88,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            if (name.StartsWithAny(Prefixes, StringComparison.Ordinal) && name.HasUpperCaseLettersAbove(2))
+            if (name.StartsWithAny(Prefixes) && name.HasUpperCaseLettersAbove(2))
             {
-                if (WellKnownNames.Contains(name) || name.StartsWithAny(WellKnownPrefixes, StringComparison.Ordinal) || name.EndsWithAny(WellKnownPostfixes, StringComparison.Ordinal))
+                if (WellKnownNames.Contains(name) || name.StartsWithAny(WellKnownPrefixes) || name.EndsWithAny(WellKnownPostfixes))
                 {
                     // skip all well known names
                     return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzer.cs
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return Array.Empty<Diagnostic>();
             }
 
-            if (name.StartsWithAny(Prefixes, StringComparison.Ordinal) && name.HasUpperCaseLettersAbove(2) && name.StartsWithAny(AllowedPrefixes, StringComparison.Ordinal) is false)
+            if (name.StartsWithAny(Prefixes) && name.HasUpperCaseLettersAbove(2) && name.StartsWithAny(AllowedPrefixes) is false)
             {
                 return new[] { Issue(symbol) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.TypeKind is TypeKind.Class && symbol.Name.EndsWithAny(EventArgSuffixes, StringComparison.Ordinal);
+        protected override bool ShallAnalyze(ITypeSymbol symbol) => symbol.TypeKind is TypeKind.Class && symbol.Name.EndsWithAny(EventArgSuffixes);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1076_PrismEventTypeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1076_PrismEventTypeAnalyzer.cs
@@ -54,22 +54,22 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static ReadOnlySpan<char> GetNameWithoutSuffix(in ReadOnlySpan<char> name)
         {
-            if (name.EndsWith(Arg, StringComparison.Ordinal))
+            if (name.EndsWith(Arg))
             {
                 return GetNameWithoutSuffixes(name, EventArg, EventsArg, EventBaseArg, EventsBaseArg, BaseArg, Arg);
             }
 
-            if (name.EndsWith(Args, StringComparison.Ordinal))
+            if (name.EndsWith(Args))
             {
                 return GetNameWithoutSuffixes(name, EventArgs, EventsArgs, EventBaseArgs, EventsBaseArgs, BaseArgs, Args);
             }
 
-            if (name.EndsWith(Base, StringComparison.Ordinal))
+            if (name.EndsWith(Base))
             {
                 return GetNameWithoutSuffixes(name, EventArgBase, EventsArgBase, EventArgsBase, EventsArgsBase, Base);
             }
 
-            if (name.EndsWith(Events, StringComparison.Ordinal))
+            if (name.EndsWith(Events))
             {
                 return name.WithoutSuffix(Events);
             }
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             foreach (var phrase in phrases)
             {
-                if (name.EndsWith(phrase, StringComparison.Ordinal))
+                if (name.EndsWith(phrase))
                 {
                     return name.WithoutSuffix(phrase);
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1089_GetByMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1089_GetByMethodsAnalyzer.cs
@@ -28,10 +28,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             if (Pluralizer.IsPlural(symbolName))
             {
-                return symbolName.EndsWithAny(Extensions, StringComparison.Ordinal) is false;
+                return symbolName.EndsWithAny(Extensions) is false;
             }
 
-            return symbolName.EndsWith("Repository", StringComparison.Ordinal);
+            return symbolName.EndsWith("Repository");
         }
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var name = symbol.Name;
 
-            if (name.StartsWithAny(AcceptedPrefixes, Comparison))
+            if (name.StartsWithAny(AcceptedPrefixes))
             {
                 return Array.Empty<Diagnostic>();
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var name = identifier.ValueText;
 
-                if (name.StartsWithAny(AcceptedPrefixes, Comparison))
+                if (name.StartsWithAny(AcceptedPrefixes))
                 {
                     continue;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzer.cs
@@ -11,8 +11,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1092";
 
-        private const StringComparison Comparison = StringComparison.Ordinal;
-
         private static readonly string[] TypeSuffixes =
                                                         {
                                                             Constants.Element,
@@ -26,11 +24,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => typeName.EndsWithAny(TypeSuffixes, Comparison);
+        protected override bool ShallAnalyze(string typeName, BaseTypeDeclarationSyntax declaration) => typeName.EndsWithAny(TypeSuffixes);
 
         protected override Diagnostic[] AnalyzeName(string typeName, in SyntaxToken typeNameIdentifier, BaseTypeDeclarationSyntax declaration)
         {
-            if (typeName.Contains("able") && typeName.EndsWithAny(TypeSuffixes, Comparison))
+            if (typeName.Contains("able") && typeName.EndsWithAny(TypeSuffixes))
             {
                 var proposedName = GetProposedName(typeName);
 
@@ -48,13 +46,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 foreach (var suffix in TypeSuffixes)
                 {
-                    if (proposedName.EndsWith(suffix, Comparison))
+                    if (proposedName.EndsWith(suffix))
                     {
                         proposedName = proposedName.WithoutSuffix(suffix);
                     }
                 }
             }
-            while (proposedName.EndsWithAny(TypeSuffixes, Comparison));
+            while (proposedName.EndsWithAny(TypeSuffixes));
 
             return proposedName.ToString();
         }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzer.cs
@@ -118,7 +118,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var names = CollectNames(directlyImplementedInterfaces);
 
-                if (names.Count != 0 && symbol.Name.EndsWithAny(names, StringComparison.Ordinal) is false)
+                if (names.Count != 0 && symbol.Name.EndsWithAny(names) is false)
                 {
                     return new[] { Issue(symbol, names.HumanizedConcatenated()) };
                 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
@@ -107,7 +107,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     otherIndex++;
 
                     if (otherParameterName == referenceParameterName
-                     || otherParameterName.Equals(referenceParameterName.AsSpan().WithoutNumberSuffix(), StringComparison.Ordinal))
+                     || otherParameterName.Equals(referenceParameterName.AsSpan().WithoutNumberSuffix()))
                     {
                         continue;
                     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var className = typeName.AsSpan();
 
-            if (className.EndsWith(Constants.TestsSuffix, StringComparison.Ordinal))
+            if (className.EndsWith(Constants.TestsSuffix))
             {
                 return Array.Empty<Diagnostic>();
             }
@@ -35,17 +35,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static string FindBetterName(in ReadOnlySpan<char> className)
         {
-            if (className.EndsWith("Test", StringComparison.Ordinal))
+            if (className.EndsWith("Test"))
             {
                 return className.ConcatenatedWith('s');
             }
 
-            if (className.EndsWith("TestBase", StringComparison.Ordinal))
+            if (className.EndsWith("TestBase"))
             {
                 return className.Slice(0, className.Length - 4).ConcatenatedWith('s');
             }
 
-            if (className.EndsWith("TestsBase", StringComparison.Ordinal))
+            if (className.EndsWith("TestsBase"))
             {
                 return className.Slice(0, className.Length - 4).ToString();
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     continue;
                 }
 
-                if (name.ContainsAny(MockNames))
+                if (name.ContainsAny(MockNames, StringComparison.OrdinalIgnoreCase))
                 {
                     var symbol = identifier.GetSymbol(semanticModel);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var className = typeName.AsSpan();
 
-            if (className.EndsWith(Suffix, StringComparison.Ordinal))
+            if (className.EndsWith(Suffix))
             {
                 var betterName = FindBetterName(className);
 
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(in ReadOnlySpan<char> symbolName) => symbolName.StartsWith(Prefix, StringComparison.Ordinal)
+        private static string FindBetterName(in ReadOnlySpan<char> symbolName) => symbolName.StartsWith(Prefix)
                                                                                   ? symbolName.WithoutSuffix(Suffix).ToString()
                                                                                   : Prefix.ConcatenatedWith(symbolName.WithoutSuffix(Suffix));
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzer.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                       && symbol.IsTestMethod()
                                                                       && symbol.Name.Length >= 7; // consider only long names
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => symbol.Name.ContainsAny(WrongTerms)
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => symbol.Name.ContainsAny(WrongTerms, StringComparison.OrdinalIgnoreCase)
                                                                                                                  ? new[] { Issue(symbol) }
                                                                                                                  : Array.Empty<Diagnostic>();
     }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -86,7 +86,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 }
 
                 // jump over first part
-                if (first && part.StartsWithAny(SpecialFirstPhrases, StringComparison.Ordinal))
+                if (first && part.StartsWithAny(SpecialFirstPhrases))
                 {
                     first = false;
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1118_TestMethodsButAsyncSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1118_TestMethodsButAsyncSuffixAnalyzer.cs
@@ -59,12 +59,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static ReadOnlySpan<char> FindBetterNameCore(in ReadOnlySpan<char> symbolName)
         {
-            if (symbolName.EndsWith(Constants.AsyncSuffix, StringComparison.Ordinal))
+            if (symbolName.EndsWith(Constants.AsyncSuffix))
             {
                 return symbolName.WithoutSuffix(Constants.AsyncSuffix);
             }
 
-            if (symbolName.EndsWith("_async", StringComparison.Ordinal))
+            if (symbolName.EndsWith("_async"))
             {
                 return symbolName.WithoutSuffix("_async");
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
@@ -71,7 +71,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
 
             // maybe it's a number, so we have to check for that
-            if (name.EndsWithNumber() || name.IsAcronym() || name.EndsWithAny(AllowedSuffixes))
+            if (name.EndsWithNumber() || name.IsAcronym() || name.EndsWithAny(AllowedSuffixes, StringComparison.OrdinalIgnoreCase))
             {
                 // nothing to do here
                 return name;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var symbolName = typeName.AsSpan();
 
-                if (symbolName.EndsWith(suffix, StringComparison.Ordinal))
+                if (symbolName.EndsWith(suffix))
                 {
                     var proposal = suffix.ConcatenatedWith(symbolName.WithoutSuffix(suffix));
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamesFinder.cs
@@ -331,7 +331,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             result = null;
 
-            if (part1.StartsWithAny(SpecialNotPhrases, StringComparison.Ordinal))
+            if (part1.StartsWithAny(SpecialNotPhrases))
             {
                 // it seems like this is in normal order, so do not change the order
                 return false;

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var prefix = fieldPrefixes[index];
 
-                if (prefix.Length > 0 && fieldName.StartsWith(prefix, StringComparison.Ordinal))
+                if (prefix.Length > 0 && fieldName.StartsWith(prefix))
                 {
                     return prefix;
                 }


### PR DESCRIPTION
Introduced default string comparison values for:
- `Contains`
- `ContainsAny`
- `EndsWith`
- `EndsWithAny`
- `Equals`
- `EqualsAny`
- `StartsWith`
- `StartsWithAny`
