### PR TITLE
Added new rule MiKo_1514 that reports structural names in fields

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -1528,12 +1529,12 @@ namespace MiKoSolutions.Analyzers
                                                                                       "WritingProgressChangedEventHandler",
                                                                                   };
 
-            internal static class Patterns
-            {
-                internal const string Adapter = "Adapter";
-                internal const string Wrapper = "Wrapper";
-                internal const string Decorator = "Decorator";
-            }
+            internal static readonly IReadOnlyDictionary<string, string> StructuralDesignPatternNames = new ConcurrentDictionary<string, string>(new[]
+                                                                                                                                                     {
+                                                                                                                                                         new KeyValuePair<string, string>("Adapter", "adapted"),
+                                                                                                                                                         new KeyValuePair<string, string>("Wrapper", "wrapped"),
+                                                                                                                                                         new KeyValuePair<string, string>("Decorator", "decorated"),
+                                                                                                                                                     });
         }
 
         internal static class AnalyzerCodeFixSharedData

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -882,7 +882,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        public static bool EndsWithAny(this string value, Dictionary<string, string>.KeyCollection suffixes, in StringComparison comparison = StringComparison.Ordinal)
+        public static bool EndsWithAny(this string value, IEnumerable<string> suffixes, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (value.HasCharacters())
             {

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -347,6 +347,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1513_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1514_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -504,6 +504,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1511_ProxyVariablesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1512_ProxyParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1513_TypesWithExtendedSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1885,6 +1885,19 @@ Prefixes improve IntelliSense grouping and readability, while also making relate
   <data name="MiKo_1513_Title" xml:space="preserve">
     <value>Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'</value>
   </data>
+  <data name="MiKo_1514_CodeFixTitle" xml:space="preserve">
+    <value>Fix name</value>
+  </data>
+  <data name="MiKo_1514_Description" xml:space="preserve">
+    <value>Prefer naming fields using prefixes to describe their role rather than suffixes to describe their type.
+This improves code readability, avoids confusion with class names and helps developers quickly understand the purpose of the field in context.</value>
+  </data>
+  <data name="MiKo_1514_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1514_Title" xml:space="preserve">
+    <value>Fields should not be suffixed with pattern names</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
@@ -73,7 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 }
             }
 
-            return name.AsCachedBuilder().Without(Constants.Underscore).ToUpperCaseAt(0).ToString();
+            return name.AsCachedBuilder().Without(Constants.Underscore).ToUpperCaseAt(0).ToStringAndRelease();
         }
 
         private static string FindProperNameInClass(IMethodSymbol method)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1504_PropertiesWithCounterSuffixAnalyzer.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var length = Constants.Names.Counter.Length;
 
-            return "Counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToString());
+            return "Counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToStringAndRelease());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1506_VariablesWithCounterSuffixAnalyzer.cs
@@ -49,7 +49,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var length = Constants.Names.Counter.Length;
 
-            return "counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToString());
+            return "counted" + Pluralizer.MakePluralName(name.AsCachedBuilder().Remove(name.Length - length, length).ToUpperCaseAt(0).ToStringAndRelease());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1507_ParametersWithCounterSuffixAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var length = Constants.Names.Counter.Length;
 
-            return "counted" + Pluralizer.MakePluralName(symbolName.AsCachedBuilder().Remove(symbolName.Length - length, length).ToUpperCaseAt(0).ToString());
+            return "counted" + Pluralizer.MakePluralName(symbolName.AsCachedBuilder().Remove(symbolName.Length - length, length).ToUpperCaseAt(0).ToStringAndRelease());
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -10,13 +9,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1508";
-
-        private static readonly Dictionary<string, string> StructuralDesignPatternNames = new Dictionary<string, string>
-                                                                                              {
-                                                                                                  { Constants.Names.Patterns.Adapter, "adapted" },
-                                                                                                  { Constants.Names.Patterns.Wrapper, "wrapped" },
-                                                                                                  { Constants.Names.Patterns.Decorator, "decorated" },
-                                                                                              };
 
         public MiKo_1508_VariablesWithStructuralDesignPatternSuffixAnalyzer() : base(Id)
         {
@@ -33,38 +25,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     var identifier = identifiers[index];
                     var name = identifier.ValueText;
 
-                    if (name.EndsWithAny(StructuralDesignPatternNames.Keys, StringComparison.OrdinalIgnoreCase))
+                    if (IsNameForStructuralDesignPattern(name))
                     {
-                        var betterName = FindBetterName(name);
+                        var betterName = FindBetterNameForStructuralDesignPattern(name);
 
                         yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
                     }
                 }
             }
