### PR TITLE
MiKo_5019 now supports more method types

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_InParameterAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5019_InParameterAnalyzer.cs
@@ -46,19 +46,31 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                 return false;
             }
 
-            if (symbol.CanBeReferencedByName is false)
+            if (symbol.CanBeReferencedByName)
             {
-                return false;
-            }
+                if (symbol.ReturnType.IsTask())
+                {
+                    return false;
+                }
 
-            if (symbol.ReturnType.IsTask())
-            {
-                return false;
+                if (symbol.IsInterfaceImplementation())
+                {
+                    return false;
+                }
             }
-
-            if (symbol.IsInterfaceImplementation())
+            else
             {
-                return false;
+                // seems to be a ctor or operator
+                switch (symbol.MethodKind)
+                {
+                    case MethodKind.Constructor:
+                    case MethodKind.Conversion:
+                    case MethodKind.UserDefinedOperator:
+                        break;
+
+                    default:
+                        return false;
+                }
             }
 
             return symbol.GetSyntax().DescendantNodes<YieldStatementSyntax>().None();


### PR DESCRIPTION
- Extend analyzer to constructors/operators

- Skip non-referencable unless ctor/operator

- Add tests for new method kinds

- Add code fix verifications

(resolves #1520)