### PR TITLE
Added new rule MiKo_6067 that reports if ternary operator tokens are placed at end of lines

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -191,6 +191,12 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsOnSameLineAs(this in SyntaxToken value, in SyntaxToken other) => value.GetStartingLine() == other.GetStartingLine();
 
+        internal static bool IsOnSameLineAsEndOf(this in SyntaxToken value, SyntaxNode other) => value.GetStartingLine() == other?.GetEndingLine();
+
+        internal static bool IsOnSameLineAsEndOf(this in SyntaxToken value, in SyntaxNodeOrToken other) => value.GetStartingLine() == other.GetEndingLine();
+
+        internal static bool IsOnSameLineAsEndOf(this in SyntaxToken value, in SyntaxToken other) => value.GetStartingLine() == other.GetEndingLine();
+
         internal static bool IsSpanningMultipleLines(this in SyntaxToken value)
         {
             var leadingTrivia = value.LeadingTrivia;

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -442,6 +442,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6064_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6065_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6066_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6067_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -604,6 +604,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6065_InvocationIsIndentedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6066_ExpressionElementsAreIndentedAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -17920,6 +17920,43 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Align ternary operator vertically.
+        /// </summary>
+        internal static string MiKo_6067_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6067_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Placing the ? and : tokens of the ternary operator at the start of their respective lines in multi-line ternary expressions improves readability, visual structure, and code scanning.
+        ///This style avoids dangling operators, aligns with common C# style guides and tooling, and makes complex logic easier to parse and maintain..
+        /// </summary>
+        internal static string MiKo_6067_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6067_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place ternary operator and colon on the same lines as their respective expressions.
+        /// </summary>
+        internal static string MiKo_6067_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6067_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ternary operators should be placed on same lines as their respective expressions.
+        /// </summary>
+        internal static string MiKo_6067_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6067_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
         internal static string MiKo_6070_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -6216,6 +6216,19 @@ This organization ensures clarity and makes the code easier to find, understand 
   <data name="MiKo_6066_Title" xml:space="preserve">
     <value>Collection expression elements should be indented and not outdented</value>
   </data>
+  <data name="MiKo_6067_CodeFixTitle" xml:space="preserve">
+    <value>Align ternary operator vertically</value>
+  </data>
+  <data name="MiKo_6067_Description" xml:space="preserve">
+    <value>Placing the ? and : tokens of the ternary operator at the start of their respective lines in multi-line ternary expressions improves readability, visual structure, and code scanning.
+This style avoids dangling operators, aligns with common C# style guides and tooling, and makes complex logic easier to parse and maintain.</value>
+  </data>
+  <data name="MiKo_6067_MessageFormat" xml:space="preserve">
+    <value>Place ternary operator and colon on the same lines as their respective expressions</value>
+  </data>
+  <data name="MiKo_6067_Title" xml:space="preserve">
+    <value>Ternary operators should be placed on same lines as their respective expressions</value>
+  </data>
   <data name="MiKo_6070_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_CodeFixProvider.cs
@@ -6,6 +6,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
+    /// <inheritdoc />
+    /// <seealso cref="MiKo_6067_CodeFixProvider"/>
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6031_CodeFixProvider)), Shared]
     public sealed class MiKo_6031_CodeFixProvider : SpacingCodeFixProvider
     {
@@ -17,11 +19,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var spaces = GetProposedSpaces(issue);
 
-                SyntaxToken questionToken = expression.QuestionToken.WithLeadingSpaces(spaces);
+                var questionToken = expression.QuestionToken.WithLeadingSpaces(spaces);
+                var colonToken = expression.ColonToken;
 
+                // when adjusting, also take a look at MiKo_6067 code fix
                 if (expression.WhenTrue is ObjectCreationExpressionSyntax o && o.Initializer is InitializerExpressionSyntax initializer)
                 {
-                    var colonToken = expression.ColonToken;
                     var closeBraceToken = initializer.CloseBraceToken;
 
                     if (colonToken.IsOnSameLineAs(closeBraceToken))
@@ -33,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 }
 
                 return expression.WithQuestionToken(questionToken)
-                                 .WithColonToken(expression.ColonToken.WithLeadingSpaces(spaces));
+                                 .WithColonToken(colonToken.WithLeadingSpaces(spaces));
             }
 
             return syntax;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer.cs
