### PR TITLE
Refactored how parameter comments get build as texts

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {
-            return AnalyzePlainTextStartingPhrase(parameter, parameterComment, Constants.Comments.ParameterStartingPhrase, StringComparison.OrdinalIgnoreCase);
+            return AnalyzePlainTextStartingPhrase(parameter, parameterComment, comment, Constants.Comments.ParameterStartingPhrase, StringComparison.OrdinalIgnoreCase);
         }
 
         protected override Location GetIssueLocation(XmlElementSyntax parameterComment)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var phrases = GetStartingPhrase(parameter);
 
-            return AnalyzePlainTextStartingPhrase(parameter, parameterComment, phrases);
+            return AnalyzePlainTextStartingPhrase(parameter, parameterComment, comment, phrases);
         }
 
         protected override Location GetIssueLocation(XmlElementSyntax parameterComment)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
@@ -15,6 +15,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsCancellationToken();
 
-        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment) => AnalyzePlainTextStartingPhrase(parameter, parameterComment, Constants.Comments.CancellationTokenParameterPhrase);
+        protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment) => AnalyzePlainTextStartingPhrase(parameter, parameterComment, comment, Constants.Comments.CancellationTokenParameterPhrase);
     }
 }


### PR DESCRIPTION
- Pass raw comment text to analyzers

- Update phrase checks to use comment

- Refactor parameter analysis to use the parameter `ImmutableArray`

- Remove redundant XML retrieval logic
