### PR TITLE
MiKo_1081/2/3/4/5 are now aware of bit numbers 8, 16, 32, 64 and 128

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -216,7 +216,7 @@ namespace MiKoSolutions.Analyzers
                                                                   ThreadStaticFieldPrefix,
                                                               };
 
-            internal static readonly string[] OSBitNumbers = { "32", "64" };
+            internal static readonly string[] BitNumbers = { "8", "16", "32", "64", "128" };
 
             internal static readonly string[] ReSharper = { "ReSharper disable", "ReSharper restore" };
         }

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -956,9 +956,9 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
-        public static bool EndsWithCommonNumber(this string value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers, StringComparison.OrdinalIgnoreCase) is false;
+        public static bool EndsWithCommonNumber(this string value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.BitNumbers, StringComparison.OrdinalIgnoreCase) is false;
 
-        public static bool EndsWithCommonNumber(this in ReadOnlySpan<char> value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.OSBitNumbers, StringComparison.OrdinalIgnoreCase) is false;
+        public static bool EndsWithCommonNumber(this in ReadOnlySpan<char> value) => value.EndsWithNumber() && value.EndsWithAny(Constants.Markers.BitNumbers, StringComparison.OrdinalIgnoreCase) is false;
 
         public static bool EndsWithNumber(this string value) => value.HasCharacters() && value[value.Length - 1].IsNumber();
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1081_MethodsWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1081_MethodsWithNumberSuffixAnalyzerTests.cs
@@ -38,7 +38,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_OS_bit_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_OS_bit_number_suffix_([Values(8, 16, 32, 64, 128)] in int number) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething" + number + @"() { }
@@ -46,7 +46,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_local_function_with_OS_bit_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_OS_bit_number_suffix_([Values(8, 16, 32, 64, 128)] in int number) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -57,7 +57,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething" + number + @"() { }
@@ -65,7 +65,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1082_PropertiesWithNumberSuffixAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_number_suffix_if_type_of_property_has_no_number_suffix_([Range(0, 10)] int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_number_suffix_if_type_of_property_has_no_number_suffix_([Range(0, 7)] int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -38,7 +38,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_with_number_suffix_if_type_of_property_has_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_number_suffix_if_type_of_property_has_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_OS_bit_number_suffix_if_type_of_property_has_number_suffix_([Values(8, 16, 32, 64, 128)] in int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1083_FieldsWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1083_FieldsWithNumberSuffixAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_field_with_number_suffix_if_type_of_field_has_no_number_suffix_([Range(0, 10)] int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_with_number_suffix_if_type_of_field_has_no_number_suffix_([Range(0, 7)] int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -38,7 +38,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_field_with_number_suffix_if_type_of_field_has_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_with_number_suffix_if_type_of_field_has_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -56,7 +56,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_struct_field_in_test_class_([ValueSource(nameof(TestFixtures))] string fixture, [Range(0, 10)] int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_struct_field_in_test_class_([ValueSource(nameof(TestFixtures))] string fixture, [Range(0, 7)] int number) => No_issue_is_reported_for(@"
 using System;
 
 [" + fixture + @"]
@@ -67,7 +67,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_non_struct_field_in_test_class_([ValueSource(nameof(TestFixtures))] string fixture, [Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_struct_field_in_test_class_([ValueSource(nameof(TestFixtures))] string fixture, [Range(0, 7)] int number) => An_issue_is_reported_for(@"
 public class T123
 {
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzerTests.cs
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_with_number_suffix_if_its_type_has_no_number_suffix_([Range(0, 10)] int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_with_number_suffix_if_its_type_has_no_number_suffix_([Range(0, 7)] int number) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_with_number_suffix_if_its_type_has_a_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_with_number_suffix_if_its_type_has_a_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_with_OS_bit_number_suffix_if_its_type_has_a_number_suffix_([Values(32, 64)] in int number) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_with_OS_bit_number_suffix_if_its_type_has_a_number_suffix_([Values(8, 16, 32, 64, 128)] in int number) => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1085_ParametersWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1085_ParametersWithNumberSuffixAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_parameter_with_number_suffix_([Range(0, 10)] int number) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_with_number_suffix_([Range(0, 7)] int number) => An_issue_is_reported_for(@"
 
 public class TestMe
 {


### PR DESCRIPTION
- Extend ignored bit-width numbers list

- Update analyzers to use new list

- Adjust tests to new bit-widths

- Rename constant to generic purpose

(resolves #1528)