@@ -7,6 +7,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
+    /// <inheritdoc />
+    /// <seealso cref="MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer"/>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer : SpacingAnalyzer
     {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer.cs
@@ -39,15 +39,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var colonToken = expression.ColonToken;
                 var colonPosition = colonToken.GetStartPosition();
+                var positionCharacter = conditionPosition.Character;
 
-                if (conditionPosition.Character != operatorPosition.Character)
+                if (positionCharacter != operatorPosition.Character)
                 {
-                    yield return Issue(operatorToken, CreateProposalForSpaces(conditionPosition.Character));
+                    yield return Issue(operatorToken, CreateProposalForSpaces(positionCharacter));
                 }
 
-                if (conditionPosition.Character != colonPosition.Character)
+                if (positionCharacter != colonPosition.Character)
                 {
-                    yield return Issue(colonToken, CreateProposalForSpaces(conditionPosition.Character));
+                    yield return Issue(colonToken, CreateProposalForSpaces(positionCharacter));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6067_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6067_CodeFixProvider.cs
@@ -1,0 +1,83 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    /// <inheritdoc />
+    /// <seealso cref="MiKo_6031_CodeFixProvider"/>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6067_CodeFixProvider)), Shared]
+    public sealed class MiKo_6067_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6067";
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is ConditionalExpressionSyntax expression)
+            {
+                return GetUpdatedSyntax(expression, expression.Condition, expression.QuestionToken, expression.WhenTrue, expression.ColonToken, expression.WhenFalse);
+            }
+
+            return syntax;
+        }
+
+        private static ConditionalExpressionSyntax GetUpdatedSyntax(
+                                                                ConditionalExpressionSyntax expression,
+                                                                ExpressionSyntax originalCondition,
+                                                                in SyntaxToken originalQuestionToken,
+                                                                ExpressionSyntax originalWhenTrue,
+                                                                in SyntaxToken originalColonToken,
+                                                                ExpressionSyntax originalWhenFalse)
+        {
+            var updatedCondition = originalCondition;
+            var updatedQuestionToken = originalQuestionToken;
+            var updatedColonToken = originalColonToken;
+            var updatedWhenTrue = originalWhenTrue;
+
+            if (originalQuestionToken.IsOnSameLineAsEndOf(originalCondition))
+            {
+                updatedCondition = updatedCondition.WithoutTrailingTrivia();
+
+                updatedQuestionToken = updatedQuestionToken.WithLeadingEndOfLine()
+                                                           .WithAdditionalLeadingSpacesAtEnd(originalWhenTrue.GetPositionWithinStartLine())
+                                                           .WithTrailingSpace();
+            }
+
+            if (originalColonToken.IsOnSameLineAsEndOf(originalWhenTrue))
+            {
+                updatedWhenTrue = updatedWhenTrue.WithoutTrailingTrivia();
+
+                updatedColonToken = updatedColonToken.WithLeadingEndOfLine()
+                                                     .WithAdditionalLeadingSpacesAtEnd(originalWhenFalse.GetPositionWithinStartLine())
+                                                     .WithTrailingSpace();
+            }
+            else
+            {
+                // when adjusting, also take a look at MiKo_6031 code fix
+                if (updatedWhenTrue is ObjectCreationExpressionSyntax o && o.Initializer is InitializerExpressionSyntax initializer)
+                {
+                    var closeBraceToken = initializer.CloseBraceToken;
+
+                    if (originalColonToken.IsOnSameLineAsEndOf(closeBraceToken))
+                    {
+                        updatedWhenTrue = updatedWhenTrue.ReplaceToken(closeBraceToken, closeBraceToken.WithoutTrailingTrivia());
+
+                        updatedColonToken = updatedColonToken.WithLeadingEndOfLine()
+                                                             .WithAdditionalLeadingSpacesAtEnd(originalWhenFalse.GetPositionWithinStartLine())
+                                                             .WithTrailingSpace();
+                    }
+                }
+            }
+
+            var updatedExpression = expression.WithCondition(updatedCondition)
+                                              .WithQuestionToken(updatedQuestionToken)
+                                              .WithWhenTrue(updatedWhenTrue.WithoutLeadingTrivia())
+                                              .WithColonToken(updatedColonToken)
+                                              .WithWhenFalse(originalWhenFalse.WithoutLeadingTrivia());
+
+            return updatedExpression;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    /// <inheritdoc />
+    /// <seealso cref="MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzer"/>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6067";
+
+        public MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ConditionalExpression);
+
+        private static bool HasIssue(in SyntaxToken token, ExpressionSyntax previousExpression, ExpressionSyntax ownWhenCase)
+        {
+            if (token.IsOnSameLineAsEndOf(previousExpression))
+            {
+                return token.IsOnSameLineAs(ownWhenCase) is false;
+            }
+
+            // when adjusting, also take a look at MiKo_6031
+            if (previousExpression is ObjectCreationExpressionSyntax o && o.Initializer is InitializerExpressionSyntax initializer)
+            {
+                return token.IsOnSameLineAs(initializer.CloseBraceToken);
+            }
+
+            return false;
+        }
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is ConditionalExpressionSyntax expression)
+            {
+                ReportDiagnostics(context, AnalyzeNode(expression));
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeNode(ConditionalExpressionSyntax expression)
+        {
+            var questionToken = expression.QuestionToken;
+            var colonToken = expression.ColonToken;
+
+            var condition = expression.Condition;
+            var whenTrue = expression.WhenTrue;
+            var whenFalse = expression.WhenFalse;
+
+            if (HasIssue(questionToken, condition, whenTrue))
+            {
+                yield return Issue(questionToken);
+            }
+
+            if (HasIssue(colonToken, whenTrue, whenFalse))
+            {
+                yield return Issue(colonToken);
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ternary_operator_if_condition_and_colon_is_placed_on_same_position_as_condition() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ternary_operator_if_question_and_colon_are_placed_on_same_position_as_condition() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6031_TernaryOperatorsAreOnSamePositionLikeConditionAnalyzerTests.cs
@@ -102,33 +102,37 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_ternary_operator_if_question_is_placed_on_position_before_condition()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                   ? true
-                    : false);
-    }
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition
+                                                           ? true
+                                                            : false);
+                                            }
+                                        }
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                    : false);
-    }
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                         ? true
+                                                         : false);
+                                         }
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -136,33 +140,37 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_ternary_operator_if_question_is_placed_on_position_after_condition()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                     ? true
-                    : false);
-    }
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition
+                                                             ? true
+                                                            : false);
+                                            }
+                                        }
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                    : false);
-    }
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                         ? true
+                                                         : false);
+                                         }
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -170,33 +178,37 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_ternary_operator_if_colon_is_placed_on_position_before_condition()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                   : false);
-    }
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition
+                                                            ? true
+                                                           : false);
+                                            }
+                                        }
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                    : false);
-    }
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                         ? true
+                                                         : false);
+                                         }
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -204,33 +216,37 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_ternary_operator_if_colon_is_placed_on_position_after_condition()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                     : false);
-    }
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition
+                                                            ? true
+                                                             : false);
+                                            }
+                                        }
 
