### PR TITLE
MiKo_2035 is now aware of '/// An <see cref="IEnumerable{T}"/> whose elements are the result of '

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -642,14 +642,19 @@ namespace MiKoSolutions.Analyzers
                                                                                       BooleanTaskReturnTypeEndingPhraseTemplate.FormatWith("<see langword=\"false\" />"),
                                                                                   };
 
-            internal static readonly string[] CollectionReturnTypeStartingPhrases =
-                                                                                    {
-                                                                                        CollectionReturnTypeStartingPhrase,
-                                                                                        "A <see cref=\"{0}\"/> that contains ",
-                                                                                        "A <see cref=\"{0}\" /> that contains ",
-                                                                                        "An <see cref=\"{0}\"/> that contains ",
-                                                                                        "An <see cref=\"{0}\" /> that contains ",
-                                                                                    };
+            internal static readonly string[] TypedCollectionReturnTypeStartingPhrases =
+                                                                                         {
+                                                                                             "A <see cref=\"{0}\"/> that contains ",
+                                                                                             "A <see cref=\"{0}\" /> that contains ",
+                                                                                             "An <see cref=\"{0}\"/> that contains ",
+                                                                                             "An <see cref=\"{0}\" /> that contains ",
+                                                                                             "A <see cref=\"{0}\"/> whose elements are the result of ",
+                                                                                             "A <see cref=\"{0}\" /> whose elements are the result of ",
+                                                                                             "An <see cref=\"{0}\"/> whose elements are the result of ",
+                                                                                             "An <see cref=\"{0}\" /> whose elements are the result of ",
+                                                                                         };
+
+            internal static readonly string[] CollectionReturnTypeStartingPhrases = new[] { CollectionReturnTypeStartingPhrase }.Concat(TypedCollectionReturnTypeStartingPhrases).ToArray();
 
             internal static readonly string[] StringReturnTypeStartingPhrase =
                                                                                {
@@ -711,15 +716,7 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] EnumTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + EnumTaskReturnTypeContinuePhraseTemplate + "the ");
 
-            internal static readonly string[] EnumerableReturnTypeStartingPhrases =
-                                                                                    {
-                                                                                        EnumerableReturnTypeStartingPhrase,
-                                                                                        CollectionReturnTypeStartingPhrase,
-                                                                                        "A <see cref=\"{0}\"/> that contains ",
-                                                                                        "A <see cref=\"{0}\" /> that contains ",
-                                                                                        "An <see cref=\"{0}\"/> that contains ",
-                                                                                        "An <see cref=\"{0}\" /> that contains ",
-                                                                                    };
+            internal static readonly string[] EnumerableReturnTypeStartingPhrases = new[] { EnumerableReturnTypeStartingPhrase }.Concat(CollectionReturnTypeStartingPhrases).ToArray();
 
             internal static readonly string[] EnumerableTaskReturnTypeStartingPhrase = GenericTaskReturnTypeStartingPhrase.ToArray(_ => _ + CollectionReturnTypeStartingPhraseLowerCase);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -205,6 +205,24 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_correctly_commented_Enumerable_Select_like_method_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something.
+    /// </summary>
+    /// <" + xmlTag + @">
+    /// An <see cref=""IEnumerable{T}""/> whose elements are the result of something.
+    /// </" + xmlTag + @">
+    public IEnumerable<T> Select<T>(object o) => null;
+}
+");
+
         [Test, Combinatorial]
         public void An_issue_is_reported_for_wrong_commented_method_(
                                                                  [Values("returns", "value")] string xmlTag,


### PR DESCRIPTION
The XML documentation comment of a return value can now also start with
`/// An <see cref="IEnumerable{T}"/> whose elements are the result of `.
