### PR TITLE
MiKo_2019 is now aware of 'Simple'/'Complex' and fixes it to 'Represents a simple'/'Represents a complex'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -15,6 +15,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] RepresentsCandidates =
                                                                 {
                                                                     "Repository ",
+                                                                    "Simple ",
+                                                                    "Complex ",
                                                                 };
 
         private static readonly string[] CurrentlyUnfixable =

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -369,6 +369,8 @@ public class TestMe
         [TestCase("Class used for loading something", "Loads something")]
         [TestCase("Class which holds something", "Holds something")]
         [TestCase("Classes implementing this interfaces, will be called with their something", "Provides a something")]
+        [TestCase("Simple structure to do stuff", "Represents a simple structure to do stuff")]
+        [TestCase("Complex structure to do stuff", "Represents a complex structure to do stuff")]
         public void Code_gets_fixed_for_class_text_(string originalText, string fixedText)
         {
             const string Template = @"


### PR DESCRIPTION
- Add "Simple"/"Complex" summary fix handling

- Expand code fix candidates list

- Add unit tests for new cases
