### PR TITLE
'GetStartingPhrases' code refactored to use 'string[]'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -23,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var initialPhrases = GetNonGenericInitialPhrases(returnType);
 
-                return GetStartingPhrases(returnType, initialPhrases).ToArray();
+                return GetStartingPhrases(returnType, initialPhrases);
             }
 
             if (returnType.TryGetGenericArgumentType(out var argumentType))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_FactoryAnalyzer.cs
@@ -46,16 +46,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             switch (symbol)
             {
                 case INamedTypeSymbol type: return AnalyzeStartingPhrase(type, summaryXmls, summaries.Value, Constants.Comments.FactorySummaryPhrase);
-                case IMethodSymbol method: return AnalyzeStartingPhrase(method, summaryXmls, summaries.Value, GetPhrases(method).ToArray());
+                case IMethodSymbol method: return AnalyzeStartingPhrase(method, summaryXmls, summaries.Value, GetPhrases(method));
                 default: return Array.Empty<Diagnostic>();
             }
         }
 
-        private static IEnumerable<string> GetPhrases(IMethodSymbol symbol) => symbol.ReturnType.IsEnumerable() ? GetCollectionPhrases(symbol) : GetSimplePhrases(symbol);
+        private static string[] GetPhrases(IMethodSymbol symbol) => symbol.ReturnType.IsEnumerable() ? GetCollectionPhrases(symbol) : GetSimplePhrases(symbol);
 
-        private static IEnumerable<string> GetSimplePhrases(IMethodSymbol symbol) => GetStartingPhrases(symbol.ReturnType, Constants.Comments.FactoryCreateMethodSummaryStartingPhrase);
+        private static string[] GetSimplePhrases(IMethodSymbol symbol) => GetStartingPhrases(symbol.ReturnType, Constants.Comments.FactoryCreateMethodSummaryStartingPhrase);
 
-        private static IEnumerable<string> GetCollectionPhrases(IMethodSymbol symbol)
+        private static string[] GetCollectionPhrases(IMethodSymbol symbol)
         {
             if (symbol.ReturnType.TryGetGenericArguments(out var arguments))
             {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -185,7 +185,7 @@ public class TestMe
 }
 ");
 
-        [Test, Combinatorial]
+        [Test]
         public void No_issue_is_reported_for_correctly_commented_Enumerable_only_method_([Values("returns", "value")] string xmlTag)
             => No_issue_is_reported_for(@"
 using System;


### PR DESCRIPTION
- Refactor helpers to return string arrays and remove LINQ `ToArray()` in callers

- Adjust factory analyzer phrase helpers

- Simplify a test attribute combination