### PR TITLE
MiKo_3060 can now remove multiple 'Debug' or 'Trace' calls at once

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_CodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -17,6 +18,27 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => null; // we want to remove the syntax
 
-        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue) => root.WithoutUsing("System.Diagnostics"); // remove unused "using System.Diagnostics;"
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (root.DescendantNodes<IdentifierNameSyntax>().None(_ => IsDebugOrTrace(_.GetName())))
+            {
+                return root.WithoutUsing("System.Diagnostics"); // remove unused "using System.Diagnostics;"
+            }
+
+            return root;
+        }
+
+        private static bool IsDebugOrTrace(string name)
+        {
+            switch (name)
+            {
+                case nameof(Debug):
+                case nameof(Trace):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzerTests.cs
@@ -97,6 +97,41 @@ public class TestMe
         }
 
         [Test]
+        public void Code_gets_fixed_for_multiple_Assert_usage_method_([Values("Debug", "Trace")] string className)
+        {
+            var originalCode = @"
+using System;
+using System.Diagnostics;
+
+public class TestMe
+{
+    public void DoSomething(int i)
+    {
+        " + className + @".Assert(i != 42);
+        " + className + @".Assert(i != 0815);
+
+        DoSomething(42);
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int i)
+    {
+
+        DoSomething(42);
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_fully_qualified_Assert_usage_method_([Values("Debug", "Trace")] string className)
         {
             var originalCode = @"


### PR DESCRIPTION
- Skip removing `System.Diagnostics` using when still needed

- Add tests for multiple `Assert` removals

- Introduce `Debug`/`Trace` identifier check
