### PR TITLE
MiKo_2035 now ignores XmlNode return values

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Xml;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,7 +15,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool IsAcceptedType(ITypeSymbol returnType) => returnType.IsEnumerable();
+        protected override bool IsAcceptedType(ITypeSymbol returnType)
+        {
+            if (returnType is INamedTypeSymbol type && type.Name.StartsWith("Xml", StringComparison.Ordinal) && type.InheritsFrom<XmlNode>())
+            {
+                return false; // ignore XML nodes
+            }
+
+            return returnType.IsEnumerable();
+        }
 
         protected override string[] GetStartingPhrases(ISymbol owningSymbol, ITypeSymbol returnType)
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -59,6 +59,19 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_commented_method_returning_a_([Values("XmlNode", "XmlElement", "XmlDocument")] string returnType) => No_issue_is_reported_for(@"
+using System.Xml;
+
+public class TestMe
+{
+    /// <returns>
+    /// The item
+    /// </returns>
+    public " + returnType + @" DoSomething(object o) => null;
+}
+");
+
         [Test, Combinatorial]
         public void No_issue_is_reported_for_method_that_returns_a_(
                                                                 [Values("returns", "value")] string xmlTag,


### PR DESCRIPTION
- Ignore `XmlNode` and inheritors in analyzer

- Add guard for Xml* types inheriting `XmlNode`

- Extend tests for `XmlNode`, `XmlElement`, `XmlDocument`

- Minor using import for `System.Xml`

(resolves #1487)