### PR TITLE
MiKo_6031 codefix is now aware of colon being on same line as initializer closing bracket

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_CodeFixProvider.cs
@@ -17,7 +17,22 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var spaces = GetProposedSpaces(issue);
 
-                return expression.WithQuestionToken(expression.QuestionToken.WithLeadingSpaces(spaces))
+                SyntaxToken questionToken = expression.QuestionToken.WithLeadingSpaces(spaces);
+
+                if (expression.WhenTrue is ObjectCreationExpressionSyntax o && o.Initializer is InitializerExpressionSyntax initializer)
+                {
+                    var colonToken = expression.ColonToken;
+                    var closeBraceToken = initializer.CloseBraceToken;
+
+                    if (colonToken.IsOnSameLineAs(closeBraceToken))
+                    {
+                        return expression.WithQuestionToken(questionToken)
+                                         .WithColonToken(colonToken.WithLeadingEndOfLine().WithAdditionalLeadingSpacesAtEnd(spaces))
+                                         .WithWhenTrue(o.WithInitializer(initializer.WithCloseBraceToken(closeBraceToken.WithoutTrailingTrivia()))); // remove spaces after initializer
+                    }
+                }
+
+                return expression.WithQuestionToken(questionToken)
                                  .WithColonToken(expression.ColonToken.WithLeadingSpaces(spaces));
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
@@ -235,6 +235,63 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_colon_is_placed_on_same_line_as_closing_bracket_of_initializer()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class Item
+{
+    public int Id { get; init; }
+    public string Name { get; init; }
+}
+
+public class TestMe
+{
+    public Item Item { get; set; }
+
+    public void DoSomething(object item)
+    {
+        Item = item != null
+            ? new Item
+            {
+                Id = 42,
+                Name = ""Whatever"",
+            } : null
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class Item
+{
+    public int Id { get; init; }
+    public string Name { get; init; }
+}
+
+public class TestMe
+{
+    public Item Item { get; set; }
+
+    public void DoSomething(object item)
+    {
+        Item = item != null
+               ? new Item
+            {
+                Id = 42,
+                Name = ""Whatever"",
+            }
+               : null
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer();


### PR DESCRIPTION
- Fix ternary colon alignment with object initializer

- Preserve formatting by moving colon to next line

- Remove trailing trivia after initializer brace

- Add unit test covering colon-on-brace line

(resolves #1511)