### PR TITLE
Added rule MiKo_3231 about 'Equals' comparison using 'StringComparison.Ordinal'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -132,7 +132,7 @@ namespace MiKoSolutions.Analyzers
             return Array.Empty<IFieldSymbol>();
         }
 
-        internal static IEnumerable<IFieldSymbol> GetFields(this ITypeSymbol value, string fieldName)
+        internal static IReadOnlyList<IFieldSymbol> GetFields(this ITypeSymbol value, string fieldName)
         {
             var members = value.GetMembers(fieldName);
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -407,9 +407,7 @@ namespace MiKoSolutions.Analyzers
             {
                 case IdentifierNameSyntax identifier:
                 {
-                    var text = identifier.GetName();
-
-                    if (text is "nameof" && value.Ancestors<MemberAccessExpressionSyntax>().None())
+                    if (identifier.IsNameOf() && value.Ancestors<MemberAccessExpressionSyntax>().None())
                     {
                         // nameof
                         var arguments = value.ArgumentList.Arguments;
@@ -420,7 +418,7 @@ namespace MiKoSolutions.Analyzers
                         }
                     }
 
-                    return text;
+                    return identifier.GetName();
                 }
 
                 case MemberAccessExpressionSyntax m:

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -566,6 +566,25 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        internal static bool IsNameOf(this ExpressionSyntax value)
+        {
+            switch (value)
+            {
+                case IdentifierNameSyntax identifier:
+                    return identifier.IsNameOf();
+
+                case InvocationExpressionSyntax invocation:
+                    return invocation.IsNameOf();
+
+                default:
+                    return false;
+            }
+        }
+
+        internal static bool IsNameOf(this IdentifierNameSyntax value) => value.GetName() is "nameof";
+
+        internal static bool IsNameOf(this InvocationExpressionSyntax value) => value.Expression.IsNameOf();
+
         internal static bool IsOnlyNodeInsideRegion(this SyntaxNode value)
         {
             if (value.TryGetRegionDirective(out var regionTrivia))

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -235,6 +235,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3227_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3229_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3231_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -340,6 +340,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_UsePatternMatchingForLiteralNotEqualsExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3229_KeyValuePairCreateAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -6598,7 +6598,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace &lt;br/&gt; with &lt;para/&gt;.
+        ///   Looks up a localized string similar to Replace &lt;p&gt; with &lt;para&gt;.
         /// </summary>
         internal static string MiKo_2042_CodeFixTitle {
             get {
@@ -6607,7 +6607,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the &apos;&lt;para/&gt;&apos; XML tags instead of &apos;&lt;br/&gt;&apos; or &apos;&lt;p/&gt;&apos; HTML tags. This ensures a consistent format, suitable for XML-based documentation tools and frameworks..
+        ///   Looks up a localized string similar to Documentation should use the &apos;&lt;para&gt;&apos; XML tags instead of &apos;&lt;p&gt;&apos; HTML tags. This ensures a consistent format, suitable for XML-based documentation tools and frameworks..
         /// </summary>
         internal static string MiKo_2042_Description {
             get {
@@ -6625,7 +6625,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;&lt;para/&gt;&apos; instead of &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Use &apos;&lt;para&gt;&apos; instead of &apos;&lt;p&gt;&apos;.
         /// </summary>
         internal static string MiKo_2042_MessageFormat {
             get {
@@ -6634,7 +6634,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;&lt;para/&gt;&apos; XML tags instead of &apos;&lt;br/&gt;&apos; HTML tags.
+        ///   Looks up a localized string similar to Documentation should use &apos;&lt;para&gt;&apos; XML tags instead of &apos;&lt;p&gt;&apos; HTML tags.
         /// </summary>
         internal static string MiKo_2042_Title {
             get {
@@ -14468,6 +14468,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3230_Title {
             get {
                 return ResourceManager.GetString("MiKo_3230_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is&apos; pattern.
+        /// </summary>
+        internal static string MiKo_3231_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3231_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Equality checks using &apos;is&apos; pattern matching are more intuitive and easier to read than the &apos;Equals(StringComparison.Ordinal)&apos; comparison. This makes them the preferred choice for clarity and comprehension..
+        /// </summary>
+        internal static string MiKo_3231_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3231_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;is&apos; instead of &apos;Equals&apos;.
+        /// </summary>
+        internal static string MiKo_3231_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3231_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer pattern matching for equality checks for ordinal string comparisons.
+        /// </summary>
+        internal static string MiKo_3231_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3231_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5060,6 +5060,18 @@ This approach improves type safety and makes it harder to accidentally mix up di
   <data name="MiKo_3230_Title" xml:space="preserve">
     <value>Do not use 'Guid' as type for identifiers</value>
   </data>
+  <data name="MiKo_3231_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is' pattern</value>
+  </data>
+  <data name="MiKo_3231_Description" xml:space="preserve">
+    <value>Equality checks using 'is' pattern matching are more intuitive and easier to read than the 'Equals(StringComparison.Ordinal)' comparison. This makes them the preferred choice for clarity and comprehension.</value>
+  </data>
+  <data name="MiKo_3231_MessageFormat" xml:space="preserve">
+    <value>Use 'is' instead of 'Equals'</value>
+  </data>
+  <data name="MiKo_3231_Title" xml:space="preserve">
+    <value>Prefer pattern matching for equality checks for ordinal string comparisons</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3033_PropertyChangeEventArgsCtorUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3033_PropertyChangeEventArgsCtorUsesNameofAnalyzer.cs
@@ -57,7 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (argumentExpression)
             {
-                case InvocationExpressionSyntax i when i.Expression is IdentifierNameSyntax sa && sa.GetName() is "nameof":
+                case InvocationExpressionSyntax i when i.IsNameOf():
                     return NameofHasIssue(node, i.ArgumentList.Arguments, semanticModel);
 
                 case IdentifierNameSyntax s when node.EnclosingMethodHasParameter(s.GetName(), semanticModel):

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_CodeFixProvider.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3231_CodeFixProvider)), Shared]
+    public sealed class MiKo_3231_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3231";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            var invocation = syntaxNodes.OfType<InvocationExpressionSyntax>().FirstOrDefault();
+
+            if (invocation?.Parent is PrefixUnaryExpressionSyntax unary && unary.IsKind(SyntaxKind.LogicalNotExpression))
+            {
+                return unary;
+            }
+
+            return invocation;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is PrefixUnaryExpressionSyntax unary)
+            {
+                var updatedSyntax = GetUpdatedSyntax(document, unary.Operand);
+
+                return updatedSyntax is null ? null : IsFalsePattern(updatedSyntax);
+            }
+
+            return GetUpdatedSyntax(document, syntax);
+        }
+
+        private static IsPatternExpressionSyntax GetUpdatedSyntax(Document document, SyntaxNode syntax)
+        {
+            if (syntax is InvocationExpressionSyntax invocation && invocation.Expression is MemberAccessExpressionSyntax maes)
+            {
+                var updatedSyntax = GetUpdatedSyntax(document, maes.Expression, invocation.ArgumentList.Arguments);
+
+                if (updatedSyntax != null)
+                {
+                    return updatedSyntax.WithTriviaFrom(invocation);
+                }
+            }
+
+            return null;
+        }
+
+        private static IsPatternExpressionSyntax GetUpdatedSyntax(Document document, ExpressionSyntax expression, in SeparatedSyntaxList<ArgumentSyntax> arguments)
+        {
+            var argument = arguments[0];
+            var argumentExpression = argument.Expression;
+
+            if (argumentExpression.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return IsPattern(expression, argumentExpression);
+            }
+
+            if (expression.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                return IsPattern(argumentExpression, expression);
+            }
+
+            if (argumentExpression.IsNameOf())
+            {
+                return IsPattern(expression, argumentExpression);
+            }
+
+            if (expression.IsNameOf())
+            {
+                return IsPattern(argumentExpression, expression);
+            }
+
+            if (argument.IsConst(document))
+            {
+                return IsPattern(expression, argumentExpression);
+            }
+
+            return IsPattern(argumentExpression, expression);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
@@ -1,0 +1,69 @@
+﻿using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3231";
+
+        public MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+
+        private static bool IsStringComparisonOrdinal(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax m
+                                                                                   && m.GetIdentifierName() is nameof(StringComparison)
+                                                                                   && m.GetName() is nameof(StringComparison.Ordinal);
+
+        private static bool HasIssue(InvocationExpressionSyntax invocation, in SyntaxNodeAnalysisContext context)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax maes && maes.GetName() is nameof(Equals))
+            {
+                var arguments = invocation.ArgumentList.Arguments;
+
+                if (arguments.Count is 2 && IsStringComparisonOrdinal(arguments[1].Expression))
+                {
+                    var argumentExpression = arguments[0].Expression;
+                    var expression = maes.Expression;
+
+                    if (argumentExpression.IsKind(SyntaxKind.StringLiteralExpression) || expression.IsKind(SyntaxKind.StringLiteralExpression))
+                    {
+                        return true;
+                    }
+
+                    if (argumentExpression.IsNameOf())
+                    {
+                        return true;
+                    }
+
+                    if (expression.IsNameOf())
+                    {
+                        return true;
+                    }
+
+                    if (argumentExpression.IsConst(context) || expression.IsConst(context))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax invocation && HasIssue(invocation, context))
+            {
+                ReportDiagnostics(context, Issue(invocation));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzerTests.cs
@@ -1,0 +1,494 @@
+﻿using System;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] IgnorableComparisons =
+                                                                [
+                                                                    nameof(StringComparison.CurrentCulture),
+                                                                    nameof(StringComparison.CurrentCultureIgnoreCase),
+                                                                    nameof(StringComparison.InvariantCulture),
+                                                                    nameof(StringComparison.InvariantCultureIgnoreCase),
+                                                                    nameof(StringComparison.OrdinalIgnoreCase)
+                                                                ];
+
+        [Test]
+        public void No_issue_is_reported_for_2_variables_of_type_([Values("bool", "char", "int", "object", "StringComparison")] string type) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(" + type + " a, " + type + @" b)
+    {
+        if (object.Equals(a, b))
+            return true;
+        else
+            return false;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_static_string_Equals() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a, string b)
+    {
+        if (string.Equals(a, b))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_strings_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a, string b)
+    {
+        if (a.Equals(b, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_variable_strings_compared_with_Ordinal() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a, string b)
+    {
+        if (a.Equals(b, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_hardcoded_string_as_1st_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (""someValue"".Equals(a, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_hardcoded_string_as_2nd_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(""someValue"", StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_external_constant_string_as_1st_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (Constants.SomeValue.Equals(a, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_external_constant_string_as_2nd_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(Constants.SomeValue, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_internal_constant_string_as_1st_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string a)
+    {
+        if (SomeValue.Equals(a, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_internal_constant_string_as_2nd_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(nameof(SomeValue), StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_nameof_string_as_1st_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string a)
+    {
+        if (nameof(SomeValue).Equals(a, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_nameof_string_as_2nd_argument_compared_with_([ValueSource(nameof(IgnorableComparisons))] string comparison) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(SomeValue, StringComparison." + comparison + @"))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_hardcoded_string_as_1st_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (""someValue"".Equals(a, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_hardcoded_string_as_2nd_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(""someValue"", StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_external_constant_string_as_1st_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (Constants.SomeValue.Equals(a, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_external_constant_string_as_2nd_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(Constants.SomeValue, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_internal_constant_string_as_1st_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string a)
+    {
+        if (SomeValue.Equals(a, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_internal_constant_string_as_2nd_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(SomeValue, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_nameof_string_as_1st_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string a)
+    {
+        if (nameof(SomeValue).Equals(a, StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [Test]
+        public void An_issue_is_reported_for_nameof_string_as_2nd_argument_compared_with_Ordinal() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string a)
+    {
+        if (a.Equals(nameof(SomeValue), StringComparison.Ordinal))
+            return true;
+        else
+            return false;
+    }
+}");
+
+        [TestCase(@"class TestMe { bool Do(string a) { return a.Equals(""some text"", StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return a is ""some text""; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return ""some text"".Equals(a, StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return a is ""some text""; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return /* ** */ a.Equals(""some text"", StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return /* ** */ a is ""some text""; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return /* ** */ ""some text"".Equals(a, StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return /* ** */ a is ""some text""; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return a.Equals(""some text"", StringComparison.Ordinal) /* ** */; } }", @"class TestMe { bool Do(string a) { return a is ""some text"" /* ** */; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return ""some text"".Equals(a, StringComparison.Ordinal) /* ** */; } }", @"class TestMe { bool Do(string a) { return a is ""some text"" /* ** */; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return !a.Equals(""some text"", StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return a is ""some text"" is false; } }")]
+        [TestCase(@"class TestMe { bool Do(string a) { return !""some text"".Equals(a, StringComparison.Ordinal); } }", @"class TestMe { bool Do(string a) { return a is ""some text"" is false; } }")]
+        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+
+        [Test]
+        public void Code_gets_fixed_for_external_const_string_as_1st_parameter()
+        {
+            const string OriginalCode = @"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => Constants.SomeValue.Equals(s, StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => s is Constants.SomeValue;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_external_const_string_as_2nd_parameter()
+        {
+            const string OriginalCode = @"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => s.Equals(Constants.SomeValue, StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class Constants
+{
+    public const string SomeValue = ""Some text"";
+}
+
+public class TestMe
+{
+    public bool DoSomething(string s) => s is Constants.SomeValue;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_internal_const_string_as_1st_parameter()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string s) => SomeValue.Equals(s, StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string s) => s is SomeValue;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_internal_const_string_as_2nd_parameter()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string s) => s.Equals(SomeValue, StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    private const string SomeValue = ""Some text"";
+
+    public bool DoSomething(string s) => s is SomeValue;
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nameof_string_as_1st_parameter()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string s) => nameof(SomeValue).Equals(s, StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string s) => s is nameof(SomeValue);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nameof_string_as_2nd_parameter()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string s) => s.Equals(nameof(SomeValue), StringComparison.Ordinal);
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int SomeValue { get; set; }
+
+    public bool DoSomething(string s) => s is nameof(SomeValue);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3231_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 515 rules that are currently provided by the analyzer.
+The following tables lists all the 516 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -452,6 +452,7 @@ The following tables lists all the 515 rules that are currently provided by the 
 |MiKo_3228|Prefer pattern matching for inequality checks|&#x2713;|&#x2713;|
 |MiKo_3229|'KeyValuePair.Create' should be used instead of constructors|&#x2713;|&#x2713;|
 |MiKo_3230|Do not use 'Guid' as type for identifiers|&#x2713;|\-|
+|MiKo_3231|Prefer pattern matching for equality checks for ordinal string comparisons|&#x2713;|&#x2713;|
 |MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|


### PR DESCRIPTION
- Add analyzer for ordinal `Equals` comparison

- Provide code fix to use `is`

- Improve `nameof` detection utilities

- Update resources and docs

(resolves #1493)