### PR TITLE
MiKo_2218 is now aware of plural texts when fixing 'that can be used in'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.cs
@@ -24,6 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private const string UsedInCombinationUnclearReplacement = "made to work with";
 
         private const string UsedInPluralReplacement = "are suitable for";
+        private const string SpecialUsedInPluralReplacement = "s that are suitable for";
         private const string UsedInSingularReplacement = "is suitable for";
         private const string UsedInUnclearReplacement = "suitable for";
 
@@ -192,6 +193,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                    "are to be used in",
                                                                    "have to be used in",
                                                                };
+
+        private static readonly string[] SpecialUsedInPluralPhrases =
+                                                                      {
+                                                                          "s that can be used in",
+                                                                          "s which can be used in",
+                                                                      };
 
         private static readonly string[] UsedInSingularPhrases =
                                                                  {
@@ -391,12 +398,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 issues.AddRange(AnalyzeForSpecialPhrase(token, AreUsedToPhrase, Verbalizer.MakeInfiniteVerb));
 
                 AnalyzeForPhrases(issues, token, UsedToPhrase, UsedToReplacement); // do not use case-insensitive here
+
                 AnalyzeForPhrases(issues, token, UsedInCombinationPluralPhrases, UsedInCombinationPluralReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInCombinationSingularPhrases, UsedInCombinationSingularReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInCombinationUnclearPhrases, UsedInCombinationUnclearReplacement, StringComparison.OrdinalIgnoreCase);
+
                 AnalyzeForPhrases(issues, token, UsedInternallyPluralPhrases, UsedInternallyPluralReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInternallySingularPhrases, UsedInternallySingularReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInternallyUnclearPhrases, UsedInternallyUnclearReplacement, StringComparison.OrdinalIgnoreCase);
+
+                AnalyzeForPhrases(issues, token, SpecialUsedInPluralPhrases, SpecialUsedInPluralReplacement, StringComparison.OrdinalIgnoreCase);
+
                 AnalyzeForPhrases(issues, token, UsedInPluralPhrases, UsedInPluralReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInSingularPhrases, UsedInSingularReplacement, StringComparison.OrdinalIgnoreCase);
                 AnalyzeForPhrases(issues, token, UsedInUnclearPhrases, UsedInUnclearReplacement, StringComparison.OrdinalIgnoreCase);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzerTests.cs
@@ -438,6 +438,21 @@ public sealed record TestMe(object o)
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [TestCase("that can be used in", "that are suitable for")]
+        [TestCase("which can be used in", "that are suitable for")]
+        public void Code_gets_fixed_for_description_on_extensions_class_(string originalCode, string fixedCode)
+        {
+            const string Template = @"
+/// <summary>
+/// Provides extensions for <see cref=""objects""/>s ### some area.
+/// </summary>
+public static class TestMeExtensions
+{
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalCode), Template.Replace("###", fixedCode));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2218_DocumentationShouldNotContainUsedToAnalyzer();


### PR DESCRIPTION
- Handle plural "s that can be used in"

- Add special plural replacements for extensions

- Update analyzer phrase lists and mapping

- Add tests for extensions class summaries