### PR TITLE
MiKo_2035 now uses 'A sequence that contains ' for IEnumerable return values

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -254,6 +254,7 @@ namespace MiKoSolutions.Analyzers
             internal const string DeterminesWhetherPhrase = "Determines whether";
             internal const string DisposeParameterPhrase = "Indicates whether unmanaged resources shall be freed.";
             internal const string DisposeSummaryPhrase = "Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.";
+            internal const string EnumerableReturnTypeStartingPhrase = "A sequence that contains ";
             internal const string EnumStartingPhrase = "Defines values that specify ";
             internal const string EnumReturnTypeStartingPhraseTemplate = "The enumerated constant that is the ";
             internal const string EnumTaskReturnTypeContinuePhraseTemplate = "the enumerated constant that is the ";
@@ -641,6 +642,15 @@ namespace MiKoSolutions.Analyzers
                                                                                       BooleanTaskReturnTypeEndingPhraseTemplate.FormatWith("<see langword=\"false\" />"),
                                                                                   };
 
+            internal static readonly string[] CollectionReturnTypeStartingPhrases =
+                                                                                    {
+                                                                                        CollectionReturnTypeStartingPhrase,
+                                                                                        "A <see cref=\"{0}\"/> that contains ",
+                                                                                        "A <see cref=\"{0}\" /> that contains ",
+                                                                                        "An <see cref=\"{0}\"/> that contains ",
+                                                                                        "An <see cref=\"{0}\" /> that contains ",
+                                                                                    };
+
             internal static readonly string[] StringReturnTypeStartingPhrase =
                                                                                {
                                                                                    StringReturnTypeStartingPhraseTemplate.FormatWith("<see cref=\"string\"/>", ThatContainsTerm), // this is just to have a proposal how to optimize
@@ -701,14 +711,15 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] EnumTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + EnumTaskReturnTypeContinuePhraseTemplate + "the ");
 
-            internal static readonly string[] EnumerableReturnTypeStartingPhrase =
-                                                                                   {
-                                                                                       CollectionReturnTypeStartingPhrase,
-                                                                                       "A <see cref=\"{0}\"/> that contains ",
-                                                                                       "A <see cref=\"{0}\" /> that contains ",
-                                                                                       "An <see cref=\"{0}\"/> that contains ",
-                                                                                       "An <see cref=\"{0}\" /> that contains ",
-                                                                                   };
+            internal static readonly string[] EnumerableReturnTypeStartingPhrases =
+                                                                                    {
+                                                                                        EnumerableReturnTypeStartingPhrase,
+                                                                                        CollectionReturnTypeStartingPhrase,
+                                                                                        "A <see cref=\"{0}\"/> that contains ",
+                                                                                        "A <see cref=\"{0}\" /> that contains ",
+                                                                                        "An <see cref=\"{0}\"/> that contains ",
+                                                                                        "An <see cref=\"{0}\" /> that contains ",
+                                                                                    };
 
             internal static readonly string[] EnumerableTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + CollectionReturnTypeStartingPhraseLowerCase);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -75,7 +75,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return CommentStartingWith(preparedComment, TaskParts[0], SeeCrefTaskResult(), TaskParts[1] + middlePart);
             }
 
-            var startingPhrase = Constants.Comments.CollectionReturnTypeStartingPhrase;
+            var startingPhrase = GetCollectionStartingPhrase(returnType);
 
             if (returnType.TypeArgumentList.Arguments.Count is 1)
             {
@@ -110,7 +110,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return CommentStartingWith(PrepareComment(comment), Constants.Comments.ArrayReturnTypeStartingPhrase);
             }
 
-            return CommentStartingWith(PrepareComment(comment), Constants.Comments.CollectionReturnTypeStartingPhrase);
+            var startingPhrase = GetCollectionStartingPhrase(returnType);
+
+            return CommentStartingWith(PrepareComment(comment), startingPhrase);
+        }
+
+        private static string GetCollectionStartingPhrase(TypeSyntax returnType)
+        {
+            return returnType.GetName() is "IEnumerable"
+                   ? Constants.Comments.EnumerableReturnTypeStartingPhrase
+                   : Constants.Comments.CollectionReturnTypeStartingPhrase;
         }
 
         private static string GetGenericTypeArgumentTypeName(GenericNameSyntax returnType)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
@@ -50,7 +50,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                        : Constants.Comments.ArrayReturnTypeStartingPhrase;
             }
 
-            return Constants.Comments.EnumerableReturnTypeStartingPhrase;
+            if (returnType.Name is "IEnumerable")
+            {
+                return Constants.Comments.EnumerableReturnTypeStartingPhrases;
+            }
+
+            return Constants.Comments.CollectionReturnTypeStartingPhrases;
         }
     }
 }


### PR DESCRIPTION
- Introduce `A sequence that contains` as starting comment for `IEnumerable`

- Differentiate `IEnumerable` vs collection phrases

- Update analyzer and code fix logic

- Expand and adjust unit tests