-public class TestMe
-{
-    public void DoSomething(bool condition)
-    {
-        DoSomething(condition
-                    ? true
-                    : false);
-    }
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                         ? true
+                                                         : false);
+                                         }
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -238,56 +254,108 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_ternary_operator_if_colon_is_placed_on_same_line_as_closing_bracket_of_initializer()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class Item
-{
-    public int Id { get; init; }
-    public string Name { get; init; }
-}
+                                        using System;
 
-public class TestMe
-{
-    public Item Item { get; set; }
+                                        public class Item
+                                        {
+                                            public int Id { get; init; }
+                                            public string Name { get; init; }
+                                        }
 
-    public void DoSomething(object item)
-    {
-        Item = item != null
-            ? new Item
-            {
-                Id = 42,
-                Name = ""Whatever"",
-            } : null
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public Item Item { get; set; }
 
-            const string FixedCode = @"
-using System;
+                                            public void DoSomething(object item)
+                                            {
+                                                Item = item != null
+                                                    ? new Item
+                                                    {
+                                                        Id = 42,
+                                                        Name = "Whatever",
+                                                    } : null
+                                            }
+                                        }
 
-public class Item
-{
-    public int Id { get; init; }
-    public string Name { get; init; }
-}
+                                        """;
 
-public class TestMe
-{
-    public Item Item { get; set; }
+            const string FixedCode = """
 
-    public void DoSomething(object item)
-    {
-        Item = item != null
-               ? new Item
-            {
-                Id = 42,
-                Name = ""Whatever"",
-            }
-               : null
-    }
-}
-";
+                                     using System;
+
+                                     public class Item
+                                     {
+                                         public int Id { get; init; }
+                                         public string Name { get; init; }
+                                     }
+
+                                     public class TestMe
+                                     {
+                                         public Item Item { get; set; }
+
+                                         public void DoSomething(object item)
+                                         {
+                                             Item = item != null
+                                                    ? new Item
+                                                 {
+                                                     Id = 42,
+                                                     Name = "Whatever",
+                                                 }
+                                                    : null
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_question_mark_and_colon_are_placed_at_end_of_lines_and_string_is_returned_for_multiline_condition()
+        {
+            const string OriginalCode = """
+
+                                        public record TestMe
+                                        {
+                                            public string Name { get; init; } = "";
+                                            public string Id { get; init; } = "";
+                                            public string Description { get; init; } = "";
+                                            
+                                            public string GetInformation(string s) => s;
+
+                                            public override string ToString()
+                                            {
+                                                return string.Compare(Name, Description,
+                                                    StringComparison.OrdinalIgnoreCase) == 0 ?        
+                                                    GetInformation(Id) :                  
+                                                    "whatever";
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     public record TestMe
+                                     {
+                                         public string Name { get; init; } = "";
+                                         public string Id { get; init; } = "";
+                                         public string Description { get; init; } = "";
+                                         
+                                         public string GetInformation(string s) => s;
+                                     
+                                         public override string ToString()
+                                         {
+                                             return string.Compare(Name, Description,
+                                                 StringComparison.OrdinalIgnoreCase) == 0
+                                                    ? GetInformation(Id)
+                                                    : "whatever";
+                                         }
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzerTests.cs
@@ -1,0 +1,318 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_ternary_operator_that_is_on_single_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition)
+    {
+        DoSomething(condition ? true : false);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ternary_operator_if_question_mark_and_colon_are_placed_on_same_line_as_their_when_cases_and_all_are_on_single_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition)
+    {
+        DoSomething(condition
+                        ? true : false);
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_ternary_operator_if_question_mark_and_colon_are_placed_on_same_line_as_their_when_cases_and_all_are_on_different_lines() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition)
+    {
+        DoSomething(condition
+                        ? true
+                        : false);
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_ternary_operator_if_question_mark_is_placed_on_same_line_as_condition() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition)
+    {
+        DoSomething(condition ?
+                    true : false);
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_ternary_operator_if_colon_is_placed_on_same_line_as_when_true_case() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(bool condition)
+    {
+        DoSomething(condition
+                        ? true :
+                          false);
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_question_mark_is_placed_on_same_line_as_condition()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition ?
+                                                            true : false);
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                         ? true
+                                                                : false);
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_colon_is_placed_on_same_line_as_when_true_case()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(bool condition)
+                                            {
+                                                DoSomething(condition
+                                                                ? true :
+                                                                  false);
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(bool condition)
+                                         {
+                                             DoSomething(condition
+                                                             ? true
+                                                               : false);
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_question_mark_and_colon_are_placed_on_same_line_as_closing_bracket_of_initializer()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        public class Item
+                                        {
+                                            public int Id { get; init; }
+                                            public string Name { get; init; }
+                                        }
+
+                                        public class TestMe
+                                        {
+                                            public Item Item { get; set; }
+
+                                            public void DoSomething(object item)
+                                            {
+                                                Item = item != null ?
+                                                       new Item
+                                                           {
+                                                               Id = 42,
+                                                               Name = "Whatever",
+                                                           } :
+                                                       null
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class Item
+                                     {
+                                         public int Id { get; init; }
+                                         public string Name { get; init; }
+                                     }
+
+                                     public class TestMe
+                                     {
+                                         public Item Item { get; set; }
+
+                                         public void DoSomething(object item)
+                                         {
+                                             Item = item != null
+                                                    ? new Item
+                                                        {
+                                                            Id = 42,
+                                                            Name = "Whatever",
+                                                        }
+                                                    : null
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_question_mark_and_colon_are_placed_at_end_of_lines_and_string_is_returned()
+        {
+            const string OriginalCode = """
+
+                                        public record TestMe
+                                        {
+                                            public string Name { get; init; } = "";
+                                            public string Id { get; init; } = "";
+                                            public string Description { get; init; } = "";
+
+                                            public override string ToString()
+                                            {
+                                                return string.IsNullOrWhiteSpace(Name) ?
+                                                    Description :
+                                                    $"{Id} - {Name} - {Description}";
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     public record TestMe
+                                     {
+                                         public string Name { get; init; } = "";
+                                         public string Id { get; init; } = "";
+                                         public string Description { get; init; } = "";
+
+                                         public override string ToString()
+                                         {
+                                             return string.IsNullOrWhiteSpace(Name)
+                                                 ? Description
+                                                 : $"{Id} - {Name} - {Description}";
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_ternary_operator_if_question_mark_and_colon_are_placed_at_end_of_lines_and_string_is_returned_for_multiline_condition()
+        {
+            const string OriginalCode = """
+
+                                        public record TestMe
+                                        {
+                                            public string Name { get; init; } = "";
+                                            public string Id { get; init; } = "";
+                                            public string Description { get; init; } = "";
+                                            
+                                            public string GetInformation(string s) => s;
+
+                                            public override string ToString()
+                                            {
+                                                return string.Compare(Name, Description,
+                                                    StringComparison.OrdinalIgnoreCase) == 0 ?        
+                                                    GetInformation(Id) :                  
+                                                    "whatever";
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     public record TestMe
+                                     {
+                                         public string Name { get; init; } = "";
+                                         public string Id { get; init; } = "";
+                                         public string Description { get; init; } = "";
+                                         
+                                         public string GetInformation(string s) => s;
+                                     
+                                         public override string ToString()
+                                         {
+                                             return string.Compare(Name, Description,
+                                                 StringComparison.OrdinalIgnoreCase) == 0
+                                                 ? GetInformation(Id)
+                                                 : "whatever";
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6067_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 520 rules that are currently provided by the analyzer.
+The following tables lists all the 521 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -560,5 +560,6 @@ The following tables lists all the 520 rules that are currently provided by the 
 |MiKo_6064|Identifier invocations should be placed on same line|&#x2713;|&#x2713;|
 |MiKo_6065|Consecutive invocations spanning multiple lines should be indented and not outdented|&#x2713;|&#x2713;|
 |MiKo_6066|Collection expression elements should be indented and not outdented|&#x2713;|&#x2713;|
+|MiKo_6067|Ternary operators should be placed on same lines as their respective expressions|&#x2713;|&#x2713;|
 |MiKo_6070|Console statements should be surrounded by blank lines|&#x2713;|&#x2713;|
 |MiKo_6071|Local using statements should be surrounded by blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add rule MiKo_6067 for ternary alignment

- Implement code fix to realign `?` and `:`

- Update MiKo_6031 fix for edge cases

- Add resources and docs for new rule

(resolves #1513)