-        }
-
-        private static string FindBetterName(string name)
-        {
-            foreach (var pair in StructuralDesignPatternNames)
-            {
-                if (name.EndsWith(pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    var count = name.Length - pair.Key.Length;
-
-                    if (count is 0)
-                    {
-                        return pair.Value;
-                    }
-
-                    return pair.Value
-                               .AsCachedBuilder()
-                               .Append(name, 0, count)
-                               .ToUpperCaseAt(pair.Value.Length)
-                               .ToString();
-                }
-            }
-
-            return name;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1509_ParametersWithStructuralDesignPatternSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1509_ParametersWithStructuralDesignPatternSuffixAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -11,48 +10,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1509";
 
-        private static readonly Dictionary<string, string> StructuralDesignPatternNames = new Dictionary<string, string>
-                                                                                              {
-                                                                                                  { Constants.Names.Patterns.Adapter, "adapted" },
-                                                                                                  { Constants.Names.Patterns.Wrapper, "wrapped" },
-                                                                                                  { Constants.Names.Patterns.Decorator, "decorated" },
-                                                                                              };
-
         public MiKo_1509_ParametersWithStructuralDesignPatternSuffixAnalyzer() : base(Id, SymbolKind.Parameter)
         {
         }
 
-        protected override bool ShallAnalyze(IParameterSymbol symbol) => symbol.Name.EndsWithAny(StructuralDesignPatternNames.Keys, StringComparison.OrdinalIgnoreCase);
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => IsNameForStructuralDesignPattern(symbol.Name);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
         {
-            var betterName = FindBetterName(symbol.Name);
+            var betterName = FindBetterNameForStructuralDesignPattern(symbol.Name);
 
             return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
-        }
-
-        private static string FindBetterName(string name)
-        {
-            foreach (var pair in StructuralDesignPatternNames)
-            {
-                if (name.EndsWith(pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    var count = name.Length - pair.Key.Length;
-
-                    if (count is 0)
-                    {
-                        return pair.Value;
-                    }
-
-                    return pair.Value
-                               .AsCachedBuilder()
-                               .Append(name, 0, count)
-                               .ToUpperCaseAt(pair.Value.Length)
-                               .ToString();
-                }
-            }
-
-            return name;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
@@ -40,7 +40,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         private static string FindBetterName(string name) => name.Length > 5
-                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToString() // simply remove both as we need to check them anyway (so we save some calls)
+                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToStringAndRelease() // simply remove both as we need to check them anyway (so we save some calls)
                                                              : name;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1512_ProxyParametersAnalyzer.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         private static string FindBetterName(string name) => name.Length > 5
-                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToString() // simply remove both as we need to check them anyway (so we save some calls)
+                                                             ? name.AsCachedBuilder().Without("proxy").Without("Proxy").ToLowerCaseAt(0).ToStringAndRelease() // simply remove both as we need to check them anyway (so we save some calls)
                                                              : name;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1514_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1514_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1514_CodeFixProvider)), Shared]
+    public sealed class MiKo_1514_CodeFixProvider : FieldNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1514";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1514";
+
+        public MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer() : base(Id, SymbolKind.Field)
+        {
+        }
+
+        protected override bool ShallAnalyze(IFieldSymbol symbol) => IsNameForStructuralDesignPattern(symbol.Name);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+            var prefix = GetFieldPrefix(name);
+            var betterName = FindBetterNameForStructuralDesignPattern(name, prefix);
+
+            return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Microsoft.CodeAnalysis.CodeFixes;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -12,6 +15,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1041_FieldCollectionSuffixAnalyzerTests : CodeFixVerifier
     {
         private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
+
+        private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
 
         [Test]
         public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue")] string field)
@@ -80,19 +85,8 @@ public class TestMe
 }
 ");
 
-        [TestCase("number", "numbers")]
-        [TestCase("resultOfSomething", "resultsOfSomething")]
-        [TestCase("resultToShow", "resultsToShow")]
-        [TestCase("resultWithData", "resultsWithData")]
-        [TestCase("resultInSomething", "resultsInSomething")]
-        [TestCase("resultFromSomething", "resultsFromSomething")]
-        [TestCase("itemList", "items")]
-        [TestCase("triviaList", "trivia")]
-        [TestCase("allElementNodeList", "allElements")]
-        [TestCase("allElementReferenceNodeList", "allElements")]
-        [TestCase("elementNodeList", "elements")]
-        [TestCase("elementReferenceNodeList", "elements")]
-        public void Code_gets_fixed_for_field_(string originalName, string fixedName)
+        [Test]
+        public void Code_gets_fixed_for_field_([ValueSource(nameof(CodeFixData))] TestCaseData data)
         {
             const string Template = @"
 using System;
@@ -103,7 +97,7 @@ public class TestMe
 }
 ";
 
-            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+            VerifyCSharpFix(Template.Replace("###", data.Wrong), Template.Replace("###", data.Fixed));
         }
 
         protected override string GetDiagnosticId() => MiKo_1041_FieldCollectionSuffixAnalyzer.Id;
@@ -111,5 +105,37 @@ public class TestMe
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1041_FieldCollectionSuffixAnalyzer();
 
         protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1041_CodeFixProvider();
+
+        [ExcludeFromCodeCoverage]
+        private static IEnumerable<TestCaseData> CreateCodeFixData()
+        {
+            Pair[] pairs =
+                           [
+                               new("number", "numbers"),
+                               new("resultOfSomething", "resultsOfSomething"),
+                               new("resultToShow", "resultsToShow"),
+                               new("resultWithData", "resultsWithData"),
+                               new("resultInSomething", "resultsInSomething"),
+                               new("resultFromSomething", "resultsFromSomething"),
+                               new("itemList", "items"),
+                               new("triviaList", "trivia"),
+                               new("allElementNodeList", "allElements"),
+                               new("allElementReferenceNodeList", "allElements"),
+                               new("elementNodeList", "elements"),
+                               new("elementReferenceNodeList", "elements"),
+                           ];
+
+            foreach (var prefix in FieldPrefixes)
+            {
+                foreach (var pair in pairs)
+                {
+                    yield return new TestCaseData
+                                 {
+                                     Wrong = prefix + pair.Key,
+                                     Fixed = prefix + pair.Value,
+                                 };
+                }
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzerTests.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
+
+        private static readonly string[] PatternNames = ["Adapter", "Wrapper", "Decorator"];
+
+        private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
+
+        [Test]
+        public void No_issue_is_reported_for_field_without_pattern_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int something;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_suffix_([ValueSource(nameof(FieldPrefixes))] string prefix, [ValueSource(nameof(PatternNames))] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private int " + prefix + "something" + name + @";
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_field_with_([ValueSource(nameof(CodeFixData))] TestCaseData data)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int ###;
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", data.Wrong), Template.Replace("###", data.Fixed));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1514_FieldsWithStructuralDesignPatternSuffixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1514_CodeFixProvider();
+
+        [ExcludeFromCodeCoverage]
+        private static IEnumerable<TestCaseData> CreateCodeFixData()
+        {
+            Pair[] pairs =
+                           [
+                               new("adapter", "adapted"),
+                               new("wrapper", "wrapped"),
+                               new("decorator", "decorated"),
+                               new("dataAdapter", "adaptedData"),
+                               new("dataWrapper", "wrappedData"),
+                               new("dataDecorator", "decoratedData")
+                            ];
+
+            foreach (var prefix in FieldPrefixes)
+            {
+                foreach (var pair in pairs)
+                {
+                    yield return new TestCaseData
+                                 {
+                                     Wrong = prefix + pair.Key,
+                                     Fixed = prefix + pair.Value,
+                                 };
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/TestCaseData.cs
+++ b/MiKo.Analyzer.Tests/Rules/TestCaseData.cs
@@ -7,6 +7,6 @@ namespace MiKoSolutions.Analyzers.Rules
 
         public string Fixed { get; init; }
 
-        public override string ToString() => $"Wrong: {Wrong}   -   Fixed: {Fixed}";
+        public override string ToString() => StringBuilderCache.Acquire().Append('\'').Append(Wrong).Append("' -> '").Append(Fixed).Append('\'').ToStringAndRelease();
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 516 rules that are currently provided by the analyzer.
+The following tables lists all the 517 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -173,6 +173,7 @@ The following tables lists all the 516 rules that are currently provided by the 
 |MiKo_1511|Local variables should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
 |MiKo_1512|Parameters should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
 |MiKo_1513|Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'|&#x2713;|&#x2713;|
+|MiKo_1514|Fields should not be suffixed with pattern names|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add rule MiKo_1514 for field naming

- Centralize structural pattern name mapping

- Reuse shared helpers for better names

- Release cached `StringBuilder` instances properly

(resolves #1393)