### PR TITLE
Refactored analyzer rule titles for clarity and consistency

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method is too big.
+        ///   Looks up a localized string similar to Keep methods small.
         /// </summary>
         internal static string MiKo_0001_Title {
             get {
@@ -108,7 +108,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method is too complex.
+        ///   Looks up a localized string similar to Simplify complex methods.
         /// </summary>
         internal static string MiKo_0002_Title {
             get {
@@ -135,7 +135,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type is too big.
+        ///   Looks up a localized string similar to Keep types small.
         /// </summary>
         internal static string MiKo_0003_Title {
             get {
@@ -162,7 +162,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method has too many parameters.
+        ///   Looks up a localized string similar to Limit method parameters.
         /// </summary>
         internal static string MiKo_0004_Title {
             get {
@@ -189,7 +189,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local function is too big.
+        ///   Looks up a localized string similar to Keep local functions small.
         /// </summary>
         internal static string MiKo_0005_Title {
             get {
@@ -218,7 +218,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local function is too complex.
+        ///   Looks up a localized string similar to Simplify complex local functions.
         /// </summary>
         internal static string MiKo_0006_Title {
             get {
@@ -245,7 +245,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local function has too many parameters.
+        ///   Looks up a localized string similar to Limit local function parameters.
         /// </summary>
         internal static string MiKo_0007_Title {
             get {
@@ -281,7 +281,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;System.EventArgs&apos; types should be suffixed with &apos;EventArgs&apos;.
+        ///   Looks up a localized string similar to Suffix &apos;System.EventArgs&apos; types with &apos;EventArgs&apos;.
         /// </summary>
         internal static string MiKo_1000_Title {
             get {
@@ -326,7 +326,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;System.EventArgs&apos; parameters should be named &apos;e&apos;.
+        ///   Looks up a localized string similar to Name &apos;System.EventArgs&apos; parameters &apos;e&apos;.
         /// </summary>
         internal static string MiKo_1001_Title {
             get {
@@ -371,7 +371,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should be named according the .NET Framework Design Guidelines for event handlers.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for event handler parameter names.
         /// </summary>
         internal static string MiKo_1002_Title {
             get {
@@ -416,7 +416,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Event handling method names should follow the .NET Framework Design Guidelines.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for event handling method names.
         /// </summary>
         internal static string MiKo_1003_Title {
             get {
@@ -452,7 +452,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events should not contain term &apos;Event&apos; in their names.
+        ///   Looks up a localized string similar to Remove term &apos;Event&apos; from event names.
         /// </summary>
         internal static string MiKo_1004_Title {
             get {
@@ -488,7 +488,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;System.EventArgs&apos; variables should be named properly.
+        ///   Looks up a localized string similar to Name &apos;System.EventArgs&apos; variables properly.
         /// </summary>
         internal static string MiKo_1005_Title {
             get {
@@ -516,7 +516,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events should use &apos;EventHandler&lt;T&gt;&apos; with &apos;EventArgs&apos; which are named after the event.
+        ///   Looks up a localized string similar to Use &apos;EventHandler&lt;T&gt;&apos; with &apos;EventArgs&apos; named after the event.
         /// </summary>
         internal static string MiKo_1006_Title {
             get {
@@ -543,7 +543,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events and their corresponding &apos;EventArgs&apos; types should be located in the same namespace.
+        ///   Looks up a localized string similar to Place events and their &apos;EventArgs&apos; types in the same namespace.
         /// </summary>
         internal static string MiKo_1007_Title {
             get {
@@ -579,7 +579,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should be named according the .NET Framework Design Guidelines for DependencyProperty event handlers.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for DependencyProperty event handler parameter names.
         /// </summary>
         internal static string MiKo_1008_Title {
             get {
@@ -615,7 +615,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;System.EventHandler&apos; variables should be named properly.
+        ///   Looks up a localized string similar to Name &apos;System.EventHandler&apos; variables properly.
         /// </summary>
         internal static string MiKo_1009_Title {
             get {
@@ -651,7 +651,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not contain &apos;CanExecute&apos; or &apos;Execute&apos; in their names.
+        ///   Looks up a localized string similar to Do not include &apos;CanExecute&apos; or &apos;Execute&apos; in method names.
         /// </summary>
         internal static string MiKo_1010_Title {
             get {
@@ -687,7 +687,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not contain &apos;Do&apos; in their names.
+        ///   Looks up a localized string similar to Do not include &apos;Do&apos; in method names.
         /// </summary>
         internal static string MiKo_1011_Title {
             get {
@@ -723,7 +723,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should be named &apos;Raise&apos; instead of &apos;Fire&apos;.
+        ///   Looks up a localized string similar to Use &apos;Raise&apos; instead of &apos;Fire&apos; in method names.
         /// </summary>
         internal static string MiKo_1012_Title {
             get {
@@ -759,7 +759,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be named &apos;Notify&apos; or &apos;OnNotify&apos;.
+        ///   Looks up a localized string similar to Do not name methods &apos;Notify&apos; or &apos;OnNotify&apos;.
         /// </summary>
         internal static string MiKo_1013_Title {
             get {
@@ -795,7 +795,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be named with ambiguous &apos;Check&apos;.
+        ///   Looks up a localized string similar to Do not use ambiguous &apos;Check&apos; in method names.
         /// </summary>
         internal static string MiKo_1014_Title {
             get {
@@ -831,7 +831,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should be named &apos;Initialize&apos; instead of &apos;Init&apos;.
+        ///   Looks up a localized string similar to Use &apos;Initialize&apos; instead of &apos;Init&apos; in method names.
         /// </summary>
         internal static string MiKo_1015_Title {
             get {
@@ -867,7 +867,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Factory methods should be named &apos;Create&apos;.
+        ///   Looks up a localized string similar to Name factory methods &apos;Create&apos;.
         /// </summary>
         internal static string MiKo_1016_Title {
             get {
@@ -903,7 +903,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be prefixed with &apos;Get&apos; or &apos;Set&apos; if followed by &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos;.
+        ///   Looks up a localized string similar to Do not prefix methods with &apos;Get&apos; or &apos;Set&apos; when followed by &apos;Is&apos;, &apos;Can&apos; or &apos;Has&apos;.
         /// </summary>
         internal static string MiKo_1017_Title {
             get {
@@ -939,7 +939,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be suffixed with noun of a verb.
+        ///   Looks up a localized string similar to Do not suffix methods with noun of a verb.
         /// </summary>
         internal static string MiKo_1018_Title {
             get {
@@ -977,7 +977,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;Clear&apos; and &apos;Remove&apos; methods should be named based on their number of parameters.
+        ///   Looks up a localized string similar to Name &apos;Clear&apos; and &apos;Remove&apos; methods based on their number of parameters.
         /// </summary>
         internal static string MiKo_1019_Title {
             get {
@@ -1004,7 +1004,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type names should be limited in length.
+        ///   Looks up a localized string similar to Limit type name length.
         /// </summary>
         internal static string MiKo_1020_Title {
             get {
@@ -1031,7 +1031,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method names should be limited in length.
+        ///   Looks up a localized string similar to Limit method name length.
         /// </summary>
         internal static string MiKo_1021_Title {
             get {
@@ -1058,7 +1058,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter names should be limited in length.
+        ///   Looks up a localized string similar to Limit parameter name length.
         /// </summary>
         internal static string MiKo_1022_Title {
             get {
@@ -1085,7 +1085,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field names should be limited in length.
+        ///   Looks up a localized string similar to Limit field name length.
         /// </summary>
         internal static string MiKo_1023_Title {
             get {
@@ -1112,7 +1112,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property names should be limited in length.
+        ///   Looks up a localized string similar to Limit property name length.
         /// </summary>
         internal static string MiKo_1024_Title {
             get {
@@ -1139,7 +1139,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Event names should be limited in length.
+        ///   Looks up a localized string similar to Limit event name length.
         /// </summary>
         internal static string MiKo_1025_Title {
             get {
@@ -1166,7 +1166,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable names should be limited in length.
+        ///   Looks up a localized string similar to Limit variable name length.
         /// </summary>
         internal static string MiKo_1026_Title {
             get {
@@ -1193,7 +1193,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable names in loops should be limited in length.
+        ///   Looks up a localized string similar to Limit loop variable name length.
         /// </summary>
         internal static string MiKo_1027_Title {
             get {
@@ -1220,7 +1220,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local function names should be limited in length.
+        ///   Looks up a localized string similar to Limit local function name length.
         /// </summary>
         internal static string MiKo_1028_Title {
             get {
@@ -1256,7 +1256,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Types should not have an &apos;Abstract&apos; or &apos;Base&apos; marker to indicate that they are base types.
+        ///   Looks up a localized string similar to Do not mark base types with &apos;Abstract&apos; or &apos;Base&apos;.
         /// </summary>
         internal static string MiKo_1030_Title {
             get {
@@ -1292,7 +1292,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Entity types should not use a &apos;Model&apos; suffix.
+        ///   Looks up a localized string similar to Do not suffix entity types with &apos;Model&apos;.
         /// </summary>
         internal static string MiKo_1031_Title {
             get {
@@ -1328,7 +1328,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods dealing with entities should not use a &apos;Model&apos; as marker.
+        ///   Looks up a localized string similar to Do not use &apos;Model&apos; as marker in methods dealing with entities.
         /// </summary>
         internal static string MiKo_1032_Title {
             get {
@@ -1364,7 +1364,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters representing entities should not use a &apos;Model&apos; suffix.
+        ///   Looks up a localized string similar to Do not suffix entity parameters with &apos;Model&apos;.
         /// </summary>
         internal static string MiKo_1033_Title {
             get {
@@ -1400,7 +1400,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields representing entities should not use a &apos;Model&apos; suffix.
+        ///   Looks up a localized string similar to Do not suffix entity fields with &apos;Model&apos;.
         /// </summary>
         internal static string MiKo_1034_Title {
             get {
@@ -1436,7 +1436,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties dealing with entities should not use a &apos;Model&apos; marker.
+        ///   Looks up a localized string similar to Do not use &apos;Model&apos; marker in properties dealing with entities.
         /// </summary>
         internal static string MiKo_1035_Title {
             get {
@@ -1472,7 +1472,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events dealing with entities should not use a &apos;Model&apos; marker.
+        ///   Looks up a localized string similar to Do not use &apos;Model&apos; marker in events dealing with entities.
         /// </summary>
         internal static string MiKo_1036_Title {
             get {
@@ -1508,7 +1508,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Types should not be suffixed with &apos;Type&apos;, &apos;Interface&apos;, &apos;Class&apos;, &apos;Struct&apos;, &apos;Record&apos; or &apos;Enum&apos;.
+        ///   Looks up a localized string similar to Do not suffix types with &apos;Type&apos;, &apos;Interface&apos;, &apos;Class&apos;, &apos;Struct&apos;, &apos;Record&apos; or &apos;Enum&apos;.
         /// </summary>
         internal static string MiKo_1037_Title {
             get {
@@ -1544,7 +1544,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Classes that contain extension methods should end with same suffix.
+        ///   Looks up a localized string similar to Use consistent suffix for extension method container classes.
         /// </summary>
         internal static string MiKo_1038_Title {
             get {
@@ -1580,7 +1580,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;this&apos; parameter of extension methods should have a default name.
+        ///   Looks up a localized string similar to Use default name for &apos;this&apos; parameter of extension methods.
         /// </summary>
         internal static string MiKo_1039_Title {
             get {
@@ -1616,7 +1616,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be suffixed with implementation details.
+        ///   Looks up a localized string similar to Do not suffix parameters with implementation details.
         /// </summary>
         internal static string MiKo_1040_Title {
             get {
@@ -1652,7 +1652,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields should not be suffixed with implementation details.
+        ///   Looks up a localized string similar to Do not suffix fields with implementation details.
         /// </summary>
         internal static string MiKo_1041_Title {
             get {
@@ -1688,7 +1688,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;CancellationToken&apos; parameters should have specific name.
+        ///   Looks up a localized string similar to Use specific name for &apos;CancellationToken&apos; parameters.
         /// </summary>
         internal static string MiKo_1042_Title {
             get {
@@ -1724,7 +1724,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;CancellationToken&apos; variables should have specific name.
+        ///   Looks up a localized string similar to Use specific name for &apos;CancellationToken&apos; variables.
         /// </summary>
         internal static string MiKo_1043_Title {
             get {
@@ -1760,7 +1760,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Commands should be suffixed with &apos;Command&apos;.
+        ///   Looks up a localized string similar to Suffix commands with &apos;Command&apos;.
         /// </summary>
         internal static string MiKo_1044_Title {
             get {
@@ -1796,7 +1796,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods that are invoked by commands should not be suffixed with &apos;Command&apos;.
+        ///   Looks up a localized string similar to Do not suffix command-invoked methods with &apos;Command&apos;.
         /// </summary>
         internal static string MiKo_1045_Title {
             get {
@@ -1841,7 +1841,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Asynchronous methods should follow the Task-based Asynchronous Pattern (TAP).
+        ///   Looks up a localized string similar to Follow Task-based Asynchronous Pattern (TAP) for asynchronous methods.
         /// </summary>
         internal static string MiKo_1046_Title {
             get {
@@ -1886,7 +1886,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods not following the Task-based Asynchronous Pattern (TAP) should not lie about being asynchronous.
+        ///   Looks up a localized string similar to Do not falsely indicate asynchronous behavior for methods not following Task-based Asynchronous Pattern (TAP).
         /// </summary>
         internal static string MiKo_1047_Title {
             get {
@@ -1922,7 +1922,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Classes that are value converters should end with a specific suffix.
+        ///   Looks up a localized string similar to End value converter classes with a specific suffix.
         /// </summary>
         internal static string MiKo_1048_Title {
             get {
@@ -1995,7 +1995,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return values should have descriptive names.
+        ///   Looks up a localized string similar to Use descriptive names for return values.
         /// </summary>
         internal static string MiKo_1050_Title {
             get {
@@ -2185,7 +2185,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency properties should be suffixed with &apos;Property&apos; (as in the .NET Framework).
+        ///   Looks up a localized string similar to Suffix dependency properties with &apos;Property&apos; (as in the .NET Framework).
         /// </summary>
         internal static string MiKo_1055_Title {
             get {
@@ -2221,7 +2221,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency properties should be prefixed with property names (as in the .NET Framework).
+        ///   Looks up a localized string similar to Prefix dependency properties with property names (as in the .NET Framework).
         /// </summary>
         internal static string MiKo_1056_Title {
             get {
@@ -2266,7 +2266,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency property keys should be suffixed with &apos;Key&apos; (as in the .NET Framework).
+        ///   Looks up a localized string similar to Suffix dependency property keys with &apos;Key&apos; (as in the .NET Framework).
         /// </summary>
         internal static string MiKo_1057_Title {
             get {
@@ -2302,7 +2302,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency property keys should be prefixed with property names (as in the .NET Framework).
+        ///   Looks up a localized string similar to Prefix dependency property keys with property names (as in the .NET Framework).
         /// </summary>
         internal static string MiKo_1058_Title {
             get {
@@ -2417,7 +2417,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name of &apos;Try&apos; method&apos;s [out] parameter should be specific.
+        ///   Looks up a localized string similar to Use specific name for &apos;Try&apos; method&apos;s [out] parameters.
         /// </summary>
         internal static string MiKo_1061_Title {
             get {
@@ -2445,7 +2445,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;Can/Has/Contains&apos; methods, properties or fields shall consist of only a few words.
+        ///   Looks up a localized string similar to Keep &apos;Can/Has/Contains&apos; methods, properties or fields to a few words.
         /// </summary>
         internal static string MiKo_1062_Title {
             get {
@@ -2508,7 +2508,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter names reflect their meaning and not their type.
+        ///   Looks up a localized string similar to Make parameter names reflect their meaning, not their type.
         /// </summary>
         internal static string MiKo_1064_Title {
             get {
@@ -2557,7 +2557,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Operator parameters should be named according the .NET Framework Design Guidelines for operator overloads.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for operator overload parameter names.
         /// </summary>
         internal static string MiKo_1065_Title {
             get {
@@ -2593,7 +2593,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Constructor parameters that are assigned to a property should be named after the property.
+        ///   Looks up a localized string similar to Name constructor parameters after the property they&apos;re assigned to.
         /// </summary>
         internal static string MiKo_1066_Title {
             get {
@@ -2629,7 +2629,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not contain &apos;Perform&apos; in their names.
+        ///   Looks up a localized string similar to Do not include &apos;Perform&apos; in method names.
         /// </summary>
         internal static string MiKo_1067_Title {
             get {
@@ -2656,7 +2656,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Workflow methods should be named &apos;CanRun&apos; or &apos;Run&apos;.
+        ///   Looks up a localized string similar to Name workflow methods &apos;CanRun&apos; or &apos;Run&apos;.
         /// </summary>
         internal static string MiKo_1068_Title {
             get {
@@ -2683,7 +2683,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property names reflect their meaning and not their type.
+        ///   Looks up a localized string similar to Make property names reflect their meaning, not their type.
         /// </summary>
         internal static string MiKo_1069_Title {
             get {
@@ -2720,7 +2720,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local collection variables shall use plural name.
+        ///   Looks up a localized string similar to Use plural names for local collection variables.
         /// </summary>
         internal static string MiKo_1070_Title {
             get {
@@ -2755,7 +2755,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local boolean variables should be named as statements and not as questions.
+        ///   Looks up a localized string similar to Name local boolean variables as statements, not questions.
         /// </summary>
         internal static string MiKo_1071_Title {
             get {
@@ -2790,7 +2790,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean properties or methods should be named as statements and not as questions.
+        ///   Looks up a localized string similar to Name boolean properties or methods as statements, not questions.
         /// </summary>
         internal static string MiKo_1072_Title {
             get {
@@ -2825,7 +2825,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean fields should be named as statements and not as questions.
+        ///   Looks up a localized string similar to Name boolean fields as statements, not questions.
         /// </summary>
         internal static string MiKo_1073_Title {
             get {
@@ -2852,7 +2852,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Objects used to lock on should be suffixed with &apos;Lock&apos;.
+        ///   Looks up a localized string similar to Suffix lock objects with &apos;Lock&apos;.
         /// </summary>
         internal static string MiKo_1074_Title {
             get {
@@ -2888,7 +2888,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non-&apos;System.EventArgs&apos; types should not be suffixed with &apos;EventArgs&apos;.
+        ///   Looks up a localized string similar to Do not suffix non-&apos;System.EventArgs&apos; types with &apos;EventArgs&apos;.
         /// </summary>
         internal static string MiKo_1075_Title {
             get {
@@ -2924,7 +2924,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prism event types should be suffixed with &apos;Event&apos;.
+        ///   Looks up a localized string similar to Suffix Prism event types with &apos;Event&apos;.
         /// </summary>
         internal static string MiKo_1076_Title {
             get {
@@ -2960,7 +2960,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enum members should not be suffixed with &apos;Enum&apos;.
+        ///   Looks up a localized string similar to Do not suffix enum members with &apos;Enum&apos;.
         /// </summary>
         internal static string MiKo_1077_Title {
             get {
@@ -2996,7 +2996,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Builder method names should start with &apos;Build&apos;.
+        ///   Looks up a localized string similar to Start builder method names with &apos;Build&apos;.
         /// </summary>
         internal static string MiKo_1078_Title {
             get {
@@ -3032,7 +3032,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repositories should not be suffixed with &apos;Repository&apos;.
+        ///   Looks up a localized string similar to Do not suffix repositories with &apos;Repository&apos;.
         /// </summary>
         internal static string MiKo_1079_Title {
             get {
@@ -3059,7 +3059,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Names should contain numbers instead of their spellings.
+        ///   Looks up a localized string similar to Use numbers instead of their spellings in names.
         /// </summary>
         internal static string MiKo_1080_Title {
             get {
@@ -3095,7 +3095,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be suffixed with a number.
+        ///   Looks up a localized string similar to Do not suffix methods with a number.
         /// </summary>
         internal static string MiKo_1081_Title {
             get {
@@ -3131,7 +3131,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties should not be suffixed with a number if their types have number suffixes.
+        ///   Looks up a localized string similar to Do not suffix properties with a number if their types have number suffixes.
         /// </summary>
         internal static string MiKo_1082_Title {
             get {
@@ -3167,7 +3167,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields should not be suffixed with a number if their types have number suffixes.
+        ///   Looks up a localized string similar to Do not suffix fields with a number if their types have number suffixes.
         /// </summary>
         internal static string MiKo_1083_Title {
             get {
@@ -3203,7 +3203,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variables should not be suffixed with a number if their types have number suffixes.
+        ///   Looks up a localized string similar to Do not suffix variables with a number if their types have number suffixes.
         /// </summary>
         internal static string MiKo_1084_Title {
             get {
@@ -3239,7 +3239,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be suffixed with a number.
+        ///   Looks up a localized string similar to Do not suffix parameters with a number.
         /// </summary>
         internal static string MiKo_1085_Title {
             get {
@@ -3266,7 +3266,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be named using numbers as slang.
+        ///   Looks up a localized string similar to Do not use numbers as slang in method names.
         /// </summary>
         internal static string MiKo_1086_Title {
             get {
@@ -3302,7 +3302,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name constructor parameters after their counterparts in the base class.
+        ///   Looks up a localized string similar to Name constructor parameters after their base class counterparts.
         /// </summary>
         internal static string MiKo_1087_Title {
             get {
@@ -3329,7 +3329,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Singleton instances should be named &apos;Instance&apos;.
+        ///   Looks up a localized string similar to Name singleton instances &apos;Instance&apos;.
         /// </summary>
         internal static string MiKo_1088_Title {
             get {
@@ -3366,7 +3366,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be prefixed with &apos;Get&apos;.
+        ///   Looks up a localized string similar to Do not prefix methods with &apos;Get&apos;.
         /// </summary>
         internal static string MiKo_1089_Title {
             get {
@@ -3402,7 +3402,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be suffixed with specific types.
+        ///   Looks up a localized string similar to Do not suffix parameters with specific types.
         /// </summary>
         internal static string MiKo_1090_Title {
             get {
@@ -3438,7 +3438,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variables should not be suffixed with specific types.
+        ///   Looks up a localized string similar to Do not suffix variables with specific types.
         /// </summary>
         internal static string MiKo_1091_Title {
             get {
@@ -3474,7 +3474,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;Ability&apos; Types should not be suffixed with redundant information.
+        ///   Looks up a localized string similar to Do not suffix &apos;Ability&apos; types with redundant information.
         /// </summary>
         internal static string MiKo_1092_Title {
             get {
@@ -3597,7 +3597,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Names should use &apos;Failed&apos; instead of &apos;NotSuccessful&apos;.
+        ///   Looks up a localized string similar to Use &apos;Failed&apos; instead of &apos;NotSuccessful&apos; in names.
         /// </summary>
         internal static string MiKo_1096_Title {
             get {
@@ -3633,7 +3633,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter names should not follow the naming scheme for fields.
+        ///   Looks up a localized string similar to Do not use field naming schemes for parameter names.
         /// </summary>
         internal static string MiKo_1097_Title {
             get {
@@ -3660,7 +3660,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type names should reflect the business interface(s) they implement.
+        ///   Looks up a localized string similar to Reflect implemented business interface(s) in type names.
         /// </summary>
         internal static string MiKo_1098_Title {
             get {
@@ -3696,7 +3696,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Matching parameters on method overloads should have identical names.
+        ///   Looks up a localized string similar to Use identical names for matching parameters on method overloads.
         /// </summary>
         internal static string MiKo_1099_Title {
             get {
@@ -3723,7 +3723,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test classes should start with the name of the type under test.
+        ///   Looks up a localized string similar to Start test class names with the name of the type under test.
         /// </summary>
         internal static string MiKo_1100_Title {
             get {
@@ -3759,7 +3759,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test classes should end with &apos;Tests&apos;.
+        ///   Looks up a localized string similar to End test class names with &apos;Tests&apos;.
         /// </summary>
         internal static string MiKo_1101_Title {
             get {
@@ -3795,7 +3795,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not contain &apos;Test&apos; in their names.
+        ///   Looks up a localized string similar to Do not include &apos;Test&apos; in test method names.
         /// </summary>
         internal static string MiKo_1102_Title {
             get {
@@ -3831,7 +3831,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test initialization methods should be named &apos;PrepareTest&apos;.
+        ///   Looks up a localized string similar to Name test initialization methods &apos;PrepareTest&apos;.
         /// </summary>
         internal static string MiKo_1103_Title {
             get {
@@ -3867,7 +3867,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test cleanup methods should be named &apos;CleanupTest&apos;.
+        ///   Looks up a localized string similar to Name test cleanup methods &apos;CleanupTest&apos;.
         /// </summary>
         internal static string MiKo_1104_Title {
             get {
@@ -3903,7 +3903,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One-time test initialization methods should be named &apos;PrepareTestEnvironment&apos;.
+        ///   Looks up a localized string similar to Name one-time test initialization methods &apos;PrepareTestEnvironment&apos;.
         /// </summary>
         internal static string MiKo_1105_Title {
             get {
@@ -3939,7 +3939,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One-time test cleanup methods should be named &apos;CleanupTestEnvironment&apos;.
+        ///   Looks up a localized string similar to Name one-time test cleanup methods &apos;CleanupTestEnvironment&apos;.
         /// </summary>
         internal static string MiKo_1106_Title {
             get {
@@ -3975,7 +3975,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not be in Pascal-casing.
+        ///   Looks up a localized string similar to Do not use Pascal-casing for test methods.
         /// </summary>
         internal static string MiKo_1107_Title {
             get {
@@ -4089,7 +4089,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods with parameters should be suffixed with underscore.
+        ///   Looks up a localized string similar to Suffix test methods with parameters with underscore.
         /// </summary>
         internal static string MiKo_1110_Title {
             get {
@@ -4126,7 +4126,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods without parameters should not be suffixed with underscore.
+        ///   Looks up a localized string similar to Do not suffix parameterless test methods with underscore.
         /// </summary>
         internal static string MiKo_1111_Title {
             get {
@@ -4189,7 +4189,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not be named according BDD style.
+        ///   Looks up a localized string similar to Do not use BDD style naming for test methods.
         /// </summary>
         internal static string MiKo_1113_Title {
             get {
@@ -4216,7 +4216,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not be named &apos;HappyPath&apos; or &apos;BadPath&apos;.
+        ///   Looks up a localized string similar to Do not name test methods &apos;HappyPath&apos; or &apos;BadPath&apos;.
         /// </summary>
         internal static string MiKo_1114_Title {
             get {
@@ -4254,7 +4254,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should be named in a fluent way.
+        ///   Looks up a localized string similar to Name test methods in a fluent way.
         /// </summary>
         internal static string MiKo_1115_Title {
             get {
@@ -4290,7 +4290,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods shall be named in present tense.
+        ///   Looks up a localized string similar to Use present tense for test method names.
         /// </summary>
         internal static string MiKo_1116_Title {
             get {
@@ -4318,7 +4318,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should be named more precisely.
+        ///   Looks up a localized string similar to Make test method names more precise.
         /// </summary>
         internal static string MiKo_1117_Title {
             get {
@@ -4354,7 +4354,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not end with &apos;Async&apos;.
+        ///   Looks up a localized string similar to Do not end test method names with &apos;Async&apos;.
         /// </summary>
         internal static string MiKo_1118_Title {
             get {
@@ -4390,7 +4390,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name exceptions in catch blocks consistently.
+        ///   Looks up a localized string similar to Name catch block exceptions consistently.
         /// </summary>
         internal static string MiKo_1200_Title {
             get {
@@ -4426,7 +4426,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name exceptions as parameters consistently.
+        ///   Looks up a localized string similar to Name exception parameters consistently.
         /// </summary>
         internal static string MiKo_1201_Title {
             get {
@@ -4462,7 +4462,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unimportant identifiers in lambda statements should be named &apos;_&apos;.
+        ///   Looks up a localized string similar to Name unimportant lambda statement identifiers &apos;_&apos;.
         /// </summary>
         internal static string MiKo_1300_Title {
             get {
@@ -4498,7 +4498,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespace names should be in plural.
+        ///   Looks up a localized string similar to Use plural for namespace names.
         /// </summary>
         internal static string MiKo_1400_Title {
             get {
@@ -4525,7 +4525,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespaces should not contain technical language names.
+        ///   Looks up a localized string similar to Do not include technical language names in namespaces.
         /// </summary>
         internal static string MiKo_1401_Title {
             get {
@@ -4552,7 +4552,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespaces should not be named after WPF-specific design patterns.
+        ///   Looks up a localized string similar to Do not name namespaces after WPF-specific design patterns.
         /// </summary>
         internal static string MiKo_1402_Title {
             get {
@@ -4579,7 +4579,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespaces should not be named after any of their parent namespaces.
+        ///   Looks up a localized string similar to Do not name namespaces after any of their parent namespaces.
         /// </summary>
         internal static string MiKo_1403_Title {
             get {
@@ -4606,7 +4606,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespaces should not contain unspecific names.
+        ///   Looks up a localized string similar to Do not use unspecific names for namespaces.
         /// </summary>
         internal static string MiKo_1404_Title {
             get {
@@ -4634,7 +4634,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespaces should not contain &apos;Lib&apos;.
+        ///   Looks up a localized string similar to Do not include &apos;Lib&apos; in namespaces.
         /// </summary>
         internal static string MiKo_1405_Title {
             get {
@@ -4661,7 +4661,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value converters should be placed in &apos;Converters&apos; namespace.
+        ///   Looks up a localized string similar to Place value converters in &apos;Converters&apos; namespace.
         /// </summary>
         internal static string MiKo_1406_Title {
             get {
@@ -4688,7 +4688,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test namespaces should not contain &apos;Test&apos;.
+        ///   Looks up a localized string similar to Do not include &apos;Test&apos; in test namespaces.
         /// </summary>
         internal static string MiKo_1407_Title {
             get {
@@ -4715,7 +4715,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Extension methods should be placed in same namespace as the extended types.
+        ///   Looks up a localized string similar to Place extension methods in same namespace as the extended types.
         /// </summary>
         internal static string MiKo_1408_Title {
             get {
@@ -4837,7 +4837,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should not be suffixed with &apos;Counter&apos;.
+        ///   Looks up a localized string similar to Do not suffix methods with &apos;Counter&apos;.
         /// </summary>
         internal static string MiKo_1503_Title {
             get {
@@ -4874,7 +4874,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties should not be suffixed with &apos;Counter&apos;.
+        ///   Looks up a localized string similar to Do not suffix properties with &apos;Counter&apos;.
         /// </summary>
         internal static string MiKo_1504_Title {
             get {
@@ -4911,7 +4911,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields should not be suffixed with &apos;Counter&apos;.
+        ///   Looks up a localized string similar to Do not suffix fields with &apos;Counter&apos;.
         /// </summary>
         internal static string MiKo_1505_Title {
             get {
@@ -4948,7 +4948,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local variables should not be suffixed with &apos;Counter&apos;.
+        ///   Looks up a localized string similar to Do not suffix local variables with &apos;Counter&apos;.
         /// </summary>
         internal static string MiKo_1506_Title {
             get {
@@ -4985,7 +4985,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be suffixed with &apos;Counter&apos;.
+        ///   Looks up a localized string similar to Do not suffix parameters with &apos;Counter&apos;.
         /// </summary>
         internal static string MiKo_1507_Title {
             get {
@@ -5022,7 +5022,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local variables should not be suffixed with pattern names.
+        ///   Looks up a localized string similar to Do not suffix local variables with pattern names.
         /// </summary>
         internal static string MiKo_1508_Title {
             get {
@@ -5059,7 +5059,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be suffixed with pattern names.
+        ///   Looks up a localized string similar to Do not suffix parameters with pattern names.
         /// </summary>
         internal static string MiKo_1509_Title {
             get {
@@ -5087,7 +5087,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Types should not be suffixed with &apos;Info&apos;.
+        ///   Looks up a localized string similar to Do not suffix types with &apos;Info&apos;.
         /// </summary>
         internal static string MiKo_1510_Title {
             get {
@@ -5124,7 +5124,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local variables should not be prefixed or suffixed with &apos;proxy&apos;.
+        ///   Looks up a localized string similar to Do not prefix or suffix local variables with &apos;proxy&apos;.
         /// </summary>
         internal static string MiKo_1511_Title {
             get {
@@ -5161,7 +5161,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be prefixed or suffixed with &apos;proxy&apos;.
+        ///   Looks up a localized string similar to Do not prefix or suffix parameters with &apos;proxy&apos;.
         /// </summary>
         internal static string MiKo_1512_Title {
             get {
@@ -5198,7 +5198,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Types should not be suffixed with &apos;Advanced&apos;, &apos;Complex&apos;, &apos;Enhanced&apos;, &apos;Extended&apos;, &apos;Simple&apos; or &apos;Simplified&apos;.
+        ///   Looks up a localized string similar to Do not suffix types with &apos;Advanced&apos;, &apos;Complex&apos;, &apos;Enhanced&apos;, &apos;Extended&apos;, &apos;Simple&apos; or &apos;Simplified&apos;.
         /// </summary>
         internal static string MiKo_1513_Title {
             get {
@@ -5235,7 +5235,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields should not be suffixed with pattern names.
+        ///   Looks up a localized string similar to Do not suffix fields with pattern names.
         /// </summary>
         internal static string MiKo_1514_Title {
             get {
@@ -5272,7 +5272,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean property names should clearly express a binary condition.
+        ///   Looks up a localized string similar to Express binary conditions clearly in boolean property names.
         /// </summary>
         internal static string MiKo_1515_Title {
             get {
@@ -5309,7 +5309,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean parameter names should clearly express a binary condition.
+        ///   Looks up a localized string similar to Express binary conditions clearly in boolean parameter names.
         /// </summary>
         internal static string MiKo_1516_Title {
             get {
@@ -5346,7 +5346,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean field names should clearly express a binary condition.
+        ///   Looks up a localized string similar to Express binary conditions clearly in boolean field names.
         /// </summary>
         internal static string MiKo_1517_Title {
             get {
@@ -5382,7 +5382,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should be valid XML.
+        ///   Looks up a localized string similar to Write valid XML documentation.
         /// </summary>
         internal static string MiKo_2000_Title {
             get {
@@ -5418,7 +5418,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events should be documented properly.
+        ///   Looks up a localized string similar to Document events properly.
         /// </summary>
         internal static string MiKo_2001_Title {
             get {
@@ -5454,7 +5454,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EventArgs should be documented properly.
+        ///   Looks up a localized string similar to Document EventArgs properly.
         /// </summary>
         internal static string MiKo_2002_Title {
             get {
@@ -5490,7 +5490,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of event handlers should have a default starting phrase.
+        ///   Looks up a localized string similar to Start event handler documentation with default phrase.
         /// </summary>
         internal static string MiKo_2003_Title {
             get {
@@ -5526,7 +5526,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of event handler parameter names should follow .NET Framework Design Guidelines for event handlers.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for event handler parameter names in documentation.
         /// </summary>
         internal static string MiKo_2004_Title {
             get {
@@ -5553,7 +5553,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Textual references to EventArgs should be documented properly.
+        ///   Looks up a localized string similar to Document textual references to EventArgs properly.
         /// </summary>
         internal static string MiKo_2005_Title {
             get {
@@ -5589,7 +5589,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Routed events should be documented as done by the .NET Framework.
+        ///   Looks up a localized string similar to Document routed events as done by the .NET Framework.
         /// </summary>
         internal static string MiKo_2006_Title {
             get {
@@ -5625,7 +5625,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sealed classes should document being sealed.
+        ///   Looks up a localized string similar to Document sealed classes as being sealed.
         /// </summary>
         internal static string MiKo_2010_Title {
             get {
@@ -5661,7 +5661,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unsealed classes should not lie about sealing.
+        ///   Looks up a localized string similar to Do not falsely document unsealed classes as sealed.
         /// </summary>
         internal static string MiKo_2011_Title {
             get {
@@ -5699,7 +5699,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should describe the type&apos;s responsibility.
+        ///   Looks up a localized string similar to Describe the type&apos;s responsibility in &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2012_Title {
             get {
@@ -5735,7 +5735,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of Enums should have a default starting phrase.
+        ///   Looks up a localized string similar to Start Enum &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2013_Title {
             get {
@@ -5771,7 +5771,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dispose methods should be documented as done by the .NET Framework.
+        ///   Looks up a localized string similar to Document Dispose methods as done by the .NET Framework.
         /// </summary>
         internal static string MiKo_2014_Title {
             get {
@@ -5807,7 +5807,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;raise&apos; or &apos;throw&apos; instead of &apos;fire&apos;.
+        ///   Looks up a localized string similar to Use &apos;raise&apos; or &apos;throw&apos; instead of &apos;fire&apos; in documentation.
         /// </summary>
         internal static string MiKo_2015_Title {
             get {
@@ -5843,7 +5843,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation for asynchronous methods should start with specific phrase.
+        ///   Looks up a localized string similar to Start documentation for asynchronous methods with specific phrase.
         /// </summary>
         internal static string MiKo_2016_Title {
             get {
@@ -5879,7 +5879,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dependency properties should be documented as done by the .NET Framework.
+        ///   Looks up a localized string similar to Document dependency properties as done by the .NET Framework.
         /// </summary>
         internal static string MiKo_2017_Title {
             get {
@@ -5916,7 +5916,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not use the ambiguous terms &apos;Check&apos; or &apos;Test&apos;.
+        ///   Looks up a localized string similar to Do not use ambiguous terms &apos;Check&apos; or &apos;Test&apos; in documentation.
         /// </summary>
         internal static string MiKo_2018_Title {
             get {
@@ -5952,7 +5952,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should start with a third person singular verb (for example &quot;Provides &quot;).
+        ///   Looks up a localized string similar to Start &lt;summary&gt; documentation with third person singular verb (e.g., &quot;Provides&quot;).
         /// </summary>
         internal static string MiKo_2019_Title {
             get {
@@ -5988,7 +5988,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inherited documentation should be used with &lt;inheritdoc /&gt; marker.
+        ///   Looks up a localized string similar to Use &lt;inheritdoc /&gt; marker for inherited documentation.
         /// </summary>
         internal static string MiKo_2020_Title {
             get {
@@ -6024,7 +6024,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of parameter should have a default starting phrase.
+        ///   Looks up a localized string similar to Start parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2021_Title {
             get {
@@ -6060,7 +6060,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of [out] parameters should have a default starting phrase.
+        ///   Looks up a localized string similar to Start [out] parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2022_Title {
             get {
@@ -6096,7 +6096,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Boolean parameters should have a default starting phrase.
+        ///   Looks up a localized string similar to Start Boolean parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2023_Title {
             get {
@@ -6132,7 +6132,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Enum parameters should have a default starting phrase.
+        ///   Looks up a localized string similar to Start Enum parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2024_Title {
             get {
@@ -6168,7 +6168,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of &apos;CancellationToken&apos; parameters should have a default starting phrase.
+        ///   Looks up a localized string similar to Start &apos;CancellationToken&apos; parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2025_Title {
             get {
@@ -6195,7 +6195,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Used parameters should not be documented to be unused.
+        ///   Looks up a localized string similar to Do not document used parameters as unused.
         /// </summary>
         internal static string MiKo_2026_Title {
             get {
@@ -6231,7 +6231,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Serialization constructor parameters shall be documented with a specific phrase.
+        ///   Looks up a localized string similar to Document serialization constructor parameters with specific phrase.
         /// </summary>
         internal static string MiKo_2027_Title {
             get {
@@ -6258,7 +6258,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of parameter should not just contain the name of the parameter.
+        ///   Looks up a localized string similar to Provide more information than just parameter name in documentation.
         /// </summary>
         internal static string MiKo_2028_Title {
             get {
@@ -6294,7 +6294,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;inheritdoc&gt; documentation should not use a &apos;cref&apos; to itself.
+        ///   Looks up a localized string similar to Do not use self-referencing &apos;cref&apos; in &lt;inheritdoc&gt; documentation.
         /// </summary>
         internal static string MiKo_2029_Title {
             get {
@@ -6321,7 +6321,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of return value should have a default starting phrase.
+        ///   Looks up a localized string similar to Start return value documentation with default phrase.
         /// </summary>
         internal static string MiKo_2030_Title {
             get {
@@ -6357,7 +6357,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Task return value should have a specific (starting) phrase.
+        ///   Looks up a localized string similar to Use specific (starting) phrase for Task return value documentation.
         /// </summary>
         internal static string MiKo_2031_Title {
             get {
@@ -6393,7 +6393,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Boolean return value should have a specific phrase.
+        ///   Looks up a localized string similar to Use specific phrase for Boolean return value documentation.
         /// </summary>
         internal static string MiKo_2032_Title {
             get {
@@ -6429,7 +6429,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of String return value should have a default starting phrase.
+        ///   Looks up a localized string similar to Start String return value documentation with default phrase.
         /// </summary>
         internal static string MiKo_2033_Title {
             get {
@@ -6465,7 +6465,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Enum return value should have a default starting phrase.
+        ///   Looks up a localized string similar to Start Enum return value documentation with default phrase.
         /// </summary>
         internal static string MiKo_2034_Title {
             get {
@@ -6501,7 +6501,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of collection return value should have a default starting phrase.
+        ///   Looks up a localized string similar to Start collection return value documentation with default phrase.
         /// </summary>
         internal static string MiKo_2035_Title {
             get {
@@ -6565,7 +6565,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of Boolean or Enum property shall describe the default value.
+        ///   Looks up a localized string similar to Describe default values in Boolean or Enum property documentation.
         /// </summary>
         internal static string MiKo_2036_Title {
             get {
@@ -6601,7 +6601,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of command properties should have a default starting phrase.
+        ///   Looks up a localized string similar to Start command property &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2037_Title {
             get {
@@ -6637,7 +6637,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of command should have a default starting phrase.
+        ///   Looks up a localized string similar to Start command &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2038_Title {
             get {
@@ -6674,7 +6674,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of classes that contain extension methods should have a default starting phrase.
+        ///   Looks up a localized string similar to Start extension method class &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2039_Title {
             get {
@@ -6710,7 +6710,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;see langword=&quot;...&quot;/&gt; should be used instead of &lt;c&gt;...&lt;/c&gt;.
+        ///   Looks up a localized string similar to Use &lt;see langword=&quot;...&quot;/&gt; instead of &lt;c&gt;...&lt;/c&gt;.
         /// </summary>
         internal static string MiKo_2040_Title {
             get {
@@ -6755,7 +6755,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not contain other documentation tags.
+        ///   Looks up a localized string similar to Do not include other documentation tags in &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2041_Title {
             get {
@@ -6800,7 +6800,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;&lt;para&gt;&apos; XML tags instead of &apos;&lt;p&gt;&apos; HTML tags.
+        ///   Looks up a localized string similar to Use &apos;&lt;para&gt;&apos; XML tags instead of &apos;&lt;p&gt;&apos; HTML tags in documentation.
         /// </summary>
         internal static string MiKo_2042_Title {
             get {
@@ -6837,7 +6837,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of custom delegates should have a default starting phrase.
+        ///   Looks up a localized string similar to Start custom delegate &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2043_Title {
             get {
@@ -6873,7 +6873,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation references method parameters correctly.
+        ///   Looks up a localized string similar to Reference method parameters correctly in documentation.
         /// </summary>
         internal static string MiKo_2044_Title {
             get {
@@ -6909,7 +6909,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not reference parameters.
+        ///   Looks up a localized string similar to Do not reference parameters in &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2045_Title {
             get {
@@ -6945,7 +6945,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should reference type parameters correctly.
+        ///   Looks up a localized string similar to Reference type parameters correctly in documentation.
         /// </summary>
         internal static string MiKo_2046_Title {
             get {
@@ -6972,7 +6972,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of Attributes should have a default starting phrase.
+        ///   Looks up a localized string similar to Start Attribute &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2047_Title {
             get {
@@ -7008,7 +7008,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of value converters should have a default starting phrase.
+        ///   Looks up a localized string similar to Start value converter &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2048_Title {
             get {
@@ -7045,7 +7045,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should be more explicit and not use &apos;will be&apos;.
+        ///   Looks up a localized string similar to Use explicit wording instead of &apos;will be&apos; in documentation.
         /// </summary>
         internal static string MiKo_2049_Title {
             get {
@@ -7081,7 +7081,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exceptions should be documented following the .NET Framework.
+        ///   Looks up a localized string similar to Follow .NET Framework conventions for exception documentation.
         /// </summary>
         internal static string MiKo_2050_Title {
             get {
@@ -7117,7 +7117,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thrown Exceptions should be documented as kind of a condition (such as &apos;&lt;paramref name=&quot;xyz&quot;/&gt; is &lt;c&gt;42&lt;/c&gt;&apos;).
+        ///   Looks up a localized string similar to Document thrown exceptions as conditions (e.g., &apos;&lt;paramref name=&quot;xyz&quot;/&gt; is &lt;c&gt;42&lt;/c&gt;&apos;).
         /// </summary>
         internal static string MiKo_2051_Title {
             get {
@@ -7156,7 +7156,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throwing of ArgumentNullException should be documented using a default phrase.
+        ///   Looks up a localized string similar to Use default phrase for ArgumentNullException documentation.
         /// </summary>
         internal static string MiKo_2052_Title {
             get {
@@ -7183,7 +7183,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throwing of ArgumentNullException should be documented only for reference type parameters.
+        ///   Looks up a localized string similar to Document ArgumentNullException only for reference type parameters.
         /// </summary>
         internal static string MiKo_2053_Title {
             get {
@@ -7222,7 +7222,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throwing of ArgumentException should be documented using a default starting phrase.
+        ///   Looks up a localized string similar to Start ArgumentException documentation with default phrase.
         /// </summary>
         internal static string MiKo_2054_Title {
             get {
@@ -7261,7 +7261,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throwing of ArgumentOutOfRangeException should be documented using a default starting phrase.
+        ///   Looks up a localized string similar to Start ArgumentOutOfRangeException documentation with default phrase.
         /// </summary>
         internal static string MiKo_2055_Title {
             get {
@@ -7298,7 +7298,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throwing of ObjectDisposedException should be documented using a default ending phrase.
+        ///   Looks up a localized string similar to End ObjectDisposedException documentation with default phrase.
         /// </summary>
         internal static string MiKo_2056_Title {
             get {
@@ -7334,7 +7334,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Types that are not disposable shall not throw an ObjectDisposedException.
+        ///   Looks up a localized string similar to Do not throw ObjectDisposedException from non-disposable types.
         /// </summary>
         internal static string MiKo_2057_Title {
             get {
@@ -7370,7 +7370,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple documentation of same exception should be consolidated into one.
+        ///   Looks up a localized string similar to Consolidate multiple documentations of same exception into one.
         /// </summary>
         internal static string MiKo_2059_Title {
             get {
@@ -7406,7 +7406,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Factories should be documented in an uniform way.
+        ///   Looks up a localized string similar to Document factories uniformly.
         /// </summary>
         internal static string MiKo_2060_Title {
             get {
@@ -7442,7 +7442,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not start with &apos;Returns&apos;.
+        ///   Looks up a localized string similar to Do not start &lt;summary&gt; documentation with &apos;Returns&apos;.
         /// </summary>
         internal static string MiKo_2070_Title {
             get {
@@ -7469,7 +7469,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation for methods that return Enum types should not contain phrase for boolean type.
+        ///   Looks up a localized string similar to Do not use boolean phrases in Enum return type &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2071_Title {
             get {
@@ -7505,7 +7505,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not start with &apos;Try&apos;.
+        ///   Looks up a localized string similar to Do not start &lt;summary&gt; documentation with &apos;Try&apos;.
         /// </summary>
         internal static string MiKo_2072_Title {
             get {
@@ -7541,7 +7541,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of &apos;Contains&apos; methods should start with &apos;Determines whether &apos;.
+        ///   Looks up a localized string similar to Start &apos;Contains&apos; method &lt;summary&gt; documentation with &apos;Determines whether&apos;.
         /// </summary>
         internal static string MiKo_2073_Title {
             get {
@@ -7577,7 +7577,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of parameter of &apos;Contains&apos; method should have a default ending phrase.
+        ///   Looks up a localized string similar to End &apos;Contains&apos; method parameter documentation with default phrase.
         /// </summary>
         internal static string MiKo_2074_Title {
             get {
@@ -7613,7 +7613,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the term &apos;callback&apos; instead of &apos;action&apos;, &apos;func&apos; or &apos;function&apos;.
+        ///   Looks up a localized string similar to Use &apos;callback&apos; instead of &apos;action&apos;, &apos;func&apos; or &apos;function&apos; in documentation.
         /// </summary>
         internal static string MiKo_2075_Title {
             get {
@@ -7649,7 +7649,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should document default values of optional parameters.
+        ///   Looks up a localized string similar to Document default values of optional parameters.
         /// </summary>
         internal static string MiKo_2076_Title {
             get {
@@ -7676,7 +7676,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not contain &lt;code&gt;.
+        ///   Looks up a localized string similar to Do not include &lt;code&gt; in &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2077_Title {
             get {
@@ -7703,7 +7703,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;code&gt; documentation should not contain XML tags.
+        ///   Looks up a localized string similar to Do not include XML tags in &lt;code&gt; documentation.
         /// </summary>
         internal static string MiKo_2078_Title {
             get {
@@ -7739,7 +7739,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of properties should not have obvious text.
+        ///   Looks up a localized string similar to Do not include obvious text in property &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2079_Title {
             get {
@@ -7775,7 +7775,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of fields should have a default starting phrase.
+        ///   Looks up a localized string similar to Start field &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2080_Title {
             get {
@@ -7811,7 +7811,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of public-visible read-only fields should have a default ending phrase.
+        ///   Looks up a localized string similar to End public-visible read-only field &lt;summary&gt; documentation with default phrase.
         /// </summary>
         internal static string MiKo_2081_Title {
             get {
@@ -7848,7 +7848,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation of Enum members should not start with default starting phrases of Enum &lt;summary&gt; documentation.
+        ///   Looks up a localized string similar to Use distinct phrases for Enum member &lt;summary&gt; documentation.
         /// </summary>
         internal static string MiKo_2082_Title {
             get {
@@ -7884,7 +7884,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation for equality operator shall have default phrase.
+        ///   Looks up a localized string similar to Use default phrase for equality operator documentation.
         /// </summary>
         internal static string MiKo_2090_Title {
             get {
@@ -7920,7 +7920,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation for inequality operator shall have default phrase.
+        ///   Looks up a localized string similar to Use default phrase for inequality operator documentation.
         /// </summary>
         internal static string MiKo_2091_Title {
             get {
@@ -7956,7 +7956,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;example&gt; documentation should start with descriptive default phrase.
+        ///   Looks up a localized string similar to Start &lt;example&gt; documentation with descriptive default phrase.
         /// </summary>
         internal static string MiKo_2100_Title {
             get {
@@ -7992,7 +7992,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;example&gt; documentation should show code example in &lt;code&gt; tags.
+        ///   Looks up a localized string similar to Show code examples within &lt;code&gt; tags in &lt;example&gt; documentation.
         /// </summary>
         internal static string MiKo_2101_Title {
             get {
@@ -8028,7 +8028,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use a capitalized letter to start the comment.
+        ///   Looks up a localized string similar to Start comments with a capitalized letter.
         /// </summary>
         internal static string MiKo_2200_Title {
             get {
@@ -8055,7 +8055,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use a capitalized letter to start the sentences in the comment.
+        ///   Looks up a localized string similar to Start sentences in comments with a capitalized letter.
         /// </summary>
         internal static string MiKo_2201_Title {
             get {
@@ -8091,7 +8091,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the term &apos;identifier&apos; instead of &apos;id&apos;.
+        ///   Looks up a localized string similar to Use term &apos;identifier&apos; instead of &apos;id&apos; in documentation.
         /// </summary>
         internal static string MiKo_2202_Title {
             get {
@@ -8127,7 +8127,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the term &apos;unique identifier&apos; instead of &apos;guid&apos;.
+        ///   Looks up a localized string similar to Use term &apos;unique identifier&apos; instead of &apos;guid&apos; in documentation.
         /// </summary>
         internal static string MiKo_2203_Title {
             get {
@@ -8173,7 +8173,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &lt;list&gt; for enumerations.
+        ///   Looks up a localized string similar to Use &lt;list&gt; for enumerations in documentation.
         /// </summary>
         internal static string MiKo_2204_Title {
             get {
@@ -8200,7 +8200,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &lt;note&gt; for important information.
+        ///   Looks up a localized string similar to Use &lt;note&gt; for important information in documentation.
         /// </summary>
         internal static string MiKo_2205_Title {
             get {
@@ -8227,7 +8227,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not use the term &apos;flag&apos;.
+        ///   Looks up a localized string similar to Do not use term &apos;flag&apos; in documentation.
         /// </summary>
         internal static string MiKo_2206_Title {
             get {
@@ -8254,7 +8254,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation shall be short.
+        ///   Looks up a localized string similar to Keep &lt;summary&gt; documentation short.
         /// </summary>
         internal static string MiKo_2207_Title {
             get {
@@ -8290,7 +8290,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not use the term &apos;an instance of&apos;.
+        ///   Looks up a localized string similar to Do not use term &apos;an instance of&apos; in documentation.
         /// </summary>
         internal static string MiKo_2208_Title {
             get {
@@ -8362,7 +8362,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the term &apos;information&apos; instead of &apos;info&apos;.
+        ///   Looks up a localized string similar to Use term &apos;information&apos; instead of &apos;info&apos; in documentation.
         /// </summary>
         internal static string MiKo_2210_Title {
             get {
@@ -8400,7 +8400,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enum members should not have &lt;remarks&gt; sections.
+        ///   Looks up a localized string similar to Do not use &lt;remarks&gt; sections for enum members.
         /// </summary>
         internal static string MiKo_2211_Title {
             get {
@@ -8436,7 +8436,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the phrase &apos;failed&apos; instead of &apos;was not successful&apos;.
+        ///   Looks up a localized string similar to Use phrase &apos;failed&apos; instead of &apos;was not successful&apos; in documentation.
         /// </summary>
         internal static string MiKo_2212_Title {
             get {
@@ -8472,7 +8472,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not use the contraction &quot;n&apos;t&quot;.
+        ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot; in documentation.
         /// </summary>
         internal static string MiKo_2213_Title {
             get {
@@ -8509,7 +8509,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not contain empty lines.
+        ///   Looks up a localized string similar to Remove empty lines from documentation.
         /// </summary>
         internal static string MiKo_2214_Title {
             get {
@@ -8536,7 +8536,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sentences in documentation shall be short.
+        ///   Looks up a localized string similar to Keep documentation sentences short.
         /// </summary>
         internal static string MiKo_2215_Title {
             get {
@@ -8677,7 +8677,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;list&gt; documentation is done properly.
+        ///   Looks up a localized string similar to Format &lt;list&gt; documentation properly.
         /// </summary>
         internal static string MiKo_2217_Title {
             get {
@@ -8713,7 +8713,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use shorter terms instead of longer term &apos;used to/in/by&apos;.
+        ///   Looks up a localized string similar to Use shorter terms instead of &apos;used to/in/by&apos; in documentation.
         /// </summary>
         internal static string MiKo_2218_Title {
             get {
@@ -8746,7 +8746,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use question or explamation marks in documentation.
+        ///   Looks up a localized string similar to Do not use question or exclamation marks in documentation.
         /// </summary>
         internal static string MiKo_2219_Title {
             get {
@@ -8782,7 +8782,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;to seek&apos; instead of &apos;to look for&apos;, &apos;to inspect for&apos; or &apos;to test for&apos;.
+        ///   Looks up a localized string similar to Use &apos;to seek&apos; instead of &apos;to look for&apos;, &apos;to inspect for&apos; or &apos;to test for&apos; in documentation.
         /// </summary>
         internal static string MiKo_2220_Title {
             get {
@@ -8809,7 +8809,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not use empty XML tags.
+        ///   Looks up a localized string similar to Do not use empty XML tags in documentation.
         /// </summary>
         internal static string MiKo_2221_Title {
             get {
@@ -8845,7 +8845,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use the term &apos;identification&apos; instead of &apos;ident&apos;.
+        ///   Looks up a localized string similar to Use term &apos;identification&apos; instead of &apos;ident&apos; in documentation.
         /// </summary>
         internal static string MiKo_2222_Title {
             get {
@@ -8872,7 +8872,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation links references via &lt;see cref=&quot;...&quot;/&gt;.
+        ///   Looks up a localized string similar to Link references via &lt;see cref=&quot;...&quot;/&gt; in documentation.
         /// </summary>
         internal static string MiKo_2223_Title {
             get {
@@ -8908,7 +8908,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should have XML tags and texts placed on separate lines.
+        ///   Looks up a localized string similar to Place XML tags and texts on separate lines in documentation.
         /// </summary>
         internal static string MiKo_2224_Title {
             get {
@@ -8953,7 +8953,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code marked with &lt;c&gt; tags should be placed on single line.
+        ///   Looks up a localized string similar to Place code marked with &lt;c&gt; tags on single line.
         /// </summary>
         internal static string MiKo_2225_Title {
             get {
@@ -8981,7 +8981,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should explain the &apos;Why&apos; and not the &apos;That&apos;.
+        ///   Looks up a localized string similar to Explain the &apos;Why&apos; instead of the &apos;That&apos; in documentation.
         /// </summary>
         internal static string MiKo_2226_Title {
             get {
@@ -9009,7 +9009,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not contain ReSharper suppressions.
+        ///   Looks up a localized string similar to Remove ReSharper suppressions from documentation.
         /// </summary>
         internal static string MiKo_2227_Title {
             get {
@@ -9036,7 +9036,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use positive wording instead of negative.
+        ///   Looks up a localized string similar to Use positive wording instead of negative in documentation.
         /// </summary>
         internal static string MiKo_2228_Title {
             get {
@@ -9072,7 +9072,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not contain left-over XML fragments.
+        ///   Looks up a localized string similar to Remove left-over XML fragments from documentation.
         /// </summary>
         internal static string MiKo_2229_Title {
             get {
@@ -9110,7 +9110,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of return value should use &lt;list&gt; when there are values with specific meanings.
+        ///   Looks up a localized string similar to Use &lt;list&gt; for return values with specific meanings in documentation.
         /// </summary>
         internal static string MiKo_2230_Title {
             get {
@@ -9146,7 +9146,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation of overridden &apos;GetHashCode()&apos; methods shall use &apos;&lt;inheritdoc /&gt;&apos; marker.
+        ///   Looks up a localized string similar to Use &apos;&lt;inheritdoc /&gt;&apos; marker for overridden &apos;GetHashCode()&apos; methods documentation.
         /// </summary>
         internal static string MiKo_2231_Title {
             get {
@@ -9182,7 +9182,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation should not be empty.
+        ///   Looks up a localized string similar to Do not leave &lt;summary&gt; documentation empty.
         /// </summary>
         internal static string MiKo_2232_Title {
             get {
@@ -9218,7 +9218,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XML tags should be placed on single line.
+        ///   Looks up a localized string similar to Place XML tags on single line.
         /// </summary>
         internal static string MiKo_2233_Title {
             get {
@@ -9254,7 +9254,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos;.
+        ///   Looks up a localized string similar to Use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos; in documentation.
         /// </summary>
         internal static string MiKo_2234_Title {
             get {
@@ -9290,7 +9290,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;will&apos; instead of &apos;going to&apos;.
+        ///   Looks up a localized string similar to Use &apos;will&apos; instead of &apos;going to&apos; in documentation.
         /// </summary>
         internal static string MiKo_2235_Title {
             get {
@@ -9326,7 +9326,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;for example&apos; instead of abbreviation &apos;e.g.&apos;.
+        ///   Looks up a localized string similar to Use &apos;for example&apos; instead of abbreviation &apos;e.g.&apos; in documentation.
         /// </summary>
         internal static string MiKo_2236_Title {
             get {
@@ -9364,7 +9364,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should not be separated by empty lines.
+        ///   Looks up a localized string similar to Do not separate documentation with empty lines.
         /// </summary>
         internal static string MiKo_2237_Title {
             get {
@@ -9392,7 +9392,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;summary&gt; documentation shall not start with &apos;Make sure to call this&apos;.
+        ///   Looks up a localized string similar to Do not start &lt;summary&gt; documentation with &apos;Make sure to call this&apos;.
         /// </summary>
         internal static string MiKo_2238_Title {
             get {
@@ -9429,7 +9429,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &apos;///&apos; and not &apos;/** */&apos;.
+        ///   Looks up a localized string similar to Use &apos;///&apos; instead of &apos;/** */&apos; for documentation.
         /// </summary>
         internal static string MiKo_2239_Title {
             get {
@@ -9465,7 +9465,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;response&gt; documentation should not start with &apos;Returns&apos;.
+        ///   Looks up a localized string similar to Do not start &lt;response&gt; documentation with &apos;Returns&apos;.
         /// </summary>
         internal static string MiKo_2240_Title {
             get {
@@ -9511,7 +9511,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Documentation should use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt;.
+        ///   Looks up a localized string similar to Use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt; in documentation.
         /// </summary>
         internal static string MiKo_2244_Title {
             get {
@@ -9539,7 +9539,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comments should explain the &apos;Why&apos; and not the &apos;How&apos;.
+        ///   Looks up a localized string similar to Explain the &apos;Why&apos; instead of the &apos;How&apos; in comments.
         /// </summary>
         internal static string MiKo_2300_Title {
             get {
@@ -9603,7 +9603,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not keep code that is commented out.
+        ///   Looks up a localized string similar to Remove commented-out code.
         /// </summary>
         internal static string MiKo_2302_Title {
             get {
@@ -9769,7 +9769,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comments should use the phrase &apos;failed&apos; instead of &apos;was not successful&apos;.
+        ///   Looks up a localized string similar to Use phrase &apos;failed&apos; instead of &apos;was not successful&apos; in comments.
         /// </summary>
         internal static string MiKo_2307_Title {
             get {
@@ -9805,7 +9805,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not place comment on single line before closing brace but after code.
+        ///   Looks up a localized string similar to Place comments after code instead of on single line before closing brace.
         /// </summary>
         internal static string MiKo_2308_Title {
             get {
@@ -9841,7 +9841,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comments should not use the contraction &quot;n&apos;t&quot;.
+        ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot; in comments.
         /// </summary>
         internal static string MiKo_2309_Title {
             get {
@@ -9869,7 +9869,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comments should explain the &apos;Why&apos; and not the &apos;That&apos;.
+        ///   Looks up a localized string similar to Explain the &apos;Why&apos; instead of the &apos;That&apos; in comments.
         /// </summary>
         internal static string MiKo_2310_Title {
             get {
@@ -9942,7 +9942,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comments should use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos;.
+        ///   Looks up a localized string similar to Use &apos;to&apos; instead of &apos;that is to&apos; or &apos;which is to&apos; in comments.
         /// </summary>
         internal static string MiKo_2312_Title {
             get {
@@ -9978,7 +9978,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plain documentation comments should be XML documentation.
+        ///   Looks up a localized string similar to Format plain documentation comments as XML documentation.
         /// </summary>
         internal static string MiKo_2313_Title {
             get {
@@ -10041,7 +10041,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Custom delegates should not be used.
+        ///   Looks up a localized string similar to Do not use custom delegates.
         /// </summary>
         internal static string MiKo_3001_Title {
             get {
@@ -10068,7 +10068,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Classes should not have too many dependencies.
+        ///   Looks up a localized string similar to Limit class dependencies.
         /// </summary>
         internal static string MiKo_3002_Title {
             get {
@@ -10104,7 +10104,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Events should follow .NET Framework Design Guidelines for events.
+        ///   Looks up a localized string similar to Follow .NET Framework Design Guidelines for events.
         /// </summary>
         internal static string MiKo_3003_Title {
             get {
@@ -10133,7 +10133,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property setters of EventArgs shall be private.
+        ///   Looks up a localized string similar to Make EventArgs property setters private.
         /// </summary>
         internal static string MiKo_3004_Title {
             get {
@@ -10161,7 +10161,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods named &apos;Try&apos; should follow the Trier-Doer-Pattern.
+        ///   Looks up a localized string similar to Follow Trier-Doer-Pattern for methods named &apos;Try&apos;.
         /// </summary>
         internal static string MiKo_3005_Title {
             get {
@@ -10188,7 +10188,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;CancellationToken&apos; parameter should be last method parameter.
+        ///   Looks up a localized string similar to Place &apos;CancellationToken&apos; parameter last in method parameters.
         /// </summary>
         internal static string MiKo_3006_Title {
             get {
@@ -10215,7 +10215,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use LINQ method and declarative query syntax in same method.
+        ///   Looks up a localized string similar to Do not mix LINQ method and declarative query syntax in same method.
         /// </summary>
         internal static string MiKo_3007_Title {
             get {
@@ -10242,7 +10242,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method should not return collections that can be changed from outside.
+        ///   Looks up a localized string similar to Return immutable collections.
         /// </summary>
         internal static string MiKo_3008_Title {
             get {
@@ -10269,7 +10269,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Commands should invoke only named methods and no lambda expressions.
+        ///   Looks up a localized string similar to Use named methods instead of lambda expressions with commands.
         /// </summary>
         internal static string MiKo_3009_Title {
             get {
@@ -10350,7 +10350,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thrown ArgumentExceptions (or its subtypes) shall provide the correct parameter name.
+        ///   Looks up a localized string similar to Provide correct parameter name for ArgumentExceptions.
         /// </summary>
         internal static string MiKo_3011_Title {
             get {
@@ -10386,7 +10386,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thrown ArgumentOutOfRangeExceptions (or its subtypes) shall provide the actual value that causes the exception to be thrown.
+        ///   Looks up a localized string similar to Provide actual value when throwing ArgumentOutOfRangeExceptions.
         /// </summary>
         internal static string MiKo_3012_Title {
             get {
@@ -10422,7 +10422,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;default&apos; clause in &apos;switch&apos; statements should throw an ArgumentOutOfRangeException (or subtype), but no ArgumentException.
+        ///   Looks up a localized string similar to Throw ArgumentOutOfRangeException (not ArgumentException) in &apos;switch&apos; default clauses.
         /// </summary>
         internal static string MiKo_3013_Title {
             get {
@@ -10459,7 +10459,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to InvalidOperationException, NotImplementedException and NotSupportedException should have a reason as message.
+        ///   Looks up a localized string similar to Include reason in InvalidOperationException, NotImplementedException and NotSupportedException messages.
         /// </summary>
         internal static string MiKo_3014_Title {
             get {
@@ -10504,7 +10504,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throw InvalidOperationExceptions (instead of ArgumentExceptions or its subtypes) to indicate inappropriate states of parameterless methods.
+        ///   Looks up a localized string similar to Use InvalidOperationExceptions for inappropriate states of parameterless methods.
         /// </summary>
         internal static string MiKo_3015_Title {
             get {
@@ -10554,7 +10554,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not throw ArgumentNullException for inappropriate states of property return values.
+        ///   Looks up a localized string similar to Do not throw ArgumentNullException for property return values.
         /// </summary>
         internal static string MiKo_3016_Title {
             get {
@@ -10590,7 +10590,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not swallow exceptions when throwing new exceptions.
+        ///   Looks up a localized string similar to Include original exception when throwing new exceptions.
         /// </summary>
         internal static string MiKo_3017_Title {
             get {
@@ -10626,7 +10626,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Throw ObjectDisposedExceptions on publicly visible methods of disposable types.
+        ///   Looks up a localized string similar to Throw ObjectDisposedExceptions on public methods of disposable types.
         /// </summary>
         internal static string MiKo_3018_Title {
             get {
@@ -10698,7 +10698,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use &apos;Task.Run&apos; in the implementation.
+        ///   Looks up a localized string similar to Do not use &apos;Task.Run&apos; in implementation.
         /// </summary>
         internal static string MiKo_3021_Title {
             get {
@@ -10782,7 +10782,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use the [ref] keyword on reference parameters.
+        ///   Looks up a localized string similar to Do not use [ref] keyword on reference parameters.
         /// </summary>
         internal static string MiKo_3024_Title {
             get {
@@ -10836,7 +10836,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unused parameters should be removed.
+        ///   Looks up a localized string similar to Remove unused parameters.
         /// </summary>
         internal static string MiKo_3026_Title {
             get {
@@ -10872,7 +10872,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters should not be marked to be reserved for future usage.
+        ///   Looks up a localized string similar to Do not reserve parameters for future use.
         /// </summary>
         internal static string MiKo_3027_Title {
             get {
@@ -10926,7 +10926,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Event registrations should not cause memory leaks.
+        ///   Looks up a localized string similar to Prevent memory leaks in event registrations.
         /// </summary>
         internal static string MiKo_3029_Title {
             get {
@@ -10962,7 +10962,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods should follow the Law of Demeter.
+        ///   Looks up a localized string similar to Follow Law of Demeter in methods.
         /// </summary>
         internal static string MiKo_3030_Title {
             get {
@@ -10989,7 +10989,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ICloneable.Clone() should not be implemented.
+        ///   Looks up a localized string similar to Do not implement ICloneable.Clone().
         /// </summary>
         internal static string MiKo_3031_Title {
             get {
@@ -11025,7 +11025,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;nameof&apos; instead of Cinch for names of properties for created &apos;PropertyChangedEventArgs&apos; instances.
+        ///   Looks up a localized string similar to Use &apos;nameof&apos; instead of Cinch for PropertyChangedEventArgs property names.
         /// </summary>
         internal static string MiKo_3032_Title {
             get {
@@ -11061,7 +11061,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;nameof&apos; for names of properties for created &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos; instances.
+        ///   Looks up a localized string similar to Use &apos;nameof&apos; for property names in PropertyChangingEventArgs and PropertyChangedEventArgs.
         /// </summary>
         internal static string MiKo_3033_Title {
             get {
@@ -11097,7 +11097,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PropertyChanged event raiser shall use [CallerMemberName] attribute.
+        ///   Looks up a localized string similar to Use [CallerMemberName] attribute for PropertyChanged event raisers.
         /// </summary>
         internal static string MiKo_3034_Title {
             get {
@@ -11124,7 +11124,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not invoke &apos;WaitOne&apos; methods without timeouts.
+        ///   Looks up a localized string similar to Always specify timeouts with &apos;WaitOne&apos; methods.
         /// </summary>
         internal static string MiKo_3035_Title {
             get {
@@ -11163,7 +11163,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer to use &apos;TimeSpan&apos; factory methods instead of constructors.
+        ///   Looks up a localized string similar to Use &apos;TimeSpan&apos; factory methods instead of constructors.
         /// </summary>
         internal static string MiKo_3036_Title {
             get {
@@ -11249,7 +11249,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties should not use Linq or yield.
+        ///   Looks up a localized string similar to Do not use Linq or yield in properties.
         /// </summary>
         internal static string MiKo_3039_Title {
             get {
@@ -11285,7 +11285,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use Booleans unless you are absolutely sure that you will never ever need more than 2 values.
+        ///   Looks up a localized string similar to Use enums instead of booleans when more than 2 values might be needed.
         /// </summary>
         internal static string MiKo_3040_Title {
             get {
@@ -11312,7 +11312,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EventArgs shall not use delegates.
+        ///   Looks up a localized string similar to Do not use delegates in EventArgs.
         /// </summary>
         internal static string MiKo_3041_Title {
             get {
@@ -11339,7 +11339,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EventArgs shall not implement interfaces.
+        ///   Looks up a localized string similar to Do not implement interfaces in EventArgs.
         /// </summary>
         internal static string MiKo_3042_Title {
             get {
@@ -11411,7 +11411,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;nameof&apos; to compare property names of &apos;PropertyChangingEventArgs&apos; and &apos;PropertyChangedEventArgs&apos;.
+        ///   Looks up a localized string similar to Use &apos;nameof&apos; to compare property names of PropertyChangingEventArgs and PropertyChangedEventArgs.
         /// </summary>
         internal static string MiKo_3044_Title {
             get {
@@ -11483,7 +11483,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;nameof&apos; for property names of property raising methods.
+        ///   Looks up a localized string similar to Use &apos;nameof&apos; for property names in property raising methods.
         /// </summary>
         internal static string MiKo_3046_Title {
             get {
@@ -11546,7 +11546,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ValueConverters shall have the [ValueConversion] attribute applied.
+        ///   Looks up a localized string similar to Apply [ValueConversion] attribute to ValueConverters.
         /// </summary>
         internal static string MiKo_3048_Title {
             get {
@@ -11573,7 +11573,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enum members shall have the [Description] attribute applied.
+        ///   Looks up a localized string similar to Apply [Description] attribute to enum members.
         /// </summary>
         internal static string MiKo_3049_Title {
             get {
@@ -11618,7 +11618,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DependencyProperty fields should be &apos;public static readonly&apos;.
+        ///   Looks up a localized string similar to Declare DependencyProperty fields as &apos;public static readonly&apos;.
         /// </summary>
         internal static string MiKo_3050_Title {
             get {
@@ -11663,7 +11663,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DependencyProperty fields should be properly registered.
+        ///   Looks up a localized string similar to Register DependencyProperty fields properly.
         /// </summary>
         internal static string MiKo_3051_Title {
             get {
@@ -11708,7 +11708,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DependencyPropertyKey fields should be non-public &apos;static readonly&apos;.
+        ///   Looks up a localized string similar to Declare DependencyPropertyKey fields as non-public &apos;static readonly&apos;.
         /// </summary>
         internal static string MiKo_3052_Title {
             get {
@@ -11744,7 +11744,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DependencyPropertyKey fields should be properly registered.
+        ///   Looks up a localized string similar to Register DependencyPropertyKey fields properly.
         /// </summary>
         internal static string MiKo_3053_Title {
             get {
@@ -11790,7 +11790,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A read-only DependencyProperty should have an exposed DependencyProperty identifier.
+        ///   Looks up a localized string similar to Expose DependencyProperty identifier for read-only DependencyProperties.
         /// </summary>
         internal static string MiKo_3054_Title {
             get {
@@ -11818,7 +11818,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ViewModels should implement INotifyPropertyChanged.
+        ///   Looks up a localized string similar to Implement INotifyPropertyChanged in ViewModels.
         /// </summary>
         internal static string MiKo_3055_Title {
             get {
@@ -11864,7 +11864,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Debug.Assert or Trace.Assert shall not be used.
+        ///   Looks up a localized string similar to Do not use Debug.Assert or Trace.Assert.
         /// </summary>
         internal static string MiKo_3060_Title {
             get {
@@ -11893,7 +11893,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loggers shall use a proper log category.
+        ///   Looks up a localized string similar to Use proper log categories with loggers.
         /// </summary>
         internal static string MiKo_3061_Title {
             get {
@@ -11929,7 +11929,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to End log messages for exceptions with a colon.
+        ///   Looks up a localized string similar to End exception log messages with a colon.
         /// </summary>
         internal static string MiKo_3062_Title {
             get {
@@ -12001,7 +12001,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log messages should not use the contraction &quot;n&apos;t&quot;.
+        ///   Looks up a localized string similar to Do not use contraction &quot;n&apos;t&quot; in log messages.
         /// </summary>
         internal static string MiKo_3064_Title {
             get {
@@ -12041,7 +12041,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Microsoft Logging calls should not use interpolated strings.
+        ///   Looks up a localized string similar to Do not use interpolated strings with Microsoft Logging calls.
         /// </summary>
         internal static string MiKo_3065_Title {
             get {
@@ -12068,7 +12068,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not return null for an IEnumerable.
+        ///   Looks up a localized string similar to Do not return null for IEnumerable.
         /// </summary>
         internal static string MiKo_3070_Title {
             get {
@@ -12095,7 +12095,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not return null for a Task.
+        ///   Looks up a localized string similar to Do not return null for Task.
         /// </summary>
         internal static string MiKo_3071_Title {
             get {
@@ -12122,7 +12122,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Non-private methods should not return &apos;List&lt;&gt;&apos; or &apos;Dictionary&lt;&gt;&apos;.
+        ///   Looks up a localized string similar to Do not return &apos;List&lt;&gt;&apos; or &apos;Dictionary&lt;&gt;&apos; from non-private methods.
         /// </summary>
         internal static string MiKo_3072_Title {
             get {
@@ -12149,7 +12149,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not leave objects partially initialized.
+        ///   Looks up a localized string similar to Fully initialize objects.
         /// </summary>
         internal static string MiKo_3073_Title {
             get {
@@ -12215,7 +12215,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internal and private types should be either static or sealed unless derivation from them is required.
+        ///   Looks up a localized string similar to Mark internal and private types as static or sealed unless derivation is needed.
         /// </summary>
         internal static string MiKo_3075_Title {
             get {
@@ -12244,7 +12244,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not initialize static member with static member below or in other type part.
+        ///   Looks up a localized string similar to Do not initialize static members with static members below or in other type parts.
         /// </summary>
         internal static string MiKo_3076_Title {
             get {
@@ -12281,7 +12281,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Properties that return an Enum should have a default value.
+        ///   Looks up a localized string similar to Provide default values for Enum-returning properties.
         /// </summary>
         internal static string MiKo_3077_Title {
             get {
@@ -12318,7 +12318,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enum members should have a default value.
+        ///   Looks up a localized string similar to Provide default values for enum members.
         /// </summary>
         internal static string MiKo_3078_Title {
             get {
@@ -12354,7 +12354,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to HResults should be written in hexadecimal.
+        ///   Looks up a localized string similar to Write HResults in hexadecimal.
         /// </summary>
         internal static string MiKo_3079_Title {
             get {
@@ -12383,7 +12383,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;switch ... return&apos; instead of &apos;switch ... break&apos; when assigning variables.
+        ///   Looks up a localized string similar to Use &apos;switch ... return&apos; instead of &apos;switch ... break&apos; for variable assignments.
         /// </summary>
         internal static string MiKo_3080_Title {
             get {
@@ -12419,7 +12419,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching over a logical NOT condition.
+        ///   Looks up a localized string similar to Use pattern matching instead of logical NOT conditions.
         /// </summary>
         internal static string MiKo_3081_Title {
             get {
@@ -12455,7 +12455,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching over a logical comparison with &apos;true&apos; or &apos;false&apos;.
+        ///   Looks up a localized string similar to Use pattern matching instead of comparing with &apos;true&apos; or &apos;false&apos;.
         /// </summary>
         internal static string MiKo_3082_Title {
             get {
@@ -12491,7 +12491,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching for null checks.
+        ///   Looks up a localized string similar to Use pattern matching for null checks.
         /// </summary>
         internal static string MiKo_3083_Title {
             get {
@@ -12527,7 +12527,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not place constants on the left side for comparisons.
+        ///   Looks up a localized string similar to Place variables, not constants, on the left side of comparisons.
         /// </summary>
         internal static string MiKo_3084_Title {
             get {
@@ -12563,7 +12563,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Conditional statements should be short.
+        ///   Looks up a localized string similar to Keep conditional statements short.
         /// </summary>
         internal static string MiKo_3085_Title {
             get {
@@ -12653,7 +12653,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching for not-null checks.
+        ///   Looks up a localized string similar to Use pattern matching for not-null checks.
         /// </summary>
         internal static string MiKo_3088_Title {
             get {
@@ -12689,7 +12689,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not use simple constant property patterns as conditions of &apos;if&apos; statements.
+        ///   Looks up a localized string similar to Do not use simple constant property patterns as conditions in &apos;if&apos; statements.
         /// </summary>
         internal static string MiKo_3089_Title {
             get {
@@ -12851,7 +12851,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code blocks should not be empty.
+        ///   Looks up a localized string similar to Do not use empty code blocks.
         /// </summary>
         internal static string MiKo_3095_Title {
             get {
@@ -12933,7 +12933,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Justifications of suppressed messages shall explain.
+        ///   Looks up a localized string similar to Provide meaningful explanations for suppressed messages.
         /// </summary>
         internal static string MiKo_3098_Title {
             get {
@@ -12996,7 +12996,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test classes and types under test belong in same namespace.
+        ///   Looks up a localized string similar to Place test classes in same namespace as types under test.
         /// </summary>
         internal static string MiKo_3100_Title {
             get {
@@ -13023,7 +13023,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test classes should contain tests.
+        ///   Looks up a localized string similar to Include tests in test classes.
         /// </summary>
         internal static string MiKo_3101_Title {
             get {
@@ -13050,7 +13050,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not contain conditional statements (such as &apos;if&apos;, &apos;switch&apos;, etc.).
+        ///   Looks up a localized string similar to Do not use conditional statements in test methods.
         /// </summary>
         internal static string MiKo_3102_Title {
             get {
@@ -13086,7 +13086,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not use &apos;Guid.NewGuid()&apos;.
+        ///   Looks up a localized string similar to Do not use &apos;Guid.NewGuid()&apos; in test methods.
         /// </summary>
         internal static string MiKo_3103_Title {
             get {
@@ -13122,7 +13122,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use NUnit&apos;s [Combinatorial] attribute properly.
+        ///   Looks up a localized string similar to Apply NUnit&apos;s [Combinatorial] attribute properly.
         /// </summary>
         internal static string MiKo_3104_Title {
             get {
@@ -13167,7 +13167,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should use NUnit&apos;s fluent Assert approach.
+        ///   Looks up a localized string similar to Use NUnit&apos;s fluent Assert approach in test methods.
         /// </summary>
         internal static string MiKo_3105_Title {
             get {
@@ -13198,7 +13198,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assertions should not use equality or comparison operators.
+        ///   Looks up a localized string similar to Do not use equality or comparison operators in assertions.
         /// </summary>
         internal static string MiKo_3106_Title {
             get {
@@ -13234,7 +13234,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Moq Mock condition matchers should be used on mocks only.
+        ///   Looks up a localized string similar to Use Moq Mock condition matchers only on mocks.
         /// </summary>
         internal static string MiKo_3107_Title {
             get {
@@ -13261,7 +13261,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should use assertions.
+        ///   Looks up a localized string similar to Include assertions in test methods.
         /// </summary>
         internal static string MiKo_3108_Title {
             get {
@@ -13297,7 +13297,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple assertions shall use assertion messages.
+        ///   Looks up a localized string similar to Include assertion messages with multiple assertions.
         /// </summary>
         internal static string MiKo_3109_Title {
             get {
@@ -13337,7 +13337,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assertions should not use &apos;Count&apos; or &apos;Length&apos;.
+        ///   Looks up a localized string similar to Do not use &apos;Count&apos; or &apos;Length&apos; in assertions.
         /// </summary>
         internal static string MiKo_3110_Title {
             get {
@@ -13373,7 +13373,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assertions should use &apos;Is.Zero&apos; instead of &apos;Is.EqualTo(0)&apos;.
+        ///   Looks up a localized string similar to Use &apos;Is.Zero&apos; instead of &apos;Is.EqualTo(0)&apos; in assertions.
         /// </summary>
         internal static string MiKo_3111_Title {
             get {
@@ -13409,7 +13409,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assertions should use &apos;Is.Empty&apos; instead of &apos;Has.Count.Zero&apos;.
+        ///   Looks up a localized string similar to Use &apos;Is.Empty&apos; instead of &apos;Has.Count.Zero&apos; in assertions.
         /// </summary>
         internal static string MiKo_3112_Title {
             get {
@@ -13510,7 +13510,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should contain code.
+        ///   Looks up a localized string similar to Include code in test methods.
         /// </summary>
         internal static string MiKo_3115_Title {
             get {
@@ -13537,7 +13537,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test initialization methods should contain code.
+        ///   Looks up a localized string similar to Include code in test initialization methods.
         /// </summary>
         internal static string MiKo_3116_Title {
             get {
@@ -13564,7 +13564,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test cleanup methods should contain code.
+        ///   Looks up a localized string similar to Include code in test cleanup methods.
         /// </summary>
         internal static string MiKo_3117_Title {
             get {
@@ -13593,7 +13593,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not use ambiguous Linq calls.
+        ///   Looks up a localized string similar to Do not use ambiguous Linq calls in test methods.
         /// </summary>
         internal static string MiKo_3118_Title {
             get {
@@ -13629,7 +13629,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not simply return completed task.
+        ///   Looks up a localized string similar to Do not return only completed task in test methods.
         /// </summary>
         internal static string MiKo_3119_Title {
             get {
@@ -13666,7 +13666,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Moq mocks should use values instead of &apos;It.Is&lt;&gt;(...)&apos; condition matcher to verify exact values.
+        ///   Looks up a localized string similar to Use direct values instead of &apos;It.Is&lt;&gt;(...)&apos; condition matcher to verify exact values in Moq mocks.
         /// </summary>
         internal static string MiKo_3120_Title {
             get {
@@ -13693,7 +13693,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tests should test concrete implementations and no interfaces.
+        ///   Looks up a localized string similar to Test concrete implementations instead of interfaces.
         /// </summary>
         internal static string MiKo_3121_Title {
             get {
@@ -13720,7 +13720,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not use more than 2 parameters.
+        ///   Looks up a localized string similar to Limit test method parameters to 2 or fewer.
         /// </summary>
         internal static string MiKo_3122_Title {
             get {
@@ -13756,7 +13756,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not catch exceptions.
+        ///   Looks up a localized string similar to Do not catch exceptions in test methods.
         /// </summary>
         internal static string MiKo_3123_Title {
             get {
@@ -13792,7 +13792,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test methods should not assert in finally blocks.
+        ///   Looks up a localized string similar to Do not use assertions in finally blocks in test methods.
         /// </summary>
         internal static string MiKo_3124_Title {
             get {
@@ -13828,7 +13828,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If statements can be inverted in short methods.
+        ///   Looks up a localized string similar to Invert if statements in short methods.
         /// </summary>
         internal static string MiKo_3201_Title {
             get {
@@ -13900,7 +13900,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If-continue statements can be inverted when followed by single line.
+        ///   Looks up a localized string similar to Invert if-continue statements when followed by single line.
         /// </summary>
         internal static string MiKo_3203_Title {
             get {
@@ -13936,7 +13936,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Negative If statements can be inverted when they have an else clause.
+        ///   Looks up a localized string similar to Invert negative if statements when they have an else clause.
         /// </summary>
         internal static string MiKo_3204_Title {
             get {
@@ -13965,7 +13965,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only the longest overloads should be virtual or abstract.
+        ///   Looks up a localized string similar to Make only the longest overloads virtual or abstract.
         /// </summary>
         internal static string MiKo_3210_Title {
             get {
@@ -13994,7 +13994,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Public types should not have finalizers.
+        ///   Looks up a localized string similar to Do not use finalizers in public types.
         /// </summary>
         internal static string MiKo_3211_Title {
             get {
@@ -14021,7 +14021,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not confuse developers by providing other Dispose methods.
+        ///   Looks up a localized string similar to Follow standard Dispose pattern without adding other Dispose methods.
         /// </summary>
         internal static string MiKo_3212_Title {
             get {
@@ -14048,7 +14048,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameterless Dispose method follows Basic Dispose pattern.
+        ///   Looks up a localized string similar to Implement parameterless Dispose method using Basic Dispose pattern.
         /// </summary>
         internal static string MiKo_3213_Title {
             get {
@@ -14077,7 +14077,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interfaces do not contain &apos;Begin/End&apos; or &apos;Enter/Exit&apos; scope-defining methods.
+        ///   Looks up a localized string similar to Remove &apos;Begin/End&apos; or &apos;Enter/Exit&apos; scope-defining methods from interfaces.
         /// </summary>
         internal static string MiKo_3214_Title {
             get {
@@ -14122,7 +14122,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Callbacks should be &apos;Func&lt;T, bool&gt;&apos; instead of &apos;Predicate&lt;bool&gt;&apos;.
+        ///   Looks up a localized string similar to Use &apos;Func&lt;T, bool&gt;&apos; instead of &apos;Predicate&lt;bool&gt;&apos; for callbacks.
         /// </summary>
         internal static string MiKo_3215_Title {
             get {
@@ -14158,7 +14158,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Static fields with initializers should be read-only.
+        ///   Looks up a localized string similar to Mark static fields with initializers as read-only.
         /// </summary>
         internal static string MiKo_3216_Title {
             get {
@@ -14214,7 +14214,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not define extension methods in unexpected places.
+        ///   Looks up a localized string similar to Define extension methods in expected places.
         /// </summary>
         internal static string MiKo_3218_Title {
             get {
@@ -14241,7 +14241,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Public members should not be &apos;virtual&apos;.
+        ///   Looks up a localized string similar to Do not mark public members as &apos;virtual&apos;.
         /// </summary>
         internal static string MiKo_3219_Title {
             get {
@@ -14277,7 +14277,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Logical &apos;&amp;&amp;&apos; or &apos;||&apos; conditions using &apos;true&apos; or &apos;false&apos; should be simplified.
+        ///   Looks up a localized string similar to Simplify logical &apos;&amp;&amp;&apos; or &apos;||&apos; conditions using &apos;true&apos; or &apos;false&apos;.
         /// </summary>
         internal static string MiKo_3220_Title {
             get {
@@ -14313,7 +14313,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GetHashCode overrides should use &apos;HashCode.Combine&apos;.
+        ///   Looks up a localized string similar to Use &apos;HashCode.Combine&apos; in GetHashCode overrides.
         /// </summary>
         internal static string MiKo_3221_Title {
             get {
@@ -14349,7 +14349,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to String comparisons can be simplified.
+        ///   Looks up a localized string similar to Simplify string comparisons.
         /// </summary>
         internal static string MiKo_3222_Title {
             get {
@@ -14385,7 +14385,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reference comparisons can be simplified.
+        ///   Looks up a localized string similar to Simplify reference comparisons.
         /// </summary>
         internal static string MiKo_3223_Title {
             get {
@@ -14421,7 +14421,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value comparisons can be simplified.
+        ///   Looks up a localized string similar to Simplify value comparisons.
         /// </summary>
         internal static string MiKo_3224_Title {
             get {
@@ -14457,7 +14457,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Redundant comparisons can be simplified.
+        ///   Looks up a localized string similar to Simplify redundant comparisons.
         /// </summary>
         internal static string MiKo_3225_Title {
             get {
@@ -14493,7 +14493,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Read-only fields with initializers should be const.
+        ///   Looks up a localized string similar to Make read-only fields with initializers const.
         /// </summary>
         internal static string MiKo_3226_Title {
             get {
@@ -14529,7 +14529,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching for equality checks.
+        ///   Looks up a localized string similar to Use pattern matching for equality checks.
         /// </summary>
         internal static string MiKo_3227_Title {
             get {
@@ -14565,7 +14565,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching for inequality checks.
+        ///   Looks up a localized string similar to Use pattern matching for inequality checks.
         /// </summary>
         internal static string MiKo_3228_Title {
             get {
@@ -14601,7 +14601,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;KeyValuePair.Create&apos; should be used instead of constructors.
+        ///   Looks up a localized string similar to Use &apos;KeyValuePair.Create&apos; instead of constructors.
         /// </summary>
         internal static string MiKo_3229_Title {
             get {
@@ -14665,7 +14665,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefer pattern matching for equality checks for ordinal string comparisons.
+        ///   Looks up a localized string similar to Use pattern matching for ordinal string comparison equality checks.
         /// </summary>
         internal static string MiKo_3231_Title {
             get {
@@ -14701,7 +14701,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements.
+        ///   Looks up a localized string similar to Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements.
         /// </summary>
         internal static string MiKo_3301_Title {
             get {
@@ -14737,7 +14737,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters.
+        ///   Looks up a localized string similar to Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters.
         /// </summary>
         internal static string MiKo_3302_Title {
             get {
@@ -14764,7 +14764,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Namespace hierarchies should not be too deep.
+        ///   Looks up a localized string similar to Keep namespace hierarchies from becoming too deep.
         /// </summary>
         internal static string MiKo_3401_Title {
             get {
@@ -14872,7 +14872,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not assign variables in try-catch blocks and return them directly outside the block.
+        ///   Looks up a localized string similar to Do not assign variables in try-catch blocks that are returned directly outside.
         /// </summary>
         internal static string MiKo_3503_Title {
             get {
@@ -14910,7 +14910,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods with same name should be ordered based on the number of their parameters.
+        ///   Looks up a localized string similar to Order methods with same name based on their parameter count.
         /// </summary>
         internal static string MiKo_4001_Title {
             get {
@@ -14948,7 +14948,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Methods with same name and accessibility should be placed side-by-side.
+        ///   Looks up a localized string similar to Place methods with same name and accessibility side-by-side.
         /// </summary>
         internal static string MiKo_4002_Title {
             get {
@@ -14985,7 +14985,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dispose methods should be placed directly after constructors and finalizers.
+        ///   Looks up a localized string similar to Place Dispose methods directly after constructors and finalizers.
         /// </summary>
         internal static string MiKo_4003_Title {
             get {
@@ -15022,7 +15022,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dispose methods should be placed before all other methods of the same accessibility.
+        ///   Looks up a localized string similar to Place Dispose methods before all other methods of the same accessibility.
         /// </summary>
         internal static string MiKo_4004_Title {
             get {
@@ -15058,7 +15058,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The interface that gives a type its name should be placed directly after the type&apos;s declaration.
+        ///   Looks up a localized string similar to Place the interface that gives a type its name directly after the type&apos;s declaration.
         /// </summary>
         internal static string MiKo_4005_Title {
             get {
@@ -15094,7 +15094,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Operators should be placed before methods.
+        ///   Looks up a localized string similar to Place operators before methods.
         /// </summary>
         internal static string MiKo_4007_Title {
             get {
@@ -15130,7 +15130,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GetHashCode methods should be placed directly after Equals methods.
+        ///   Looks up a localized string similar to Place GetHashCode methods directly after Equals methods.
         /// </summary>
         internal static string MiKo_4008_Title {
             get {
@@ -15166,7 +15166,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test initialization methods should be ordered directly after One-Time methods.
+        ///   Looks up a localized string similar to Place test initialization methods directly after One-Time methods.
         /// </summary>
         internal static string MiKo_4101_Title {
             get {
@@ -15202,7 +15202,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test cleanup methods should be ordered after test initialization methods and before test methods.
+        ///   Looks up a localized string similar to Place test cleanup methods after test initialization methods and before test methods.
         /// </summary>
         internal static string MiKo_4102_Title {
             get {
@@ -15238,7 +15238,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One-Time test initialization methods should be ordered before all other methods.
+        ///   Looks up a localized string similar to Place One-Time test initialization methods before all other methods.
         /// </summary>
         internal static string MiKo_4103_Title {
             get {
@@ -15274,7 +15274,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One-Time test cleanup methods should be ordered directly after One-Time test initialization methods.
+        ///   Looks up a localized string similar to Place One-Time test cleanup methods directly after One-Time test initialization methods.
         /// </summary>
         internal static string MiKo_4104_Title {
             get {
@@ -15310,7 +15310,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object under test fields should be ordered before all other fields.
+        ///   Looks up a localized string similar to Place object under test fields before all other fields.
         /// </summary>
         internal static string MiKo_4105_Title {
             get {
@@ -15346,7 +15346,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;Debug&apos; and &apos;DebugFormat&apos; methods should be invoked only after &apos;IsDebugEnabled&apos;.
+        ///   Looks up a localized string similar to Invoke &apos;Debug&apos; and &apos;DebugFormat&apos; methods only after checking &apos;IsDebugEnabled&apos;.
         /// </summary>
         internal static string MiKo_5001_Title {
             get {
@@ -15382,7 +15382,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;xxxFormat&apos; methods should be invoked with multiple arguments only.
+        ///   Looks up a localized string similar to Use &apos;xxxFormat&apos; methods only with multiple arguments.
         /// </summary>
         internal static string MiKo_5002_Title {
             get {
@@ -15409,7 +15409,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Correct Log methods should be invoked for exceptions.
+        ///   Looks up a localized string similar to Use appropriate Log methods for exceptions.
         /// </summary>
         internal static string MiKo_5003_Title {
             get {
@@ -15580,7 +15580,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not create empty lists if the return value is read-only.
+        ///   Looks up a localized string similar to Do not create empty lists when return value is read-only.
         /// </summary>
         internal static string MiKo_5014_Title {
             get {
@@ -15643,7 +15643,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use a HashSet for lookups in &apos;List.RemoveAll&apos;.
+        ///   Looks up a localized string similar to Use HashSet for lookups in &apos;List.RemoveAll&apos;.
         /// </summary>
         internal static string MiKo_5016_Title {
             get {
@@ -15679,7 +15679,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields or variables assigned with string literals should be constant.
+        ///   Looks up a localized string similar to Make fields or variables assigned with string literals constant.
         /// </summary>
         internal static string MiKo_5017_Title {
             get {
@@ -15715,7 +15715,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Read-only struct parameters should have the [in] modifier.
+        ///   Looks up a localized string similar to Add [in] modifier to read-only struct parameters.
         /// </summary>
         internal static string MiKo_5019_Title {
             get {
@@ -15751,7 +15751,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround log statements with blank lines.
         /// </summary>
         internal static string MiKo_6001_Title {
             get {
@@ -15787,7 +15787,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assertion statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround assertion statements with blank lines.
         /// </summary>
         internal static string MiKo_6002_Title {
             get {
@@ -15823,7 +15823,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local variable statements should be preceded by blank lines.
+        ///   Looks up a localized string similar to Precede local variable statements with blank lines.
         /// </summary>
         internal static string MiKo_6003_Title {
             get {
@@ -15859,7 +15859,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable assignment statements should be preceded by blank lines.
+        ///   Looks up a localized string similar to Precede variable assignment statements with blank lines.
         /// </summary>
         internal static string MiKo_6004_Title {
             get {
@@ -15895,7 +15895,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return statements should be preceded by blank lines.
+        ///   Looks up a localized string similar to Precede return statements with blank lines.
         /// </summary>
         internal static string MiKo_6005_Title {
             get {
@@ -15931,7 +15931,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Awaited statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround awaited statements with blank lines.
         /// </summary>
         internal static string MiKo_6006_Title {
             get {
@@ -15967,7 +15967,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround test statements with blank lines.
         /// </summary>
         internal static string MiKo_6007_Title {
             get {
@@ -16003,7 +16003,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using directives should be preceded by blank lines.
+        ///   Looks up a localized string similar to Precede using directives with blank lines.
         /// </summary>
         internal static string MiKo_6008_Title {
             get {
@@ -16039,7 +16039,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Try statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround try statements with blank lines.
         /// </summary>
         internal static string MiKo_6009_Title {
             get {
@@ -16075,7 +16075,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround if statements with blank lines.
         /// </summary>
         internal static string MiKo_6010_Title {
             get {
@@ -16111,7 +16111,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lock statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround lock statements with blank lines.
         /// </summary>
         internal static string MiKo_6011_Title {
             get {
@@ -16147,7 +16147,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to foreach loops should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround foreach loops with blank lines.
         /// </summary>
         internal static string MiKo_6012_Title {
             get {
@@ -16183,7 +16183,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to for loops should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround for loops with blank lines.
         /// </summary>
         internal static string MiKo_6013_Title {
             get {
@@ -16219,7 +16219,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to while loops should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround while loops with blank lines.
         /// </summary>
         internal static string MiKo_6014_Title {
             get {
@@ -16255,7 +16255,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to do/while loops should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround do/while loops with blank lines.
         /// </summary>
         internal static string MiKo_6015_Title {
             get {
@@ -16291,7 +16291,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to using statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround using statements with blank lines.
         /// </summary>
         internal static string MiKo_6016_Title {
             get {
@@ -16327,7 +16327,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to switch statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround switch statements with blank lines.
         /// </summary>
         internal static string MiKo_6017_Title {
             get {
@@ -16363,7 +16363,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to break statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround break statements with blank lines.
         /// </summary>
         internal static string MiKo_6018_Title {
             get {
@@ -16399,7 +16399,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to continue statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround continue statements with blank lines.
         /// </summary>
         internal static string MiKo_6019_Title {
             get {
@@ -16435,7 +16435,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to throw statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround throw statements with blank lines.
         /// </summary>
         internal static string MiKo_6020_Title {
             get {
@@ -16471,7 +16471,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ArgumentNullException.ThrowIfNull statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround ArgumentNullException.ThrowIfNull statements with blank lines.
         /// </summary>
         internal static string MiKo_6021_Title {
             get {
@@ -16507,7 +16507,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ArgumentException.ThrowIfNullOrEmpty statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround ArgumentException.ThrowIfNullOrEmpty statements with blank lines.
         /// </summary>
         internal static string MiKo_6022_Title {
             get {
@@ -16543,7 +16543,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ArgumentOutOfRangeException.ThrowIf statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround ArgumentOutOfRangeException.ThrowIf statements with blank lines.
         /// </summary>
         internal static string MiKo_6023_Title {
             get {
@@ -16579,7 +16579,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ObjectDisposedException.ThrowIf statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround ObjectDisposedException.ThrowIf statements with blank lines.
         /// </summary>
         internal static string MiKo_6024_Title {
             get {
@@ -16615,7 +16615,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open braces of initializers should be placed directly below the corresponding type definition.
+        ///   Looks up a localized string similar to Place open braces of initializers directly below the corresponding type definition.
         /// </summary>
         internal static string MiKo_6030_Title {
             get {
@@ -16651,7 +16651,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Question and colon tokens of ternary operators should be placed directly below the corresponding condition.
+        ///   Looks up a localized string similar to Place question and colon tokens of ternary operators directly below the corresponding condition.
         /// </summary>
         internal static string MiKo_6031_Title {
             get {
@@ -16687,7 +16687,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multi-line parameters are positioned outdented at end of method.
+        ///   Looks up a localized string similar to Position multi-line parameters outdented at end of method.
         /// </summary>
         internal static string MiKo_6032_Title {
             get {
@@ -16723,7 +16723,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Braces of blocks below case sections should be placed directly below the corresponding case keyword.
+        ///   Looks up a localized string similar to Place braces of blocks below case sections directly below the corresponding case keyword.
         /// </summary>
         internal static string MiKo_6033_Title {
             get {
@@ -16759,7 +16759,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dots should be placed on same line(s) as invoked members.
+        ///   Looks up a localized string similar to Place dots on same line(s) as invoked members.
         /// </summary>
         internal static string MiKo_6034_Title {
             get {
@@ -16795,7 +16795,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open parenthesis should be placed on same line(s) as invoked methods.
+        ///   Looks up a localized string similar to Place open parenthesis on same line(s) as invoked methods.
         /// </summary>
         internal static string MiKo_6035_Title {
             get {
@@ -16831,7 +16831,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lambda blocks should be placed directly below the corresponding arrow(s).
+        ///   Looks up a localized string similar to Place lambda blocks directly below the corresponding arrow(s).
         /// </summary>
         internal static string MiKo_6036_Title {
             get {
@@ -16867,7 +16867,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Single arguments should be placed on same line(s) as invoked methods.
+        ///   Looks up a localized string similar to Place single arguments on same line(s) as invoked methods.
         /// </summary>
         internal static string MiKo_6037_Title {
             get {
@@ -16903,7 +16903,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Casts should be placed on same line(s).
+        ///   Looks up a localized string similar to Place casts on same line(s).
         /// </summary>
         internal static string MiKo_6038_Title {
             get {
@@ -16939,7 +16939,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return values should be placed on same line(s) as return keywords.
+        ///   Looks up a localized string similar to Place return values on same line(s) as return keywords.
         /// </summary>
         internal static string MiKo_6039_Title {
             get {
@@ -16975,7 +16975,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consecutive invocations spanning multiple lines should be aligned by their dots.
+        ///   Looks up a localized string similar to Align consecutive multi-line invocations by their dots.
         /// </summary>
         internal static string MiKo_6040_Title {
             get {
@@ -17011,7 +17011,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assignments should be placed on same line(s).
+        ///   Looks up a localized string similar to Place assignments on same line(s).
         /// </summary>
         internal static string MiKo_6041_Title {
             get {
@@ -17047,7 +17047,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;new&apos; keywords should be placed on same line(s) as the types.
+        ///   Looks up a localized string similar to Place &apos;new&apos; keywords on same line(s) as the types.
         /// </summary>
         internal static string MiKo_6042_Title {
             get {
@@ -17083,7 +17083,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expression bodies of lambdas should be placed on same line as lambda itself when fitting.
+        ///   Looks up a localized string similar to Place expression bodies of lambdas on same line as lambda when fitting.
         /// </summary>
         internal static string MiKo_6043_Title {
             get {
@@ -17119,7 +17119,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Operators such as &apos;&amp;&amp;&apos; or &apos;||&apos; should be placed on same line(s) as their (right) operands.
+        ///   Looks up a localized string similar to Place operators such as &apos;&amp;&amp;&apos; or &apos;||&apos; on same line(s) as their (right) operands.
         /// </summary>
         internal static string MiKo_6044_Title {
             get {
@@ -17155,7 +17155,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comparisons using operators such as &apos;==&apos; or &apos;!=&apos; should be placed on same line(s).
+        ///   Looks up a localized string similar to Place comparisons using operators such as &apos;==&apos; or &apos;!=&apos; on same line(s).
         /// </summary>
         internal static string MiKo_6045_Title {
             get {
@@ -17191,7 +17191,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Calculations using operators such as &apos;+&apos; or &apos;%&apos; should be placed on same line(s).
+        ///   Looks up a localized string similar to Place calculations using operators such as &apos;+&apos; or &apos;%&apos; on same line(s).
         /// </summary>
         internal static string MiKo_6046_Title {
             get {
@@ -17227,7 +17227,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Braces of switch expressions should be placed directly below the corresponding switch keyword.
+        ///   Looks up a localized string similar to Place braces of switch expressions directly below the corresponding switch keyword.
         /// </summary>
         internal static string MiKo_6047_Title {
             get {
@@ -17263,7 +17263,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Logical conditions should be placed on a single line.
+        ///   Looks up a localized string similar to Place logical conditions on a single line.
         /// </summary>
         internal static string MiKo_6048_Title {
             get {
@@ -17299,7 +17299,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Event (un-)registrations should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround event (un-)registrations with blank lines.
         /// </summary>
         internal static string MiKo_6049_Title {
             get {
@@ -17335,7 +17335,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multi-line arguments are positioned outdented at end of method call.
+        ///   Looks up a localized string similar to Position multi-line arguments outdented at end of method call.
         /// </summary>
         internal static string MiKo_6050_Title {
             get {
@@ -17371,7 +17371,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Colon of constructor call shall be placed on same line as constructor call.
+        ///   Looks up a localized string similar to Place colon of constructor call on same line as constructor call.
         /// </summary>
         internal static string MiKo_6051_Title {
             get {
@@ -17407,7 +17407,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Colon of list of base types shall be placed on same line as first base type.
+        ///   Looks up a localized string similar to Place colon of list of base types on same line as first base type.
         /// </summary>
         internal static string MiKo_6052_Title {
             get {
@@ -17443,7 +17443,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Single-line arguments shall be placed on single line.
+        ///   Looks up a localized string similar to Place single-line arguments on single line.
         /// </summary>
         internal static string MiKo_6053_Title {
             get {
@@ -17479,7 +17479,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lambda arrows shall be placed on same line as the parameter(s) of the lambda.
+        ///   Looks up a localized string similar to Place lambda arrows on same line as the parameter(s) of the lambda.
         /// </summary>
         internal static string MiKo_6054_Title {
             get {
@@ -17515,7 +17515,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Assignment statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround assignment statements with blank lines.
         /// </summary>
         internal static string MiKo_6055_Title {
             get {
@@ -17551,7 +17551,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned.
+        ///   Looks up a localized string similar to Place brackets of collection expressions at the same position as collection initializer braces.
         /// </summary>
         internal static string MiKo_6056_Title {
             get {
@@ -17587,7 +17587,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type parameter constraint clauses should be aligned vertically.
+        ///   Looks up a localized string similar to Align type parameter constraint clauses vertically.
         /// </summary>
         internal static string MiKo_6057_Title {
             get {
@@ -17623,7 +17623,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type parameter constraint clauses should be indented below parameter list.
+        ///   Looks up a localized string similar to Indent type parameter constraint clauses below parameter list.
         /// </summary>
         internal static string MiKo_6058_Title {
             get {
@@ -17659,7 +17659,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multi-line conditions are positioned outdented below associated calls.
+        ///   Looks up a localized string similar to Position multi-line conditions outdented below associated calls.
         /// </summary>
         internal static string MiKo_6059_Title {
             get {
@@ -17695,7 +17695,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Switch case labels should be placed on same line.
+        ///   Looks up a localized string similar to Place switch case labels on same line.
         /// </summary>
         internal static string MiKo_6060_Title {
             get {
@@ -17731,7 +17731,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Switch expression arms should be placed on same line.
+        ///   Looks up a localized string similar to Place switch expression arms on same line.
         /// </summary>
         internal static string MiKo_6061_Title {
             get {
@@ -17767,7 +17767,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expressions within complex initializer expressions should be placed beside open brace.
+        ///   Looks up a localized string similar to Place expressions within complex initializer expressions beside open brace.
         /// </summary>
         internal static string MiKo_6062_Title {
             get {
@@ -17803,7 +17803,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invocations should be placed on same line.
+        ///   Looks up a localized string similar to Place invocations on same line.
         /// </summary>
         internal static string MiKo_6063_Title {
             get {
@@ -17839,7 +17839,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Identifier invocations should be placed on same line.
+        ///   Looks up a localized string similar to Place identifier invocations on same line.
         /// </summary>
         internal static string MiKo_6064_Title {
             get {
@@ -17875,7 +17875,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consecutive invocations spanning multiple lines should be indented and not outdented.
+        ///   Looks up a localized string similar to Indent rather than outdent consecutive invocations spanning multiple lines.
         /// </summary>
         internal static string MiKo_6065_Title {
             get {
@@ -17911,7 +17911,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Collection expression elements should be indented and not outdented.
+        ///   Looks up a localized string similar to Indent rather than outdent collection expression elements.
         /// </summary>
         internal static string MiKo_6066_Title {
             get {
@@ -17948,7 +17948,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ternary operators should be placed on same lines as their respective expressions.
+        ///   Looks up a localized string similar to Place ternary operators on same lines as their respective expressions.
         /// </summary>
         internal static string MiKo_6067_Title {
             get {
@@ -17984,7 +17984,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Console statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround Console statements with blank lines.
         /// </summary>
         internal static string MiKo_6070_Title {
             get {
@@ -18020,7 +18020,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local using statements should be surrounded by blank lines.
+        ///   Looks up a localized string similar to Surround local using statements with blank lines.
         /// </summary>
         internal static string MiKo_6071_Title {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -124,7 +124,7 @@
     <value>Too many LoC: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0001_Title" xml:space="preserve">
-    <value>Method is too big</value>
+    <value>Keep methods small</value>
   </data>
   <data name="MiKo_0002_Description" xml:space="preserve">
     <value>To make maintenance easier, methods should be kept simple. This follows the Keep It Simple, Stupid (KISS) principle.
@@ -135,7 +135,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too high CC: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0002_Title" xml:space="preserve">
-    <value>Method is too complex</value>
+    <value>Simplify complex methods</value>
   </data>
   <data name="MiKo_0003_Description" xml:space="preserve">
     <value>To make code easier to read and maintain, types should be kept small. This follows the Single Responsibility Principle (SRP).</value>
@@ -144,7 +144,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too many LoC: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0003_Title" xml:space="preserve">
-    <value>Type is too big</value>
+    <value>Keep types small</value>
   </data>
   <data name="MiKo_0004_Description" xml:space="preserve">
     <value>To follow the Single Responsibility Principle (SRP), methods should use as few parameters as possible.</value>
@@ -153,7 +153,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too many parameters: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0004_Title" xml:space="preserve">
-    <value>Method has too many parameters</value>
+    <value>Limit method parameters</value>
   </data>
   <data name="MiKo_0005_Description" xml:space="preserve">
     <value>To make code easier to read and maintain, local functions should be kept short. This follows the Single Responsibility Principle (SRP) and the Single Level of Abstraction (SLoA) principle.</value>
@@ -162,7 +162,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too many LoC: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0005_Title" xml:space="preserve">
-    <value>Local function is too big</value>
+    <value>Keep local functions small</value>
   </data>
   <data name="MiKo_0006_Description" xml:space="preserve">
     <value>To make maintenance easier, local functions should be kept simple. This follows the Keep It Simple, Stupid (KISS) principle.
@@ -173,7 +173,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too high CC: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0006_Title" xml:space="preserve">
-    <value>Local function is too complex</value>
+    <value>Simplify complex local functions</value>
   </data>
   <data name="MiKo_0007_Description" xml:space="preserve">
     <value>To follow the Single Responsibility Principle (SRP), local functions should use as few parameters as possible.</value>
@@ -182,7 +182,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Too many parameters: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_0007_Title" xml:space="preserve">
-    <value>Local function has too many parameters</value>
+    <value>Limit local function parameters</value>
   </data>
   <data name="MiKo_1000_CodeFixTitle" xml:space="preserve">
     <value>Append suffix 'EventArgs'</value>
@@ -194,7 +194,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}' instead</value>
   </data>
   <data name="MiKo_1000_Title" xml:space="preserve">
-    <value>'System.EventArgs' types should be suffixed with 'EventArgs'</value>
+    <value>Suffix 'System.EventArgs' types with 'EventArgs'</value>
   </data>
   <data name="MiKo_1001_CodeFixTitle" xml:space="preserve">
     <value>Rename event argument</value>
@@ -209,7 +209,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1001_Title" xml:space="preserve">
-    <value>'System.EventArgs' parameters should be named 'e'</value>
+    <value>Name 'System.EventArgs' parameters 'e'</value>
   </data>
   <data name="MiKo_1002_CodeFixTitle" xml:space="preserve">
     <value>Rename event argument</value>
@@ -224,7 +224,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1002_Title" xml:space="preserve">
-    <value>Parameters should be named according the .NET Framework Design Guidelines for event handlers</value>
+    <value>Follow .NET Framework Design Guidelines for event handler parameter names</value>
   </data>
   <data name="MiKo_1003_CodeFixTitle" xml:space="preserve">
     <value>Rename method according to event pattern</value>
@@ -239,7 +239,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1003_Title" xml:space="preserve">
-    <value>Event handling method names should follow the .NET Framework Design Guidelines</value>
+    <value>Follow .NET Framework Design Guidelines for event handling method names</value>
   </data>
   <data name="MiKo_1004_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Event' suffix</value>
@@ -251,7 +251,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1004_Title" xml:space="preserve">
-    <value>Events should not contain term 'Event' in their names</value>
+    <value>Remove term 'Event' from event names</value>
   </data>
   <data name="MiKo_1005_CodeFixTitle" xml:space="preserve">
     <value>Rename EventArgs variable</value>
@@ -263,7 +263,7 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1005_Title" xml:space="preserve">
-    <value>'System.EventArgs' variables should be named properly</value>
+    <value>Name 'System.EventArgs' variables properly</value>
   </data>
   <data name="MiKo_1006_Description" xml:space="preserve">
     <value>Events should use 'EventHandler&lt;T&gt;', where 'T' is a class that inherits from 'System.EventArgs' and is named after the event.
@@ -273,7 +273,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Use 'EventHandler&lt;{1}&gt;' instead</value>
   </data>
   <data name="MiKo_1006_Title" xml:space="preserve">
-    <value>Events should use 'EventHandler&lt;T&gt;' with 'EventArgs' which are named after the event</value>
+    <value>Use 'EventHandler&lt;T&gt;' with 'EventArgs' named after the event</value>
   </data>
   <data name="MiKo_1007_Description" xml:space="preserve">
     <value>Events and their event arguments are logically related, so they should be placed in the same namespace for better organization.</value>
@@ -282,7 +282,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Used '{1}' should be in namespace '{2}'</value>
   </data>
   <data name="MiKo_1007_Title" xml:space="preserve">
-    <value>Events and their corresponding 'EventArgs' types should be located in the same namespace</value>
+    <value>Place events and their 'EventArgs' types in the same namespace</value>
   </data>
   <data name="MiKo_1008_CodeFixTitle" xml:space="preserve">
     <value>Rename DependencyProperty event handler argument</value>
@@ -294,7 +294,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1008_Title" xml:space="preserve">
-    <value>Parameters should be named according the .NET Framework Design Guidelines for DependencyProperty event handlers</value>
+    <value>Follow .NET Framework Design Guidelines for DependencyProperty event handler parameter names</value>
   </data>
   <data name="MiKo_1009_CodeFixTitle" xml:space="preserve">
     <value>Name event handler variable 'handler'</value>
@@ -306,7 +306,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it 'handler'</value>
   </data>
   <data name="MiKo_1009_Title" xml:space="preserve">
-    <value>'System.EventHandler' variables should be named properly</value>
+    <value>Name 'System.EventHandler' variables properly</value>
   </data>
   <data name="MiKo_1010_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Execute' from name</value>
@@ -318,7 +318,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1010_Title" xml:space="preserve">
-    <value>Methods should not contain 'CanExecute' or 'Execute' in their names</value>
+    <value>Do not include 'CanExecute' or 'Execute' in method names</value>
   </data>
   <data name="MiKo_1011_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Do' from name</value>
@@ -330,7 +330,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1011_Title" xml:space="preserve">
-    <value>Methods should not contain 'Do' in their names</value>
+    <value>Do not include 'Do' in method names</value>
   </data>
   <data name="MiKo_1012_CodeFixTitle" xml:space="preserve">
     <value>Rename 'fire' to 'raise'</value>
@@ -342,7 +342,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1012_Title" xml:space="preserve">
-    <value>Methods should be named 'Raise' instead of 'Fire'</value>
+    <value>Use 'Raise' instead of 'Fire' in method names</value>
   </data>
   <data name="MiKo_1013_CodeFixTitle" xml:space="preserve">
     <value>Rename 'Notify' to 'On'</value>
@@ -354,7 +354,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Do not use term 'Notify'</value>
   </data>
   <data name="MiKo_1013_Title" xml:space="preserve">
-    <value>Methods should not be named 'Notify' or 'OnNotify'</value>
+    <value>Do not name methods 'Notify' or 'OnNotify'</value>
   </data>
   <data name="MiKo_1014_CodeFixTitle" xml:space="preserve">
     <value>Rename 'Check'</value>
@@ -366,7 +366,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Do not use ambiguous term 'Check'</value>
   </data>
   <data name="MiKo_1014_Title" xml:space="preserve">
-    <value>Methods should not be named with ambiguous 'Check'</value>
+    <value>Do not use ambiguous 'Check' in method names</value>
   </data>
   <data name="MiKo_1015_CodeFixTitle" xml:space="preserve">
     <value>Rename 'Init' to 'Initialize'</value>
@@ -378,7 +378,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1015_Title" xml:space="preserve">
-    <value>Methods should be named 'Initialize' instead of 'Init'</value>
+    <value>Use 'Initialize' instead of 'Init' in method names</value>
   </data>
   <data name="MiKo_1016_CodeFixTitle" xml:space="preserve">
     <value>Rename factory method</value>
@@ -390,7 +390,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Start name with 'Create'</value>
   </data>
   <data name="MiKo_1016_Title" xml:space="preserve">
-    <value>Factory methods should be named 'Create'</value>
+    <value>Name factory methods 'Create'</value>
   </data>
   <data name="MiKo_1017_CodeFixTitle" xml:space="preserve">
     <value>Remove prefix from method</value>
@@ -402,7 +402,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1017_Title" xml:space="preserve">
-    <value>Methods should not be prefixed with 'Get' or 'Set' if followed by 'Is', 'Can' or 'Has'</value>
+    <value>Do not prefix methods with 'Get' or 'Set' when followed by 'Is', 'Can' or 'Has'</value>
   </data>
   <data name="MiKo_1018_CodeFixTitle" xml:space="preserve">
     <value>Change noun to verb</value>
@@ -414,7 +414,7 @@ Example: A 'Loaded' event should use an 'EventHandler&lt;LoadedEventArgs&gt;'.</
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1018_Title" xml:space="preserve">
-    <value>Methods should not be suffixed with noun of a verb</value>
+    <value>Do not suffix methods with noun of a verb</value>
   </data>
   <data name="MiKo_1019_CodeFixTitle" xml:space="preserve">
     <value>Rename 'Clear' and 'Remove'</value>
@@ -428,7 +428,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1019_Title" xml:space="preserve">
-    <value>'Clear' and 'Remove' methods should be named based on their number of parameters</value>
+    <value>Name 'Clear' and 'Remove' methods based on their number of parameters</value>
   </data>
   <data name="MiKo_1020_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -437,7 +437,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Type name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1020_Title" xml:space="preserve">
-    <value>Type names should be limited in length</value>
+    <value>Limit type name length</value>
   </data>
   <data name="MiKo_1021_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -446,7 +446,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Method name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1021_Title" xml:space="preserve">
-    <value>Method names should be limited in length</value>
+    <value>Limit method name length</value>
   </data>
   <data name="MiKo_1022_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -455,7 +455,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Parameter name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1022_Title" xml:space="preserve">
-    <value>Parameter names should be limited in length</value>
+    <value>Limit parameter name length</value>
   </data>
   <data name="MiKo_1023_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -464,7 +464,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Field name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1023_Title" xml:space="preserve">
-    <value>Field names should be limited in length</value>
+    <value>Limit field name length</value>
   </data>
   <data name="MiKo_1024_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -473,7 +473,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Property name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1024_Title" xml:space="preserve">
-    <value>Property names should be limited in length</value>
+    <value>Limit property name length</value>
   </data>
   <data name="MiKo_1025_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -482,7 +482,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Event name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1025_Title" xml:space="preserve">
-    <value>Event names should be limited in length</value>
+    <value>Limit event name length</value>
   </data>
   <data name="MiKo_1026_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -491,7 +491,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Variable name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1026_Title" xml:space="preserve">
-    <value>Variable names should be limited in length</value>
+    <value>Limit variable name length</value>
   </data>
   <data name="MiKo_1027_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -500,7 +500,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Variable name in loop exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1027_Title" xml:space="preserve">
-    <value>Variable names in loops should be limited in length</value>
+    <value>Limit loop variable name length</value>
   </data>
   <data name="MiKo_1028_Description" xml:space="preserve">
     <value>Long names can be difficult to read and use, making both writing code and conducting code reviews more challenging. Keeping names concise improves readability and efficiency.</value>
@@ -509,7 +509,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Local function name exceeds limit of {2} chars by {1}</value>
   </data>
   <data name="MiKo_1028_Title" xml:space="preserve">
-    <value>Local function names should be limited in length</value>
+    <value>Limit local function name length</value>
   </data>
   <data name="MiKo_1030_CodeFixTitle" xml:space="preserve">
     <value>Remove base type indicator</value>
@@ -521,7 +521,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Remove '{1}' from name</value>
   </data>
   <data name="MiKo_1030_Title" xml:space="preserve">
-    <value>Types should not have an 'Abstract' or 'Base' marker to indicate that they are base types</value>
+    <value>Do not mark base types with 'Abstract' or 'Base'</value>
   </data>
   <data name="MiKo_1031_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -533,7 +533,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1031_Title" xml:space="preserve">
-    <value>Entity types should not use a 'Model' suffix</value>
+    <value>Do not suffix entity types with 'Model'</value>
   </data>
   <data name="MiKo_1032_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -545,7 +545,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1032_Title" xml:space="preserve">
-    <value>Methods dealing with entities should not use a 'Model' as marker</value>
+    <value>Do not use 'Model' as marker in methods dealing with entities</value>
   </data>
   <data name="MiKo_1033_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -557,7 +557,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1033_Title" xml:space="preserve">
-    <value>Parameters representing entities should not use a 'Model' suffix</value>
+    <value>Do not suffix entity parameters with 'Model'</value>
   </data>
   <data name="MiKo_1034_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -569,7 +569,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1034_Title" xml:space="preserve">
-    <value>Fields representing entities should not use a 'Model' suffix</value>
+    <value>Do not suffix entity fields with 'Model'</value>
   </data>
   <data name="MiKo_1035_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -581,7 +581,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1035_Title" xml:space="preserve">
-    <value>Properties dealing with entities should not use a 'Model' marker</value>
+    <value>Do not use 'Model' marker in properties dealing with entities</value>
   </data>
   <data name="MiKo_1036_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Model' indicator</value>
@@ -593,7 +593,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1036_Title" xml:space="preserve">
-    <value>Events dealing with entities should not use a 'Model' marker</value>
+    <value>Do not use 'Model' marker in events dealing with entities</value>
   </data>
   <data name="MiKo_1037_CodeFixTitle" xml:space="preserve">
     <value>Remove type suffix</value>
@@ -605,7 +605,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1037_Title" xml:space="preserve">
-    <value>Types should not be suffixed with 'Type', 'Interface', 'Class', 'Struct', 'Record' or 'Enum'</value>
+    <value>Do not suffix types with 'Type', 'Interface', 'Class', 'Struct', 'Record' or 'Enum'</value>
   </data>
   <data name="MiKo_1038_CodeFixTitle" xml:space="preserve">
     <value>Suffix type with 'Extensions'</value>
@@ -617,7 +617,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>End name with '{1}'</value>
   </data>
   <data name="MiKo_1038_Title" xml:space="preserve">
-    <value>Classes that contain extension methods should end with same suffix</value>
+    <value>Use consistent suffix for extension method container classes</value>
   </data>
   <data name="MiKo_1039_CodeFixTitle" xml:space="preserve">
     <value>Rename 'this' argument</value>
@@ -629,7 +629,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it {1}</value>
   </data>
   <data name="MiKo_1039_Title" xml:space="preserve">
-    <value>The 'this' parameter of extension methods should have a default name</value>
+    <value>Use default name for 'this' parameter of extension methods</value>
   </data>
   <data name="MiKo_1040_CodeFixTitle" xml:space="preserve">
     <value>Rename parameter and remove implementation detail suffix</value>
@@ -641,7 +641,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1040_Title" xml:space="preserve">
-    <value>Parameters should not be suffixed with implementation details</value>
+    <value>Do not suffix parameters with implementation details</value>
   </data>
   <data name="MiKo_1041_CodeFixTitle" xml:space="preserve">
     <value>Rename field and remove implementation detail suffix</value>
@@ -653,7 +653,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1041_Title" xml:space="preserve">
-    <value>Fields should not be suffixed with implementation details</value>
+    <value>Do not suffix fields with implementation details</value>
   </data>
   <data name="MiKo_1042_CodeFixTitle" xml:space="preserve">
     <value>Name it 'cancellationToken'</value>
@@ -665,7 +665,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1042_Title" xml:space="preserve">
-    <value>'CancellationToken' parameters should have specific name</value>
+    <value>Use specific name for 'CancellationToken' parameters</value>
   </data>
   <data name="MiKo_1043_CodeFixTitle" xml:space="preserve">
     <value>Name it 'token'</value>
@@ -677,7 +677,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1043_Title" xml:space="preserve">
-    <value>'CancellationToken' variables should have specific name</value>
+    <value>Use specific name for 'CancellationToken' variables</value>
   </data>
   <data name="MiKo_1044_CodeFixTitle" xml:space="preserve">
     <value>Append 'Command' suffix</value>
@@ -689,7 +689,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Add '{1}' as suffix</value>
   </data>
   <data name="MiKo_1044_Title" xml:space="preserve">
-    <value>Commands should be suffixed with 'Command'</value>
+    <value>Suffix commands with 'Command'</value>
   </data>
   <data name="MiKo_1045_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Command' suffix</value>
@@ -701,7 +701,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1045_Title" xml:space="preserve">
-    <value>Methods that are invoked by commands should not be suffixed with 'Command'</value>
+    <value>Do not suffix command-invoked methods with 'Command'</value>
   </data>
   <data name="MiKo_1046_CodeFixTitle" xml:space="preserve">
     <value>Append 'Async' suffix</value>
@@ -716,7 +716,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1046_Title" xml:space="preserve">
-    <value>Asynchronous methods should follow the Task-based Asynchronous Pattern (TAP)</value>
+    <value>Follow Task-based Asynchronous Pattern (TAP) for asynchronous methods</value>
   </data>
   <data name="MiKo_1047_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Async' suffix</value>
@@ -731,7 +731,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1047_Title" xml:space="preserve">
-    <value>Methods not following the Task-based Asynchronous Pattern (TAP) should not lie about being asynchronous</value>
+    <value>Do not falsely indicate asynchronous behavior for methods not following Task-based Asynchronous Pattern (TAP)</value>
   </data>
   <data name="MiKo_1048_CodeFixTitle" xml:space="preserve">
     <value>Append 'Converter' suffix</value>
@@ -743,7 +743,7 @@ This naming convention helps ensure clarity and consistency in method functional
     <value>End name with '{1}'</value>
   </data>
   <data name="MiKo_1048_Title" xml:space="preserve">
-    <value>Classes that are value converters should end with a specific suffix</value>
+    <value>End value converter classes with a specific suffix</value>
   </data>
   <data name="MiKo_1049_CodeFixTitle" xml:space="preserve">
     <value>Replace requirement term</value>
@@ -768,7 +768,7 @@ So, use meaningful names instead of vague ones like 'ret', 'retVal', or 'returnV
     <value>Use a more descriptive name than '{1}'</value>
   </data>
   <data name="MiKo_1050_Title" xml:space="preserve">
-    <value>Return values should have descriptive names</value>
+    <value>Use descriptive names for return values</value>
   </data>
   <data name="MiKo_1051_CodeFixTitle" xml:space="preserve">
     <value>Name it 'callback'</value>
@@ -832,7 +832,7 @@ Instead, use specific names that describe their exact purpose, making the code e
     <value>Name it '{1}' instead</value>
   </data>
   <data name="MiKo_1055_Title" xml:space="preserve">
-    <value>Dependency properties should be suffixed with 'Property' (as in the .NET Framework)</value>
+    <value>Suffix dependency properties with 'Property' (as in the .NET Framework)</value>
   </data>
   <data name="MiKo_1056_Description" xml:space="preserve">
     <value>To show that fields are containers for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework.</value>
@@ -844,7 +844,7 @@ Instead, use specific names that describe their exact purpose, making the code e
     <value>Name it {1} instead</value>
   </data>
   <data name="MiKo_1056_Title" xml:space="preserve">
-    <value>Dependency properties should be prefixed with property names (as in the .NET Framework)</value>
+    <value>Prefix dependency properties with property names (as in the .NET Framework)</value>
   </data>
   <data name="MiKo_1057_CodeFixTitle" xml:space="preserve">
     <value>Rename dependency property key</value>
@@ -859,7 +859,7 @@ Instead, use specific names that describe their exact purpose, making the code e
     <value>Name it '{1}' instead</value>
   </data>
   <data name="MiKo_1057_Title" xml:space="preserve">
-    <value>Dependency property keys should be suffixed with 'Key' (as in the .NET Framework)</value>
+    <value>Suffix dependency property keys with 'Key' (as in the .NET Framework)</value>
   </data>
   <data name="MiKo_1058_Description" xml:space="preserve">
     <value>To show that fields are keys for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework.</value>
@@ -871,7 +871,7 @@ Instead, use specific names that describe their exact purpose, making the code e
     <value>Name it {1} instead</value>
   </data>
   <data name="MiKo_1058_Title" xml:space="preserve">
-    <value>Dependency property keys should be prefixed with property names (as in the .NET Framework)</value>
+    <value>Prefix dependency property keys with property names (as in the .NET Framework)</value>
   </data>
   <data name="MiKo_1059_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Impl' marker suffix</value>
@@ -914,7 +914,7 @@ For example, in the 'TryGetMyValue' method, the parameter should be named 'myVal
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1061_Title" xml:space="preserve">
-    <value>The name of 'Try' method's [out] parameter should be specific</value>
+    <value>Use specific name for 'Try' method's [out] parameters</value>
   </data>
   <data name="MiKo_1062_Description" xml:space="preserve">
     <value>Detection methods, properties, or fields like 'Can', 'Has', or 'Contains' should be concise, like 'HasConnection' or 'ContainsKey'.
@@ -924,7 +924,7 @@ If their names are longer, it likely means they are misplaced and violate the Si
     <value>Avoid name with more than {1} words</value>
   </data>
   <data name="MiKo_1062_Title" xml:space="preserve">
-    <value>'Can/Has/Contains' methods, properties or fields shall consist of only a few words</value>
+    <value>Keep 'Can/Has/Contains' methods, properties or fields to a few words</value>
   </data>
   <data name="MiKo_1063_CodeFixTitle" xml:space="preserve">
     <value>Replace abbreviations in name</value>
@@ -945,7 +945,7 @@ If their names are longer, it likely means they are misplaced and violate the Si
     <value>Name parameter based on its meaning instead of its type</value>
   </data>
   <data name="MiKo_1064_Title" xml:space="preserve">
-    <value>Parameter names reflect their meaning and not their type</value>
+    <value>Make parameter names reflect their meaning, not their type</value>
   </data>
   <data name="MiKo_1065_CodeFixTitle" xml:space="preserve">
     <value>Rename operator parameter</value>
@@ -964,7 +964,7 @@ This ensures clarity and consistency in your code.</value>
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1065_Title" xml:space="preserve">
-    <value>Operator parameters should be named according the .NET Framework Design Guidelines for operator overloads</value>
+    <value>Follow .NET Framework Design Guidelines for operator overload parameter names</value>
   </data>
   <data name="MiKo_1066_CodeFixTitle" xml:space="preserve">
     <value>Rename parameter to match its property</value>
@@ -976,7 +976,7 @@ This ensures clarity and consistency in your code.</value>
     <value>Name parameter according to the assigned property</value>
   </data>
   <data name="MiKo_1066_Title" xml:space="preserve">
-    <value>Constructor parameters that are assigned to a property should be named after the property</value>
+    <value>Name constructor parameters after the property they're assigned to</value>
   </data>
   <data name="MiKo_1067_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Perform' from name</value>
@@ -988,7 +988,7 @@ This ensures clarity and consistency in your code.</value>
     <value>Remove 'Perform' from name</value>
   </data>
   <data name="MiKo_1067_Title" xml:space="preserve">
-    <value>Methods should not contain 'Perform' in their names</value>
+    <value>Do not include 'Perform' in method names</value>
   </data>
   <data name="MiKo_1068_Description" xml:space="preserve">
     <value>Workflows, being high-level constructs within the business layer, should have methods named 'CanRun' or 'Run', much like commands that use 'CanExecute' and 'Execute'. This naming convention keeps things consistent and clear.</value>
@@ -997,7 +997,7 @@ This ensures clarity and consistency in your code.</value>
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1068_Title" xml:space="preserve">
-    <value>Workflow methods should be named 'CanRun' or 'Run'</value>
+    <value>Name workflow methods 'CanRun' or 'Run'</value>
   </data>
   <data name="MiKo_1069_Description" xml:space="preserve">
     <value>To ease maintenance, property names should be based on the property's meaning rather than its type.</value>
@@ -1006,7 +1006,7 @@ This ensures clarity and consistency in your code.</value>
     <value>Name property based on its meaning instead of its type</value>
   </data>
   <data name="MiKo_1069_Title" xml:space="preserve">
-    <value>Property names reflect their meaning and not their type</value>
+    <value>Make property names reflect their meaning, not their type</value>
   </data>
   <data name="MiKo_1070_CodeFixTitle" xml:space="preserve">
     <value>Rename variable into plural</value>
@@ -1019,7 +1019,7 @@ For example, instead of naming a variable 'userCollection', name it 'users' to c
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1070_Title" xml:space="preserve">
-    <value>Local collection variables shall use plural name</value>
+    <value>Use plural names for local collection variables</value>
   </data>
   <data name="MiKo_1071_Description" xml:space="preserve">
     <value>Boolean variables define some state. So they should be named as statements and not as questions.
@@ -1036,7 +1036,7 @@ Example:
     <value>Formulate question as statement</value>
   </data>
   <data name="MiKo_1071_Title" xml:space="preserve">
-    <value>Local boolean variables should be named as statements and not as questions</value>
+    <value>Name local boolean variables as statements, not questions</value>
   </data>
   <data name="MiKo_1072_Description" xml:space="preserve">
     <value>Boolean properties or methods define some state. So they should be named as statements and not as questions.
@@ -1053,7 +1053,7 @@ Example:
     <value>Formulate question as statement</value>
   </data>
   <data name="MiKo_1072_Title" xml:space="preserve">
-    <value>Boolean properties or methods should be named as statements and not as questions</value>
+    <value>Name boolean properties or methods as statements, not questions</value>
   </data>
   <data name="MiKo_1073_Description" xml:space="preserve">
     <value>Boolean fields represent a state and should be named as statements, not questions.
@@ -1070,7 +1070,7 @@ Example:
     <value>Formulate question as statement</value>
   </data>
   <data name="MiKo_1073_Title" xml:space="preserve">
-    <value>Boolean fields should be named as statements and not as questions</value>
+    <value>Name boolean fields as statements, not questions</value>
   </data>
   <data name="MiKo_1074_Description" xml:space="preserve">
     <value>If an object is used for synchronizing threads with lock statements, add the suffix 'Lock' to its name. This makes it clear that the object is used as a synchronization mechanism.</value>
@@ -1079,7 +1079,7 @@ Example:
     <value>Suffix field with 'Lock' because it is used as lock object</value>
   </data>
   <data name="MiKo_1074_Title" xml:space="preserve">
-    <value>Objects used to lock on should be suffixed with 'Lock'</value>
+    <value>Suffix lock objects with 'Lock'</value>
   </data>
   <data name="MiKo_1075_CodeFixTitle" xml:space="preserve">
     <value>Remove suffix 'EventArgs'</value>
@@ -1091,7 +1091,7 @@ Example:
     <value>Name it '{1}' instead</value>
   </data>
   <data name="MiKo_1075_Title" xml:space="preserve">
-    <value>Non-'System.EventArgs' types should not be suffixed with 'EventArgs'</value>
+    <value>Do not suffix non-'System.EventArgs' types with 'EventArgs'</value>
   </data>
   <data name="MiKo_1076_CodeFixTitle" xml:space="preserve">
     <value>Change suffix to 'Event'</value>
@@ -1103,7 +1103,7 @@ Example:
     <value>Name it '{1}' instead</value>
   </data>
   <data name="MiKo_1076_Title" xml:space="preserve">
-    <value>Prism event types should be suffixed with 'Event'</value>
+    <value>Suffix Prism event types with 'Event'</value>
   </data>
   <data name="MiKo_1077_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Enum' suffix</value>
@@ -1115,7 +1115,7 @@ Example:
     <value>Name it '{0}'</value>
   </data>
   <data name="MiKo_1077_Title" xml:space="preserve">
-    <value>Enum members should not be suffixed with 'Enum'</value>
+    <value>Do not suffix enum members with 'Enum'</value>
   </data>
   <data name="MiKo_1078_CodeFixTitle" xml:space="preserve">
     <value>Rename builder method</value>
@@ -1127,7 +1127,7 @@ Example:
     <value>Start name with 'Build'</value>
   </data>
   <data name="MiKo_1078_Title" xml:space="preserve">
-    <value>Builder method names should start with 'Build'</value>
+    <value>Start builder method names with 'Build'</value>
   </data>
   <data name="MiKo_1079_CodeFixTitle" xml:space="preserve">
     <value>Remove suffix 'Repository'</value>
@@ -1139,7 +1139,7 @@ Example:
     <value>Remove suffix 'Repository'</value>
   </data>
   <data name="MiKo_1079_Title" xml:space="preserve">
-    <value>Repositories should not be suffixed with 'Repository'</value>
+    <value>Do not suffix repositories with 'Repository'</value>
   </data>
   <data name="MiKo_1080_Description" xml:space="preserve">
     <value>It is much easier to read a number inside a name if it is written as number and not its spelling (e.g. 'issue42' in contrast to 'issueFortyTwo').</value>
@@ -1148,7 +1148,7 @@ Example:
     <value>Use number instead of spelling</value>
   </data>
   <data name="MiKo_1080_Title" xml:space="preserve">
-    <value>Names should contain numbers instead of their spellings</value>
+    <value>Use numbers instead of their spellings in names</value>
   </data>
   <data name="MiKo_1081_CodeFixTitle" xml:space="preserve">
     <value>Remove number</value>
@@ -1160,7 +1160,7 @@ Example:
     <value>Do not use a number as suffix</value>
   </data>
   <data name="MiKo_1081_Title" xml:space="preserve">
-    <value>Methods should not be suffixed with a number</value>
+    <value>Do not suffix methods with a number</value>
   </data>
   <data name="MiKo_1082_CodeFixTitle" xml:space="preserve">
     <value>Remove number</value>
@@ -1172,7 +1172,7 @@ Example:
     <value>Do not use a number as suffix</value>
   </data>
   <data name="MiKo_1082_Title" xml:space="preserve">
-    <value>Properties should not be suffixed with a number if their types have number suffixes</value>
+    <value>Do not suffix properties with a number if their types have number suffixes</value>
   </data>
   <data name="MiKo_1083_CodeFixTitle" xml:space="preserve">
     <value>Remove number</value>
@@ -1184,7 +1184,7 @@ Example:
     <value>Do not use a number as suffix</value>
   </data>
   <data name="MiKo_1083_Title" xml:space="preserve">
-    <value>Fields should not be suffixed with a number if their types have number suffixes</value>
+    <value>Do not suffix fields with a number if their types have number suffixes</value>
   </data>
   <data name="MiKo_1084_CodeFixTitle" xml:space="preserve">
     <value>Remove number</value>
@@ -1196,7 +1196,7 @@ Example:
     <value>Do not use a number as suffix</value>
   </data>
   <data name="MiKo_1084_Title" xml:space="preserve">
-    <value>Variables should not be suffixed with a number if their types have number suffixes</value>
+    <value>Do not suffix variables with a number if their types have number suffixes</value>
   </data>
   <data name="MiKo_1085_CodeFixTitle" xml:space="preserve">
     <value>Remove number</value>
@@ -1208,7 +1208,7 @@ Example:
     <value>Do not use a number as suffix</value>
   </data>
   <data name="MiKo_1085_Title" xml:space="preserve">
-    <value>Parameters should not be suffixed with a number</value>
+    <value>Do not suffix parameters with a number</value>
   </data>
   <data name="MiKo_1086_Description" xml:space="preserve">
     <value>Using numbers in method names such 'Send2You' or 'Do4You' is slang and should be avoided. Instead, the correct words 'To' or 'For' should be used.</value>
@@ -1217,7 +1217,7 @@ Example:
     <value>Do not use a number as slang</value>
   </data>
   <data name="MiKo_1086_Title" xml:space="preserve">
-    <value>Methods should not be named using numbers as slang</value>
+    <value>Do not use numbers as slang in method names</value>
   </data>
   <data name="MiKo_1087_CodeFixTitle" xml:space="preserve">
     <value>Rename constructor parameter after counterpart in base class</value>
@@ -1229,7 +1229,7 @@ Example:
     <value>Name constructor parameter '{1}'</value>
   </data>
   <data name="MiKo_1087_Title" xml:space="preserve">
-    <value>Name constructor parameters after their counterparts in the base class</value>
+    <value>Name constructor parameters after their base class counterparts</value>
   </data>
   <data name="MiKo_1088_Description" xml:space="preserve">
     <value>To indicate that something is a singleton, the specific property or field should be named 'Instance' as convention. That makes it easier to spot.</value>
@@ -1238,7 +1238,7 @@ Example:
     <value>Name it 'Instance'</value>
   </data>
   <data name="MiKo_1088_Title" xml:space="preserve">
-    <value>Singleton instances should be named 'Instance'</value>
+    <value>Name singleton instances 'Instance'</value>
   </data>
   <data name="MiKo_1089_CodeFixTitle" xml:space="preserve">
     <value>Rename method and remove 'Get' prefix</value>
@@ -1251,7 +1251,7 @@ For example, 'GetUsersByCity' should be renamed to 'UsersWithCity', as the code 
     <value>Do not prefix with 'Get'</value>
   </data>
   <data name="MiKo_1089_Title" xml:space="preserve">
-    <value>Methods should not be prefixed with 'Get'</value>
+    <value>Do not prefix methods with 'Get'</value>
   </data>
   <data name="MiKo_1090_CodeFixTitle" xml:space="preserve">
     <value>Rename parameter</value>
@@ -1263,7 +1263,7 @@ For example, 'GetUsersByCity' should be renamed to 'UsersWithCity', as the code 
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1090_Title" xml:space="preserve">
-    <value>Parameters should not be suffixed with specific types</value>
+    <value>Do not suffix parameters with specific types</value>
   </data>
   <data name="MiKo_1091_CodeFixTitle" xml:space="preserve">
     <value>Remove variable suffix</value>
@@ -1275,7 +1275,7 @@ For example, 'GetUsersByCity' should be renamed to 'UsersWithCity', as the code 
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1091_Title" xml:space="preserve">
-    <value>Variables should not be suffixed with specific types</value>
+    <value>Do not suffix variables with specific types</value>
   </data>
   <data name="MiKo_1092_CodeFixTitle" xml:space="preserve">
     <value>Remove suffix</value>
@@ -1287,7 +1287,7 @@ For example, 'GetUsersByCity' should be renamed to 'UsersWithCity', as the code 
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1092_Title" xml:space="preserve">
-    <value>'Ability' Types should not be suffixed with redundant information</value>
+    <value>Do not suffix 'Ability' types with redundant information</value>
   </data>
   <data name="MiKo_1093_CodeFixTitle" xml:space="preserve">
     <value>Remove suffix 'Object' or 'Struct'</value>
@@ -1332,7 +1332,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Use 'Failed' instead of 'NotSuccessful'</value>
   </data>
   <data name="MiKo_1096_Title" xml:space="preserve">
-    <value>Names should use 'Failed' instead of 'NotSuccessful'</value>
+    <value>Use 'Failed' instead of 'NotSuccessful' in names</value>
   </data>
   <data name="MiKo_1097_CodeFixTitle" xml:space="preserve">
     <value>Remove field prefix</value>
@@ -1344,7 +1344,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Do not use field prefix '{1}'</value>
   </data>
   <data name="MiKo_1097_Title" xml:space="preserve">
-    <value>Parameter names should not follow the naming scheme for fields</value>
+    <value>Do not use field naming schemes for parameter names</value>
   </data>
   <data name="MiKo_1098_Description" xml:space="preserve">
     <value>When a type implements a business interface, its name should reflect that. This makes it easier for developers to identify and use the type. For instance, if a type implements the 'IPart' interface, it should be named something like 'XyzPart'.</value>
@@ -1353,7 +1353,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Suffix type name according to one of the following interfaces: {1}</value>
   </data>
   <data name="MiKo_1098_Title" xml:space="preserve">
-    <value>Type names should reflect the business interface(s) they implement</value>
+    <value>Reflect implemented business interface(s) in type names</value>
   </data>
   <data name="MiKo_1099_CodeFixTitle" xml:space="preserve">
     <value>Rename parameter to match overload</value>
@@ -1365,7 +1365,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}' to match overload</value>
   </data>
   <data name="MiKo_1099_Title" xml:space="preserve">
-    <value>Matching parameters on method overloads should have identical names</value>
+    <value>Use identical names for matching parameters on method overloads</value>
   </data>
   <data name="MiKo_1100_Description" xml:space="preserve">
     <value>A unit test class should clearly indicate the type it tests by naming it with the type's name as a prefix, followed by 'Tests'. For example, if testing 'MyXyzClass', the test class should be named 'MyXyzClassTests'. This makes it easy to identify what is being tested.</value>
@@ -1374,7 +1374,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1100_Title" xml:space="preserve">
-    <value>Test classes should start with the name of the type under test</value>
+    <value>Start test class names with the name of the type under test</value>
   </data>
   <data name="MiKo_1101_CodeFixTitle" xml:space="preserve">
     <value>Append 'Tests' suffix</value>
@@ -1386,7 +1386,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1101_Title" xml:space="preserve">
-    <value>Test classes should end with 'Tests'</value>
+    <value>End test class names with 'Tests'</value>
   </data>
   <data name="MiKo_1102_CodeFixTitle" xml:space="preserve">
     <value>Remove test marker from name</value>
@@ -1398,7 +1398,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Remove '{1}' from name</value>
   </data>
   <data name="MiKo_1102_Title" xml:space="preserve">
-    <value>Test methods should not contain 'Test' in their names</value>
+    <value>Do not include 'Test' in test method names</value>
   </data>
   <data name="MiKo_1103_CodeFixTitle" xml:space="preserve">
     <value>Rename to 'PrepareTest'</value>
@@ -1410,7 +1410,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1103_Title" xml:space="preserve">
-    <value>Test initialization methods should be named 'PrepareTest'</value>
+    <value>Name test initialization methods 'PrepareTest'</value>
   </data>
   <data name="MiKo_1104_CodeFixTitle" xml:space="preserve">
     <value>Rename to 'CleanupTest'</value>
@@ -1422,7 +1422,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1104_Title" xml:space="preserve">
-    <value>Test cleanup methods should be named 'CleanupTest'</value>
+    <value>Name test cleanup methods 'CleanupTest'</value>
   </data>
   <data name="MiKo_1105_CodeFixTitle" xml:space="preserve">
     <value>Rename to 'PrepareTestEnvironment'</value>
@@ -1434,7 +1434,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1105_Title" xml:space="preserve">
-    <value>One-time test initialization methods should be named 'PrepareTestEnvironment'</value>
+    <value>Name one-time test initialization methods 'PrepareTestEnvironment'</value>
   </data>
   <data name="MiKo_1106_CodeFixTitle" xml:space="preserve">
     <value>Rename to 'CleanupTestEnvironment'</value>
@@ -1446,7 +1446,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1106_Title" xml:space="preserve">
-    <value>One-time test cleanup methods should be named 'CleanupTestEnvironment'</value>
+    <value>Name one-time test cleanup methods 'CleanupTestEnvironment'</value>
   </data>
   <data name="MiKo_1107_CodeFixTitle" xml:space="preserve">
     <value>Use underscores instead of Pascal-casing</value>
@@ -1458,7 +1458,7 @@ For instance, do not name a method 'RemoveUser' if the documentation states it '
     <value>Use underscores instead of Pascal-casing</value>
   </data>
   <data name="MiKo_1107_Title" xml:space="preserve">
-    <value>Test methods should not be in Pascal-casing</value>
+    <value>Do not use Pascal-casing for test methods</value>
   </data>
   <data name="MiKo_1108_CodeFixTitle" xml:space="preserve">
     <value>Remove Mock suffix</value>
@@ -1500,7 +1500,7 @@ For example, 'Do_something_for_value_(42)' is easier to read than 'Do_something_
     <value>Suffix name with underscore</value>
   </data>
   <data name="MiKo_1110_Title" xml:space="preserve">
-    <value>Test methods with parameters should be suffixed with underscore</value>
+    <value>Suffix test methods with parameters with underscore</value>
   </data>
   <data name="MiKo_1111_CodeFixTitle" xml:space="preserve">
     <value>Remove underscore</value>
@@ -1513,7 +1513,7 @@ For example, 'Do_something_for_value()' is more readable than 'Do_something_for_
     <value>Do not suffix name with underscore</value>
   </data>
   <data name="MiKo_1111_Title" xml:space="preserve">
-    <value>Test methods without parameters should not be suffixed with underscore</value>
+    <value>Do not suffix parameterless test methods with underscore</value>
   </data>
   <data name="MiKo_1112_CodeFixTitle" xml:space="preserve">
     <value>Remove 'arbitrary' from name</value>
@@ -1534,7 +1534,7 @@ For example, 'Do_something_for_value()' is more readable than 'Do_something_for_
     <value>Do not name BDD style</value>
   </data>
   <data name="MiKo_1113_Title" xml:space="preserve">
-    <value>Test methods should not be named according BDD style</value>
+    <value>Do not use BDD style naming for test methods</value>
   </data>
   <data name="MiKo_1114_Description" xml:space="preserve">
     <value>Test methods should be named based on the specific scenarios they test, rather than labeling them as 'happy path' or 'bad path'. This approach makes the purpose of each test clearer and more understandable.</value>
@@ -1543,7 +1543,7 @@ For example, 'Do_something_for_value()' is more readable than 'Do_something_for_
     <value>Do not name '{0}' a happy or bad path</value>
   </data>
   <data name="MiKo_1114_Title" xml:space="preserve">
-    <value>Test methods should not be named 'HappyPath' or 'BadPath'</value>
+    <value>Do not name test methods 'HappyPath' or 'BadPath'</value>
   </data>
   <data name="MiKo_1115_CodeFixTitle" xml:space="preserve">
     <value>Fix "Yoda-speak" method name</value>
@@ -1557,7 +1557,7 @@ A clearer name would be "Send_sends_email_to_valid_address", which is easier to 
     <value>Do not use "Yoda-speak" for method names</value>
   </data>
   <data name="MiKo_1115_Title" xml:space="preserve">
-    <value>Test methods should be named in a fluent way</value>
+    <value>Name test methods in a fluent way</value>
   </data>
   <data name="MiKo_1116_CodeFixTitle" xml:space="preserve">
     <value>Use present tense in test name</value>
@@ -1569,7 +1569,7 @@ A clearer name would be "Send_sends_email_to_valid_address", which is easier to 
     <value>Use present tense</value>
   </data>
   <data name="MiKo_1116_Title" xml:space="preserve">
-    <value>Test methods shall be named in present tense</value>
+    <value>Use present tense for test method names</value>
   </data>
   <data name="MiKo_1117_Description" xml:space="preserve">
     <value>Tests with names like 'EventIsRaised' or 'ExceptionThrown' are too vague because they don't specify the particular event or exception involved.
@@ -1579,7 +1579,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Test name should contain the exact event being raised or the exception being thrown</value>
   </data>
   <data name="MiKo_1117_Title" xml:space="preserve">
-    <value>Test methods should be named more precisely</value>
+    <value>Make test method names more precise</value>
   </data>
   <data name="MiKo_1118_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Async' suffix</value>
@@ -1591,7 +1591,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1118_Title" xml:space="preserve">
-    <value>Test methods should not end with 'Async'</value>
+    <value>Do not end test method names with 'Async'</value>
   </data>
   <data name="MiKo_1200_CodeFixTitle" xml:space="preserve">
     <value>Rename exception</value>
@@ -1603,7 +1603,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Name it '{1}'</value>
   </data>
   <data name="MiKo_1200_Title" xml:space="preserve">
-    <value>Name exceptions in catch blocks consistently</value>
+    <value>Name catch block exceptions consistently</value>
   </data>
   <data name="MiKo_1201_CodeFixTitle" xml:space="preserve">
     <value>Rename exception</value>
@@ -1615,7 +1615,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Name it '{1}' or '{2}'</value>
   </data>
   <data name="MiKo_1201_Title" xml:space="preserve">
-    <value>Name exceptions as parameters consistently</value>
+    <value>Name exception parameters consistently</value>
   </data>
   <data name="MiKo_1300_CodeFixTitle" xml:space="preserve">
     <value>Name it '_'</value>
@@ -1627,7 +1627,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Name it '_' instead</value>
   </data>
   <data name="MiKo_1300_Title" xml:space="preserve">
-    <value>Unimportant identifiers in lambda statements should be named '_'</value>
+    <value>Name unimportant lambda statement identifiers '_'</value>
   </data>
   <data name="MiKo_1400_Description" xml:space="preserve">
     <value>Namespaces group functionalities, so their names should be plural. This makes it clear that they encompass multiple related functions or classes, enhancing readability and organization.</value>
@@ -1639,7 +1639,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Use plural for namespace, such as '{1}'</value>
   </data>
   <data name="MiKo_1400_Title" xml:space="preserve">
-    <value>Namespace names should be in plural</value>
+    <value>Use plural for namespace names</value>
   </data>
   <data name="MiKo_1401_Description" xml:space="preserve">
     <value>Avoid including language-specific terms like 'Interfaces', 'Exceptions', or 'Enums' in namespace names. Namespaces should focus on grouping related functionalities, not the technical aspects of the code. This keeps them clear and more universal.</value>
@@ -1648,7 +1648,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Do not use technical name '{0}' in namespace</value>
   </data>
   <data name="MiKo_1401_Title" xml:space="preserve">
-    <value>Namespaces should not contain technical language names</value>
+    <value>Do not include technical language names in namespaces</value>
   </data>
   <data name="MiKo_1402_Description" xml:space="preserve">
     <value>Namespaces should not be named after WPF-specific design patterns like 'Commands', 'Models', 'ViewModels', or 'Views.' Models are entities, while commands, view models, and views are UI-specific components that belong together. Clear and descriptive names help keep the code organized and more understandable.</value>
@@ -1657,7 +1657,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Do not use WPF design pattern name '{0}' in namespace</value>
   </data>
   <data name="MiKo_1402_Title" xml:space="preserve">
-    <value>Namespaces should not be named after WPF-specific design patterns</value>
+    <value>Do not name namespaces after WPF-specific design patterns</value>
   </data>
   <data name="MiKo_1403_Description" xml:space="preserve">
     <value>To prevent redundancy and confusion, avoid naming namespaces after parent namespaces. Instead, choose names that clearly indicate the namespace's purpose and the functionalities it contains. This helps developers easily understand and navigate the code structure.</value>
@@ -1666,7 +1666,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Do not re-use '{0}' in namespace</value>
   </data>
   <data name="MiKo_1403_Title" xml:space="preserve">
-    <value>Namespaces should not be named after any of their parent namespaces</value>
+    <value>Do not name namespaces after any of their parent namespaces</value>
   </data>
   <data name="MiKo_1404_Description" xml:space="preserve">
     <value>Avoid using vague names like 'Miscellaneous' or 'Utilities' for namespaces. Instead, choose specific names that clearly describe the functionalitiesthey contain. This helps developers easily understand and navigate the code structure.</value>
@@ -1675,7 +1675,7 @@ To make them clearer and more descriptive, the names should include details abou
     <value>Do not use '{0}' in namespace</value>
   </data>
   <data name="MiKo_1404_Title" xml:space="preserve">
-    <value>Namespaces should not contain unspecific names</value>
+    <value>Do not use unspecific names for namespaces</value>
   </data>
   <data name="MiKo_1405_Description" xml:space="preserve">
     <value>Namespaces should be named based on the features they provide, not deployment details.
@@ -1685,7 +1685,7 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
     <value>Do not use '{1}' in namespace</value>
   </data>
   <data name="MiKo_1405_Title" xml:space="preserve">
-    <value>Namespaces should not contain 'Lib'</value>
+    <value>Do not include 'Lib' in namespaces</value>
   </data>
   <data name="MiKo_1406_Description" xml:space="preserve">
     <value>Value converters should be placed in and grouped under a specific namespace called 'Converters' to make them easier to find. This keeps the code organized and more navigable.</value>
@@ -1694,7 +1694,7 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
     <value>Place in 'Converters' namespace</value>
   </data>
   <data name="MiKo_1406_Title" xml:space="preserve">
-    <value>Value converters should be placed in 'Converters' namespace</value>
+    <value>Place value converters in 'Converters' namespace</value>
   </data>
   <data name="MiKo_1407_Description" xml:space="preserve">
     <value>A test should reside in the same namespace as the class it tests. This makes it easier to find and relate the test to the class, enhancing organization and clarity.</value>
@@ -1703,7 +1703,7 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
     <value>Do not use 'Test' in namespace</value>
   </data>
   <data name="MiKo_1407_Title" xml:space="preserve">
-    <value>Test namespaces should not contain 'Test'</value>
+    <value>Do not include 'Test' in test namespaces</value>
   </data>
   <data name="MiKo_1408_Description" xml:space="preserve">
     <value>To make usage easier, place extension method classes in the same namespace as the types they extend. This helps developers easily detect and use them with IntelliSense.</value>
@@ -1712,7 +1712,7 @@ For example, using a 'Lib' suffix just indicates the assembly is a DLL, which is
     <value>Place class in namespace '{1}'</value>
   </data>
   <data name="MiKo_1408_Title" xml:space="preserve">
-    <value>Extension methods should be placed in same namespace as the extended types</value>
+    <value>Place extension methods in same namespace as the extended types</value>
   </data>
   <data name="MiKo_1409_Description" xml:space="preserve">
     <value>Namespaces should be made up of full words without any leading or trailing underscores. This helps developers easily understand and navigate the code structure.</value>
@@ -1756,7 +1756,7 @@ So they should be suffixed with 'Count'.</value>
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1503_Title" xml:space="preserve">
-    <value>Methods should not be suffixed with 'Counter'</value>
+    <value>Do not suffix methods with 'Counter'</value>
   </data>
   <data name="MiKo_1504_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Counter' with 'Counted'</value>
@@ -1769,7 +1769,7 @@ So they should be named accordingly.</value>
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1504_Title" xml:space="preserve">
-    <value>Properties should not be suffixed with 'Counter'</value>
+    <value>Do not suffix properties with 'Counter'</value>
   </data>
   <data name="MiKo_1505_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Counter' with 'counted'</value>
@@ -1782,7 +1782,7 @@ So they should be named accordingly.</value>
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1505_Title" xml:space="preserve">
-    <value>Fields should not be suffixed with 'Counter'</value>
+    <value>Do not suffix fields with 'Counter'</value>
   </data>
   <data name="MiKo_1506_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Counter' with 'counted'</value>
@@ -1795,7 +1795,7 @@ So they should be named accordingly.</value>
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1506_Title" xml:space="preserve">
-    <value>Local variables should not be suffixed with 'Counter'</value>
+    <value>Do not suffix local variables with 'Counter'</value>
   </data>
   <data name="MiKo_1507_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Counter' with 'counted'</value>
@@ -1808,7 +1808,7 @@ So they should be named accordingly.</value>
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1507_Title" xml:space="preserve">
-    <value>Parameters should not be suffixed with 'Counter'</value>
+    <value>Do not suffix parameters with 'Counter'</value>
   </data>
   <data name="MiKo_1508_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1821,7 +1821,7 @@ This improves code readability, avoids confusion with class names and helps deve
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1508_Title" xml:space="preserve">
-    <value>Local variables should not be suffixed with pattern names</value>
+    <value>Do not suffix local variables with pattern names</value>
   </data>
   <data name="MiKo_1509_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1834,7 +1834,7 @@ This improves code readability, avoids confusion with class names and helps deve
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1509_Title" xml:space="preserve">
-    <value>Parameters should not be suffixed with pattern names</value>
+    <value>Do not suffix parameters with pattern names</value>
   </data>
   <data name="MiKo_1510_Description" xml:space="preserve">
     <value>The 'Info' suffix is too generic and does not clearly convey the purpose or structure of a type.
@@ -1844,7 +1844,7 @@ Replacing it with more descriptive and intent-revealing names (such as 'Data', '
     <value>Change suffix 'Info' to a more intent-revealing name</value>
   </data>
   <data name="MiKo_1510_Title" xml:space="preserve">
-    <value>Types should not be suffixed with 'Info'</value>
+    <value>Do not suffix types with 'Info'</value>
   </data>
   <data name="MiKo_1511_CodeFixTitle" xml:space="preserve">
     <value>Remove 'proxy' from name</value>
@@ -1857,7 +1857,7 @@ Therefore, names should reflect the intended role rather than the implementation
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1511_Title" xml:space="preserve">
-    <value>Local variables should not be prefixed or suffixed with 'proxy'</value>
+    <value>Do not prefix or suffix local variables with 'proxy'</value>
   </data>
   <data name="MiKo_1512_CodeFixTitle" xml:space="preserve">
     <value>Remove 'proxy' from name</value>
@@ -1870,7 +1870,7 @@ Therefore, names should reflect the intended role rather than the implementation
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1512_Title" xml:space="preserve">
-    <value>Parameters should not be prefixed or suffixed with 'proxy'</value>
+    <value>Do not prefix or suffix parameters with 'proxy'</value>
   </data>
   <data name="MiKo_1513_CodeFixTitle" xml:space="preserve">
     <value>Change suffix into prefix</value>
@@ -1883,7 +1883,7 @@ Prefixes improve IntelliSense grouping and readability, while also making relate
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1513_Title" xml:space="preserve">
-    <value>Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'</value>
+    <value>Do not suffix types with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'</value>
   </data>
   <data name="MiKo_1514_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1896,7 +1896,7 @@ This improves code readability, avoids confusion with class names and helps deve
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1514_Title" xml:space="preserve">
-    <value>Fields should not be suffixed with pattern names</value>
+    <value>Do not suffix fields with pattern names</value>
   </data>
   <data name="MiKo_1515_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1909,7 +1909,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1515_Title" xml:space="preserve">
-    <value>Boolean property names should clearly express a binary condition</value>
+    <value>Express binary conditions clearly in boolean property names</value>
   </data>
   <data name="MiKo_1516_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1922,7 +1922,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1516_Title" xml:space="preserve">
-    <value>Boolean parameter names should clearly express a binary condition</value>
+    <value>Express binary conditions clearly in boolean parameter names</value>
   </data>
   <data name="MiKo_1517_CodeFixTitle" xml:space="preserve">
     <value>Fix name</value>
@@ -1935,7 +1935,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1517_Title" xml:space="preserve">
-    <value>Boolean field names should clearly express a binary condition</value>
+    <value>Express binary conditions clearly in boolean field names</value>
   </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
@@ -1947,7 +1947,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Documentation is malformed and contains invalid characters (such as '&amp;' or '&lt;')</value>
   </data>
   <data name="MiKo_2000_Title" xml:space="preserve">
-    <value>Documentation should be valid XML</value>
+    <value>Write valid XML documentation</value>
   </data>
   <data name="MiKo_2001_CodeFixTitle" xml:space="preserve">
     <value>Start comment with 'Occurs '</value>
@@ -1959,7 +1959,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2001_Title" xml:space="preserve">
-    <value>Events should be documented properly</value>
+    <value>Document events properly</value>
   </data>
   <data name="MiKo_2002_CodeFixTitle" xml:space="preserve">
     <value>Apply 'Provides data for the &lt;see cref="TODO"/&gt; event.' comment</value>
@@ -1971,7 +1971,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>&lt;summary&gt; should follow pattern: '{1} ... {2}'</value>
   </data>
   <data name="MiKo_2002_Title" xml:space="preserve">
-    <value>EventArgs should be documented properly</value>
+    <value>Document EventArgs properly</value>
   </data>
   <data name="MiKo_2003_CodeFixTitle" xml:space="preserve">
     <value>Start comment with 'Handles the '</value>
@@ -1983,7 +1983,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2003_Title" xml:space="preserve">
-    <value>Documentation of event handlers should have a default starting phrase</value>
+    <value>Start event handler documentation with default phrase</value>
   </data>
   <data name="MiKo_2004_CodeFixTitle" xml:space="preserve">
     <value>Fix comment of event handler parameter</value>
@@ -1995,7 +1995,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Change documentation to: '{1}'</value>
   </data>
   <data name="MiKo_2004_Title" xml:space="preserve">
-    <value>Documentation of event handler parameter names should follow .NET Framework Design Guidelines for event handlers</value>
+    <value>Follow .NET Framework Design Guidelines for event handler parameter names in documentation</value>
   </data>
   <data name="MiKo_2005_Description" xml:space="preserve">
     <value>Documentation should avoid using 'event arg'. Instead, directly reference the specific class like this: '&lt;see cref="XyzEventArgs" /&gt;'. This approach provides clarity and allows easy navigation to the related event argument type.</value>
@@ -2004,7 +2004,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Do not use term 'event arg'</value>
   </data>
   <data name="MiKo_2005_Title" xml:space="preserve">
-    <value>Textual references to EventArgs should be documented properly</value>
+    <value>Document textual references to EventArgs properly</value>
   </data>
   <data name="MiKo_2006_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment to RoutedEvent</value>
@@ -2016,7 +2016,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>&lt;{1}&gt; should be: '{2}'</value>
   </data>
   <data name="MiKo_2006_Title" xml:space="preserve">
-    <value>Routed events should be documented as done by the .NET Framework</value>
+    <value>Document routed events as done by the .NET Framework</value>
   </data>
   <data name="MiKo_2010_CodeFixTitle" xml:space="preserve">
     <value>Append sealed text to comment</value>
@@ -2028,7 +2028,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>End &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2010_Title" xml:space="preserve">
-    <value>Sealed classes should document being sealed</value>
+    <value>Document sealed classes as being sealed</value>
   </data>
   <data name="MiKo_2011_CodeFixTitle" xml:space="preserve">
     <value>Remove sealed text to comment</value>
@@ -2040,7 +2040,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>&lt;summary&gt; should not contain: '{1}'</value>
   </data>
   <data name="MiKo_2011_Title" xml:space="preserve">
-    <value>Unsealed classes should not lie about sealing</value>
+    <value>Do not falsely document unsealed classes as sealed</value>
   </data>
   <data name="MiKo_2012_CodeFixTitle" xml:space="preserve">
     <value>Fix meaningless phrase</value>
@@ -2054,7 +2054,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>&lt;summary&gt; should not {1} meaningless phrase: '{2}'</value>
   </data>
   <data name="MiKo_2012_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should describe the type's responsibility</value>
+    <value>Describe the type's responsibility in &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2013_CodeFixTitle" xml:space="preserve">
     <value>Start comment with '{0}'</value>
@@ -2066,7 +2066,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2013_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of Enums should have a default starting phrase</value>
+    <value>Start Enum &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2014_CodeFixTitle" xml:space="preserve">
     <value>Apply standard 'Dispose' comment</value>
@@ -2078,7 +2078,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>Change documentation to: '{1}'</value>
   </data>
   <data name="MiKo_2014_Title" xml:space="preserve">
-    <value>Dispose methods should be documented as done by the .NET Framework</value>
+    <value>Document Dispose methods as done by the .NET Framework</value>
   </data>
   <data name="MiKo_2015_CodeFixTitle" xml:space="preserve">
     <value>Replace term 'fire'</value>
@@ -2090,7 +2090,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>Use {1} instead of {2} in documentation</value>
   </data>
   <data name="MiKo_2015_Title" xml:space="preserve">
-    <value>Documentation should use 'raise' or 'throw' instead of 'fire'</value>
+    <value>Use 'raise' or 'throw' instead of 'fire' in documentation</value>
   </data>
   <data name="MiKo_2016_CodeFixTitle" xml:space="preserve">
     <value>Start comment with '{0}'</value>
@@ -2102,7 +2102,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2016_Title" xml:space="preserve">
-    <value>Documentation for asynchronous methods should start with specific phrase</value>
+    <value>Start documentation for asynchronous methods with specific phrase</value>
   </data>
   <data name="MiKo_2017_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment to DependencyProperty</value>
@@ -2114,7 +2114,7 @@ This approach keeps the documentation clear and user-focused.</value>
     <value>&lt;{1}&gt; should be: '{2}'</value>
   </data>
   <data name="MiKo_2017_Title" xml:space="preserve">
-    <value>Dependency properties should be documented as done by the .NET Framework</value>
+    <value>Document dependency properties as done by the .NET Framework</value>
   </data>
   <data name="MiKo_2018_CodeFixTitle" xml:space="preserve">
     <value>Start &lt;summary&gt; with '{0}'</value>
@@ -2127,7 +2127,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;summary&gt; with '{1}'</value>
   </data>
   <data name="MiKo_2018_Title" xml:space="preserve">
-    <value>Documentation should not use the ambiguous terms 'Check' or 'Test'</value>
+    <value>Do not use ambiguous terms 'Check' or 'Test' in documentation</value>
   </data>
   <data name="MiKo_2019_CodeFixTitle" xml:space="preserve">
     <value>Start &lt;summary&gt; with a third person singular verb</value>
@@ -2139,7 +2139,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;summary&gt; with a third person singular verb</value>
   </data>
   <data name="MiKo_2019_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should start with a third person singular verb (for example "Provides ")</value>
+    <value>Start &lt;summary&gt; documentation with third person singular verb (e.g., "Provides")</value>
   </data>
   <data name="MiKo_2020_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;inheritdoc/&gt;</value>
@@ -2151,7 +2151,7 @@ This ensures clarity and precision in your code.</value>
     <value>Use &lt;inheritdoc /&gt; instead</value>
   </data>
   <data name="MiKo_2020_Title" xml:space="preserve">
-    <value>Inherited documentation should be used with &lt;inheritdoc /&gt; marker</value>
+    <value>Use &lt;inheritdoc /&gt; marker for inherited documentation</value>
   </data>
   <data name="MiKo_2021_CodeFixTitle" xml:space="preserve">
     <value>Start documentation with 'The '</value>
@@ -2163,7 +2163,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start documentation with: {1}</value>
   </data>
   <data name="MiKo_2021_Title" xml:space="preserve">
-    <value>Documentation of parameter should have a default starting phrase</value>
+    <value>Start parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2022_CodeFixTitle" xml:space="preserve">
     <value>Fix comment start of [out] parameter</value>
@@ -2175,7 +2175,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start documentation with: {1}</value>
   </data>
   <data name="MiKo_2022_Title" xml:space="preserve">
-    <value>Documentation of [out] parameters should have a default starting phrase</value>
+    <value>Start [out] parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2023_CodeFixTitle" xml:space="preserve">
     <value>Fix comment start of Boolean parameter</value>
@@ -2187,7 +2187,7 @@ This ensures clarity and precision in your code.</value>
     <value>Documentation should follow pattern: '{1} ... {2}'</value>
   </data>
   <data name="MiKo_2023_Title" xml:space="preserve">
-    <value>Documentation of Boolean parameters should have a default starting phrase</value>
+    <value>Start Boolean parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2024_CodeFixTitle" xml:space="preserve">
     <value>Fix comment start of Enum parameter</value>
@@ -2199,7 +2199,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start documentation with: {1}</value>
   </data>
   <data name="MiKo_2024_Title" xml:space="preserve">
-    <value>Documentation of Enum parameters should have a default starting phrase</value>
+    <value>Start Enum parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2025_CodeFixTitle" xml:space="preserve">
     <value>Fix comment start of CancellationToken</value>
@@ -2211,7 +2211,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start documentation with: {1}</value>
   </data>
   <data name="MiKo_2025_Title" xml:space="preserve">
-    <value>Documentation of 'CancellationToken' parameters should have a default starting phrase</value>
+    <value>Start 'CancellationToken' parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2026_Description" xml:space="preserve">
     <value>Documentation must always be accurate. If a parameter is still in use, it should never be labeled as unused. Keeping documentation truthful and clear is crucial for effective maintenance and development.</value>
@@ -2220,7 +2220,7 @@ This ensures clarity and precision in your code.</value>
     <value>Documentation lies about being unused</value>
   </data>
   <data name="MiKo_2026_Title" xml:space="preserve">
-    <value>Used parameters should not be documented to be unused</value>
+    <value>Do not document used parameters as unused</value>
   </data>
   <data name="MiKo_2027_CodeFixTitle" xml:space="preserve">
     <value>Fix comment start of parameter of serialization constructor</value>
@@ -2232,7 +2232,7 @@ This ensures clarity and precision in your code.</value>
     <value>Change documentation to: '{1}'</value>
   </data>
   <data name="MiKo_2027_Title" xml:space="preserve">
-    <value>Serialization constructor parameters shall be documented with a specific phrase</value>
+    <value>Document serialization constructor parameters with specific phrase</value>
   </data>
   <data name="MiKo_2028_Description" xml:space="preserve">
     <value>Documentation must go beyond just listing parameter names. It should clearly describe what the parameters represent and how they are used. Simply stating the parameter's name doesn't provide enough context or information. Accurate and detailed documentation makes code easier to understand and maintain.</value>
@@ -2241,7 +2241,7 @@ This ensures clarity and precision in your code.</value>
     <value>Documentation should contain more than just the parameter name</value>
   </data>
   <data name="MiKo_2028_Title" xml:space="preserve">
-    <value>Documentation of parameter should not just contain the name of the parameter</value>
+    <value>Provide more information than just parameter name in documentation</value>
   </data>
   <data name="MiKo_2029_CodeFixTitle" xml:space="preserve">
     <value>Remove 'cref' value from &lt;inheritdoc/&gt;</value>
@@ -2253,7 +2253,7 @@ This ensures clarity and precision in your code.</value>
     <value>Do not use &lt;inheritdoc cref="{0}" /&gt;</value>
   </data>
   <data name="MiKo_2029_Title" xml:space="preserve">
-    <value>&lt;inheritdoc&gt; documentation should not use a 'cref' to itself</value>
+    <value>Do not use self-referencing 'cref' in &lt;inheritdoc&gt; documentation</value>
   </data>
   <data name="MiKo_2030_Description" xml:space="preserve">
     <value>Documentation for a return value should start with a default phrase that provides a detailed description of what the returned value is. This approach helps clarify the purpose and use of the return value for developers.</value>
@@ -2262,7 +2262,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2030_Title" xml:space="preserve">
-    <value>Documentation of return value should have a default starting phrase</value>
+    <value>Start return value documentation with default phrase</value>
   </data>
   <data name="MiKo_2031_CodeFixTitle" xml:space="preserve">
     <value>Fix return comment</value>
@@ -2274,7 +2274,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2031_Title" xml:space="preserve">
-    <value>Documentation of Task return value should have a specific (starting) phrase</value>
+    <value>Use specific (starting) phrase for Task return value documentation</value>
   </data>
   <data name="MiKo_2032_CodeFixTitle" xml:space="preserve">
     <value>Fix return comment</value>
@@ -2286,7 +2286,7 @@ This ensures clarity and precision in your code.</value>
     <value>&lt;{1}&gt; should follow pattern: '{2} ... {3}'</value>
   </data>
   <data name="MiKo_2032_Title" xml:space="preserve">
-    <value>Documentation of Boolean return value should have a specific phrase</value>
+    <value>Use specific phrase for Boolean return value documentation</value>
   </data>
   <data name="MiKo_2033_CodeFixTitle" xml:space="preserve">
     <value>Fix return comment</value>
@@ -2298,7 +2298,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2033_Title" xml:space="preserve">
-    <value>Documentation of String return value should have a default starting phrase</value>
+    <value>Start String return value documentation with default phrase</value>
   </data>
   <data name="MiKo_2034_CodeFixTitle" xml:space="preserve">
     <value>Fix return comment</value>
@@ -2310,7 +2310,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2034_Title" xml:space="preserve">
-    <value>Documentation of Enum return value should have a default starting phrase</value>
+    <value>Start Enum return value documentation with default phrase</value>
   </data>
   <data name="MiKo_2035_CodeFixTitle" xml:space="preserve">
     <value>Fix return comment</value>
@@ -2322,7 +2322,7 @@ This ensures clarity and precision in your code.</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2035_Title" xml:space="preserve">
-    <value>Documentation of collection return value should have a default starting phrase</value>
+    <value>Start collection return value documentation with default phrase</value>
   </data>
   <data name="MiKo_2036_CodeFixTitle_DefaultFalse" xml:space="preserve">
     <value>Fix comment for default value 'false'</value>
@@ -2344,7 +2344,7 @@ This ensures clarity and precision in your code.</value>
 Or with: '{3}'</value>
   </data>
   <data name="MiKo_2036_Title" xml:space="preserve">
-    <value>Documentation of Boolean or Enum property shall describe the default value</value>
+    <value>Describe default values in Boolean or Enum property documentation</value>
   </data>
   <data name="MiKo_2037_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment to command property</value>
@@ -2356,7 +2356,7 @@ Or with: '{3}'</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2037_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of command properties should have a default starting phrase</value>
+    <value>Start command property &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2038_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment to command</value>
@@ -2368,7 +2368,7 @@ Or with: '{3}'</value>
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2038_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of command should have a default starting phrase</value>
+    <value>Start command &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2039_CodeFixTitle" xml:space="preserve">
     <value>Apply standard extension methods comment to class</value>
@@ -2381,7 +2381,7 @@ This format clearly describes the purpose of the class and its functionality, ma
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2039_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of classes that contain extension methods should have a default starting phrase</value>
+    <value>Start extension method class &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2040_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;see langword="..."/&gt;</value>
@@ -2393,7 +2393,7 @@ This format clearly describes the purpose of the class and its functionality, ma
     <value>Use '{2}' instead of '{1}'</value>
   </data>
   <data name="MiKo_2040_Title" xml:space="preserve">
-    <value>&lt;see langword="..."/&gt; should be used instead of &lt;c&gt;...&lt;/c&gt;</value>
+    <value>Use &lt;see langword="..."/&gt; instead of &lt;c&gt;...&lt;/c&gt;</value>
   </data>
   <data name="MiKo_2041_CodeFixTitle" xml:space="preserve">
     <value>Place XML tag outside &lt;summary&gt;</value>
@@ -2408,7 +2408,7 @@ This format clearly describes the purpose of the class and its functionality, ma
     <value>&lt;summary&gt; should not contain: '&lt;{0}/&gt;'</value>
   </data>
   <data name="MiKo_2041_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not contain other documentation tags</value>
+    <value>Do not include other documentation tags in &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2042_CodeFixTitle" xml:space="preserve">
     <value>Replace &lt;p&gt; with &lt;para&gt;</value>
@@ -2423,7 +2423,7 @@ This format clearly describes the purpose of the class and its functionality, ma
     <value>Use '&lt;para&gt;' instead of '&lt;p&gt;'</value>
   </data>
   <data name="MiKo_2042_Title" xml:space="preserve">
-    <value>Documentation should use '&lt;para&gt;' XML tags instead of '&lt;p&gt;' HTML tags</value>
+    <value>Use '&lt;para&gt;' XML tags instead of '&lt;p&gt;' HTML tags in documentation</value>
   </data>
   <data name="MiKo_2043_CodeFixTitle" xml:space="preserve">
     <value>Start &lt;summary&gt; with 'Encapsulates a method that '</value>
@@ -2436,7 +2436,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2043_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of custom delegates should have a default starting phrase</value>
+    <value>Start custom delegate &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2044_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;paramref&gt; tag for parameter</value>
@@ -2448,7 +2448,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>Fix incorrect parameter reference '{0}'</value>
   </data>
   <data name="MiKo_2044_Title" xml:space="preserve">
-    <value>Documentation references method parameters correctly</value>
+    <value>Reference method parameters correctly in documentation</value>
   </data>
   <data name="MiKo_2045_CodeFixTitle" xml:space="preserve">
     <value>Fix parameter reference</value>
@@ -2460,7 +2460,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>&lt;summary&gt; should not contain parameter reference ' {0} '</value>
   </data>
   <data name="MiKo_2045_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not reference parameters</value>
+    <value>Do not reference parameters in &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2046_CodeFixTitle" xml:space="preserve">
     <value>Replace invalid type parameter reference</value>
@@ -2472,7 +2472,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>Replace invalid type parameter reference</value>
   </data>
   <data name="MiKo_2046_Title" xml:space="preserve">
-    <value>Documentation should reference type parameters correctly</value>
+    <value>Reference type parameters correctly in documentation</value>
   </data>
   <data name="MiKo_2047_Description" xml:space="preserve">
     <value>The documentation of an Attribute should start with a specific phrase that describes its purpose.</value>
@@ -2481,7 +2481,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>Start &lt;summary&gt; with: {1}</value>
   </data>
   <data name="MiKo_2047_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of Attributes should have a default starting phrase</value>
+    <value>Start Attribute &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2048_CodeFixTitle" xml:space="preserve">
     <value>Start comment with '{0}'</value>
@@ -2493,7 +2493,7 @@ Declaring a delegate type sets a contract specifying the method signatures it ca
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2048_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of value converters should have a default starting phrase</value>
+    <value>Start value converter &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2049_CodeFixTitle" xml:space="preserve">
     <value>Replace 'will be' with 'is'</value>
@@ -2506,7 +2506,7 @@ This practice ensures clarity and precision, making your code's behavior easier 
     <value>Replace '{0}' with '{1}'</value>
   </data>
   <data name="MiKo_2049_Title" xml:space="preserve">
-    <value>Documentation should be more explicit and not use 'will be'</value>
+    <value>Use explicit wording instead of 'will be' in documentation</value>
   </data>
   <data name="MiKo_2050_CodeFixTitle" xml:space="preserve">
     <value>Apply standard exception comment</value>
@@ -2518,7 +2518,7 @@ This practice ensures clarity and precision, making your code's behavior easier 
     <value>Start &lt;{1}&gt; with: '{2}'</value>
   </data>
   <data name="MiKo_2050_Title" xml:space="preserve">
-    <value>Exceptions should be documented following the .NET Framework</value>
+    <value>Follow .NET Framework conventions for exception documentation</value>
   </data>
   <data name="MiKo_2051_CodeFixTitle" xml:space="preserve">
     <value>Fix exception comment</value>
@@ -2530,7 +2530,7 @@ This practice ensures clarity and precision, making your code's behavior easier 
     <value>Use condition form to document thrown exception</value>
   </data>
   <data name="MiKo_2051_Title" xml:space="preserve">
-    <value>Thrown Exceptions should be documented as kind of a condition (such as '&lt;paramref name="xyz"/&gt; is &lt;c&gt;42&lt;/c&gt;')</value>
+    <value>Document thrown exceptions as conditions (e.g., '&lt;paramref name="xyz"/&gt; is &lt;c&gt;42&lt;/c&gt;')</value>
   </data>
   <data name="MiKo_2052_CodeFixTitle" xml:space="preserve">
     <value>Fix exception comment</value>
@@ -2545,7 +2545,7 @@ This approach ensures clarity and consistency, helping developers understand the
 {2}</value>
   </data>
   <data name="MiKo_2052_Title" xml:space="preserve">
-    <value>Throwing of ArgumentNullException should be documented using a default phrase</value>
+    <value>Use default phrase for ArgumentNullException documentation</value>
   </data>
   <data name="MiKo_2053_Description" xml:space="preserve">
     <value>An ArgumentNullException should not be documented for value-type parameters as value types inherently cannot have a null value.</value>
@@ -2554,7 +2554,7 @@ This approach ensures clarity and consistency, helping developers understand the
     <value>Remove '{2}' from &lt;exception cref="ArgumentNullException"/&gt; as '{1}' is a value type</value>
   </data>
   <data name="MiKo_2053_Title" xml:space="preserve">
-    <value>Throwing of ArgumentNullException should be documented only for reference type parameters</value>
+    <value>Document ArgumentNullException only for reference type parameters</value>
   </data>
   <data name="MiKo_2054_CodeFixTitle" xml:space="preserve">
     <value>Fix exception comment</value>
@@ -2569,7 +2569,7 @@ This approach ensures clarity and consistency, helping developers understand the
 {2}</value>
   </data>
   <data name="MiKo_2054_Title" xml:space="preserve">
-    <value>Throwing of ArgumentException should be documented using a default starting phrase</value>
+    <value>Start ArgumentException documentation with default phrase</value>
   </data>
   <data name="MiKo_2055_CodeFixTitle" xml:space="preserve">
     <value>Fix exception comment</value>
@@ -2584,7 +2584,7 @@ This approach ensures clarity and consistency, helping developers understand und
 {2}</value>
   </data>
   <data name="MiKo_2055_Title" xml:space="preserve">
-    <value>Throwing of ArgumentOutOfRangeException should be documented using a default starting phrase</value>
+    <value>Start ArgumentOutOfRangeException documentation with default phrase</value>
   </data>
   <data name="MiKo_2056_CodeFixTitle" xml:space="preserve">
     <value>Apply default ending comment to documentation of thrown 'ObjectDisposedException'</value>
@@ -2597,7 +2597,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>{1} should end with: '{2}'</value>
   </data>
   <data name="MiKo_2056_Title" xml:space="preserve">
-    <value>Throwing of ObjectDisposedException should be documented using a default ending phrase</value>
+    <value>End ObjectDisposedException documentation with default phrase</value>
   </data>
   <data name="MiKo_2057_CodeFixTitle" xml:space="preserve">
     <value>Remove exception comment</value>
@@ -2609,7 +2609,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Remove '{1}' because type does not inherit from 'IDisposable'</value>
   </data>
   <data name="MiKo_2057_Title" xml:space="preserve">
-    <value>Types that are not disposable shall not throw an ObjectDisposedException</value>
+    <value>Do not throw ObjectDisposedException from non-disposable types</value>
   </data>
   <data name="MiKo_2059_CodeFixTitle" xml:space="preserve">
     <value>Consolidate exception documentation</value>
@@ -2621,7 +2621,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Consolidate the documentation of &lt;exception cref='{1}'&gt;</value>
   </data>
   <data name="MiKo_2059_Title" xml:space="preserve">
-    <value>Multiple documentation of same exception should be consolidated into one</value>
+    <value>Consolidate multiple documentations of same exception into one</value>
   </data>
   <data name="MiKo_2060_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment to factory</value>
@@ -2633,7 +2633,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2060_Title" xml:space="preserve">
-    <value>Factories should be documented in an uniform way</value>
+    <value>Document factories uniformly</value>
   </data>
   <data name="MiKo_2070_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Return' in comment</value>
@@ -2645,7 +2645,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2070_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not start with 'Returns'</value>
+    <value>Do not start &lt;summary&gt; documentation with 'Returns'</value>
   </data>
   <data name="MiKo_2071_Description" xml:space="preserve">
     <value>&lt;summary&gt; documentation for methods returning Enum types should avoid phrases meant for boolean types. Enum values are not booleans, so the documentation should not use terms like 'indicates whether', which imply a boolean context. This ensures the documentation accurately reflects the nature of the Enum type.</value>
@@ -2654,7 +2654,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Do not use '{0}' in &lt;summary&gt;</value>
   </data>
   <data name="MiKo_2071_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation for methods that return Enum types should not contain phrase for boolean type</value>
+    <value>Do not use boolean phrases in Enum return type &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2072_CodeFixTitle" xml:space="preserve">
     <value>Start &lt;summary&gt; with 'Attempts to'</value>
@@ -2666,7 +2666,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Start &lt;summary&gt; with 'Attempts to '</value>
   </data>
   <data name="MiKo_2072_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not start with 'Try'</value>
+    <value>Do not start &lt;summary&gt; documentation with 'Try'</value>
   </data>
   <data name="MiKo_2073_CodeFixTitle" xml:space="preserve">
     <value>Start &lt;summary&gt; with 'Determines whether'</value>
@@ -2678,7 +2678,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Start &lt;summary&gt; with 'Determines whether'</value>
   </data>
   <data name="MiKo_2073_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of 'Contains' methods should start with 'Determines whether '</value>
+    <value>Start 'Contains' method &lt;summary&gt; documentation with 'Determines whether'</value>
   </data>
   <data name="MiKo_2074_CodeFixTitle" xml:space="preserve">
     <value>Fix comment of parameter</value>
@@ -2690,7 +2690,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>&lt;param name="{0}"&gt; should end with: '{1}'</value>
   </data>
   <data name="MiKo_2074_Title" xml:space="preserve">
-    <value>Documentation of parameter of 'Contains' method should have a default ending phrase</value>
+    <value>End 'Contains' method parameter documentation with default phrase</value>
   </data>
   <data name="MiKo_2075_CodeFixTitle" xml:space="preserve">
     <value>Change to '{0}'</value>
@@ -2702,7 +2702,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Replace '{0}' with '{1}'</value>
   </data>
   <data name="MiKo_2075_Title" xml:space="preserve">
-    <value>Documentation should use the term 'callback' instead of 'action', 'func' or 'function'</value>
+    <value>Use 'callback' instead of 'action', 'func' or 'function' in documentation</value>
   </data>
   <data name="MiKo_2076_CodeFixTitle" xml:space="preserve">
     <value>Document default value</value>
@@ -2714,7 +2714,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Document the default value via '{1}'</value>
   </data>
   <data name="MiKo_2076_Title" xml:space="preserve">
-    <value>Documentation should document default values of optional parameters</value>
+    <value>Document default values of optional parameters</value>
   </data>
   <data name="MiKo_2077_Description" xml:space="preserve">
     <value>&lt;summary&gt; documentation should not include &lt;code&gt; snippets. The summary should be brief. Code snippets, which typically serve as examples, should be placed in the &lt;example&gt; section instead.</value>
@@ -2723,7 +2723,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>&lt;summary&gt; should not contain &lt;code&gt;</value>
   </data>
   <data name="MiKo_2077_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not contain &lt;code&gt;</value>
+    <value>Do not include &lt;code&gt; in &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2078_Description" xml:space="preserve">
     <value>&lt;code&gt; documentation should not include XML tags. Code snippets usually serve as examples and typically contain source code. If they contain plain XML, the XML won't be converted into documentation. Consequently, the resulting online help or IntelliSense will not display them.</value>
@@ -2732,7 +2732,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>&lt;code&gt; should not contain XML</value>
   </data>
   <data name="MiKo_2078_Title" xml:space="preserve">
-    <value>&lt;code&gt; documentation should not contain XML tags</value>
+    <value>Do not include XML tags in &lt;code&gt; documentation</value>
   </data>
   <data name="MiKo_2079_CodeFixTitle" xml:space="preserve">
     <value>Remove obvious comment</value>
@@ -2744,7 +2744,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Comment is obvious and provides no value</value>
   </data>
   <data name="MiKo_2079_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of properties should not have obvious text</value>
+    <value>Do not include obvious text in property &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2080_CodeFixTitle" xml:space="preserve">
     <value>Start field with default phrase</value>
@@ -2756,7 +2756,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>Start &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2080_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of fields should have a default starting phrase</value>
+    <value>Start field &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2081_CodeFixTitle" xml:space="preserve">
     <value>Append read-only text</value>
@@ -2768,7 +2768,7 @@ This distinction clearly indicates the reason for the exception and helps develo
     <value>End &lt;summary&gt; with: '{1}'</value>
   </data>
   <data name="MiKo_2081_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of public-visible read-only fields should have a default ending phrase</value>
+    <value>End public-visible read-only field &lt;summary&gt; documentation with default phrase</value>
   </data>
   <data name="MiKo_2082_CodeFixTitle" xml:space="preserve">
     <value>Fix enum member starting phrase</value>
@@ -2781,7 +2781,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Do not start &lt;summary&gt; with: '{0}'</value>
   </data>
   <data name="MiKo_2082_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation of Enum members should not start with default starting phrases of Enum &lt;summary&gt; documentation</value>
+    <value>Use distinct phrases for Enum member &lt;summary&gt; documentation</value>
   </data>
   <data name="MiKo_2090_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment</value>
@@ -2793,7 +2793,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>&lt;{1}&gt; should be: '{2}'</value>
   </data>
   <data name="MiKo_2090_Title" xml:space="preserve">
-    <value>Documentation for equality operator shall have default phrase</value>
+    <value>Use default phrase for equality operator documentation</value>
   </data>
   <data name="MiKo_2091_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment</value>
@@ -2805,7 +2805,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>&lt;{1}&gt; should be: '{2}'</value>
   </data>
   <data name="MiKo_2091_Title" xml:space="preserve">
-    <value>Documentation for inequality operator shall have default phrase</value>
+    <value>Use default phrase for inequality operator documentation</value>
   </data>
   <data name="MiKo_2100_CodeFixTitle" xml:space="preserve">
     <value>Start comment with '{0}'</value>
@@ -2817,7 +2817,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Start &lt;example&gt; with: '{0}'</value>
   </data>
   <data name="MiKo_2100_Title" xml:space="preserve">
-    <value>&lt;example&gt; documentation should start with descriptive default phrase</value>
+    <value>Start &lt;example&gt; documentation with descriptive default phrase</value>
   </data>
   <data name="MiKo_2101_CodeFixTitle" xml:space="preserve">
     <value>Surround sample code with '&lt;code&gt;'</value>
@@ -2829,7 +2829,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Place sample code in &lt;example&gt; inside '&lt;code&gt;' tags</value>
   </data>
   <data name="MiKo_2101_Title" xml:space="preserve">
-    <value>&lt;example&gt; documentation should show code example in &lt;code&gt; tags</value>
+    <value>Show code examples within &lt;code&gt; tags in &lt;example&gt; documentation</value>
   </data>
   <data name="MiKo_2200_CodeFixTitle" xml:space="preserve">
     <value>Use capitalized letter</value>
@@ -2841,7 +2841,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Start &lt;{1}&gt; with capitalized letter</value>
   </data>
   <data name="MiKo_2200_Title" xml:space="preserve">
-    <value>Use a capitalized letter to start the comment</value>
+    <value>Start comments with a capitalized letter</value>
   </data>
   <data name="MiKo_2201_Description" xml:space="preserve">
     <value>Sentences within documentation should always begin with a capitalized letter to form a complete sentence. This ensures clarity, readability, and professionalism, making the documentation easier to understand and more effective. Full sentences convey clear, complete thoughts, which is essential for precise communication.</value>
@@ -2850,7 +2850,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Start the sentence(s) in &lt;{1}&gt; with capitalized letter</value>
   </data>
   <data name="MiKo_2201_Title" xml:space="preserve">
-    <value>Use a capitalized letter to start the sentences in the comment</value>
+    <value>Start sentences in comments with a capitalized letter</value>
   </data>
   <data name="MiKo_2202_CodeFixTitle" xml:space="preserve">
     <value>Change 'id' into 'identifier'</value>
@@ -2862,7 +2862,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Use 'identifier' instead of 'id'</value>
   </data>
   <data name="MiKo_2202_Title" xml:space="preserve">
-    <value>Documentation should use the term 'identifier' instead of 'id'</value>
+    <value>Use term 'identifier' instead of 'id' in documentation</value>
   </data>
   <data name="MiKo_2203_CodeFixTitle" xml:space="preserve">
     <value>Change 'GUID' into 'unique identifier'</value>
@@ -2874,7 +2874,7 @@ This ensures the documentation is precise and informative, helping developers un
     <value>Use 'unique identifier' instead of 'guid'</value>
   </data>
   <data name="MiKo_2203_Title" xml:space="preserve">
-    <value>Documentation should use the term 'unique identifier' instead of 'guid'</value>
+    <value>Use term 'unique identifier' instead of 'guid' in documentation</value>
   </data>
   <data name="MiKo_2204_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;list&gt; to list items</value>
@@ -2890,7 +2890,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Use &lt;list&gt; to list items in documentation</value>
   </data>
   <data name="MiKo_2204_Title" xml:space="preserve">
-    <value>Documentation should use &lt;list&gt; for enumerations</value>
+    <value>Use &lt;list&gt; for enumerations in documentation</value>
   </data>
   <data name="MiKo_2205_Description" xml:space="preserve">
     <value>XML documentation should utilize the &lt;note&gt; tag for important information. Avoid using terms like 'Important' or 'Attention' directly. This approach allows XML documentation tools to recognize and format the information in a distinct and noticeable way, ensuring clarity and emphasis.</value>
@@ -2899,7 +2899,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Use &lt;note&gt; for important information in documentation</value>
   </data>
   <data name="MiKo_2205_Title" xml:space="preserve">
-    <value>Documentation should use &lt;note&gt; for important information</value>
+    <value>Use &lt;note&gt; for important information in documentation</value>
   </data>
   <data name="MiKo_2206_Description" xml:space="preserve">
     <value>Documentation should avoid using the term 'flag' for boolean values. Instead, rephrase the documentation to eliminate the need for this term. This ensures clarity and precision, making it easier for developers to understand the context and purpose of the boolean value.</value>
@@ -2908,7 +2908,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Remove '{0}' from documentation</value>
   </data>
   <data name="MiKo_2206_Title" xml:space="preserve">
-    <value>Documentation should not use the term 'flag'</value>
+    <value>Do not use term 'flag' in documentation</value>
   </data>
   <data name="MiKo_2207_Description" xml:space="preserve">
     <value>The &lt;summary&gt; documentation should be brief and descriptive, providing an overview of the functionality. For more detailed information, use the &lt;remarks&gt; section. This keeps the summary concise and the documentation well-organized, making it easier for developers to understand.</value>
@@ -2917,7 +2917,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>&lt;summary&gt; is too long, use &lt;remarks&gt; section for all the details</value>
   </data>
   <data name="MiKo_2207_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation shall be short</value>
+    <value>Keep &lt;summary&gt; documentation short</value>
   </data>
   <data name="MiKo_2208_CodeFixTitle" xml:space="preserve">
     <value>Remove 'an instance of'</value>
@@ -2929,7 +2929,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Use a better description than '{0}'</value>
   </data>
   <data name="MiKo_2208_Title" xml:space="preserve">
-    <value>Documentation should not use the term 'an instance of'</value>
+    <value>Do not use term 'an instance of' in documentation</value>
   </data>
   <data name="MiKo_2209_CodeFixTitle" xml:space="preserve">
     <value>Remove '..' from documentation</value>
@@ -2953,7 +2953,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Use 'information' instead of 'info'</value>
   </data>
   <data name="MiKo_2210_Title" xml:space="preserve">
-    <value>Documentation should use the term 'information' instead of 'info'</value>
+    <value>Use term 'information' instead of 'info' in documentation</value>
   </data>
   <data name="MiKo_2211_CodeFixTitle" xml:space="preserve">
     <value>Move remarks comment into summary</value>
@@ -2967,7 +2967,7 @@ To ensure developers have all the necessary information, it's best to place this
     <value>Use &lt;summary&gt; instead of &lt;remarks&gt;</value>
   </data>
   <data name="MiKo_2211_Title" xml:space="preserve">
-    <value>Enum members should not have &lt;remarks&gt; sections</value>
+    <value>Do not use &lt;remarks&gt; sections for enum members</value>
   </data>
   <data name="MiKo_2212_CodeFixTitle" xml:space="preserve">
     <value>Change 'was not successful' to 'failed'</value>
@@ -2979,7 +2979,7 @@ To ensure developers have all the necessary information, it's best to place this
     <value>Use 'failed' instead of 'was not successful'</value>
   </data>
   <data name="MiKo_2212_Title" xml:space="preserve">
-    <value>Documentation should use the phrase 'failed' instead of 'was not successful'</value>
+    <value>Use phrase 'failed' instead of 'was not successful' in documentation</value>
   </data>
   <data name="MiKo_2213_CodeFixTitle" xml:space="preserve">
     <value>Change "n't" to " not"</value>
@@ -2991,7 +2991,7 @@ To ensure developers have all the necessary information, it's best to place this
     <value>Do not use contraction "n't"</value>
   </data>
   <data name="MiKo_2213_Title" xml:space="preserve">
-    <value>Documentation should not use the contraction "n't"</value>
+    <value>Do not use contraction "n't" in documentation</value>
   </data>
   <data name="MiKo_2214_CodeFixTitle" xml:space="preserve">
     <value>Replace empty line with &lt;para/&gt;</value>
@@ -3004,7 +3004,7 @@ Instead, use &lt;para&gt; tags, which are designed to mark paragraphs properly, 
     <value>Replace empty line with &lt;para/&gt;</value>
   </data>
   <data name="MiKo_2214_Title" xml:space="preserve">
-    <value>Documentation should not contain empty lines</value>
+    <value>Remove empty lines from documentation</value>
   </data>
   <data name="MiKo_2215_Description" xml:space="preserve">
     <value>Keep documentation sentences up to 15 words. Shorter sentences are clearer and more descriptive. Longer sentences can be hard to read and may bore readers. This approach ensures effective communication.</value>
@@ -3013,7 +3013,7 @@ Instead, use &lt;para&gt; tags, which are designed to mark paragraphs properly, 
     <value>Shorten sentences to contain up to 15 words each</value>
   </data>
   <data name="MiKo_2215_Title" xml:space="preserve">
-    <value>Sentences in documentation shall be short</value>
+    <value>Keep documentation sentences short</value>
   </data>
   <data name="MiKo_2216_CodeFixTitle" xml:space="preserve">
     <value>Change &lt;param&gt; to &lt;paramref&gt;</value>
@@ -3068,7 +3068,7 @@ This ensures your list documentation is clear and accurately structured.</value>
     <value>Use &lt;list&gt; properly: {0}</value>
   </data>
   <data name="MiKo_2217_Title" xml:space="preserve">
-    <value>&lt;list&gt; documentation is done properly</value>
+    <value>Format &lt;list&gt; documentation properly</value>
   </data>
   <data name="MiKo_2218_CodeFixTitle" xml:space="preserve">
     <value>Shorten term</value>
@@ -3080,7 +3080,7 @@ This ensures your list documentation is clear and accurately structured.</value>
     <value>Replace '{0}' with '{1}'</value>
   </data>
   <data name="MiKo_2218_Title" xml:space="preserve">
-    <value>Documentation should use shorter terms instead of longer term 'used to/in/by'</value>
+    <value>Use shorter terms instead of 'used to/in/by' in documentation</value>
   </data>
   <data name="MiKo_2219_Description" xml:space="preserve">
     <value>XML documentation should be clear and comprehensive for developers. It must contain all important information in an easily readable and understandable format.
@@ -3095,7 +3095,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Do not use '{0}' in documentation</value>
   </data>
   <data name="MiKo_2219_Title" xml:space="preserve">
-    <value>Do not use question or explamation marks in documentation</value>
+    <value>Do not use question or exclamation marks in documentation</value>
   </data>
   <data name="MiKo_2220_CodeFixTitle" xml:space="preserve">
     <value>Replace with 'to seek'</value>
@@ -3107,7 +3107,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Use 'to seek' instead</value>
   </data>
   <data name="MiKo_2220_Title" xml:space="preserve">
-    <value>Documentation should use 'to seek' instead of 'to look for', 'to inspect for' or 'to test for'</value>
+    <value>Use 'to seek' instead of 'to look for', 'to inspect for' or 'to test for' in documentation</value>
   </data>
   <data name="MiKo_2221_Description" xml:space="preserve">
     <value>An empty documentation is a code smell. It indicates that the developer created the XML documentation tag intentionally but failed to provide any actual content. This suggests a potential oversight or lack of attention to detail. Proper documentation is crucial for code clarity and maintenance.</value>
@@ -3116,7 +3116,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Provide a documentation for &lt;{0}/&gt;</value>
   </data>
   <data name="MiKo_2221_Title" xml:space="preserve">
-    <value>Documentation should not use empty XML tags</value>
+    <value>Do not use empty XML tags in documentation</value>
   </data>
   <data name="MiKo_2222_CodeFixTitle" xml:space="preserve">
     <value>Change 'ident' into identification'</value>
@@ -3128,7 +3128,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Use 'identification' instead of 'ident'</value>
   </data>
   <data name="MiKo_2222_Title" xml:space="preserve">
-    <value>Documentation should use the term 'identification' instead of 'ident'</value>
+    <value>Use term 'identification' instead of 'ident' in documentation</value>
   </data>
   <data name="MiKo_2223_Description" xml:space="preserve">
     <value>XML documentation should link references like methods or types using &lt;see cref="..."/&gt; instead of plain text. This approach ensures refactoring tools can update these references during renames, preventing the documentation from pointing to non-existent code.</value>
@@ -3137,7 +3137,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Use '&lt;see cref="{0}"/&gt;' instead</value>
   </data>
   <data name="MiKo_2223_Title" xml:space="preserve">
-    <value>Documentation links references via &lt;see cref="..."/&gt;</value>
+    <value>Link references via &lt;see cref="..."/&gt; in documentation</value>
   </data>
   <data name="MiKo_2224_CodeFixTitle" xml:space="preserve">
     <value>Place on separate line</value>
@@ -3149,7 +3149,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Place '{0}' on separate line</value>
   </data>
   <data name="MiKo_2224_Title" xml:space="preserve">
-    <value>Documentation should have XML tags and texts placed on separate lines</value>
+    <value>Place XML tags and texts on separate lines in documentation</value>
   </data>
   <data name="MiKo_2225_CodeFixTitle" xml:space="preserve">
     <value>Place on same line</value>
@@ -3164,7 +3164,7 @@ This ensures clarity and usability in your documentation, making it straightforw
     <value>Place '&lt;c&gt;' tag with its content on same line</value>
   </data>
   <data name="MiKo_2225_Title" xml:space="preserve">
-    <value>Code marked with &lt;c&gt; tags should be placed on single line</value>
+    <value>Place code marked with &lt;c&gt; tags on single line</value>
   </data>
   <data name="MiKo_2226_Description" xml:space="preserve">
     <value>Instead of simply stating *that* an intention exists, documentation should clearly explain *what* the intention actually is. This provides developers with valuable background information, enabling them to make more informed decisions based on that context.
@@ -3174,7 +3174,7 @@ Clear intentions help convey the purpose and reasoning behind code, which is cru
     <value>Explain what the intention behind actually is</value>
   </data>
   <data name="MiKo_2226_Title" xml:space="preserve">
-    <value>Documentation should explain the 'Why' and not the 'That'</value>
+    <value>Explain the 'Why' instead of the 'That' in documentation</value>
   </data>
   <data name="MiKo_2227_Description" xml:space="preserve">
     <value>ReSharper allows you to suppress certain rules using inline comments like // ReSharper disable or // ReSharper disable once. These suppressions can apply either once or until the document's end, or until the rule is re-enabled.
@@ -3184,7 +3184,7 @@ However, these suppressions should remain inline comments and must not be part o
     <value>Remove from documentation and use inline comment instead</value>
   </data>
   <data name="MiKo_2227_Title" xml:space="preserve">
-    <value>Documentation should not contain ReSharper suppressions</value>
+    <value>Remove ReSharper suppressions from documentation</value>
   </data>
   <data name="MiKo_2228_Description" xml:space="preserve">
     <value>Negative wording can be confusing, especially when combined with other negative terms (e.g., "You cannot do this if it is not empty"). Positive wording is clearer and more direct, making the documentation straightforward and to the point. This approach enhances readability and comprehension, helping developers easily grasp the information.</value>
@@ -3193,7 +3193,7 @@ However, these suppressions should remain inline comments and must not be part o
     <value>Use positive wording instead of negative</value>
   </data>
   <data name="MiKo_2228_Title" xml:space="preserve">
-    <value>Documentation should use positive wording instead of negative</value>
+    <value>Use positive wording instead of negative in documentation</value>
   </data>
   <data name="MiKo_2229_CodeFixTitle" xml:space="preserve">
     <value>Delete XML fragment</value>
@@ -3205,7 +3205,7 @@ However, these suppressions should remain inline comments and must not be part o
     <value>Delete XML fragment '{0}'</value>
   </data>
   <data name="MiKo_2229_Title" xml:space="preserve">
-    <value>Documentation should not contain left-over XML fragments</value>
+    <value>Remove left-over XML fragments from documentation</value>
   </data>
   <data name="MiKo_2230_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;list&gt; for values and meaning</value>
@@ -3219,7 +3219,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Use &lt;list&gt; instead for values and their meaning</value>
   </data>
   <data name="MiKo_2230_Title" xml:space="preserve">
-    <value>Documentation of return value should use &lt;list&gt; when there are values with specific meanings</value>
+    <value>Use &lt;list&gt; for return values with specific meanings in documentation</value>
   </data>
   <data name="MiKo_2231_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;inheritdoc/&gt;</value>
@@ -3231,7 +3231,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Use &lt;inheritdoc/&gt; instead</value>
   </data>
   <data name="MiKo_2231_Title" xml:space="preserve">
-    <value>Documentation of overridden 'GetHashCode()' methods shall use '&lt;inheritdoc /&gt;' marker</value>
+    <value>Use '&lt;inheritdoc /&gt;' marker for overridden 'GetHashCode()' methods documentation</value>
   </data>
   <data name="MiKo_2232_CodeFixTitle" xml:space="preserve">
     <value>Remove empty &lt;summary&gt;</value>
@@ -3243,7 +3243,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Remove empty &lt;summary&gt;</value>
   </data>
   <data name="MiKo_2232_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation should not be empty</value>
+    <value>Do not leave &lt;summary&gt; documentation empty</value>
   </data>
   <data name="MiKo_2233_CodeFixTitle" xml:space="preserve">
     <value>Place on same line</value>
@@ -3255,7 +3255,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Place XML tag on single line</value>
   </data>
   <data name="MiKo_2233_Title" xml:space="preserve">
-    <value>XML tags should be placed on single line</value>
+    <value>Place XML tags on single line</value>
   </data>
   <data name="MiKo_2234_CodeFixTitle" xml:space="preserve">
     <value>Replace with 'to'</value>
@@ -3267,7 +3267,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Use 'to' instead</value>
   </data>
   <data name="MiKo_2234_Title" xml:space="preserve">
-    <value>Documentation should use 'to' instead of 'that is to' or 'which is to'</value>
+    <value>Use 'to' instead of 'that is to' or 'which is to' in documentation</value>
   </data>
   <data name="MiKo_2235_CodeFixTitle" xml:space="preserve">
     <value>Replace 'going to' with 'will'</value>
@@ -3279,7 +3279,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Replace '{0}' with 'will'</value>
   </data>
   <data name="MiKo_2235_Title" xml:space="preserve">
-    <value>Documentation should use 'will' instead of 'going to'</value>
+    <value>Use 'will' instead of 'going to' in documentation</value>
   </data>
   <data name="MiKo_2236_CodeFixTitle" xml:space="preserve">
     <value>Replace 'e.g.' with 'for example'</value>
@@ -3291,7 +3291,7 @@ In contrast, when the documentation is just some plain text then that is very di
     <value>Replace '{0}' with 'for example'</value>
   </data>
   <data name="MiKo_2236_Title" xml:space="preserve">
-    <value>Documentation should use 'for example' instead of abbreviation 'e.g.'</value>
+    <value>Use 'for example' instead of abbreviation 'e.g.' in documentation</value>
   </data>
   <data name="MiKo_2237_CodeFixTitle" xml:space="preserve">
     <value>Remove empty lines between documentation</value>
@@ -3305,7 +3305,7 @@ Keeping your comments compact and continuous makes them easier to read and ensur
     <value>Remove empty lines between documentation</value>
   </data>
   <data name="MiKo_2237_Title" xml:space="preserve">
-    <value>Documentation should not be separated by empty lines</value>
+    <value>Do not separate documentation with empty lines</value>
   </data>
   <data name="MiKo_2238_Description" xml:space="preserve">
     <value>XML documentation should be clear and purposeful. Vague phrases like "Make sure to call this" fail to describe the functionality or behavior of the code, leading to ambiguity about the method’s purpose.
@@ -3315,7 +3315,7 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
     <value>&lt;summary&gt; should describe the purpose and not the usage</value>
   </data>
   <data name="MiKo_2238_Title" xml:space="preserve">
-    <value>&lt;summary&gt; documentation shall not start with 'Make sure to call this'</value>
+    <value>Do not start &lt;summary&gt; documentation with 'Make sure to call this'</value>
   </data>
   <data name="MiKo_2239_CodeFixTitle" xml:space="preserve">
     <value>Convert into '/// &lt;summary&gt;' comment</value>
@@ -3328,7 +3328,7 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
     <value>Use '///' with XML tags instead of '/** */'</value>
   </data>
   <data name="MiKo_2239_Title" xml:space="preserve">
-    <value>Documentation should use '///' and not '/** */'</value>
+    <value>Use '///' instead of '/** */' for documentation</value>
   </data>
   <data name="MiKo_2240_CodeFixTitle" xml:space="preserve">
     <value>Fix response documentation</value>
@@ -3340,7 +3340,7 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
     <value>Start &lt;response&gt; with: '{0}'</value>
   </data>
   <data name="MiKo_2240_Title" xml:space="preserve">
-    <value>&lt;response&gt; documentation should not start with 'Returns'</value>
+    <value>Do not start &lt;response&gt; documentation with 'Returns'</value>
   </data>
   <data name="MiKo_2244_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;list&gt; to list items</value>
@@ -3356,7 +3356,7 @@ Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lis
     <value>Use &lt;list&gt; to list items in documentation</value>
   </data>
   <data name="MiKo_2244_Title" xml:space="preserve">
-    <value>Documentation should use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt;</value>
+    <value>Use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt; in documentation</value>
   </data>
   <data name="MiKo_2300_Description" xml:space="preserve">
     <value>Comments should provide the deeper reasons behind the code, explaining why it is written that way. Avoid detailing how the code works—let the code itself do that.
@@ -3366,7 +3366,7 @@ This approach ensures comments are insightful and add real value by giving conte
     <value>Remove comment or describe why exactly the code is the way it is</value>
   </data>
   <data name="MiKo_2300_Title" xml:space="preserve">
-    <value>Comments should explain the 'Why' and not the 'How'</value>
+    <value>Explain the 'Why' instead of the 'How' in comments</value>
   </data>
   <data name="MiKo_2301_CodeFixTitle" xml:space="preserve">
     <value>Remove obvious AAA comment</value>
@@ -3388,7 +3388,7 @@ Therefore, there's no need to keep commented-out code in the codebase, keeping t
     <value>Remove commented out code</value>
   </data>
   <data name="MiKo_2302_Title" xml:space="preserve">
-    <value>Do not keep code that is commented out</value>
+    <value>Remove commented-out code</value>
   </data>
   <data name="MiKo_2303_CodeFixTitle" xml:space="preserve">
     <value>Remove ending period from comment</value>
@@ -3446,7 +3446,7 @@ This rule contradicts MiKo_2303.</value>
     <value>Use 'failed' instead of 'was not successful'</value>
   </data>
   <data name="MiKo_2307_Title" xml:space="preserve">
-    <value>Comments should use the phrase 'failed' instead of 'was not successful'</value>
+    <value>Use phrase 'failed' instead of 'was not successful' in comments</value>
   </data>
   <data name="MiKo_2308_CodeFixTitle" xml:space="preserve">
     <value>Place comment before code</value>
@@ -3458,7 +3458,7 @@ This rule contradicts MiKo_2303.</value>
     <value>Place comment before code</value>
   </data>
   <data name="MiKo_2308_Title" xml:space="preserve">
-    <value>Do not place comment on single line before closing brace but after code</value>
+    <value>Place comments after code instead of on single line before closing brace</value>
   </data>
   <data name="MiKo_2309_CodeFixTitle" xml:space="preserve">
     <value>Change "n't" to " not"</value>
@@ -3470,7 +3470,7 @@ This rule contradicts MiKo_2303.</value>
     <value>Do not use contraction "n't"</value>
   </data>
   <data name="MiKo_2309_Title" xml:space="preserve">
-    <value>Comments should not use the contraction "n't"</value>
+    <value>Do not use contraction "n't" in comments</value>
   </data>
   <data name="MiKo_2310_Description" xml:space="preserve">
     <value>Instead of simply stating *that* an intention exists, documentation should clearly explain *what* the intention actually is. This provides developers with valuable background information, enabling them to make more informed decisions based on that context.
@@ -3480,7 +3480,7 @@ Clear intentions help convey the purpose and reasoning behind code, which is cru
     <value>Explain what the intention behind actually is</value>
   </data>
   <data name="MiKo_2310_Title" xml:space="preserve">
-    <value>Comments should explain the 'Why' and not the 'That'</value>
+    <value>Explain the 'Why' instead of the 'That' in comments</value>
   </data>
   <data name="MiKo_2311_CodeFixTitle" xml:space="preserve">
     <value>Remove separator comment</value>
@@ -3505,7 +3505,7 @@ Instead, comments should enhance understanding, giving context and reasoning for
     <value>Use 'to' instead</value>
   </data>
   <data name="MiKo_2312_Title" xml:space="preserve">
-    <value>Comments should use 'to' instead of 'that is to' or 'which is to'</value>
+    <value>Use 'to' instead of 'that is to' or 'which is to' in comments</value>
   </data>
   <data name="MiKo_2313_CodeFixTitle" xml:space="preserve">
     <value>Convert to XML documentation</value>
@@ -3517,7 +3517,7 @@ Instead, comments should enhance understanding, giving context and reasoning for
     <value>Use XML documentation instead</value>
   </data>
   <data name="MiKo_2313_Title" xml:space="preserve">
-    <value>Plain documentation comments should be XML documentation</value>
+    <value>Format plain documentation comments as XML documentation</value>
   </data>
   <data name="MiKo_3000_Description" xml:space="preserve">
     <value>If #region directives are used, avoid any empty #region. They just clutter the code without adding any value. When regions are truly needed, keep them meaningful and populated to ensure the code remains clean and efficient. This approach maintains clarity and organization in the codebase.</value>
@@ -3538,7 +3538,7 @@ Instead, comments should enhance understanding, giving context and reasoning for
     <value>Use 'Action', 'Func' or 'Expression' instead</value>
   </data>
   <data name="MiKo_3001_Title" xml:space="preserve">
-    <value>Custom delegates should not be used</value>
+    <value>Do not use custom delegates</value>
   </data>
   <data name="MiKo_3002_Description" xml:space="preserve">
     <value>If a class has too many dependencies, it's taking on too many responsibilities and violating the Single Responsibility Principle (SRP). This indicates a need for refactoring the class into smaller, more focused units, ensuring the codebase remains clean and manageable.</value>
@@ -3547,7 +3547,7 @@ Instead, comments should enhance understanding, giving context and reasoning for
     <value>Too many MEF dependencies: {1,4} (allowed are max. {2})</value>
   </data>
   <data name="MiKo_3002_Title" xml:space="preserve">
-    <value>Classes should not have too many dependencies</value>
+    <value>Limit class dependencies</value>
   </data>
   <data name="MiKo_3003_Description" xml:space="preserve">
     <value>To ease usage, events should follow the .NET Framework Design Guidelines for Event Design.</value>
@@ -3559,7 +3559,7 @@ Instead, comments should enhance understanding, giving context and reasoning for
     <value>Use 'EventHandler' or 'EventHandler&lt;T&gt;' instead</value>
   </data>
   <data name="MiKo_3003_Title" xml:space="preserve">
-    <value>Events should follow .NET Framework Design Guidelines for events</value>
+    <value>Follow .NET Framework Design Guidelines for events</value>
   </data>
   <data name="MiKo_3004_Description" xml:space="preserve">
     <value>EventArgs are meant solely for raising events and passing data to event handlers. If the event data changes between handlers, it leads to unpredictable behavior and potential race conditions.
@@ -3570,7 +3570,7 @@ To prevent this, make EventArgs properties read-only or only privately settable.
     <value>Make setter private or property read-only</value>
   </data>
   <data name="MiKo_3004_Title" xml:space="preserve">
-    <value>Property setters of EventArgs shall be private</value>
+    <value>Make EventArgs property setters private</value>
   </data>
   <data name="MiKo_3005_Description" xml:space="preserve">
     <value>'Try' methods should follow the Try-Doer pattern to ease maintenance. They should return a Boolean and use the last parameter as an [out] parameter for the result. If successful, the method returns 'true' and provides valid output; otherwise, it returns 'false'.
@@ -3580,7 +3580,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Follow the Trier-Doer-Pattern</value>
   </data>
   <data name="MiKo_3005_Title" xml:space="preserve">
-    <value>Methods named 'Try' should follow the Trier-Doer-Pattern</value>
+    <value>Follow Trier-Doer-Pattern for methods named 'Try'</value>
   </data>
   <data name="MiKo_3006_Description" xml:space="preserve">
     <value>To ensure consistency with .NET Framework classes and ease maintenance, place 'CancellationToken' parameters after all other method parameters. This practice keeps your codebase predictable and aligned with established conventions, making it easier for developers to understand and maintain.</value>
@@ -3589,7 +3589,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Place '{0}' as last parameter</value>
   </data>
   <data name="MiKo_3006_Title" xml:space="preserve">
-    <value>'CancellationToken' parameter should be last method parameter</value>
+    <value>Place 'CancellationToken' parameter last in method parameters</value>
   </data>
   <data name="MiKo_3007_Description" xml:space="preserve">
     <value>To improve maintainability and readability, stick to a single language when writing methods. Avoid mixing LINQ method syntax with declarative query syntax within the same method. This practice ensures consistency, making the code clean, easier to read, and more straightforward to maintain.</value>
@@ -3598,7 +3598,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Do not mix LINQ syntax</value>
   </data>
   <data name="MiKo_3007_Title" xml:space="preserve">
-    <value>Do not use LINQ method and declarative query syntax in same method</value>
+    <value>Do not mix LINQ method and declarative query syntax in same method</value>
   </data>
   <data name="MiKo_3008_Description" xml:space="preserve">
     <value>Methods should avoid returning mutable collections like 'ICollection&lt;T&gt;' since these can be modified from outside the method. Instead, they should return read-only variants like 'IReadOnlyCollection&lt;T&gt;'. This practice ensures data integrity and encapsulation, making the code more secure and predictable.</value>
@@ -3607,7 +3607,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Use a read-only immutable variant or 'IEnumerable&lt;T&gt;' instead</value>
   </data>
   <data name="MiKo_3008_Title" xml:space="preserve">
-    <value>Method should not return collections that can be changed from outside</value>
+    <value>Return immutable collections</value>
   </data>
   <data name="MiKo_3009_Description" xml:space="preserve">
     <value>Avoid using anonymous lambdas for methods invoked by commands. They can be hard to read, understand, and maintain. Instead, use named methods with meaningful names. This practice enhances code readability and maintainability, making the code clear and straightforward for developers.</value>
@@ -3616,7 +3616,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Use named method instead</value>
   </data>
   <data name="MiKo_3009_Title" xml:space="preserve">
-    <value>Commands should invoke only named methods and no lambda expressions</value>
+    <value>Use named methods instead of lambda expressions with commands</value>
   </data>
   <data name="MiKo_3010_Description" xml:space="preserve">
     <value>Certain exceptions are reserved for and thrown by the Common Language Runtime (CLR) and often signal bugs. Developers should not throw these exceptions themselves to maintain code cleanliness and avoid confusion. Following this principle ensures clear and robust code management.</value>
@@ -3643,7 +3643,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Change 'paramName' parameter to {1}</value>
   </data>
   <data name="MiKo_3011_Title" xml:space="preserve">
-    <value>Thrown ArgumentExceptions (or its subtypes) shall provide the correct parameter name</value>
+    <value>Provide correct parameter name for ArgumentExceptions</value>
   </data>
   <data name="MiKo_3012_CodeFixTitle" xml:space="preserve">
     <value>Provide actual value</value>
@@ -3655,7 +3655,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Provide the actual value that causes the exception to be thrown</value>
   </data>
   <data name="MiKo_3012_Title" xml:space="preserve">
-    <value>Thrown ArgumentOutOfRangeExceptions (or its subtypes) shall provide the actual value that causes the exception to be thrown</value>
+    <value>Provide actual value when throwing ArgumentOutOfRangeExceptions</value>
   </data>
   <data name="MiKo_3013_CodeFixTitle" xml:space="preserve">
     <value>Change to 'ArgumentOutOfRangeException'</value>
@@ -3667,7 +3667,7 @@ This pattern keeps methods consistent and predictable, enhancing readability and
     <value>Throw an 'ArgumentOutOfRangeException' instead</value>
   </data>
   <data name="MiKo_3013_Title" xml:space="preserve">
-    <value>The 'default' clause in 'switch' statements should throw an ArgumentOutOfRangeException (or subtype), but no ArgumentException</value>
+    <value>Throw ArgumentOutOfRangeException (not ArgumentException) in 'switch' default clauses</value>
   </data>
   <data name="MiKo_3014_CodeFixTitle" xml:space="preserve">
     <value>Add a default reason</value>
@@ -3680,7 +3680,7 @@ This practice ensures that developers understand why the exception was thrown an
     <value>Provide a reason for the thrown '{0}'</value>
   </data>
   <data name="MiKo_3014_Title" xml:space="preserve">
-    <value>InvalidOperationException, NotImplementedException and NotSupportedException should have a reason as message</value>
+    <value>Include reason in InvalidOperationException, NotImplementedException and NotSupportedException messages</value>
   </data>
   <data name="MiKo_3015_CodeFixTitle" xml:space="preserve">
     <value>Change to 'InvalidOperationException'</value>
@@ -3695,7 +3695,7 @@ This practice ensures that developers understand why the exception was thrown an
     <value>Throw an 'InvalidOperationException' instead</value>
   </data>
   <data name="MiKo_3015_Title" xml:space="preserve">
-    <value>Throw InvalidOperationExceptions (instead of ArgumentExceptions or its subtypes) to indicate inappropriate states of parameterless methods</value>
+    <value>Use InvalidOperationExceptions for inappropriate states of parameterless methods</value>
   </data>
   <data name="MiKo_3016_CodeFixTitle" xml:space="preserve">
     <value>Change to 'ArgumentException' or 'InvalidOperationException'</value>
@@ -3715,7 +3715,7 @@ This approach ensures that the exception thrown accurately reflects the nature o
     <value>Throw an 'ArgumentException' or 'InvalidOperationException' instead</value>
   </data>
   <data name="MiKo_3016_Title" xml:space="preserve">
-    <value>Do not throw ArgumentNullException for inappropriate states of property return values</value>
+    <value>Do not throw ArgumentNullException for property return values</value>
   </data>
   <data name="MiKo_3017_CodeFixTitle" xml:space="preserve">
     <value>Add inner exception</value>
@@ -3727,7 +3727,7 @@ This approach ensures that the exception thrown accurately reflects the nature o
     <value>Provide exception as inner exception</value>
   </data>
   <data name="MiKo_3017_Title" xml:space="preserve">
-    <value>Do not swallow exceptions when throwing new exceptions</value>
+    <value>Include original exception when throwing new exceptions</value>
   </data>
   <data name="MiKo_3018_Description" xml:space="preserve">
     <value>Already disposed instances of disposable types should throw ObjectDisposedExceptions when methods are invoked on them. This practice makes it easier to identify bugs, as user code should never access already disposed types. Ensuring this indication helps maintain code integrity and prevents unintended errors.</value>
@@ -3739,7 +3739,7 @@ This approach ensures that the exception thrown accurately reflects the nature o
     <value>Throw ObjectDisposedException if disposed</value>
   </data>
   <data name="MiKo_3018_Title" xml:space="preserve">
-    <value>Throw ObjectDisposedExceptions on publicly visible methods of disposable types</value>
+    <value>Throw ObjectDisposedExceptions on public methods of disposable types</value>
   </data>
   <data name="MiKo_3020_CodeFixTitle" xml:space="preserve">
     <value>Use 'Task.CompletedTask'</value>
@@ -3763,7 +3763,7 @@ This approach ensures that the exception thrown accurately reflects the nature o
     <value>Use '{0}' to invoke method '{1}', but not inside</value>
   </data>
   <data name="MiKo_3021_Title" xml:space="preserve">
-    <value>Do not use 'Task.Run' in the implementation</value>
+    <value>Do not use 'Task.Run' in implementation</value>
   </data>
   <data name="MiKo_3022_Description" xml:space="preserve">
     <value>If a method returns 'Task&lt;IEnumerable&gt;' or 'Task&lt;IEnumerable&lt;T&gt;&gt;', the enumerable is likely not evaluated until accessed in a foreach or LINQ call. This evaluation likely occurs on another thread (e.g., the main thread), which contradicts the idea of returning a dedicated task.</value>
@@ -3793,7 +3793,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Do not use 'ref'</value>
   </data>
   <data name="MiKo_3024_Title" xml:space="preserve">
-    <value>Do not use the [ref] keyword on reference parameters</value>
+    <value>Do not use [ref] keyword on reference parameters</value>
   </data>
   <data name="MiKo_3025_Description" xml:space="preserve">
     <value>Treat method parameters as read-only. Avoid re-assigning them to other values. If another value is needed, use a local variable instead. This approach keeps the method clean and predictable.</value>
@@ -3811,7 +3811,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Parameter is not used and can be safely removed</value>
   </data>
   <data name="MiKo_3026_Title" xml:space="preserve">
-    <value>Unused parameters should be removed</value>
+    <value>Remove unused parameters</value>
   </data>
   <data name="MiKo_3027_Description" xml:space="preserve">
     <value>Marking parameters for future use results in poor design. It's uncertain if the parameter will ever be used or if its type will fit future needs. Instead, override methods and add new parameters as needed. This approach maintains clarity and adaptability in your code, avoiding unnecessary clutter and potential issues. Keeps your codebase clean and efficient.</value>
@@ -3823,7 +3823,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Do not reserve '{0}' for future usage</value>
   </data>
   <data name="MiKo_3027_Title" xml:space="preserve">
-    <value>Parameters should not be marked to be reserved for future usage</value>
+    <value>Do not reserve parameters for future use</value>
   </data>
   <data name="MiKo_3028_Description" xml:space="preserve">
     <value>To clear a collection, use 'Clear()'. Assigning 'null' to a parameter will not work because the parameter is just a copy (reference) of the original. 'Clear()' effectively empties the collection, maintaining clarity and correct functionality. Keeps everything working as expected.</value>
@@ -3841,7 +3841,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Assignment causes potential memory leak</value>
   </data>
   <data name="MiKo_3029_Title" xml:space="preserve">
-    <value>Event registrations should not cause memory leaks</value>
+    <value>Prevent memory leaks in event registrations</value>
   </data>
   <data name="MiKo_3030_Description" xml:space="preserve">
     <value>To ease maintenance, methods should make minimal assumptions about the structure or properties of the objects they use. They should work only with objects they receive directly and avoid reaching through these objects to access other objects or their services. This practice keeps methods focused, modular, and easier to maintain.</value>
@@ -3853,7 +3853,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Avoid to violate the Law of Demeter</value>
   </data>
   <data name="MiKo_3030_Title" xml:space="preserve">
-    <value>Methods should follow the Law of Demeter</value>
+    <value>Follow Law of Demeter in methods</value>
   </data>
   <data name="MiKo_3031_Description" xml:space="preserve">
     <value>Avoid implementing 'ICloneable.Clone()' because the method does not specify whether it returns a deep or shallow copy, leading to potential inconsistencies. This ambiguity makes it unreliable, as there's a significant difference between deep and shallow copies. Ensuring clear, predictable behavior in your code is crucial.</value>
@@ -3862,7 +3862,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Do not implement 'ICloneable.Clone()'</value>
   </data>
   <data name="MiKo_3031_Title" xml:space="preserve">
-    <value>ICloneable.Clone() should not be implemented</value>
+    <value>Do not implement ICloneable.Clone()</value>
   </data>
   <data name="MiKo_3032_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -3874,7 +3874,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Use '{1}' instead</value>
   </data>
   <data name="MiKo_3032_Title" xml:space="preserve">
-    <value>Use 'nameof' instead of Cinch for names of properties for created 'PropertyChangedEventArgs' instances</value>
+    <value>Use 'nameof' instead of Cinch for PropertyChangedEventArgs property names</value>
   </data>
   <data name="MiKo_3033_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -3886,7 +3886,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Use 'nameof'</value>
   </data>
   <data name="MiKo_3033_Title" xml:space="preserve">
-    <value>Use 'nameof' for names of properties for created 'PropertyChangingEventArgs' and 'PropertyChangedEventArgs' instances</value>
+    <value>Use 'nameof' for property names in PropertyChangingEventArgs and PropertyChangedEventArgs</value>
   </data>
   <data name="MiKo_3034_CodeFixTitle" xml:space="preserve">
     <value>Apply [CallerMemberName]</value>
@@ -3898,7 +3898,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Apply [CallerMemberName] attribute</value>
   </data>
   <data name="MiKo_3034_Title" xml:space="preserve">
-    <value>PropertyChanged event raiser shall use [CallerMemberName] attribute</value>
+    <value>Use [CallerMemberName] attribute for PropertyChanged event raisers</value>
   </data>
   <data name="MiKo_3035_Description" xml:space="preserve">
     <value>'WaitOne' methods are used to wait for a specific situation to occur. Waiting indefinitely can lead to deadlocks or livelocks. To prevent this, provide a TimeSpan to 'WaitOne' to allow the wait to time out. This ensures better control and avoids potential blocking issues, keeping the system responsive and efficient.</value>
@@ -3907,7 +3907,7 @@ Generally, this behavior is not desirable. The object reference should remain th
     <value>Provide a timeout value</value>
   </data>
   <data name="MiKo_3035_Title" xml:space="preserve">
-    <value>Do not invoke 'WaitOne' methods without timeouts</value>
+    <value>Always specify timeouts with 'WaitOne' methods</value>
   </data>
   <data name="MiKo_3036_CodeFixTitle" xml:space="preserve">
     <value>Use factory method</value>
@@ -3922,7 +3922,7 @@ It would be even better to use extension methods like 'Minutes()' or 'Days()'. T
     <value>Use factory or extension method instead</value>
   </data>
   <data name="MiKo_3036_Title" xml:space="preserve">
-    <value>Prefer to use 'TimeSpan' factory methods instead of constructors</value>
+    <value>Use 'TimeSpan' factory methods instead of constructors</value>
   </data>
   <data name="MiKo_3037_Description" xml:space="preserve">
     <value>Classes often have methods like 'WaitForExit' or 'WaitOne' that use an 'int' parameter for timeouts. This 'magic' number makes it unclear if the value is in milliseconds, seconds, etc. To improve readability and maintenance, avoid hard-coding these numbers. Instead, use a 'TimeSpan', which clarifies the duration and is easier to read.
@@ -3954,7 +3954,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Do not use '{1}' inside property</value>
   </data>
   <data name="MiKo_3039_Title" xml:space="preserve">
-    <value>Properties should not use Linq or yield</value>
+    <value>Do not use Linq or yield in properties</value>
   </data>
   <data name="MiKo_3040_Description" xml:space="preserve">
     <value>To ease maintenance and improve readability, avoid using Booleans as parameters unless absolutely sure the value will never exceed two options. Instead, use an Enum. This practice ensures the code remains clear, flexible, and easier to maintain.</value>
@@ -3966,7 +3966,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Use an Enum instead</value>
   </data>
   <data name="MiKo_3040_Title" xml:space="preserve">
-    <value>Do not use Booleans unless you are absolutely sure that you will never ever need more than 2 values</value>
+    <value>Use enums instead of booleans when more than 2 values might be needed</value>
   </data>
   <data name="MiKo_3041_Description" xml:space="preserve">
     <value>Avoid using delegates like 'Action' or 'Func' in 'EventArgs'. The callee must understand exactly how the delegate behaves. Failures within the delegate are difficult to debug, as exceptions are thrown in unrelated areas.</value>
@@ -3975,7 +3975,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Do not use a delegate</value>
   </data>
   <data name="MiKo_3041_Title" xml:space="preserve">
-    <value>EventArgs shall not use delegates</value>
+    <value>Do not use delegates in EventArgs</value>
   </data>
   <data name="MiKo_3042_Description" xml:space="preserve">
     <value>EventArgs are standalone contracts. They should not implement any additional interfaces. This keeps their purpose clear and their usage straightforward, avoiding unnecessary complexity. Keeps the code clean and maintains the integrity of the event handling mechanism.</value>
@@ -3984,7 +3984,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Do not implement interface</value>
   </data>
   <data name="MiKo_3042_Title" xml:space="preserve">
-    <value>EventArgs shall not implement interfaces</value>
+    <value>Do not implement interfaces in EventArgs</value>
   </data>
   <data name="MiKo_3043_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -4008,7 +4008,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Use 'nameof'</value>
   </data>
   <data name="MiKo_3044_Title" xml:space="preserve">
-    <value>Use 'nameof' to compare property names of 'PropertyChangingEventArgs' and 'PropertyChangedEventArgs'</value>
+    <value>Use 'nameof' to compare property names of PropertyChangingEventArgs and PropertyChangedEventArgs</value>
   </data>
   <data name="MiKo_3045_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -4032,7 +4032,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Use 'nameof'</value>
   </data>
   <data name="MiKo_3046_Title" xml:space="preserve">
-    <value>Use 'nameof' for property names of property raising methods</value>
+    <value>Use 'nameof' for property names in property raising methods</value>
   </data>
   <data name="MiKo_3047_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -4053,7 +4053,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Apply the [ValueConversion] attribute</value>
   </data>
   <data name="MiKo_3048_Title" xml:space="preserve">
-    <value>ValueConverters shall have the [ValueConversion] attribute applied</value>
+    <value>Apply [ValueConversion] attribute to ValueConverters</value>
   </data>
   <data name="MiKo_3049_Description" xml:space="preserve">
     <value>In C#, you might need a string description for an enum value. Achieve this by using the 'System.ComponentModel.DescriptionAttribute' to decorate the enum member. This method associates descriptive text with enum values, enhancing both readability and usability.</value>
@@ -4062,7 +4062,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Apply a [Description] attribute with a proper description</value>
   </data>
   <data name="MiKo_3049_Title" xml:space="preserve">
-    <value>Enum members shall have the [Description] attribute applied</value>
+    <value>Apply [Description] attribute to enum members</value>
   </data>
   <data name="MiKo_3050_CodeFixTitle" xml:space="preserve">
     <value>Make DependencyProperty 'public static readonly'</value>
@@ -4077,7 +4077,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Make it 'public static readonly'</value>
   </data>
   <data name="MiKo_3050_Title" xml:space="preserve">
-    <value>DependencyProperty fields should be 'public static readonly'</value>
+    <value>Declare DependencyProperty fields as 'public static readonly'</value>
   </data>
   <data name="MiKo_3051_CodeFixTitle" xml:space="preserve">
     <value>Use 'nameof'</value>
@@ -4092,7 +4092,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Use '{1}' instead</value>
   </data>
   <data name="MiKo_3051_Title" xml:space="preserve">
-    <value>DependencyProperty fields should be properly registered</value>
+    <value>Register DependencyProperty fields properly</value>
   </data>
   <data name="MiKo_3052_CodeFixTitle" xml:space="preserve">
     <value>Make DependencyPropertyKey 'private static readonly'</value>
@@ -4107,7 +4107,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Make it non-public 'static readonly'</value>
   </data>
   <data name="MiKo_3052_Title" xml:space="preserve">
-    <value>DependencyPropertyKey fields should be non-public 'static readonly'</value>
+    <value>Declare DependencyPropertyKey fields as non-public 'static readonly'</value>
   </data>
   <data name="MiKo_3053_Description" xml:space="preserve">
     <value>To prevent typos, register fields that are the key of a DependencyProperty using 'DependencyProperty.RegisterReadOnly()' and the 'nameof' operator. Also, ensure you provide the correct property names, property types, and owning types.</value>
@@ -4119,7 +4119,7 @@ Instead, use methods to make it clear that the behavior might differ between cal
     <value>Use '{1}' instead</value>
   </data>
   <data name="MiKo_3053_Title" xml:space="preserve">
-    <value>DependencyPropertyKey fields should be properly registered</value>
+    <value>Register DependencyPropertyKey fields properly</value>
   </data>
   <data name="MiKo_3054_CodeFixTitle" xml:space="preserve">
     <value>Expose DependencyProperty identifier</value>
@@ -4135,7 +4135,7 @@ This maintains encapsulation while allowing access to the property.</value>
     <value>Expose a DependencyProperty identifier for the read-only dependency property '{0}'</value>
   </data>
   <data name="MiKo_3054_Title" xml:space="preserve">
-    <value>A read-only DependencyProperty should have an exposed DependencyProperty identifier</value>
+    <value>Expose DependencyProperty identifier for read-only DependencyProperties</value>
   </data>
   <data name="MiKo_3055_Description" xml:space="preserve">
     <value>In WPF, view models use bindings. If a view model does not implement 'INotifyPropertyChanged', WPF uses reflection to detect changes, causing a memory leak. The binding instance (descriptor) stays in a static hash table for the app's lifetime.
@@ -4145,7 +4145,7 @@ To avoid this, make sure types implement 'INotifyPropertyChanged' and raise the 
     <value>Implement INotifyPropertyChanged to avoid WPF binding memory leaks</value>
   </data>
   <data name="MiKo_3055_Title" xml:space="preserve">
-    <value>ViewModels should implement INotifyPropertyChanged</value>
+    <value>Implement INotifyPropertyChanged in ViewModels</value>
   </data>
   <data name="MiKo_3060_CodeFixTitle" xml:space="preserve">
     <value>Remove Assert call</value>
@@ -4169,7 +4169,7 @@ Never use 'Debug.Assert()' or 'Trace.Assert()' in (unit) test code. Let the test
     <value>Do not use '{1}'</value>
   </data>
   <data name="MiKo_3060_Title" xml:space="preserve">
-    <value>Debug.Assert or Trace.Assert shall not be used</value>
+    <value>Do not use Debug.Assert or Trace.Assert</value>
   </data>
   <data name="MiKo_3061_Description" xml:space="preserve">
     <value>Loggers are often requested via a type, which results in logs lacking useful categories. Developers might control log output using different severities (Debug, Info, etc.), leading to cluttered logs. This makes it unclear which log statement belongs to which category.
@@ -4180,7 +4180,7 @@ Instead, request the logger via a string as the category. This approach ensures 
     <value>Use a string as category instead</value>
   </data>
   <data name="MiKo_3061_Title" xml:space="preserve">
-    <value>Loggers shall use a proper log category</value>
+    <value>Use proper log categories with loggers</value>
   </data>
   <data name="MiKo_3062_CodeFixTitle" xml:space="preserve">
     <value>End log message with colon</value>
@@ -4192,7 +4192,7 @@ Instead, request the logger via a string as the category. This approach ensures 
     <value>End log message with colon</value>
   </data>
   <data name="MiKo_3062_Title" xml:space="preserve">
-    <value>End log messages for exceptions with a colon</value>
+    <value>End exception log messages with a colon</value>
   </data>
   <data name="MiKo_3063_CodeFixTitle" xml:space="preserve">
     <value>End log message with dot</value>
@@ -4216,7 +4216,7 @@ Instead, request the logger via a string as the category. This approach ensures 
     <value>Do not use contraction "n't"</value>
   </data>
   <data name="MiKo_3064_Title" xml:space="preserve">
-    <value>Log messages should not use the contraction "n't"</value>
+    <value>Do not use contraction "n't" in log messages</value>
   </data>
   <data name="MiKo_3065_CodeFixTitle" xml:space="preserve">
     <value>Change interpolated string into normal string</value>
@@ -4232,7 +4232,7 @@ Using interpolated strings instead of message templates prevents this filtering 
     <value>Do not use interpolated string</value>
   </data>
   <data name="MiKo_3065_Title" xml:space="preserve">
-    <value>Microsoft Logging calls should not use interpolated strings</value>
+    <value>Do not use interpolated strings with Microsoft Logging calls</value>
   </data>
   <data name="MiKo_3070_Description" xml:space="preserve">
     <value>Methods returning 'IEnumerable' are meant for foreach loops or LINQ queries. These methods should never return null, as it could lead to NullReferenceException or ArgumentNullException. Ensuring they do not return null keeps your code predictable and safe from unexpected runtime errors.</value>
@@ -4241,7 +4241,7 @@ Using interpolated strings instead of message templates prevents this filtering 
     <value>Do not return null</value>
   </data>
   <data name="MiKo_3070_Title" xml:space="preserve">
-    <value>Do not return null for an IEnumerable</value>
+    <value>Do not return null for IEnumerable</value>
   </data>
   <data name="MiKo_3071_Description" xml:space="preserve">
     <value>Methods that return 'Task' are intended for async calls. These methods should never return null, as this could lead to a NullReferenceException. Ensuring they do not return null keeps your code predictable and safe from unexpected runtime errors, maintaining reliability and smooth functionality.</value>
@@ -4250,7 +4250,7 @@ Using interpolated strings instead of message templates prevents this filtering 
     <value>Do not return null</value>
   </data>
   <data name="MiKo_3071_Title" xml:space="preserve">
-    <value>Do not return null for a Task</value>
+    <value>Do not return null for Task</value>
   </data>
   <data name="MiKo_3072_Description" xml:space="preserve">
     <value>Public methods should return interfaces like 'IList&lt;&gt;' or 'IDictionary&lt;&gt;' instead of concrete types like 'List&lt;&gt;' or 'Dictionary&lt;&gt;'. This approach provides flexibility, allowing you to change the implementation of the return value without affecting the method's signature, keeping your code adaptable and maintainable.</value>
@@ -4259,7 +4259,7 @@ Using interpolated strings instead of message templates prevents this filtering 
     <value>Do not return {1}&lt;&gt;</value>
   </data>
   <data name="MiKo_3072_Title" xml:space="preserve">
-    <value>Non-private methods should not return 'List&lt;&gt;' or 'Dictionary&lt;&gt;'</value>
+    <value>Do not return 'List&lt;&gt;' or 'Dictionary&lt;&gt;' from non-private methods</value>
   </data>
   <data name="MiKo_3073_Description" xml:space="preserve">
     <value>Avoid returning from within a constructor. Constructors should execute fully, ensuring the objects are completely initialized. Partial initialization can lead to unpredictable behavior and inconsistencies.</value>
@@ -4268,7 +4268,7 @@ Using interpolated strings instead of message templates prevents this filtering 
     <value>Do not return inside constructor</value>
   </data>
   <data name="MiKo_3073_Title" xml:space="preserve">
-    <value>Do not leave objects partially initialized</value>
+    <value>Fully initialize objects</value>
   </data>
   <data name="MiKo_3074_Description" xml:space="preserve">
     <value>A constructor's main purpose is to create an initialized instance of its specific type. It should not be used to create instances of other types.
@@ -4292,7 +4292,7 @@ These types can be modified later if derivation becomes necessary. Keeping them 
     <value>Seal class or make it static</value>
   </data>
   <data name="MiKo_3075_Title" xml:space="preserve">
-    <value>Internal and private types should be either static or sealed unless derivation from them is required</value>
+    <value>Mark internal and private types as static or sealed unless derivation is needed</value>
   </data>
   <data name="MiKo_3076_Description" xml:space="preserve">
     <value>If a static member initializer uses another member defined below or in another type part, it might get initialized with the wrong value at runtime. This happens because the static member initializes before the other referenced member.
@@ -4303,7 +4303,7 @@ This can cause subtle bugs like 'TypeInitializerException's or incorrect values.
     <value>Static member initializer refers to static member(s) {1} below or in other type part</value>
   </data>
   <data name="MiKo_3076_Title" xml:space="preserve">
-    <value>Do not initialize static member with static member below or in other type part</value>
+    <value>Do not initialize static members with static members below or in other type parts</value>
   </data>
   <data name="MiKo_3077_CodeFixTitle" xml:space="preserve">
     <value>Apply a default value</value>
@@ -4316,7 +4316,7 @@ This practice aids in ensuring the value is the intended one, keeping the code c
     <value>Set a default value</value>
   </data>
   <data name="MiKo_3077_Title" xml:space="preserve">
-    <value>Properties that return an Enum should have a default value</value>
+    <value>Provide default values for Enum-returning properties</value>
   </data>
   <data name="MiKo_3078_CodeFixTitle" xml:space="preserve">
     <value>Apply a default value</value>
@@ -4329,7 +4329,7 @@ This approach ensures stability and clarity, keeping the Enum's behavior consist
     <value>Set a default value</value>
   </data>
   <data name="MiKo_3078_Title" xml:space="preserve">
-    <value>Enum members should have a default value</value>
+    <value>Provide default values for enum members</value>
   </data>
   <data name="MiKo_3079_CodeFixTitle" xml:space="preserve">
     <value>Replace with hex value</value>
@@ -4341,7 +4341,7 @@ This approach ensures stability and clarity, keeping the Enum's behavior consist
     <value>Use 'unchecked((int)0x{0})' instead for HResult</value>
   </data>
   <data name="MiKo_3079_Title" xml:space="preserve">
-    <value>HResults should be written in hexadecimal</value>
+    <value>Write HResults in hexadecimal</value>
   </data>
   <data name="MiKo_3080_Description" xml:space="preserve">
     <value>Using switch statements to assign variables within methods increases complexity and reduces readability. Simplify this by refactoring the switch statement into its own method.
@@ -4352,7 +4352,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Place switch statement in separate method and return value within case blocks</value>
   </data>
   <data name="MiKo_3080_Title" xml:space="preserve">
-    <value>Use 'switch ... return' instead of 'switch ... break' when assigning variables</value>
+    <value>Use 'switch ... return' instead of 'switch ... break' for variable assignments</value>
   </data>
   <data name="MiKo_3081_CodeFixTitle" xml:space="preserve">
     <value>Apply 'is false' pattern</value>
@@ -4364,7 +4364,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Use pattern 'is false' instead of ' ! '</value>
   </data>
   <data name="MiKo_3081_Title" xml:space="preserve">
-    <value>Prefer pattern matching over a logical NOT condition</value>
+    <value>Use pattern matching instead of logical NOT conditions</value>
   </data>
   <data name="MiKo_3082_CodeFixTitle" xml:space="preserve">
     <value>Apply 'is' pattern</value>
@@ -4376,7 +4376,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Use 'is' instead of '=='</value>
   </data>
   <data name="MiKo_3082_Title" xml:space="preserve">
-    <value>Prefer pattern matching over a logical comparison with 'true' or 'false'</value>
+    <value>Use pattern matching instead of comparing with 'true' or 'false'</value>
   </data>
   <data name="MiKo_3083_CodeFixTitle" xml:space="preserve">
     <value>Apply 'is null' pattern</value>
@@ -4388,7 +4388,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Use 'is' instead of '=='</value>
   </data>
   <data name="MiKo_3083_Title" xml:space="preserve">
-    <value>Prefer pattern matching for null checks</value>
+    <value>Use pattern matching for null checks</value>
   </data>
   <data name="MiKo_3084_CodeFixTitle" xml:space="preserve">
     <value>Place constant value on right side</value>
@@ -4400,7 +4400,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Place it on right side of '{0}'</value>
   </data>
   <data name="MiKo_3084_Title" xml:space="preserve">
-    <value>Do not place constants on the left side for comparisons</value>
+    <value>Place variables, not constants, on the left side of comparisons</value>
   </data>
   <data name="MiKo_3085_CodeFixTitle" xml:space="preserve">
     <value>Convert to 'if ... else ...'</value>
@@ -4412,7 +4412,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Shorten conditional or use 'if ... else ...' instead</value>
   </data>
   <data name="MiKo_3085_Title" xml:space="preserve">
-    <value>Conditional statements should be short</value>
+    <value>Keep conditional statements short</value>
   </data>
   <data name="MiKo_3086_Description" xml:space="preserve">
     <value>Nested conditional or coalesce statements are difficult to read and understand. Avoid nesting them. Instead, use if-else statements to improve clarity. This approach keeps your code clean and maintainable.</value>
@@ -4442,7 +4442,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Use 'is not' instead of '!='</value>
   </data>
   <data name="MiKo_3088_Title" xml:space="preserve">
-    <value>Prefer pattern matching for not-null checks</value>
+    <value>Use pattern matching for not-null checks</value>
   </data>
   <data name="MiKo_3089_CodeFixTitle" xml:space="preserve">
     <value>Convert property pattern condition into normal condition</value>
@@ -4454,7 +4454,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Convert property pattern condition into normal condition</value>
   </data>
   <data name="MiKo_3089_Title" xml:space="preserve">
-    <value>Do not use simple constant property patterns as conditions of 'if' statements</value>
+    <value>Do not use simple constant property patterns as conditions in 'if' statements</value>
   </data>
   <data name="MiKo_3090_Description" xml:space="preserve">
     <value>Throw exceptions inside try or catch blocks, not within finally blocks. Finally blocks are meant for cleanup or to ensure certain code runs regardless of other factors. This maintains their intended purpose and keeps your code clear.</value>
@@ -4508,7 +4508,7 @@ This approach enhances clarity and maintainability.</value>
     <value>Provide a comment that reasons why the block is empty</value>
   </data>
   <data name="MiKo_3095_Title" xml:space="preserve">
-    <value>Code blocks should not be empty</value>
+    <value>Do not use empty code blocks</value>
   </data>
   <data name="MiKo_3096_Description" xml:space="preserve">
     <value>For switch statements with many cases that map values, use a dictionary instead. This approach makes the code easier to read and maintain.</value>
@@ -4536,7 +4536,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Explain the reason why the message is suppressed</value>
   </data>
   <data name="MiKo_3098_Title" xml:space="preserve">
-    <value>Justifications of suppressed messages shall explain</value>
+    <value>Provide meaningful explanations for suppressed messages</value>
   </data>
   <data name="MiKo_3099_CodeFixTitle" xml:space="preserve">
     <value>Fix comparison to null</value>
@@ -4557,7 +4557,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Place test class in namespace '{1}'</value>
   </data>
   <data name="MiKo_3100_Title" xml:space="preserve">
-    <value>Test classes and types under test belong in same namespace</value>
+    <value>Place test classes in same namespace as types under test</value>
   </data>
   <data name="MiKo_3101_Description" xml:space="preserve">
     <value>A unit test class should contain unit tests. This ensures the class fulfills its purpose and maintains clarity in your codebase.</value>
@@ -4566,7 +4566,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Test class should contain tests</value>
   </data>
   <data name="MiKo_3101_Title" xml:space="preserve">
-    <value>Test classes should contain tests</value>
+    <value>Include tests in test classes</value>
   </data>
   <data name="MiKo_3102_Description" xml:space="preserve">
     <value>Tests should focus on a specific scenario. Including a condition in a test means it's testing more than one scenario, which is a code smell. Keep tests simple and specific to ensure clarity and maintainability.</value>
@@ -4575,7 +4575,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Refactor test to remove condition</value>
   </data>
   <data name="MiKo_3102_Title" xml:space="preserve">
-    <value>Test methods should not contain conditional statements (such as 'if', 'switch', etc.)</value>
+    <value>Do not use conditional statements in test methods</value>
   </data>
   <data name="MiKo_3103_CodeFixTitle" xml:space="preserve">
     <value>Use hard-coded GUID</value>
@@ -4587,7 +4587,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Use a hard-coded GUID instead</value>
   </data>
   <data name="MiKo_3103_Title" xml:space="preserve">
-    <value>Test methods should not use 'Guid.NewGuid()'</value>
+    <value>Do not use 'Guid.NewGuid()' in test methods</value>
   </data>
   <data name="MiKo_3104_CodeFixTitle" xml:space="preserve">
     <value>Remove [Combinatorial] attribute</value>
@@ -4599,7 +4599,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Wrong usage of [Combinatorial]</value>
   </data>
   <data name="MiKo_3104_Title" xml:space="preserve">
-    <value>Use NUnit's [Combinatorial] attribute properly</value>
+    <value>Apply NUnit's [Combinatorial] attribute properly</value>
   </data>
   <data name="MiKo_3105_CodeFixTitle" xml:space="preserve">
     <value>Use 'Assert.That'</value>
@@ -4614,7 +4614,7 @@ This practice ensures clarity and transparency in your codebase.</value>
     <value>Use 'Assert.That' instead</value>
   </data>
   <data name="MiKo_3105_Title" xml:space="preserve">
-    <value>Test methods should use NUnit's fluent Assert approach</value>
+    <value>Use NUnit's fluent Assert approach in test methods</value>
   </data>
   <data name="MiKo_3106_Description" xml:space="preserve">
     <value>Assertions like 'Assert.That(...)' with operators (==, !=, &lt;=, &lt;, &gt;=, &gt;) assert for booleans. Patterns like 'is true', type checks via 'is', or 'Equals()' method also do the same.
@@ -4627,7 +4627,7 @@ Instead, tests should immediately state the expected value (e.g., '5' was expect
     <value>Do not use '{1}' in assertion</value>
   </data>
   <data name="MiKo_3106_Title" xml:space="preserve">
-    <value>Assertions should not use equality or comparison operators</value>
+    <value>Do not use equality or comparison operators in assertions</value>
   </data>
   <data name="MiKo_3107_CodeFixTitle" xml:space="preserve">
     <value>Change Moq call to default value</value>
@@ -4639,7 +4639,7 @@ Instead, tests should immediately state the expected value (e.g., '5' was expect
     <value>Use a mock instead</value>
   </data>
   <data name="MiKo_3107_Title" xml:space="preserve">
-    <value>Moq Mock condition matchers should be used on mocks only</value>
+    <value>Use Moq Mock condition matchers only on mocks</value>
   </data>
   <data name="MiKo_3108_Description" xml:space="preserve">
     <value>Tests need assertions to verify code behavior. Without an assertion, the test does not check anything and is not useful. This ensures tests are effective and your code works as expected.</value>
@@ -4648,7 +4648,7 @@ Instead, tests should immediately state the expected value (e.g., '5' was expect
     <value>Add assertion to test</value>
   </data>
   <data name="MiKo_3108_Title" xml:space="preserve">
-    <value>Test methods should use assertions</value>
+    <value>Include assertions in test methods</value>
   </data>
   <data name="MiKo_3109_CodeFixTitle" xml:space="preserve">
     <value>Add default assertion message</value>
@@ -4660,7 +4660,7 @@ Instead, tests should immediately state the expected value (e.g., '5' was expect
     <value>Provide an assertion message</value>
   </data>
   <data name="MiKo_3109_Title" xml:space="preserve">
-    <value>Multiple assertions shall use assertion messages</value>
+    <value>Include assertion messages with multiple assertions</value>
   </data>
   <data name="MiKo_3110_CodeFixTitle" xml:space="preserve">
     <value>Use 'Assert.That(..., Has...)'</value>
@@ -4676,7 +4676,7 @@ In contrast, tests should state exactly what was expected and found (e.g., 'Expe
     <value>Do not use '{0}' in assertion</value>
   </data>
   <data name="MiKo_3110_Title" xml:space="preserve">
-    <value>Assertions should not use 'Count' or 'Length'</value>
+    <value>Do not use 'Count' or 'Length' in assertions</value>
   </data>
   <data name="MiKo_3111_CodeFixTitle" xml:space="preserve">
     <value>Use 'Zero'</value>
@@ -4688,7 +4688,7 @@ In contrast, tests should state exactly what was expected and found (e.g., 'Expe
     <value>Use 'Zero' instead</value>
   </data>
   <data name="MiKo_3111_Title" xml:space="preserve">
-    <value>Assertions should use 'Is.Zero' instead of 'Is.EqualTo(0)'</value>
+    <value>Use 'Is.Zero' instead of 'Is.EqualTo(0)' in assertions</value>
   </data>
   <data name="MiKo_3112_CodeFixTitle" xml:space="preserve">
     <value>Use 'Is.Empty'</value>
@@ -4700,7 +4700,7 @@ In contrast, tests should state exactly what was expected and found (e.g., 'Expe
     <value>Use 'Is.Empty' instead</value>
   </data>
   <data name="MiKo_3112_Title" xml:space="preserve">
-    <value>Assertions should use 'Is.Empty' instead of 'Has.Count.Zero'</value>
+    <value>Use 'Is.Empty' instead of 'Has.Count.Zero' in assertions</value>
   </data>
   <data name="MiKo_3113_CodeFixTitle" xml:space="preserve">
     <value>Use 'Assert.That'</value>
@@ -4735,7 +4735,7 @@ Commented-out code within these methods raises questions. If uncommented, it mig
     <value>Delete empty test method or implement a test</value>
   </data>
   <data name="MiKo_3115_Title" xml:space="preserve">
-    <value>Test methods should contain code</value>
+    <value>Include code in test methods</value>
   </data>
   <data name="MiKo_3116_Description" xml:space="preserve">
     <value>Empty unit test initialization methods clutter the codebase and serve no purpose. They can be safely removed to keep the code clean and maintainable.</value>
@@ -4744,7 +4744,7 @@ Commented-out code within these methods raises questions. If uncommented, it mig
     <value>Delete empty test initialization method</value>
   </data>
   <data name="MiKo_3116_Title" xml:space="preserve">
-    <value>Test initialization methods should contain code</value>
+    <value>Include code in test initialization methods</value>
   </data>
   <data name="MiKo_3117_Description" xml:space="preserve">
     <value>Empty unit test cleanup methods clutter the codebase and serve no purpose. They can be safely removed to keep the code clean and maintainable.</value>
@@ -4753,7 +4753,7 @@ Commented-out code within these methods raises questions. If uncommented, it mig
     <value>Delete empty test cleanup method</value>
   </data>
   <data name="MiKo_3117_Title" xml:space="preserve">
-    <value>Test cleanup methods should contain code</value>
+    <value>Include code in test cleanup methods</value>
   </data>
   <data name="MiKo_3118_Description" xml:space="preserve">
     <value>Make tests as explicit as possible.
@@ -4764,7 +4764,7 @@ Avoid this by being more explicit about the expected outcome.</value>
     <value>Do not use ambiguous Linq call '{0}'</value>
   </data>
   <data name="MiKo_3118_Title" xml:space="preserve">
-    <value>Test methods should not use ambiguous Linq calls</value>
+    <value>Do not use ambiguous Linq calls in test methods</value>
   </data>
   <data name="MiKo_3119_CodeFixTitle" xml:space="preserve">
     <value>Change return type of test method to 'void'</value>
@@ -4776,7 +4776,7 @@ Avoid this by being more explicit about the expected outcome.</value>
     <value>Return void instead of Task</value>
   </data>
   <data name="MiKo_3119_Title" xml:space="preserve">
-    <value>Test methods should not simply return completed task</value>
+    <value>Do not return only completed task in test methods</value>
   </data>
   <data name="MiKo_3120_CodeFixTitle" xml:space="preserve">
     <value>Use value directly instead of condition matcher</value>
@@ -4789,7 +4789,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Use value directly instead of condition matcher</value>
   </data>
   <data name="MiKo_3120_Title" xml:space="preserve">
-    <value>Moq mocks should use values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values</value>
+    <value>Use direct values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values in Moq mocks</value>
   </data>
   <data name="MiKo_3121_Description" xml:space="preserve">
     <value>For easier development and direct code access, use a concrete type for the object under test, not an interface. Otherwise, developers end up at the interface and have to find the actual implementation.</value>
@@ -4798,7 +4798,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Test concrete type instead of interface</value>
   </data>
   <data name="MiKo_3121_Title" xml:space="preserve">
-    <value>Tests should test concrete implementations and no interfaces</value>
+    <value>Test concrete implementations instead of interfaces</value>
   </data>
   <data name="MiKo_3122_Description" xml:space="preserve">
     <value>Test methods with more than 2 parameters are often combined tests and can be hard to read. To improve readability, split these tests into separate ones. This makes them easier to understand and maintain.</value>
@@ -4807,7 +4807,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Split into multiple tests so that you do not need more than 2 parameters</value>
   </data>
   <data name="MiKo_3122_Title" xml:space="preserve">
-    <value>Test methods should not use more than 2 parameters</value>
+    <value>Limit test method parameters to 2 or fewer</value>
   </data>
   <data name="MiKo_3123_CodeFixTitle" xml:space="preserve">
     <value>Fix catch block</value>
@@ -4819,7 +4819,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Do not catch exception in test</value>
   </data>
   <data name="MiKo_3123_Title" xml:space="preserve">
-    <value>Test methods should not catch exceptions</value>
+    <value>Do not catch exceptions in test methods</value>
   </data>
   <data name="MiKo_3124_CodeFixTitle" xml:space="preserve">
     <value>Move assertion outside finally block</value>
@@ -4831,7 +4831,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Do not assert in finally block</value>
   </data>
   <data name="MiKo_3124_Title" xml:space="preserve">
-    <value>Test methods should not assert in finally blocks</value>
+    <value>Do not use assertions in finally blocks in test methods</value>
   </data>
   <data name="MiKo_3201_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
@@ -4843,7 +4843,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Invert if to simplify</value>
   </data>
   <data name="MiKo_3201_Title" xml:space="preserve">
-    <value>If statements can be inverted in short methods</value>
+    <value>Invert if statements in short methods</value>
   </data>
   <data name="MiKo_3202_CodeFixTitle" xml:space="preserve">
     <value>Invert condition into positive</value>
@@ -4867,7 +4867,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Invert if to simplify</value>
   </data>
   <data name="MiKo_3203_Title" xml:space="preserve">
-    <value>If-continue statements can be inverted when followed by single line</value>
+    <value>Invert if-continue statements when followed by single line</value>
   </data>
   <data name="MiKo_3204_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
@@ -4879,7 +4879,7 @@ This ensures precision in your tests and maintains clear expectations.</value>
     <value>Invert if to simplify</value>
   </data>
   <data name="MiKo_3204_Title" xml:space="preserve">
-    <value>Negative If statements can be inverted when they have an else clause</value>
+    <value>Invert negative if statements when they have an else clause</value>
   </data>
   <data name="MiKo_3210_Description" xml:space="preserve">
     <value>Overloads are methods with the same name within a type. Generally, those with fewer parameters call the ones with more parameters, providing default values.
@@ -4890,7 +4890,7 @@ When inheritance requires overriding such methods, override the overload with th
     <value>Do not make method '{0}'</value>
   </data>
   <data name="MiKo_3210_Title" xml:space="preserve">
-    <value>Only the longest overloads should be virtual or abstract</value>
+    <value>Make only the longest overloads virtual or abstract</value>
   </data>
   <data name="MiKo_3211_Description" xml:space="preserve">
     <value>If a public type contains a finalizable resource, use a private nested type (or an internal type for multiple classes) as the finalizable resource holder.
@@ -4901,7 +4901,7 @@ Finalizers are challenging to implement correctly because they can't assume the 
     <value>Do not use a finalizer</value>
   </data>
   <data name="MiKo_3211_Title" xml:space="preserve">
-    <value>Public types should not have finalizers</value>
+    <value>Do not use finalizers in public types</value>
   </data>
   <data name="MiKo_3212_Description" xml:space="preserve">
     <value>Stick to the basic Dispose pattern to avoid confusing developers. The only methods named 'Dispose' should be void 'IDisposable.Dispose()' and 'void Dispose(bool disposing)'. Any other methods would deviate from the Dispose pattern and cause confusion.</value>
@@ -4910,7 +4910,7 @@ Finalizers are challenging to implement correctly because they can't assume the 
     <value>Do not provide such Dispose method</value>
   </data>
   <data name="MiKo_3212_Title" xml:space="preserve">
-    <value>Do not confuse developers by providing other Dispose methods</value>
+    <value>Follow standard Dispose pattern without adding other Dispose methods</value>
   </data>
   <data name="MiKo_3213_Description" xml:space="preserve">
     <value>The public 'Dispose()' method should only call 'Dispose(bool disposing)' with 'disposing' set to 'true'. All other disposal logic should reside in the 'Dispose(bool disposing)' method. This keeps the Dispose pattern consistent and clear.</value>
@@ -4919,7 +4919,7 @@ Finalizers are challenging to implement correctly because they can't assume the 
     <value>Only invoke 'Dispose(false)' but nothing more</value>
   </data>
   <data name="MiKo_3213_Title" xml:space="preserve">
-    <value>Parameterless Dispose method follows Basic Dispose pattern</value>
+    <value>Implement parameterless Dispose method using Basic Dispose pattern</value>
   </data>
   <data name="MiKo_3214_Description" xml:space="preserve">
     <value>Methods starting with 'Begin' or 'Enter' often have counterparts like 'End' or 'Exit', defining a scope (e.g., 'BeginUpdate' and 'EndUpdate'). Public access to these methods can lead to errors if 'End' methods are not correctly invoked.
@@ -4930,7 +4930,7 @@ Instead, provide a method that returns an 'IDisposable'. This way, developers ca
     <value>Rename scope-defining method to not start with '{1}'</value>
   </data>
   <data name="MiKo_3214_Title" xml:space="preserve">
-    <value>Interfaces do not contain 'Begin/End' or 'Enter/Exit' scope-defining methods</value>
+    <value>Remove 'Begin/End' or 'Enter/Exit' scope-defining methods from interfaces</value>
   </data>
   <data name="MiKo_3215_CodeFixTitle" xml:space="preserve">
     <value>Convert 'Predicate' into 'Func'</value>
@@ -4945,7 +4945,7 @@ Instead, provide a method that returns an 'IDisposable'. This way, developers ca
     <value>Use 'Func&lt;{0}, bool&gt;' instead of 'Predicate&lt;{0}&gt;'</value>
   </data>
   <data name="MiKo_3215_Title" xml:space="preserve">
-    <value>Callbacks should be 'Func&lt;T, bool&gt;' instead of 'Predicate&lt;bool&gt;'</value>
+    <value>Use 'Func&lt;T, bool&gt;' instead of 'Predicate&lt;bool&gt;' for callbacks</value>
   </data>
   <data name="MiKo_3216_CodeFixTitle" xml:space="preserve">
     <value>Make field read-only</value>
@@ -4957,7 +4957,7 @@ Instead, provide a method that returns an 'IDisposable'. This way, developers ca
     <value>Make field read-only</value>
   </data>
   <data name="MiKo_3216_Title" xml:space="preserve">
-    <value>Static fields with initializers should be read-only</value>
+    <value>Mark static fields with initializers as read-only</value>
   </data>
   <data name="MiKo_3217_Description" xml:space="preserve">
     <value>Generic types with other generic types as type arguments are hard to understand and maintain. This complexity makes it difficult to interpret their purpose and suggests hidden type information due to primitive obsession.
@@ -4977,7 +4977,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Change from extension method into normal static method</value>
   </data>
   <data name="MiKo_3218_Title" xml:space="preserve">
-    <value>Do not define extension methods in unexpected places</value>
+    <value>Define extension methods in expected places</value>
   </data>
   <data name="MiKo_3219_Description" xml:space="preserve">
     <value>Public members should offer the correct functionality for class consumers. If extensibility is needed, they should call a 'protected virtual' member with the same name suffixed by 'Core'. These serve as clear, easily identifiable extensibility points.</value>
@@ -4986,7 +4986,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Remove 'virtual' and provide a 'protected virtual {0}' member instead</value>
   </data>
   <data name="MiKo_3219_Title" xml:space="preserve">
-    <value>Public members should not be 'virtual'</value>
+    <value>Do not mark public members as 'virtual'</value>
   </data>
   <data name="MiKo_3220_CodeFixTitle" xml:space="preserve">
     <value>Simplify condition</value>
@@ -4998,7 +4998,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Simplify condition</value>
   </data>
   <data name="MiKo_3220_Title" xml:space="preserve">
-    <value>Logical '&amp;&amp;' or '||' conditions using 'true' or 'false' should be simplified</value>
+    <value>Simplify logical '&amp;&amp;' or '||' conditions using 'true' or 'false'</value>
   </data>
   <data name="MiKo_3221_CodeFixTitle" xml:space="preserve">
     <value>Use 'HashCode.Combine'</value>
@@ -5010,7 +5010,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Use 'HashCode.Combine' instead</value>
   </data>
   <data name="MiKo_3221_Title" xml:space="preserve">
-    <value>GetHashCode overrides should use 'HashCode.Combine'</value>
+    <value>Use 'HashCode.Combine' in GetHashCode overrides</value>
   </data>
   <data name="MiKo_3222_CodeFixTitle" xml:space="preserve">
     <value>Simplify comparison</value>
@@ -5022,7 +5022,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>String comparison can be simplified</value>
   </data>
   <data name="MiKo_3222_Title" xml:space="preserve">
-    <value>String comparisons can be simplified</value>
+    <value>Simplify string comparisons</value>
   </data>
   <data name="MiKo_3223_CodeFixTitle" xml:space="preserve">
     <value>Simplify comparison</value>
@@ -5034,7 +5034,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Comparison can be simplified</value>
   </data>
   <data name="MiKo_3223_Title" xml:space="preserve">
-    <value>Reference comparisons can be simplified</value>
+    <value>Simplify reference comparisons</value>
   </data>
   <data name="MiKo_3224_CodeFixTitle" xml:space="preserve">
     <value>Simplify comparison</value>
@@ -5046,7 +5046,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Comparison can be simplified</value>
   </data>
   <data name="MiKo_3224_Title" xml:space="preserve">
-    <value>Value comparisons can be simplified</value>
+    <value>Simplify value comparisons</value>
   </data>
   <data name="MiKo_3225_CodeFixTitle" xml:space="preserve">
     <value>Simplify redundant comparison</value>
@@ -5058,7 +5058,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Redundant comparison can be simplified</value>
   </data>
   <data name="MiKo_3225_Title" xml:space="preserve">
-    <value>Redundant comparisons can be simplified</value>
+    <value>Simplify redundant comparisons</value>
   </data>
   <data name="MiKo_3226_CodeFixTitle" xml:space="preserve">
     <value>Convert field to const</value>
@@ -5070,7 +5070,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Convert field to const</value>
   </data>
   <data name="MiKo_3226_Title" xml:space="preserve">
-    <value>Read-only fields with initializers should be const</value>
+    <value>Make read-only fields with initializers const</value>
   </data>
   <data name="MiKo_3227_CodeFixTitle" xml:space="preserve">
     <value>Apply 'is' pattern</value>
@@ -5082,7 +5082,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Use 'is' instead of '=='</value>
   </data>
   <data name="MiKo_3227_Title" xml:space="preserve">
-    <value>Prefer pattern matching for equality checks</value>
+    <value>Use pattern matching for equality checks</value>
   </data>
   <data name="MiKo_3228_CodeFixTitle" xml:space="preserve">
     <value>Apply 'is not' pattern</value>
@@ -5094,7 +5094,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Use 'is not' instead of '!='</value>
   </data>
   <data name="MiKo_3228_Title" xml:space="preserve">
-    <value>Prefer pattern matching for inequality checks</value>
+    <value>Use pattern matching for inequality checks</value>
   </data>
   <data name="MiKo_3229_CodeFixTitle" xml:space="preserve">
     <value>Use 'KeyValuePair.Create'</value>
@@ -5106,7 +5106,7 @@ Instead, use non-generic types as type arguments. This approach makes the code's
     <value>Use 'KeyValuePair.Create' instead</value>
   </data>
   <data name="MiKo_3229_Title" xml:space="preserve">
-    <value>'KeyValuePair.Create' should be used instead of constructors</value>
+    <value>Use 'KeyValuePair.Create' instead of constructors</value>
   </data>
   <data name="MiKo_3230_Description" xml:space="preserve">
     <value>Using 'Guid' directly as an identifier type is considered a form of primitive obsession, which is generally discouraged. Instead, you should define custom types (e.g., CustomerId, OrderId) to represent identifiers.
@@ -5128,7 +5128,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
     <value>Use 'is' instead of 'Equals'</value>
   </data>
   <data name="MiKo_3231_Title" xml:space="preserve">
-    <value>Prefer pattern matching for equality checks for ordinal string comparisons</value>
+    <value>Use pattern matching for ordinal string comparison equality checks</value>
   </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
@@ -5140,7 +5140,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
     <value>Use lambda expression body instead</value>
   </data>
   <data name="MiKo_3301_Title" xml:space="preserve">
-    <value>Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements</value>
+    <value>Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements</value>
   </data>
   <data name="MiKo_3302_CodeFixTitle" xml:space="preserve">
     <value>Remove braces around parameter</value>
@@ -5152,7 +5152,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
     <value>Use simple lambda expression body instead</value>
   </data>
   <data name="MiKo_3302_Title" xml:space="preserve">
-    <value>Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters</value>
+    <value>Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters</value>
   </data>
   <data name="MiKo_3401_Description" xml:space="preserve">
     <value>Keep namespace hierarchies shallow. If a namespace hierarchy becomes too deep, it likely means the namespaces are too specific or specialized. Flatten such namespaces to keep your codebase understandable and manageable.</value>
@@ -5161,7 +5161,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
     <value>Namespace hierarchy too deep: {1,4} (max. {2})</value>
   </data>
   <data name="MiKo_3401_Title" xml:space="preserve">
-    <value>Namespace hierarchies should not be too deep</value>
+    <value>Keep namespace hierarchies from becoming too deep</value>
   </data>
   <data name="MiKo_3501_CodeFixTitle" xml:space="preserve">
     <value>Remove suppressed nullable warning</value>
@@ -5197,7 +5197,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
     <value>Place return inside the try/catch block</value>
   </data>
   <data name="MiKo_3503_Title" xml:space="preserve">
-    <value>Do not assign variables in try-catch blocks and return them directly outside the block</value>
+    <value>Do not assign variables in try-catch blocks that are returned directly outside</value>
   </data>
   <data name="MiKo_4001_CodeFixTitle" xml:space="preserve">
     <value>Place and order method side-by-side with overloads</value>
@@ -5211,7 +5211,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
 </value>
   </data>
   <data name="MiKo_4001_Title" xml:space="preserve">
-    <value>Methods with same name should be ordered based on the number of their parameters</value>
+    <value>Order methods with same name based on their parameter count</value>
   </data>
   <data name="MiKo_4002_CodeFixTitle" xml:space="preserve">
     <value>Place method side-by-side with overloads</value>
@@ -5225,7 +5225,7 @@ This approach improves type safety and makes it harder to accidentally mix up di
 </value>
   </data>
   <data name="MiKo_4002_Title" xml:space="preserve">
-    <value>Methods with same name and accessibility should be placed side-by-side</value>
+    <value>Place methods with same name and accessibility side-by-side</value>
   </data>
   <data name="MiKo_4003_CodeFixTitle" xml:space="preserve">
     <value>Place 'Dispose' directly after all ctors and finalizers</value>
@@ -5238,7 +5238,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place 'Dispose' directly after all ctors and finalizers</value>
   </data>
   <data name="MiKo_4003_Title" xml:space="preserve">
-    <value>Dispose methods should be placed directly after constructors and finalizers</value>
+    <value>Place Dispose methods directly after constructors and finalizers</value>
   </data>
   <data name="MiKo_4004_CodeFixTitle" xml:space="preserve">
     <value>Place 'Dispose' method first</value>
@@ -5251,7 +5251,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place 'Dispose' method first</value>
   </data>
   <data name="MiKo_4004_Title" xml:space="preserve">
-    <value>Dispose methods should be placed before all other methods of the same accessibility</value>
+    <value>Place Dispose methods before all other methods of the same accessibility</value>
   </data>
   <data name="MiKo_4005_CodeFixTitle" xml:space="preserve">
     <value>Place interface directly after type declaration</value>
@@ -5263,7 +5263,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place '{1}' as first interface directly after type declaration</value>
   </data>
   <data name="MiKo_4005_Title" xml:space="preserve">
-    <value>The interface that gives a type its name should be placed directly after the type's declaration</value>
+    <value>Place the interface that gives a type its name directly after the type's declaration</value>
   </data>
   <data name="MiKo_4007_CodeFixTitle" xml:space="preserve">
     <value>Place operator before methods</value>
@@ -5275,7 +5275,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place operator before methods</value>
   </data>
   <data name="MiKo_4007_Title" xml:space="preserve">
-    <value>Operators should be placed before methods</value>
+    <value>Place operators before methods</value>
   </data>
   <data name="MiKo_4008_CodeFixTitle" xml:space="preserve">
     <value>Place 'GetHashCode' after 'Equals'</value>
@@ -5287,7 +5287,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place 'GetHashCode' after 'Equals'</value>
   </data>
   <data name="MiKo_4008_Title" xml:space="preserve">
-    <value>GetHashCode methods should be placed directly after Equals methods</value>
+    <value>Place GetHashCode methods directly after Equals methods</value>
   </data>
   <data name="MiKo_4101_CodeFixTitle" xml:space="preserve">
     <value>Place method after one-time methods and before test cleanup and all other test methods</value>
@@ -5299,7 +5299,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place test initialization method after [OneTimeSetUp] / [OneTimeTearDown] methods and before test cleanup and all other test methods</value>
   </data>
   <data name="MiKo_4101_Title" xml:space="preserve">
-    <value>Test initialization methods should be ordered directly after One-Time methods</value>
+    <value>Place test initialization methods directly after One-Time methods</value>
   </data>
   <data name="MiKo_4102_CodeFixTitle" xml:space="preserve">
     <value>Place method after test initialization methods and before all test methods</value>
@@ -5311,7 +5311,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place test cleanup method after test initialization methods and before all test methods</value>
   </data>
   <data name="MiKo_4102_Title" xml:space="preserve">
-    <value>Test cleanup methods should be ordered after test initialization methods and before test methods</value>
+    <value>Place test cleanup methods after test initialization methods and before test methods</value>
   </data>
   <data name="MiKo_4103_CodeFixTitle" xml:space="preserve">
     <value>Place method before all other methods</value>
@@ -5323,7 +5323,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place [OneTimeSetUp] method before all other methods</value>
   </data>
   <data name="MiKo_4103_Title" xml:space="preserve">
-    <value>One-Time test initialization methods should be ordered before all other methods</value>
+    <value>Place One-Time test initialization methods before all other methods</value>
   </data>
   <data name="MiKo_4104_CodeFixTitle" xml:space="preserve">
     <value>Place method directly after [OneTimeSetUp] method and before all other methods</value>
@@ -5335,7 +5335,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place [OneTimeTearDown] method directly after [OneTimeSetUp] method and before all other methods</value>
   </data>
   <data name="MiKo_4104_Title" xml:space="preserve">
-    <value>One-Time test cleanup methods should be ordered directly after One-Time test initialization methods</value>
+    <value>Place One-Time test cleanup methods directly after One-Time test initialization methods</value>
   </data>
   <data name="MiKo_4105_CodeFixTitle" xml:space="preserve">
     <value>Place field before all other fields</value>
@@ -5347,7 +5347,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place object under test field before all other fields</value>
   </data>
   <data name="MiKo_4105_Title" xml:space="preserve">
-    <value>Object under test fields should be ordered before all other fields</value>
+    <value>Place object under test fields before all other fields</value>
   </data>
   <data name="MiKo_5001_CodeFixTitle" xml:space="preserve">
     <value>Place inside 'if'</value>
@@ -5359,7 +5359,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Invoke '{2}' before invoking '{1}'</value>
   </data>
   <data name="MiKo_5001_Title" xml:space="preserve">
-    <value>'Debug' and 'DebugFormat' methods should be invoked only after 'IsDebugEnabled'</value>
+    <value>Invoke 'Debug' and 'DebugFormat' methods only after checking 'IsDebugEnabled'</value>
   </data>
   <data name="MiKo_5002_CodeFixTitle" xml:space="preserve">
     <value>Replace with non-'Format' method</value>
@@ -5371,7 +5371,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Invoke '{2}' instead</value>
   </data>
   <data name="MiKo_5002_Title" xml:space="preserve">
-    <value>'xxxFormat' methods should be invoked with multiple arguments only</value>
+    <value>Use 'xxxFormat' methods only with multiple arguments</value>
   </data>
   <data name="MiKo_5003_Description" xml:space="preserve">
     <value>When logging exceptions, use Log methods that accept an exception parameter (like 'Debug', 'Info', 'Warn', etc.). This allows the Log framework to capture not just the exception name but also additional details like the stack trace, keeping your logs detailed and informative.</value>
@@ -5380,7 +5380,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Invoke '{1}' overload with exception parameter</value>
   </data>
   <data name="MiKo_5003_Title" xml:space="preserve">
-    <value>Correct Log methods should be invoked for exceptions</value>
+    <value>Use appropriate Log methods for exceptions</value>
   </data>
   <data name="MiKo_5010_CodeFixTitle" xml:space="preserve">
     <value>Replace 'Equals' by '=='</value>
@@ -5437,7 +5437,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Do not create empty lists</value>
   </data>
   <data name="MiKo_5014_Title" xml:space="preserve">
-    <value>Do not create empty lists if the return value is read-only</value>
+    <value>Do not create empty lists when return value is read-only</value>
   </data>
   <data name="MiKo_5015_CodeFixTitle" xml:space="preserve">
     <value>Remove unneeded call to string.Intern()</value>
@@ -5458,7 +5458,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Use a HashSet for the lookup</value>
   </data>
   <data name="MiKo_5016_Title" xml:space="preserve">
-    <value>Use a HashSet for lookups in 'List.RemoveAll'</value>
+    <value>Use HashSet for lookups in 'List.RemoveAll'</value>
   </data>
   <data name="MiKo_5017_CodeFixTitle" xml:space="preserve">
     <value>Convert to const</value>
@@ -5470,7 +5470,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Convert to const</value>
   </data>
   <data name="MiKo_5017_Title" xml:space="preserve">
-    <value>Fields or variables assigned with string literals should be constant</value>
+    <value>Make fields or variables assigned with string literals constant</value>
   </data>
   <data name="MiKo_5019_CodeFixTitle" xml:space="preserve">
     <value>Add [in] modifier</value>
@@ -5482,7 +5482,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Add [in] modifier</value>
   </data>
   <data name="MiKo_5019_Title" xml:space="preserve">
-    <value>Read-only struct parameters should have the [in] modifier</value>
+    <value>Add [in] modifier to read-only struct parameters</value>
   </data>
   <data name="MiKo_6001_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5494,7 +5494,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround log statement(s) with blank lines</value>
   </data>
   <data name="MiKo_6001_Title" xml:space="preserve">
-    <value>Log statements should be surrounded by blank lines</value>
+    <value>Surround log statements with blank lines</value>
   </data>
   <data name="MiKo_6002_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5506,7 +5506,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround assertion statement(s) with blank lines</value>
   </data>
   <data name="MiKo_6002_Title" xml:space="preserve">
-    <value>Assertion statements should be surrounded by blank lines</value>
+    <value>Surround assertion statements with blank lines</value>
   </data>
   <data name="MiKo_6003_CodeFixTitle" xml:space="preserve">
     <value>Precede with blank line</value>
@@ -5518,7 +5518,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Precede local variable with a blank line</value>
   </data>
   <data name="MiKo_6003_Title" xml:space="preserve">
-    <value>Local variable statements should be preceded by blank lines</value>
+    <value>Precede local variable statements with blank lines</value>
   </data>
   <data name="MiKo_6004_CodeFixTitle" xml:space="preserve">
     <value>Precede with blank line</value>
@@ -5530,7 +5530,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Precede variable assignment with a blank line</value>
   </data>
   <data name="MiKo_6004_Title" xml:space="preserve">
-    <value>Variable assignment statements should be preceded by blank lines</value>
+    <value>Precede variable assignment statements with blank lines</value>
   </data>
   <data name="MiKo_6005_CodeFixTitle" xml:space="preserve">
     <value>Precede with blank line</value>
@@ -5542,7 +5542,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Precede return statement with a blank line</value>
   </data>
   <data name="MiKo_6005_Title" xml:space="preserve">
-    <value>Return statements should be preceded by blank lines</value>
+    <value>Precede return statements with blank lines</value>
   </data>
   <data name="MiKo_6006_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5554,7 +5554,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround awaited statement with a blank line</value>
   </data>
   <data name="MiKo_6006_Title" xml:space="preserve">
-    <value>Awaited statements should be surrounded by blank lines</value>
+    <value>Surround awaited statements with blank lines</value>
   </data>
   <data name="MiKo_6007_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5566,7 +5566,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround test statement with a blank line</value>
   </data>
   <data name="MiKo_6007_Title" xml:space="preserve">
-    <value>Test statements should be surrounded by blank lines</value>
+    <value>Surround test statements with blank lines</value>
   </data>
   <data name="MiKo_6008_CodeFixTitle" xml:space="preserve">
     <value>Precede with blank line</value>
@@ -5578,7 +5578,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Precede using directive with a blank line</value>
   </data>
   <data name="MiKo_6008_Title" xml:space="preserve">
-    <value>Using directives should be preceded by blank lines</value>
+    <value>Precede using directives with blank lines</value>
   </data>
   <data name="MiKo_6009_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5590,7 +5590,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'try' statement with a blank line</value>
   </data>
   <data name="MiKo_6009_Title" xml:space="preserve">
-    <value>Try statements should be surrounded by blank lines</value>
+    <value>Surround try statements with blank lines</value>
   </data>
   <data name="MiKo_6010_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5602,7 +5602,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'if' statement with a blank line</value>
   </data>
   <data name="MiKo_6010_Title" xml:space="preserve">
-    <value>If statements should be surrounded by blank lines</value>
+    <value>Surround if statements with blank lines</value>
   </data>
   <data name="MiKo_6011_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5614,7 +5614,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'lock' statement with a blank line</value>
   </data>
   <data name="MiKo_6011_Title" xml:space="preserve">
-    <value>Lock statements should be surrounded by blank lines</value>
+    <value>Surround lock statements with blank lines</value>
   </data>
   <data name="MiKo_6012_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5626,7 +5626,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'foreach' loop with a blank line</value>
   </data>
   <data name="MiKo_6012_Title" xml:space="preserve">
-    <value>foreach loops should be surrounded by blank lines</value>
+    <value>Surround foreach loops with blank lines</value>
   </data>
   <data name="MiKo_6013_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5638,7 +5638,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'for' loop with a blank line</value>
   </data>
   <data name="MiKo_6013_Title" xml:space="preserve">
-    <value>for loops should be surrounded by blank lines</value>
+    <value>Surround for loops with blank lines</value>
   </data>
   <data name="MiKo_6014_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5650,7 +5650,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'while' loop with a blank line</value>
   </data>
   <data name="MiKo_6014_Title" xml:space="preserve">
-    <value>while loops should be surrounded by blank lines</value>
+    <value>Surround while loops with blank lines</value>
   </data>
   <data name="MiKo_6015_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5662,7 +5662,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'do/while' loop with a blank line</value>
   </data>
   <data name="MiKo_6015_Title" xml:space="preserve">
-    <value>do/while loops should be surrounded by blank lines</value>
+    <value>Surround do/while loops with blank lines</value>
   </data>
   <data name="MiKo_6016_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5674,7 +5674,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'using' with a blank line</value>
   </data>
   <data name="MiKo_6016_Title" xml:space="preserve">
-    <value>using statements should be surrounded by blank lines</value>
+    <value>Surround using statements with blank lines</value>
   </data>
   <data name="MiKo_6017_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5686,7 +5686,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'switch' with a blank line</value>
   </data>
   <data name="MiKo_6017_Title" xml:space="preserve">
-    <value>switch statements should be surrounded by blank lines</value>
+    <value>Surround switch statements with blank lines</value>
   </data>
   <data name="MiKo_6018_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5698,7 +5698,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'break' with a blank line</value>
   </data>
   <data name="MiKo_6018_Title" xml:space="preserve">
-    <value>break statements should be surrounded by blank lines</value>
+    <value>Surround break statements with blank lines</value>
   </data>
   <data name="MiKo_6019_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5710,7 +5710,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'continue' with a blank line</value>
   </data>
   <data name="MiKo_6019_Title" xml:space="preserve">
-    <value>continue statements should be surrounded by blank lines</value>
+    <value>Surround continue statements with blank lines</value>
   </data>
   <data name="MiKo_6020_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5722,7 +5722,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'throw' with a blank line</value>
   </data>
   <data name="MiKo_6020_Title" xml:space="preserve">
-    <value>throw statements should be surrounded by blank lines</value>
+    <value>Surround throw statements with blank lines</value>
   </data>
   <data name="MiKo_6021_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5734,7 +5734,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'ThrowIfNull' with a blank line</value>
   </data>
   <data name="MiKo_6021_Title" xml:space="preserve">
-    <value>ArgumentNullException.ThrowIfNull statements should be surrounded by blank lines</value>
+    <value>Surround ArgumentNullException.ThrowIfNull statements with blank lines</value>
   </data>
   <data name="MiKo_6022_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5746,7 +5746,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'ThrowIfNullOrEmpty' with a blank line</value>
   </data>
   <data name="MiKo_6022_Title" xml:space="preserve">
-    <value>ArgumentException.ThrowIfNullOrEmpty statements should be surrounded by blank lines</value>
+    <value>Surround ArgumentException.ThrowIfNullOrEmpty statements with blank lines</value>
   </data>
   <data name="MiKo_6023_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5758,7 +5758,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'ThrowIf' with a blank line</value>
   </data>
   <data name="MiKo_6023_Title" xml:space="preserve">
-    <value>ArgumentOutOfRangeException.ThrowIf statements should be surrounded by blank lines</value>
+    <value>Surround ArgumentOutOfRangeException.ThrowIf statements with blank lines</value>
   </data>
   <data name="MiKo_6024_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -5770,7 +5770,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround 'ThrowIf' with a blank line</value>
   </data>
   <data name="MiKo_6024_Title" xml:space="preserve">
-    <value>ObjectDisposedException.ThrowIf statements should be surrounded by blank lines</value>
+    <value>Surround ObjectDisposedException.ThrowIf statements with blank lines</value>
   </data>
   <data name="MiKo_6030_CodeFixTitle" xml:space="preserve">
     <value>Align open brace directly below type</value>
@@ -5782,7 +5782,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align open brace directly below type</value>
   </data>
   <data name="MiKo_6030_Title" xml:space="preserve">
-    <value>Open braces of initializers should be placed directly below the corresponding type definition</value>
+    <value>Place open braces of initializers directly below the corresponding type definition</value>
   </data>
   <data name="MiKo_6031_CodeFixTitle" xml:space="preserve">
     <value>Align ternary operator directly below condition</value>
@@ -5794,7 +5794,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align ternary operator directly below condition</value>
   </data>
   <data name="MiKo_6031_Title" xml:space="preserve">
-    <value>Question and colon tokens of ternary operators should be placed directly below the corresponding condition</value>
+    <value>Place question and colon tokens of ternary operators directly below the corresponding condition</value>
   </data>
   <data name="MiKo_6032_CodeFixTitle" xml:space="preserve">
     <value>Align parameter outdented below method</value>
@@ -5806,7 +5806,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align parameter '{0}' outdented below method</value>
   </data>
   <data name="MiKo_6032_Title" xml:space="preserve">
-    <value>Multi-line parameters are positioned outdented at end of method</value>
+    <value>Position multi-line parameters outdented at end of method</value>
   </data>
   <data name="MiKo_6033_CodeFixTitle" xml:space="preserve">
     <value>Align open brace directly below case</value>
@@ -5818,7 +5818,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align open brace directly below case</value>
   </data>
   <data name="MiKo_6033_Title" xml:space="preserve">
-    <value>Braces of blocks below case sections should be placed directly below the corresponding case keyword</value>
+    <value>Place braces of blocks below case sections directly below the corresponding case keyword</value>
   </data>
   <data name="MiKo_6034_CodeFixTitle" xml:space="preserve">
     <value>Place dot on same line</value>
@@ -5830,7 +5830,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place dot on same line as member</value>
   </data>
   <data name="MiKo_6034_Title" xml:space="preserve">
-    <value>Dots should be placed on same line(s) as invoked members</value>
+    <value>Place dots on same line(s) as invoked members</value>
   </data>
   <data name="MiKo_6035_CodeFixTitle" xml:space="preserve">
     <value>Place parenthesis on same line</value>
@@ -5842,7 +5842,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place open parenthesis on same line as invocation</value>
   </data>
   <data name="MiKo_6035_Title" xml:space="preserve">
-    <value>Open parenthesis should be placed on same line(s) as invoked methods</value>
+    <value>Place open parenthesis on same line(s) as invoked methods</value>
   </data>
   <data name="MiKo_6036_CodeFixTitle" xml:space="preserve">
     <value>Align block directly below arrow</value>
@@ -5854,7 +5854,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align lambda block directly below arrow</value>
   </data>
   <data name="MiKo_6036_Title" xml:space="preserve">
-    <value>Lambda blocks should be placed directly below the corresponding arrow(s)</value>
+    <value>Place lambda blocks directly below the corresponding arrow(s)</value>
   </data>
   <data name="MiKo_6037_CodeFixTitle" xml:space="preserve">
     <value>Place argument on same line as invocation</value>
@@ -5866,7 +5866,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place argument on same line as invocation</value>
   </data>
   <data name="MiKo_6037_Title" xml:space="preserve">
-    <value>Single arguments should be placed on same line(s) as invoked methods</value>
+    <value>Place single arguments on same line(s) as invoked methods</value>
   </data>
   <data name="MiKo_6038_CodeFixTitle" xml:space="preserve">
     <value>Place cast on same line</value>
@@ -5878,7 +5878,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place cast on same line</value>
   </data>
   <data name="MiKo_6038_Title" xml:space="preserve">
-    <value>Casts should be placed on same line(s)</value>
+    <value>Place casts on same line(s)</value>
   </data>
   <data name="MiKo_6039_CodeFixTitle" xml:space="preserve">
     <value>Place return value on same line as return keyword</value>
@@ -5890,7 +5890,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place return value on same line as return keyword</value>
   </data>
   <data name="MiKo_6039_Title" xml:space="preserve">
-    <value>Return values should be placed on same line(s) as return keywords</value>
+    <value>Place return values on same line(s) as return keywords</value>
   </data>
   <data name="MiKo_6040_CodeFixTitle" xml:space="preserve">
     <value>Indent dots</value>
@@ -5902,7 +5902,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Indent dots</value>
   </data>
   <data name="MiKo_6040_Title" xml:space="preserve">
-    <value>Consecutive invocations spanning multiple lines should be aligned by their dots</value>
+    <value>Align consecutive multi-line invocations by their dots</value>
   </data>
   <data name="MiKo_6041_CodeFixTitle" xml:space="preserve">
     <value>Place assignment on same line</value>
@@ -5914,7 +5914,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place assignment on same line</value>
   </data>
   <data name="MiKo_6041_Title" xml:space="preserve">
-    <value>Assignments should be placed on same line(s)</value>
+    <value>Place assignments on same line(s)</value>
   </data>
   <data name="MiKo_6042_CodeFixTitle" xml:space="preserve">
     <value>Place new keyword on same line as type</value>
@@ -5926,7 +5926,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place new keyword on same line as type</value>
   </data>
   <data name="MiKo_6042_Title" xml:space="preserve">
-    <value>'new' keywords should be placed on same line(s) as the types</value>
+    <value>Place 'new' keywords on same line(s) as the types</value>
   </data>
   <data name="MiKo_6043_CodeFixTitle" xml:space="preserve">
     <value>Place lambda on single line</value>
@@ -5938,7 +5938,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place lambda on single line</value>
   </data>
   <data name="MiKo_6043_Title" xml:space="preserve">
-    <value>Expression bodies of lambdas should be placed on same line as lambda itself when fitting</value>
+    <value>Place expression bodies of lambdas on same line as lambda when fitting</value>
   </data>
   <data name="MiKo_6044_CodeFixTitle" xml:space="preserve">
     <value>Place operator on same line as right operand</value>
@@ -5950,7 +5950,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place operator on same line as right operand</value>
   </data>
   <data name="MiKo_6044_Title" xml:space="preserve">
-    <value>Operators such as '&amp;&amp;' or '||' should be placed on same line(s) as their (right) operands</value>
+    <value>Place operators such as '&amp;&amp;' or '||' on same line(s) as their (right) operands</value>
   </data>
   <data name="MiKo_6045_CodeFixTitle" xml:space="preserve">
     <value>Place comparison on same line</value>
@@ -5962,7 +5962,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place comparison on same line</value>
   </data>
   <data name="MiKo_6045_Title" xml:space="preserve">
-    <value>Comparisons using operators such as '==' or '!=' should be placed on same line(s)</value>
+    <value>Place comparisons using operators such as '==' or '!=' on same line(s)</value>
   </data>
   <data name="MiKo_6046_CodeFixTitle" xml:space="preserve">
     <value>Place calculation on same line</value>
@@ -5974,7 +5974,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place calculation on same line</value>
   </data>
   <data name="MiKo_6046_Title" xml:space="preserve">
-    <value>Calculations using operators such as '+' or '%' should be placed on same line(s)</value>
+    <value>Place calculations using operators such as '+' or '%' on same line(s)</value>
   </data>
   <data name="MiKo_6047_CodeFixTitle" xml:space="preserve">
     <value>Align open brace directly below switch</value>
@@ -5986,7 +5986,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align open brace directly below switch</value>
   </data>
   <data name="MiKo_6047_Title" xml:space="preserve">
-    <value>Braces of switch expressions should be placed directly below the corresponding switch keyword</value>
+    <value>Place braces of switch expressions directly below the corresponding switch keyword</value>
   </data>
   <data name="MiKo_6048_CodeFixTitle" xml:space="preserve">
     <value>Place condition on single line</value>
@@ -5998,7 +5998,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place condition on single line</value>
   </data>
   <data name="MiKo_6048_Title" xml:space="preserve">
-    <value>Logical conditions should be placed on a single line</value>
+    <value>Place logical conditions on a single line</value>
   </data>
   <data name="MiKo_6049_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -6010,7 +6010,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround event (un-)registration with a blank line</value>
   </data>
   <data name="MiKo_6049_Title" xml:space="preserve">
-    <value>Event (un-)registrations should be surrounded by blank lines</value>
+    <value>Surround event (un-)registrations with blank lines</value>
   </data>
   <data name="MiKo_6050_CodeFixTitle" xml:space="preserve">
     <value>Align argument outdented below method call</value>
@@ -6022,7 +6022,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align argument '{0}' outdented below method call</value>
   </data>
   <data name="MiKo_6050_Title" xml:space="preserve">
-    <value>Multi-line arguments are positioned outdented at end of method call</value>
+    <value>Position multi-line arguments outdented at end of method call</value>
   </data>
   <data name="MiKo_6051_CodeFixTitle" xml:space="preserve">
     <value>Place colon on same line as constructor call</value>
@@ -6034,7 +6034,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place colon on same line as constructor call</value>
   </data>
   <data name="MiKo_6051_Title" xml:space="preserve">
-    <value>Colon of constructor call shall be placed on same line as constructor call</value>
+    <value>Place colon of constructor call on same line as constructor call</value>
   </data>
   <data name="MiKo_6052_CodeFixTitle" xml:space="preserve">
     <value>Place colon on same line as first base type</value>
@@ -6046,7 +6046,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place colon on same line as first base type</value>
   </data>
   <data name="MiKo_6052_Title" xml:space="preserve">
-    <value>Colon of list of base types shall be placed on same line as first base type</value>
+    <value>Place colon of list of base types on same line as first base type</value>
   </data>
   <data name="MiKo_6053_CodeFixTitle" xml:space="preserve">
     <value>Place argument on single line</value>
@@ -6058,7 +6058,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place argument on single line</value>
   </data>
   <data name="MiKo_6053_Title" xml:space="preserve">
-    <value>Single-line arguments shall be placed on single line</value>
+    <value>Place single-line arguments on single line</value>
   </data>
   <data name="MiKo_6054_CodeFixTitle" xml:space="preserve">
     <value>Place lambda arrow on same line as its parameter(s)</value>
@@ -6070,7 +6070,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place lambda arrow on same line as its parameter(s)</value>
   </data>
   <data name="MiKo_6054_Title" xml:space="preserve">
-    <value>Lambda arrows shall be placed on same line as the parameter(s) of the lambda</value>
+    <value>Place lambda arrows on same line as the parameter(s) of the lambda</value>
   </data>
   <data name="MiKo_6055_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -6082,7 +6082,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Surround assignment with a blank line</value>
   </data>
   <data name="MiKo_6055_Title" xml:space="preserve">
-    <value>Assignment statements should be surrounded by blank lines</value>
+    <value>Surround assignment statements with blank lines</value>
   </data>
   <data name="MiKo_6056_CodeFixTitle" xml:space="preserve">
     <value>Align collection expression brackets</value>
@@ -6094,7 +6094,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align collection expression brackets</value>
   </data>
   <data name="MiKo_6056_Title" xml:space="preserve">
-    <value>Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned</value>
+    <value>Place brackets of collection expressions at the same position as collection initializer braces</value>
   </data>
   <data name="MiKo_6057_CodeFixTitle" xml:space="preserve">
     <value>Align type parameter constraint vertically along with others</value>
@@ -6106,7 +6106,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align type parameter constraint vertically along with others</value>
   </data>
   <data name="MiKo_6057_Title" xml:space="preserve">
-    <value>Type parameter constraint clauses should be aligned vertically</value>
+    <value>Align type parameter constraint clauses vertically</value>
   </data>
   <data name="MiKo_6058_CodeFixTitle" xml:space="preserve">
     <value>Align type parameter constraint indented below parameter list</value>
@@ -6118,7 +6118,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align type parameter constraint indented below parameter list</value>
   </data>
   <data name="MiKo_6058_Title" xml:space="preserve">
-    <value>Type parameter constraint clauses should be indented below parameter list</value>
+    <value>Indent type parameter constraint clauses below parameter list</value>
   </data>
   <data name="MiKo_6059_CodeFixTitle" xml:space="preserve">
     <value>Align condition outdented</value>
@@ -6130,7 +6130,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align condition outdented</value>
   </data>
   <data name="MiKo_6059_Title" xml:space="preserve">
-    <value>Multi-line conditions are positioned outdented below associated calls</value>
+    <value>Position multi-line conditions outdented below associated calls</value>
   </data>
   <data name="MiKo_6060_CodeFixTitle" xml:space="preserve">
     <value>Place switch case label on single line</value>
@@ -6142,7 +6142,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place switch case label on single line</value>
   </data>
   <data name="MiKo_6060_Title" xml:space="preserve">
-    <value>Switch case labels should be placed on same line</value>
+    <value>Place switch case labels on same line</value>
   </data>
   <data name="MiKo_6061_CodeFixTitle" xml:space="preserve">
     <value>Place switch expression arm on single line</value>
@@ -6154,7 +6154,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place switch expression arm on single line</value>
   </data>
   <data name="MiKo_6061_Title" xml:space="preserve">
-    <value>Switch expression arms should be placed on same line</value>
+    <value>Place switch expression arms on same line</value>
   </data>
   <data name="MiKo_6062_CodeFixTitle" xml:space="preserve">
     <value>Align expression right beside open brace</value>
@@ -6166,7 +6166,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Align expression right beside open brace</value>
   </data>
   <data name="MiKo_6062_Title" xml:space="preserve">
-    <value>Expressions within complex initializer expressions should be placed beside open brace</value>
+    <value>Place expressions within complex initializer expressions beside open brace</value>
   </data>
   <data name="MiKo_6063_CodeFixTitle" xml:space="preserve">
     <value>Place invocation on same line</value>
@@ -6178,7 +6178,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place invocation on same line</value>
   </data>
   <data name="MiKo_6063_Title" xml:space="preserve">
-    <value>Invocations should be placed on same line</value>
+    <value>Place invocations on same line</value>
   </data>
   <data name="MiKo_6064_CodeFixTitle" xml:space="preserve">
     <value>Place identifier invocation on same line</value>
@@ -6190,7 +6190,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Place identifier invocation on same line</value>
   </data>
   <data name="MiKo_6064_Title" xml:space="preserve">
-    <value>Identifier invocations should be placed on same line</value>
+    <value>Place identifier invocations on same line</value>
   </data>
   <data name="MiKo_6065_CodeFixTitle" xml:space="preserve">
     <value>Indent dot</value>
@@ -6202,7 +6202,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Indent dot</value>
   </data>
   <data name="MiKo_6065_Title" xml:space="preserve">
-    <value>Consecutive invocations spanning multiple lines should be indented and not outdented</value>
+    <value>Indent rather than outdent consecutive invocations spanning multiple lines</value>
   </data>
   <data name="MiKo_6066_CodeFixTitle" xml:space="preserve">
     <value>Indent element</value>
@@ -6214,7 +6214,7 @@ This organization ensures clarity and makes the code easier to find, understand 
     <value>Indent element</value>
   </data>
   <data name="MiKo_6066_Title" xml:space="preserve">
-    <value>Collection expression elements should be indented and not outdented</value>
+    <value>Indent rather than outdent collection expression elements</value>
   </data>
   <data name="MiKo_6067_CodeFixTitle" xml:space="preserve">
     <value>Align ternary operator vertically</value>
@@ -6227,7 +6227,7 @@ This style avoids dangling operators, aligns with common C# style guides and too
     <value>Place ternary operator and colon on the same lines as their respective expressions</value>
   </data>
   <data name="MiKo_6067_Title" xml:space="preserve">
-    <value>Ternary operators should be placed on same lines as their respective expressions</value>
+    <value>Place ternary operators on same lines as their respective expressions</value>
   </data>
   <data name="MiKo_6070_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -6239,7 +6239,7 @@ This style avoids dangling operators, aligns with common C# style guides and too
     <value>Surround Console statement(s) with blank lines</value>
   </data>
   <data name="MiKo_6070_Title" xml:space="preserve">
-    <value>Console statements should be surrounded by blank lines</value>
+    <value>Surround Console statements with blank lines</value>
   </data>
   <data name="MiKo_6071_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
@@ -6251,6 +6251,6 @@ This style avoids dangling operators, aligns with common C# style guides and too
     <value>Surround local 'using' with a blank line</value>
   </data>
   <data name="MiKo_6071_Title" xml:space="preserve">
-    <value>Local using statements should be surrounded by blank lines</value>
+    <value>Surround local using statements with blank lines</value>
   </data>
 </root>

--- a/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Extensions
                 }
             }
 
-            Assert.That(words, Is.EqualTo(new[] { "This", "is", "a", "test", "to", "see", "if", "everything", "is", "working", "Another", "line.", "Some", "more", "text." }));
+            Assert.That(words, Is.EqualTo(["This", "is", "a", "test", "to", "see", "if", "everything", "is", "working", "Another", "line.", "Some", "more", "text."]));
         }
 
         [Test]

--- a/README.md
+++ b/README.md
@@ -18,548 +18,548 @@ The following tables lists all the 521 rules that are currently provided by the 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_0001|Method is too big|&#x2713;|\-|
-|MiKo_0002|Method is too complex|&#x2713;|\-|
-|MiKo_0003|Type is too big|&#x2713;|\-|
-|MiKo_0004|Method has too many parameters|&#x2713;|\-|
-|MiKo_0005|Local function is too big|&#x2713;|\-|
-|MiKo_0006|Local function is too complex|&#x2713;|\-|
-|MiKo_0007|Local function has too many parameters|&#x2713;|\-|
+|MiKo_0001|Keep methods small|&#x2713;|\-|
+|MiKo_0002|Simplify complex methods|&#x2713;|\-|
+|MiKo_0003|Keep types small|&#x2713;|\-|
+|MiKo_0004|Limit method parameters|&#x2713;|\-|
+|MiKo_0005|Keep local functions small|&#x2713;|\-|
+|MiKo_0006|Simplify complex local functions|&#x2713;|\-|
+|MiKo_0007|Limit local function parameters|&#x2713;|\-|
 
 ### Naming
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_1000|'System.EventArgs' types should be suffixed with 'EventArgs'|&#x2713;|&#x2713;|
-|MiKo_1001|'System.EventArgs' parameters should be named 'e'|&#x2713;|&#x2713;|
-|MiKo_1002|Parameters should be named according the .NET Framework Design Guidelines for event handlers|&#x2713;|&#x2713;|
-|MiKo_1003|Event handling method names should follow the .NET Framework Design Guidelines|&#x2713;|&#x2713;|
-|MiKo_1004|Events should not contain term 'Event' in their names|&#x2713;|&#x2713;|
-|MiKo_1005|'System.EventArgs' variables should be named properly|&#x2713;|&#x2713;|
-|MiKo_1006|Events should use 'EventHandler&lt;T&gt;' with 'EventArgs' which are named after the event|&#x2713;|\-|
-|MiKo_1007|Events and their corresponding 'EventArgs' types should be located in the same namespace|&#x2713;|\-|
-|MiKo_1008|Parameters should be named according the .NET Framework Design Guidelines for DependencyProperty event handlers|&#x2713;|&#x2713;|
-|MiKo_1009|'System.EventHandler' variables should be named properly|&#x2713;|&#x2713;|
-|MiKo_1010|Methods should not contain 'CanExecute' or 'Execute' in their names|&#x2713;|&#x2713;|
-|MiKo_1011|Methods should not contain 'Do' in their names|&#x2713;|&#x2713;|
-|MiKo_1012|Methods should be named 'Raise' instead of 'Fire'|&#x2713;|&#x2713;|
-|MiKo_1013|Methods should not be named 'Notify' or 'OnNotify'|&#x2713;|&#x2713;|
-|MiKo_1014|Methods should not be named with ambiguous 'Check'|&#x2713;|&#x2713;|
-|MiKo_1015|Methods should be named 'Initialize' instead of 'Init'|&#x2713;|&#x2713;|
-|MiKo_1016|Factory methods should be named 'Create'|&#x2713;|&#x2713;|
-|MiKo_1017|Methods should not be prefixed with 'Get' or 'Set' if followed by 'Is', 'Can' or 'Has'|&#x2713;|&#x2713;|
-|MiKo_1018|Methods should not be suffixed with noun of a verb|&#x2713;|&#x2713;|
-|MiKo_1019|'Clear' and 'Remove' methods should be named based on their number of parameters|&#x2713;|&#x2713;|
-|MiKo_1020|Type names should be limited in length|\-|\-|
-|MiKo_1021|Method names should be limited in length|\-|\-|
-|MiKo_1022|Parameter names should be limited in length|\-|\-|
-|MiKo_1023|Field names should be limited in length|\-|\-|
-|MiKo_1024|Property names should be limited in length|\-|\-|
-|MiKo_1025|Event names should be limited in length|\-|\-|
-|MiKo_1026|Variable names should be limited in length|\-|\-|
-|MiKo_1027|Variable names in loops should be limited in length|\-|\-|
-|MiKo_1028|Local function names should be limited in length|\-|\-|
-|MiKo_1030|Types should not have an 'Abstract' or 'Base' marker to indicate that they are base types|&#x2713;|&#x2713;|
-|MiKo_1031|Entity types should not use a 'Model' suffix|&#x2713;|&#x2713;|
-|MiKo_1032|Methods dealing with entities should not use a 'Model' as marker|&#x2713;|&#x2713;|
-|MiKo_1033|Parameters representing entities should not use a 'Model' suffix|&#x2713;|&#x2713;|
-|MiKo_1034|Fields representing entities should not use a 'Model' suffix|&#x2713;|&#x2713;|
-|MiKo_1035|Properties dealing with entities should not use a 'Model' marker|&#x2713;|&#x2713;|
-|MiKo_1036|Events dealing with entities should not use a 'Model' marker|&#x2713;|&#x2713;|
-|MiKo_1037|Types should not be suffixed with 'Type', 'Interface', 'Class', 'Struct', 'Record' or 'Enum'|&#x2713;|&#x2713;|
-|MiKo_1038|Classes that contain extension methods should end with same suffix|&#x2713;|&#x2713;|
-|MiKo_1039|The 'this' parameter of extension methods should have a default name|&#x2713;|&#x2713;|
-|MiKo_1040|Parameters should not be suffixed with implementation details|&#x2713;|&#x2713;|
-|MiKo_1041|Fields should not be suffixed with implementation details|&#x2713;|&#x2713;|
-|MiKo_1042|'CancellationToken' parameters should have specific name|&#x2713;|&#x2713;|
-|MiKo_1043|'CancellationToken' variables should have specific name|&#x2713;|&#x2713;|
-|MiKo_1044|Commands should be suffixed with 'Command'|&#x2713;|&#x2713;|
-|MiKo_1045|Methods that are invoked by commands should not be suffixed with 'Command'|&#x2713;|&#x2713;|
-|MiKo_1046|Asynchronous methods should follow the Task-based Asynchronous Pattern (TAP)|&#x2713;|&#x2713;|
-|MiKo_1047|Methods not following the Task-based Asynchronous Pattern (TAP) should not lie about being asynchronous|&#x2713;|&#x2713;|
-|MiKo_1048|Classes that are value converters should end with a specific suffix|&#x2713;|&#x2713;|
+|MiKo_1000|Suffix 'System.EventArgs' types with 'EventArgs'|&#x2713;|&#x2713;|
+|MiKo_1001|Name 'System.EventArgs' parameters 'e'|&#x2713;|&#x2713;|
+|MiKo_1002|Follow .NET Framework Design Guidelines for event handler parameter names|&#x2713;|&#x2713;|
+|MiKo_1003|Follow .NET Framework Design Guidelines for event handling method names|&#x2713;|&#x2713;|
+|MiKo_1004|Remove term 'Event' from event names|&#x2713;|&#x2713;|
+|MiKo_1005|Name 'System.EventArgs' variables properly|&#x2713;|&#x2713;|
+|MiKo_1006|Use 'EventHandler&lt;T&gt;' with 'EventArgs' named after the event|&#x2713;|\-|
+|MiKo_1007|Place events and their 'EventArgs' types in the same namespace|&#x2713;|\-|
+|MiKo_1008|Follow .NET Framework Design Guidelines for DependencyProperty event handler parameter names|&#x2713;|&#x2713;|
+|MiKo_1009|Name 'System.EventHandler' variables properly|&#x2713;|&#x2713;|
+|MiKo_1010|Do not include 'CanExecute' or 'Execute' in method names|&#x2713;|&#x2713;|
+|MiKo_1011|Do not include 'Do' in method names|&#x2713;|&#x2713;|
+|MiKo_1012|Use 'Raise' instead of 'Fire' in method names|&#x2713;|&#x2713;|
+|MiKo_1013|Do not name methods 'Notify' or 'OnNotify'|&#x2713;|&#x2713;|
+|MiKo_1014|Do not use ambiguous 'Check' in method names|&#x2713;|&#x2713;|
+|MiKo_1015|Use 'Initialize' instead of 'Init' in method names|&#x2713;|&#x2713;|
+|MiKo_1016|Name factory methods 'Create'|&#x2713;|&#x2713;|
+|MiKo_1017|Do not prefix methods with 'Get' or 'Set' when followed by 'Is', 'Can' or 'Has'|&#x2713;|&#x2713;|
+|MiKo_1018|Do not suffix methods with noun of a verb|&#x2713;|&#x2713;|
+|MiKo_1019|Name 'Clear' and 'Remove' methods based on their number of parameters|&#x2713;|&#x2713;|
+|MiKo_1020|Limit type name length|\-|\-|
+|MiKo_1021|Limit method name length|\-|\-|
+|MiKo_1022|Limit parameter name length|\-|\-|
+|MiKo_1023|Limit field name length|\-|\-|
+|MiKo_1024|Limit property name length|\-|\-|
+|MiKo_1025|Limit event name length|\-|\-|
+|MiKo_1026|Limit variable name length|\-|\-|
+|MiKo_1027|Limit loop variable name length|\-|\-|
+|MiKo_1028|Limit local function name length|\-|\-|
+|MiKo_1030|Do not mark base types with 'Abstract' or 'Base'|&#x2713;|&#x2713;|
+|MiKo_1031|Do not suffix entity types with 'Model'|&#x2713;|&#x2713;|
+|MiKo_1032|Do not use 'Model' as marker in methods dealing with entities|&#x2713;|&#x2713;|
+|MiKo_1033|Do not suffix entity parameters with 'Model'|&#x2713;|&#x2713;|
+|MiKo_1034|Do not suffix entity fields with 'Model'|&#x2713;|&#x2713;|
+|MiKo_1035|Do not use 'Model' marker in properties dealing with entities|&#x2713;|&#x2713;|
+|MiKo_1036|Do not use 'Model' marker in events dealing with entities|&#x2713;|&#x2713;|
+|MiKo_1037|Do not suffix types with 'Type', 'Interface', 'Class', 'Struct', 'Record' or 'Enum'|&#x2713;|&#x2713;|
+|MiKo_1038|Use consistent suffix for extension method container classes|&#x2713;|&#x2713;|
+|MiKo_1039|Use default name for 'this' parameter of extension methods|&#x2713;|&#x2713;|
+|MiKo_1040|Do not suffix parameters with implementation details|&#x2713;|&#x2713;|
+|MiKo_1041|Do not suffix fields with implementation details|&#x2713;|&#x2713;|
+|MiKo_1042|Use specific name for 'CancellationToken' parameters|&#x2713;|&#x2713;|
+|MiKo_1043|Use specific name for 'CancellationToken' variables|&#x2713;|&#x2713;|
+|MiKo_1044|Suffix commands with 'Command'|&#x2713;|&#x2713;|
+|MiKo_1045|Do not suffix command-invoked methods with 'Command'|&#x2713;|&#x2713;|
+|MiKo_1046|Follow Task-based Asynchronous Pattern (TAP) for asynchronous methods|&#x2713;|&#x2713;|
+|MiKo_1047|Do not falsely indicate asynchronous behavior for methods not following Task-based Asynchronous Pattern (TAP)|&#x2713;|&#x2713;|
+|MiKo_1048|End value converter classes with a specific suffix|&#x2713;|&#x2713;|
 |MiKo_1049|Do not use requirement terms such as 'Shall', 'Should', 'Must' or 'Need' for names|&#x2713;|&#x2713;|
-|MiKo_1050|Return values should have descriptive names|&#x2713;|&#x2713;|
+|MiKo_1050|Use descriptive names for return values|&#x2713;|&#x2713;|
 |MiKo_1051|Do not suffix parameters with delegate types|&#x2713;|&#x2713;|
 |MiKo_1052|Do not suffix variables with delegate types|&#x2713;|&#x2713;|
 |MiKo_1053|Do not suffix fields with delegate types|&#x2713;|&#x2713;|
 |MiKo_1054|Do not name types 'Helper' or 'Utility'|&#x2713;|&#x2713;|
-|MiKo_1055|Dependency properties should be suffixed with 'Property' (as in the .NET Framework)|&#x2713;|&#x2713;|
-|MiKo_1056|Dependency properties should be prefixed with property names (as in the .NET Framework)|&#x2713;|&#x2713;|
-|MiKo_1057|Dependency property keys should be suffixed with 'Key' (as in the .NET Framework)|&#x2713;|&#x2713;|
-|MiKo_1058|Dependency property keys should be prefixed with property names (as in the .NET Framework)|&#x2713;|&#x2713;|
+|MiKo_1055|Suffix dependency properties with 'Property' (as in the .NET Framework)|&#x2713;|&#x2713;|
+|MiKo_1056|Prefix dependency properties with property names (as in the .NET Framework)|&#x2713;|&#x2713;|
+|MiKo_1057|Suffix dependency property keys with 'Key' (as in the .NET Framework)|&#x2713;|&#x2713;|
+|MiKo_1058|Prefix dependency property keys with property names (as in the .NET Framework)|&#x2713;|&#x2713;|
 |MiKo_1059|Do not name types 'Impl' or 'Implementation'|&#x2713;|&#x2713;|
 |MiKo_1060|Use '&lt;Entity&gt;NotFound' instead of 'Get&lt;Entity&gt;Failed' or '&lt;Entity&gt;Missing'|&#x2713;|&#x2713;|
-|MiKo_1061|The name of 'Try' method's [out] parameter should be specific|&#x2713;|&#x2713;|
-|MiKo_1062|'Can/Has/Contains' methods, properties or fields shall consist of only a few words|&#x2713;|\-|
+|MiKo_1061|Use specific name for 'Try' method's [out] parameters|&#x2713;|&#x2713;|
+|MiKo_1062|Keep 'Can/Has/Contains' methods, properties or fields to a few words|&#x2713;|\-|
 |MiKo_1063|Do not use abbreviations in names|&#x2713;|&#x2713;|
-|MiKo_1064|Parameter names reflect their meaning and not their type|&#x2713;|\-|
-|MiKo_1065|Operator parameters should be named according the .NET Framework Design Guidelines for operator overloads|&#x2713;|&#x2713;|
-|MiKo_1066|Constructor parameters that are assigned to a property should be named after the property|&#x2713;|&#x2713;|
-|MiKo_1067|Methods should not contain 'Perform' in their names|&#x2713;|&#x2713;|
-|MiKo_1068|Workflow methods should be named 'CanRun' or 'Run'|&#x2713;|\-|
-|MiKo_1069|Property names reflect their meaning and not their type|&#x2713;|\-|
-|MiKo_1070|Local collection variables shall use plural name|&#x2713;|&#x2713;|
-|MiKo_1071|Local boolean variables should be named as statements and not as questions|&#x2713;|\-|
-|MiKo_1072|Boolean properties or methods should be named as statements and not as questions|&#x2713;|\-|
-|MiKo_1073|Boolean fields should be named as statements and not as questions|&#x2713;|\-|
-|MiKo_1074|Objects used to lock on should be suffixed with 'Lock'|&#x2713;|\-|
-|MiKo_1075|Non-'System.EventArgs' types should not be suffixed with 'EventArgs'|&#x2713;|&#x2713;|
-|MiKo_1076|Prism event types should be suffixed with 'Event'|&#x2713;|&#x2713;|
-|MiKo_1077|Enum members should not be suffixed with 'Enum'|&#x2713;|&#x2713;|
-|MiKo_1078|Builder method names should start with 'Build'|&#x2713;|&#x2713;|
-|MiKo_1079|Repositories should not be suffixed with 'Repository'|&#x2713;|&#x2713;|
-|MiKo_1080|Names should contain numbers instead of their spellings|&#x2713;|\-|
-|MiKo_1081|Methods should not be suffixed with a number|&#x2713;|&#x2713;|
-|MiKo_1082|Properties should not be suffixed with a number if their types have number suffixes|&#x2713;|&#x2713;|
-|MiKo_1083|Fields should not be suffixed with a number if their types have number suffixes|&#x2713;|&#x2713;|
-|MiKo_1084|Variables should not be suffixed with a number if their types have number suffixes|&#x2713;|&#x2713;|
-|MiKo_1085|Parameters should not be suffixed with a number|&#x2713;|&#x2713;|
-|MiKo_1086|Methods should not be named using numbers as slang|&#x2713;|\-|
-|MiKo_1087|Name constructor parameters after their counterparts in the base class|&#x2713;|&#x2713;|
-|MiKo_1088|Singleton instances should be named 'Instance'|&#x2713;|\-|
-|MiKo_1089|Methods should not be prefixed with 'Get'|&#x2713;|&#x2713;|
-|MiKo_1090|Parameters should not be suffixed with specific types|&#x2713;|&#x2713;|
-|MiKo_1091|Variables should not be suffixed with specific types|&#x2713;|&#x2713;|
-|MiKo_1092|'Ability' Types should not be suffixed with redundant information|&#x2713;|&#x2713;|
+|MiKo_1064|Make parameter names reflect their meaning, not their type|&#x2713;|\-|
+|MiKo_1065|Follow .NET Framework Design Guidelines for operator overload parameter names|&#x2713;|&#x2713;|
+|MiKo_1066|Name constructor parameters after the property they're assigned to|&#x2713;|&#x2713;|
+|MiKo_1067|Do not include 'Perform' in method names|&#x2713;|&#x2713;|
+|MiKo_1068|Name workflow methods 'CanRun' or 'Run'|&#x2713;|\-|
+|MiKo_1069|Make property names reflect their meaning, not their type|&#x2713;|\-|
+|MiKo_1070|Use plural names for local collection variables|&#x2713;|&#x2713;|
+|MiKo_1071|Name local boolean variables as statements, not questions|&#x2713;|\-|
+|MiKo_1072|Name boolean properties or methods as statements, not questions|&#x2713;|\-|
+|MiKo_1073|Name boolean fields as statements, not questions|&#x2713;|\-|
+|MiKo_1074|Suffix lock objects with 'Lock'|&#x2713;|\-|
+|MiKo_1075|Do not suffix non-'System.EventArgs' types with 'EventArgs'|&#x2713;|&#x2713;|
+|MiKo_1076|Suffix Prism event types with 'Event'|&#x2713;|&#x2713;|
+|MiKo_1077|Do not suffix enum members with 'Enum'|&#x2713;|&#x2713;|
+|MiKo_1078|Start builder method names with 'Build'|&#x2713;|&#x2713;|
+|MiKo_1079|Do not suffix repositories with 'Repository'|&#x2713;|&#x2713;|
+|MiKo_1080|Use numbers instead of their spellings in names|&#x2713;|\-|
+|MiKo_1081|Do not suffix methods with a number|&#x2713;|&#x2713;|
+|MiKo_1082|Do not suffix properties with a number if their types have number suffixes|&#x2713;|&#x2713;|
+|MiKo_1083|Do not suffix fields with a number if their types have number suffixes|&#x2713;|&#x2713;|
+|MiKo_1084|Do not suffix variables with a number if their types have number suffixes|&#x2713;|&#x2713;|
+|MiKo_1085|Do not suffix parameters with a number|&#x2713;|&#x2713;|
+|MiKo_1086|Do not use numbers as slang in method names|&#x2713;|\-|
+|MiKo_1087|Name constructor parameters after their base class counterparts|&#x2713;|&#x2713;|
+|MiKo_1088|Name singleton instances 'Instance'|&#x2713;|\-|
+|MiKo_1089|Do not prefix methods with 'Get'|&#x2713;|&#x2713;|
+|MiKo_1090|Do not suffix parameters with specific types|&#x2713;|&#x2713;|
+|MiKo_1091|Do not suffix variables with specific types|&#x2713;|&#x2713;|
+|MiKo_1092|Do not suffix 'Ability' types with redundant information|&#x2713;|&#x2713;|
 |MiKo_1093|Do not use the suffix 'Object' or 'Struct'|&#x2713;|&#x2713;|
 |MiKo_1094|Do not suffix types with passive namespace names|&#x2713;|\-|
 |MiKo_1095|Do not use 'Delete' and 'Remove' both in names and documentation|&#x2713;|\-|
-|MiKo_1096|Names should use 'Failed' instead of 'NotSuccessful'|&#x2713;|\-|
-|MiKo_1097|Parameter names should not follow the naming scheme for fields|&#x2713;|&#x2713;|
-|MiKo_1098|Type names should reflect the business interface(s) they implement|&#x2713;|\-|
-|MiKo_1099|Matching parameters on method overloads should have identical names|&#x2713;|&#x2713;|
-|MiKo_1100|Test classes should start with the name of the type under test|&#x2713;|\-|
-|MiKo_1101|Test classes should end with 'Tests'|&#x2713;|&#x2713;|
-|MiKo_1102|Test methods should not contain 'Test' in their names|&#x2713;|&#x2713;|
-|MiKo_1103|Test initialization methods should be named 'PrepareTest'|&#x2713;|&#x2713;|
-|MiKo_1104|Test cleanup methods should be named 'CleanupTest'|&#x2713;|&#x2713;|
-|MiKo_1105|One-time test initialization methods should be named 'PrepareTestEnvironment'|&#x2713;|&#x2713;|
-|MiKo_1106|One-time test cleanup methods should be named 'CleanupTestEnvironment'|&#x2713;|&#x2713;|
-|MiKo_1107|Test methods should not be in Pascal-casing|&#x2713;|&#x2713;|
+|MiKo_1096|Use 'Failed' instead of 'NotSuccessful' in names|&#x2713;|\-|
+|MiKo_1097|Do not use field naming schemes for parameter names|&#x2713;|&#x2713;|
+|MiKo_1098|Reflect implemented business interface(s) in type names|&#x2713;|\-|
+|MiKo_1099|Use identical names for matching parameters on method overloads|&#x2713;|&#x2713;|
+|MiKo_1100|Start test class names with the name of the type under test|&#x2713;|\-|
+|MiKo_1101|End test class names with 'Tests'|&#x2713;|&#x2713;|
+|MiKo_1102|Do not include 'Test' in test method names|&#x2713;|&#x2713;|
+|MiKo_1103|Name test initialization methods 'PrepareTest'|&#x2713;|&#x2713;|
+|MiKo_1104|Name test cleanup methods 'CleanupTest'|&#x2713;|&#x2713;|
+|MiKo_1105|Name one-time test initialization methods 'PrepareTestEnvironment'|&#x2713;|&#x2713;|
+|MiKo_1106|Name one-time test cleanup methods 'CleanupTestEnvironment'|&#x2713;|&#x2713;|
+|MiKo_1107|Do not use Pascal-casing for test methods|&#x2713;|&#x2713;|
 |MiKo_1108|Do not name variables, parameters, fields and properties 'Mock', 'Stub', 'Fake' or 'Shim'|&#x2713;|&#x2713;|
 |MiKo_1109|Prefix testable types with 'Testable' instead of using the 'Ut' suffix|&#x2713;|&#x2713;|
-|MiKo_1110|Test methods with parameters should be suffixed with underscore|&#x2713;|&#x2713;|
-|MiKo_1111|Test methods without parameters should not be suffixed with underscore|&#x2713;|&#x2713;|
+|MiKo_1110|Suffix test methods with parameters with underscore|&#x2713;|&#x2713;|
+|MiKo_1111|Do not suffix parameterless test methods with underscore|&#x2713;|&#x2713;|
 |MiKo_1112|Do not name test data 'arbitrary'|&#x2713;|&#x2713;|
-|MiKo_1113|Test methods should not be named according BDD style|&#x2713;|\-|
-|MiKo_1114|Test methods should not be named 'HappyPath' or 'BadPath'|&#x2713;|\-|
-|MiKo_1115|Test methods should be named in a fluent way|&#x2713;|&#x2713;|
-|MiKo_1116|Test methods shall be named in present tense|&#x2713;|\-|
-|MiKo_1117|Test methods should be named more precisely|&#x2713;|\-|
-|MiKo_1118|Test methods should not end with 'Async'|&#x2713;|&#x2713;|
-|MiKo_1200|Name exceptions in catch blocks consistently|&#x2713;|&#x2713;|
-|MiKo_1201|Name exceptions as parameters consistently|&#x2713;|&#x2713;|
-|MiKo_1300|Unimportant identifiers in lambda statements should be named '_'|&#x2713;|&#x2713;|
-|MiKo_1400|Namespace names should be in plural|&#x2713;|\-|
-|MiKo_1401|Namespaces should not contain technical language names|&#x2713;|\-|
-|MiKo_1402|Namespaces should not be named after WPF-specific design patterns|&#x2713;|\-|
-|MiKo_1403|Namespaces should not be named after any of their parent namespaces|&#x2713;|\-|
-|MiKo_1404|Namespaces should not contain unspecific names|&#x2713;|\-|
-|MiKo_1405|Namespaces should not contain 'Lib'|&#x2713;|\-|
-|MiKo_1406|Value converters should be placed in 'Converters' namespace|&#x2713;|\-|
-|MiKo_1407|Test namespaces should not contain 'Test'|&#x2713;|\-|
-|MiKo_1408|Extension methods should be placed in same namespace as the extended types|&#x2713;|\-|
+|MiKo_1113|Do not use BDD style naming for test methods|&#x2713;|\-|
+|MiKo_1114|Do not name test methods 'HappyPath' or 'BadPath'|&#x2713;|\-|
+|MiKo_1115|Name test methods in a fluent way|&#x2713;|&#x2713;|
+|MiKo_1116|Use present tense for test method names|&#x2713;|&#x2713;|
+|MiKo_1117|Make test method names more precise|&#x2713;|\-|
+|MiKo_1118|Do not end test method names with 'Async'|&#x2713;|&#x2713;|
+|MiKo_1200|Name catch block exceptions consistently|&#x2713;|&#x2713;|
+|MiKo_1201|Name exception parameters consistently|&#x2713;|&#x2713;|
+|MiKo_1300|Name unimportant lambda statement identifiers '_'|&#x2713;|&#x2713;|
+|MiKo_1400|Use plural for namespace names|&#x2713;|\-|
+|MiKo_1401|Do not include technical language names in namespaces|&#x2713;|\-|
+|MiKo_1402|Do not name namespaces after WPF-specific design patterns|&#x2713;|\-|
+|MiKo_1403|Do not name namespaces after any of their parent namespaces|&#x2713;|\-|
+|MiKo_1404|Do not use unspecific names for namespaces|&#x2713;|\-|
+|MiKo_1405|Do not include 'Lib' in namespaces|&#x2713;|\-|
+|MiKo_1406|Place value converters in 'Converters' namespace|&#x2713;|\-|
+|MiKo_1407|Do not include 'Test' in test namespaces|&#x2713;|\-|
+|MiKo_1408|Place extension methods in same namespace as the extended types|&#x2713;|\-|
 |MiKo_1409|Do not prefix or suffix namespaces with underscores|&#x2713;|\-|
 |MiKo_1501|Do not use 'Filter' in names|&#x2713;|\-|
 |MiKo_1502|Do not use 'Process' in names|&#x2713;|\-|
-|MiKo_1503|Methods should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
-|MiKo_1504|Properties should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
-|MiKo_1505|Fields should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
-|MiKo_1506|Local variables should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
-|MiKo_1507|Parameters should not be suffixed with 'Counter'|&#x2713;|&#x2713;|
-|MiKo_1508|Local variables should not be suffixed with pattern names|&#x2713;|&#x2713;|
-|MiKo_1509|Parameters should not be suffixed with pattern names|&#x2713;|&#x2713;|
-|MiKo_1510|Types should not be suffixed with 'Info'|&#x2713;|\-|
-|MiKo_1511|Local variables should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
-|MiKo_1512|Parameters should not be prefixed or suffixed with 'proxy'|&#x2713;|&#x2713;|
-|MiKo_1513|Types should not be suffixed with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'|&#x2713;|&#x2713;|
-|MiKo_1514|Fields should not be suffixed with pattern names|&#x2713;|&#x2713;|
-|MiKo_1515|Boolean property names should clearly express a binary condition|&#x2713;|&#x2713;|
-|MiKo_1516|Boolean parameter names should clearly express a binary condition|&#x2713;|&#x2713;|
-|MiKo_1517|Boolean field names should clearly express a binary condition|&#x2713;|&#x2713;|
+|MiKo_1503|Do not suffix methods with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1504|Do not suffix properties with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1505|Do not suffix fields with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1506|Do not suffix local variables with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1507|Do not suffix parameters with 'Counter'|&#x2713;|&#x2713;|
+|MiKo_1508|Do not suffix local variables with pattern names|&#x2713;|&#x2713;|
+|MiKo_1509|Do not suffix parameters with pattern names|&#x2713;|&#x2713;|
+|MiKo_1510|Do not suffix types with 'Info'|&#x2713;|\-|
+|MiKo_1511|Do not prefix or suffix local variables with 'proxy'|&#x2713;|&#x2713;|
+|MiKo_1512|Do not prefix or suffix parameters with 'proxy'|&#x2713;|&#x2713;|
+|MiKo_1513|Do not suffix types with 'Advanced', 'Complex', 'Enhanced', 'Extended', 'Simple' or 'Simplified'|&#x2713;|&#x2713;|
+|MiKo_1514|Do not suffix fields with pattern names|&#x2713;|&#x2713;|
+|MiKo_1515|Express binary conditions clearly in boolean property names|&#x2713;|&#x2713;|
+|MiKo_1516|Express binary conditions clearly in boolean parameter names|&#x2713;|&#x2713;|
+|MiKo_1517|Express binary conditions clearly in boolean field names|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_2000|Documentation should be valid XML|&#x2713;|&#x2713;|
-|MiKo_2001|Events should be documented properly|&#x2713;|&#x2713;|
-|MiKo_2002|EventArgs should be documented properly|&#x2713;|&#x2713;|
-|MiKo_2003|Documentation of event handlers should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2004|Documentation of event handler parameter names should follow .NET Framework Design Guidelines for event handlers|&#x2713;|&#x2713;|
-|MiKo_2005|Textual references to EventArgs should be documented properly|&#x2713;|\-|
-|MiKo_2006|Routed events should be documented as done by the .NET Framework|&#x2713;|&#x2713;|
-|MiKo_2010|Sealed classes should document being sealed|&#x2713;|&#x2713;|
-|MiKo_2011|Unsealed classes should not lie about sealing|&#x2713;|&#x2713;|
-|MiKo_2012|&lt;summary&gt; documentation should describe the type's responsibility|&#x2713;|&#x2713;|
-|MiKo_2013|&lt;summary&gt; documentation of Enums should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2014|Dispose methods should be documented as done by the .NET Framework|&#x2713;|&#x2713;|
-|MiKo_2015|Documentation should use 'raise' or 'throw' instead of 'fire'|&#x2713;|&#x2713;|
-|MiKo_2016|Documentation for asynchronous methods should start with specific phrase|&#x2713;|&#x2713;|
-|MiKo_2017|Dependency properties should be documented as done by the .NET Framework|&#x2713;|&#x2713;|
-|MiKo_2018|Documentation should not use the ambiguous terms 'Check' or 'Test'|&#x2713;|&#x2713;|
-|MiKo_2019|&lt;summary&gt; documentation should start with a third person singular verb (for example "Provides ")|&#x2713;|&#x2713;|
-|MiKo_2020|Inherited documentation should be used with &lt;inheritdoc /&gt; marker|&#x2713;|&#x2713;|
-|MiKo_2021|Documentation of parameter should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2022|Documentation of [out] parameters should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2023|Documentation of Boolean parameters should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2024|Documentation of Enum parameters should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2025|Documentation of 'CancellationToken' parameters should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2026|Used parameters should not be documented to be unused|&#x2713;|\-|
-|MiKo_2027|Serialization constructor parameters shall be documented with a specific phrase|&#x2713;|&#x2713;|
-|MiKo_2028|Documentation of parameter should not just contain the name of the parameter|&#x2713;|\-|
-|MiKo_2029|&lt;inheritdoc&gt; documentation should not use a 'cref' to itself|&#x2713;|&#x2713;|
-|MiKo_2030|Documentation of return value should have a default starting phrase|&#x2713;|\-|
-|MiKo_2031|Documentation of Task return value should have a specific (starting) phrase|&#x2713;|&#x2713;|
-|MiKo_2032|Documentation of Boolean return value should have a specific phrase|&#x2713;|&#x2713;|
-|MiKo_2033|Documentation of String return value should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2034|Documentation of Enum return value should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2035|Documentation of collection return value should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2036|Documentation of Boolean or Enum property shall describe the default value|&#x2713;|&#x2713;|
-|MiKo_2037|&lt;summary&gt; documentation of command properties should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2038|&lt;summary&gt; documentation of command should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2039|&lt;summary&gt; documentation of classes that contain extension methods should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2040|&lt;see langword="..."/&gt; should be used instead of &lt;c&gt;...&lt;/c&gt;|&#x2713;|&#x2713;|
-|MiKo_2041|&lt;summary&gt; documentation should not contain other documentation tags|&#x2713;|&#x2713;|
-|MiKo_2042|Documentation should use '&lt;para&gt;' XML tags instead of '&lt;p&gt;' HTML tags|&#x2713;|&#x2713;|
-|MiKo_2043|&lt;summary&gt; documentation of custom delegates should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2044|Documentation references method parameters correctly|&#x2713;|&#x2713;|
-|MiKo_2045|&lt;summary&gt; documentation should not reference parameters|&#x2713;|&#x2713;|
-|MiKo_2046|Documentation should reference type parameters correctly|&#x2713;|&#x2713;|
-|MiKo_2047|&lt;summary&gt; documentation of Attributes should have a default starting phrase|&#x2713;|\-|
-|MiKo_2048|&lt;summary&gt; documentation of value converters should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2049|Documentation should be more explicit and not use 'will be'|&#x2713;|&#x2713;|
-|MiKo_2050|Exceptions should be documented following the .NET Framework|&#x2713;|&#x2713;|
-|MiKo_2051|Thrown Exceptions should be documented as kind of a condition (such as '&lt;paramref name="xyz"/&gt; is &lt;c&gt;42&lt;/c&gt;')|&#x2713;|&#x2713;|
-|MiKo_2052|Throwing of ArgumentNullException should be documented using a default phrase|&#x2713;|&#x2713;|
-|MiKo_2053|Throwing of ArgumentNullException should be documented only for reference type parameters|&#x2713;|\-|
-|MiKo_2054|Throwing of ArgumentException should be documented using a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2055|Throwing of ArgumentOutOfRangeException should be documented using a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2056|Throwing of ObjectDisposedException should be documented using a default ending phrase|&#x2713;|&#x2713;|
-|MiKo_2057|Types that are not disposable shall not throw an ObjectDisposedException|&#x2713;|&#x2713;|
-|MiKo_2059|Multiple documentation of same exception should be consolidated into one|&#x2713;|&#x2713;|
-|MiKo_2060|Factories should be documented in an uniform way|&#x2713;|&#x2713;|
-|MiKo_2070|&lt;summary&gt; documentation should not start with 'Returns'|&#x2713;|&#x2713;|
-|MiKo_2071|&lt;summary&gt; documentation for methods that return Enum types should not contain phrase for boolean type|&#x2713;|\-|
-|MiKo_2072|&lt;summary&gt; documentation should not start with 'Try'|&#x2713;|&#x2713;|
-|MiKo_2073|&lt;summary&gt; documentation of 'Contains' methods should start with 'Determines whether '|&#x2713;|&#x2713;|
-|MiKo_2074|Documentation of parameter of 'Contains' method should have a default ending phrase|&#x2713;|&#x2713;|
-|MiKo_2075|Documentation should use the term 'callback' instead of 'action', 'func' or 'function'|&#x2713;|&#x2713;|
-|MiKo_2076|Documentation should document default values of optional parameters|&#x2713;|&#x2713;|
-|MiKo_2077|&lt;summary&gt; documentation should not contain &lt;code&gt;|&#x2713;|\-|
-|MiKo_2078|&lt;code&gt; documentation should not contain XML tags|&#x2713;|\-|
-|MiKo_2079|&lt;summary&gt; documentation of properties should not have obvious text|&#x2713;|&#x2713;|
-|MiKo_2080|&lt;summary&gt; documentation of fields should have a default starting phrase|&#x2713;|&#x2713;|
-|MiKo_2081|&lt;summary&gt; documentation of public-visible read-only fields should have a default ending phrase|&#x2713;|&#x2713;|
-|MiKo_2082|&lt;summary&gt; documentation of Enum members should not start with default starting phrases of Enum &lt;summary&gt; documentation|&#x2713;|&#x2713;|
-|MiKo_2090|Documentation for equality operator shall have default phrase|&#x2713;|&#x2713;|
-|MiKo_2091|Documentation for inequality operator shall have default phrase|&#x2713;|&#x2713;|
-|MiKo_2100|&lt;example&gt; documentation should start with descriptive default phrase|&#x2713;|&#x2713;|
-|MiKo_2101|&lt;example&gt; documentation should show code example in &lt;code&gt; tags|&#x2713;|&#x2713;|
-|MiKo_2200|Use a capitalized letter to start the comment|&#x2713;|&#x2713;|
-|MiKo_2201|Use a capitalized letter to start the sentences in the comment|&#x2713;|\-|
-|MiKo_2202|Documentation should use the term 'identifier' instead of 'id'|&#x2713;|&#x2713;|
-|MiKo_2203|Documentation should use the term 'unique identifier' instead of 'guid'|&#x2713;|&#x2713;|
-|MiKo_2204|Documentation should use &lt;list&gt; for enumerations|&#x2713;|&#x2713;|
-|MiKo_2205|Documentation should use &lt;note&gt; for important information|&#x2713;|\-|
-|MiKo_2206|Documentation should not use the term 'flag'|&#x2713;|\-|
-|MiKo_2207|&lt;summary&gt; documentation shall be short|&#x2713;|\-|
-|MiKo_2208|Documentation should not use the term 'an instance of'|&#x2713;|&#x2713;|
+|MiKo_2000|Write valid XML documentation|&#x2713;|&#x2713;|
+|MiKo_2001|Document events properly|&#x2713;|&#x2713;|
+|MiKo_2002|Document EventArgs properly|&#x2713;|&#x2713;|
+|MiKo_2003|Start event handler documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2004|Follow .NET Framework Design Guidelines for event handler parameter names in documentation|&#x2713;|&#x2713;|
+|MiKo_2005|Document textual references to EventArgs properly|&#x2713;|\-|
+|MiKo_2006|Document routed events as done by the .NET Framework|&#x2713;|&#x2713;|
+|MiKo_2010|Document sealed classes as being sealed|&#x2713;|&#x2713;|
+|MiKo_2011|Do not falsely document unsealed classes as sealed|&#x2713;|&#x2713;|
+|MiKo_2012|Describe the type's responsibility in &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2013|Start Enum &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2014|Document Dispose methods as done by the .NET Framework|&#x2713;|&#x2713;|
+|MiKo_2015|Use 'raise' or 'throw' instead of 'fire' in documentation|&#x2713;|&#x2713;|
+|MiKo_2016|Start documentation for asynchronous methods with specific phrase|&#x2713;|&#x2713;|
+|MiKo_2017|Document dependency properties as done by the .NET Framework|&#x2713;|&#x2713;|
+|MiKo_2018|Do not use ambiguous terms 'Check' or 'Test' in documentation|&#x2713;|&#x2713;|
+|MiKo_2019|Start &lt;summary&gt; documentation with third person singular verb (e.g., "Provides")|&#x2713;|&#x2713;|
+|MiKo_2020|Use &lt;inheritdoc /&gt; marker for inherited documentation|&#x2713;|&#x2713;|
+|MiKo_2021|Start parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2022|Start [out] parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2023|Start Boolean parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2024|Start Enum parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2025|Start 'CancellationToken' parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2026|Do not document used parameters as unused|&#x2713;|\-|
+|MiKo_2027|Document serialization constructor parameters with specific phrase|&#x2713;|&#x2713;|
+|MiKo_2028|Provide more information than just parameter name in documentation|&#x2713;|\-|
+|MiKo_2029|Do not use self-referencing 'cref' in &lt;inheritdoc&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2030|Start return value documentation with default phrase|&#x2713;|\-|
+|MiKo_2031|Use specific (starting) phrase for Task return value documentation|&#x2713;|&#x2713;|
+|MiKo_2032|Use specific phrase for Boolean return value documentation|&#x2713;|&#x2713;|
+|MiKo_2033|Start String return value documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2034|Start Enum return value documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2035|Start collection return value documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2036|Describe default values in Boolean or Enum property documentation|&#x2713;|&#x2713;|
+|MiKo_2037|Start command property &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2038|Start command &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2039|Start extension method class &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2040|Use &lt;see langword="..."/&gt; instead of &lt;c&gt;...&lt;/c&gt;|&#x2713;|&#x2713;|
+|MiKo_2041|Do not include other documentation tags in &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2042|Use '&lt;para&gt;' XML tags instead of '&lt;p&gt;' HTML tags in documentation|&#x2713;|&#x2713;|
+|MiKo_2043|Start custom delegate &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2044|Reference method parameters correctly in documentation|&#x2713;|&#x2713;|
+|MiKo_2045|Do not reference parameters in &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2046|Reference type parameters correctly in documentation|&#x2713;|&#x2713;|
+|MiKo_2047|Start Attribute &lt;summary&gt; documentation with default phrase|&#x2713;|\-|
+|MiKo_2048|Start value converter &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2049|Use explicit wording instead of 'will be' in documentation|&#x2713;|&#x2713;|
+|MiKo_2050|Follow .NET Framework conventions for exception documentation|&#x2713;|&#x2713;|
+|MiKo_2051|Document thrown exceptions as conditions (e.g., '&lt;paramref name="xyz"/&gt; is &lt;c&gt;42&lt;/c&gt;')|&#x2713;|&#x2713;|
+|MiKo_2052|Use default phrase for ArgumentNullException documentation|&#x2713;|&#x2713;|
+|MiKo_2053|Document ArgumentNullException only for reference type parameters|&#x2713;|\-|
+|MiKo_2054|Start ArgumentException documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2055|Start ArgumentOutOfRangeException documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2056|End ObjectDisposedException documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2057|Do not throw ObjectDisposedException from non-disposable types|&#x2713;|&#x2713;|
+|MiKo_2059|Consolidate multiple documentations of same exception into one|&#x2713;|&#x2713;|
+|MiKo_2060|Document factories uniformly|&#x2713;|&#x2713;|
+|MiKo_2070|Do not start &lt;summary&gt; documentation with 'Returns'|&#x2713;|&#x2713;|
+|MiKo_2071|Do not use boolean phrases in Enum return type &lt;summary&gt; documentation|&#x2713;|\-|
+|MiKo_2072|Do not start &lt;summary&gt; documentation with 'Try'|&#x2713;|&#x2713;|
+|MiKo_2073|Start 'Contains' method &lt;summary&gt; documentation with 'Determines whether'|&#x2713;|&#x2713;|
+|MiKo_2074|End 'Contains' method parameter documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2075|Use 'callback' instead of 'action', 'func' or 'function' in documentation|&#x2713;|&#x2713;|
+|MiKo_2076|Document default values of optional parameters|&#x2713;|&#x2713;|
+|MiKo_2077|Do not include &lt;code&gt; in &lt;summary&gt; documentation|&#x2713;|\-|
+|MiKo_2078|Do not include XML tags in &lt;code&gt; documentation|&#x2713;|\-|
+|MiKo_2079|Do not include obvious text in property &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2080|Start field &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2081|End public-visible read-only field &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
+|MiKo_2082|Use distinct phrases for Enum member &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2090|Use default phrase for equality operator documentation|&#x2713;|&#x2713;|
+|MiKo_2091|Use default phrase for inequality operator documentation|&#x2713;|&#x2713;|
+|MiKo_2100|Start &lt;example&gt; documentation with descriptive default phrase|&#x2713;|&#x2713;|
+|MiKo_2101|Show code examples within &lt;code&gt; tags in &lt;example&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2200|Start comments with a capitalized letter|&#x2713;|&#x2713;|
+|MiKo_2201|Start sentences in comments with a capitalized letter|&#x2713;|\-|
+|MiKo_2202|Use term 'identifier' instead of 'id' in documentation|&#x2713;|&#x2713;|
+|MiKo_2203|Use term 'unique identifier' instead of 'guid' in documentation|&#x2713;|&#x2713;|
+|MiKo_2204|Use &lt;list&gt; for enumerations in documentation|&#x2713;|&#x2713;|
+|MiKo_2205|Use &lt;note&gt; for important information in documentation|&#x2713;|\-|
+|MiKo_2206|Do not use term 'flag' in documentation|&#x2713;|\-|
+|MiKo_2207|Keep &lt;summary&gt; documentation short|&#x2713;|\-|
+|MiKo_2208|Do not use term 'an instance of' in documentation|&#x2713;|&#x2713;|
 |MiKo_2209|Do not use double periods in documentation|&#x2713;|&#x2713;|
-|MiKo_2210|Documentation should use the term 'information' instead of 'info'|&#x2713;|&#x2713;|
-|MiKo_2211|Enum members should not have &lt;remarks&gt; sections|&#x2713;|&#x2713;|
-|MiKo_2212|Documentation should use the phrase 'failed' instead of 'was not successful'|&#x2713;|&#x2713;|
-|MiKo_2213|Documentation should not use the contraction "n't"|&#x2713;|&#x2713;|
-|MiKo_2214|Documentation should not contain empty lines|&#x2713;|&#x2713;|
-|MiKo_2215|Sentences in documentation shall be short|&#x2713;|\-|
+|MiKo_2210|Use term 'information' instead of 'info' in documentation|&#x2713;|&#x2713;|
+|MiKo_2211|Do not use &lt;remarks&gt; sections for enum members|&#x2713;|&#x2713;|
+|MiKo_2212|Use phrase 'failed' instead of 'was not successful' in documentation|&#x2713;|&#x2713;|
+|MiKo_2213|Do not use contraction "n't" in documentation|&#x2713;|&#x2713;|
+|MiKo_2214|Remove empty lines from documentation|&#x2713;|&#x2713;|
+|MiKo_2215|Keep documentation sentences short|&#x2713;|\-|
 |MiKo_2216|Use &lt;paramref&gt; instead of &lt;param&gt; to reference parameters|&#x2713;|&#x2713;|
-|MiKo_2217|&lt;list&gt; documentation is done properly|&#x2713;|&#x2713;|
-|MiKo_2218|Documentation should use shorter terms instead of longer term 'used to/in/by'|&#x2713;|&#x2713;|
-|MiKo_2219|Do not use question or explamation marks in documentation|&#x2713;|\-|
-|MiKo_2220|Documentation should use 'to seek' instead of 'to look for', 'to inspect for' or 'to test for'|&#x2713;|&#x2713;|
-|MiKo_2221|Documentation should not use empty XML tags|&#x2713;|\-|
-|MiKo_2222|Documentation should use the term 'identification' instead of 'ident'|&#x2713;|&#x2713;|
-|MiKo_2223|Documentation links references via &lt;see cref="..."/&gt;|&#x2713;|\-|
-|MiKo_2224|Documentation should have XML tags and texts placed on separate lines|&#x2713;|&#x2713;|
-|MiKo_2225|Code marked with &lt;c&gt; tags should be placed on single line|&#x2713;|&#x2713;|
-|MiKo_2226|Documentation should explain the 'Why' and not the 'That'|&#x2713;|\-|
-|MiKo_2227|Documentation should not contain ReSharper suppressions|&#x2713;|\-|
-|MiKo_2228|Documentation should use positive wording instead of negative|&#x2713;|\-|
-|MiKo_2229|Documentation should not contain left-over XML fragments|&#x2713;|&#x2713;|
-|MiKo_2230|Documentation of return value should use &lt;list&gt; when there are values with specific meanings|&#x2713;|&#x2713;|
-|MiKo_2231|Documentation of overridden 'GetHashCode()' methods shall use '&lt;inheritdoc /&gt;' marker|&#x2713;|&#x2713;|
-|MiKo_2232|&lt;summary&gt; documentation should not be empty|&#x2713;|&#x2713;|
-|MiKo_2233|XML tags should be placed on single line|&#x2713;|&#x2713;|
-|MiKo_2234|Documentation should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
-|MiKo_2235|Documentation should use 'will' instead of 'going to'|&#x2713;|&#x2713;|
-|MiKo_2236|Documentation should use 'for example' instead of abbreviation 'e.g.'|&#x2713;|&#x2713;|
-|MiKo_2237|Documentation should not be separated by empty lines|&#x2713;|&#x2713;|
-|MiKo_2238|&lt;summary&gt; documentation shall not start with 'Make sure to call this'|&#x2713;|\-|
-|MiKo_2239|Documentation should use '///' and not '/** */'|&#x2713;|&#x2713;|
-|MiKo_2240|&lt;response&gt; documentation should not start with 'Returns'|&#x2713;|&#x2713;|
-|MiKo_2244|Documentation should use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt;|&#x2713;|&#x2713;|
-|MiKo_2300|Comments should explain the 'Why' and not the 'How'|&#x2713;|\-|
+|MiKo_2217|Format &lt;list&gt; documentation properly|&#x2713;|&#x2713;|
+|MiKo_2218|Use shorter terms instead of 'used to/in/by' in documentation|&#x2713;|&#x2713;|
+|MiKo_2219|Do not use question or exclamation marks in documentation|&#x2713;|\-|
+|MiKo_2220|Use 'to seek' instead of 'to look for', 'to inspect for' or 'to test for' in documentation|&#x2713;|&#x2713;|
+|MiKo_2221|Do not use empty XML tags in documentation|&#x2713;|\-|
+|MiKo_2222|Use term 'identification' instead of 'ident' in documentation|&#x2713;|&#x2713;|
+|MiKo_2223|Link references via &lt;see cref="..."/&gt; in documentation|&#x2713;|\-|
+|MiKo_2224|Place XML tags and texts on separate lines in documentation|&#x2713;|&#x2713;|
+|MiKo_2225|Place code marked with &lt;c&gt; tags on single line|&#x2713;|&#x2713;|
+|MiKo_2226|Explain the 'Why' instead of the 'That' in documentation|&#x2713;|\-|
+|MiKo_2227|Remove ReSharper suppressions from documentation|&#x2713;|\-|
+|MiKo_2228|Use positive wording instead of negative in documentation|&#x2713;|\-|
+|MiKo_2229|Remove left-over XML fragments from documentation|&#x2713;|&#x2713;|
+|MiKo_2230|Use &lt;list&gt; for return values with specific meanings in documentation|&#x2713;|&#x2713;|
+|MiKo_2231|Use '&lt;inheritdoc /&gt;' marker for overridden 'GetHashCode()' methods documentation|&#x2713;|&#x2713;|
+|MiKo_2232|Do not leave &lt;summary&gt; documentation empty|&#x2713;|&#x2713;|
+|MiKo_2233|Place XML tags on single line|&#x2713;|&#x2713;|
+|MiKo_2234|Use 'to' instead of 'that is to' or 'which is to' in documentation|&#x2713;|&#x2713;|
+|MiKo_2235|Use 'will' instead of 'going to' in documentation|&#x2713;|&#x2713;|
+|MiKo_2236|Use 'for example' instead of abbreviation 'e.g.' in documentation|&#x2713;|&#x2713;|
+|MiKo_2237|Do not separate documentation with empty lines|&#x2713;|&#x2713;|
+|MiKo_2238|Do not start &lt;summary&gt; documentation with 'Make sure to call this'|&#x2713;|\-|
+|MiKo_2239|Use '///' instead of '/** */' for documentation|&#x2713;|&#x2713;|
+|MiKo_2240|Do not start &lt;response&gt; documentation with 'Returns'|&#x2713;|&#x2713;|
+|MiKo_2244|Use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt; in documentation|&#x2713;|&#x2713;|
+|MiKo_2300|Explain the 'Why' instead of the 'How' in comments|&#x2713;|\-|
 |MiKo_2301|Do not use obvious comments in AAA-Tests|&#x2713;|&#x2713;|
-|MiKo_2302|Do not keep code that is commented out|&#x2713;|\-|
+|MiKo_2302|Remove commented-out code|&#x2713;|\-|
 |MiKo_2303|Do not end comments with a period|&#x2713;|&#x2713;|
 |MiKo_2304|Do not formulate comments as questions|&#x2713;|\-|
 |MiKo_2305|Do not use double periods in comments|&#x2713;|&#x2713;|
 |MiKo_2306|End comments with a period|\-|\-|
-|MiKo_2307|Comments should use the phrase 'failed' instead of 'was not successful'|&#x2713;|&#x2713;|
-|MiKo_2308|Do not place comment on single line before closing brace but after code|&#x2713;|&#x2713;|
-|MiKo_2309|Comments should not use the contraction "n't"|&#x2713;|&#x2713;|
-|MiKo_2310|Comments should explain the 'Why' and not the 'That'|&#x2713;|\-|
+|MiKo_2307|Use phrase 'failed' instead of 'was not successful' in comments|&#x2713;|&#x2713;|
+|MiKo_2308|Place comments after code instead of on single line before closing brace|&#x2713;|&#x2713;|
+|MiKo_2309|Do not use contraction "n't" in comments|&#x2713;|&#x2713;|
+|MiKo_2310|Explain the 'Why' instead of the 'That' in comments|&#x2713;|\-|
 |MiKo_2311|Do not use separator comments|&#x2713;|&#x2713;|
-|MiKo_2312|Comments should use 'to' instead of 'that is to' or 'which is to'|&#x2713;|&#x2713;|
-|MiKo_2313|Plain documentation comments should be XML documentation|&#x2713;|&#x2713;|
+|MiKo_2312|Use 'to' instead of 'that is to' or 'which is to' in comments|&#x2713;|&#x2713;|
+|MiKo_2313|Format plain documentation comments as XML documentation|&#x2713;|&#x2713;|
 
 ### Maintainability
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |MiKo_3000|Do not use empty regions|&#x2713;|\-|
-|MiKo_3001|Custom delegates should not be used|&#x2713;|\-|
-|MiKo_3002|Classes should not have too many dependencies|&#x2713;|\-|
-|MiKo_3003|Events should follow .NET Framework Design Guidelines for events|&#x2713;|\-|
-|MiKo_3004|Property setters of EventArgs shall be private|&#x2713;|\-|
-|MiKo_3005|Methods named 'Try' should follow the Trier-Doer-Pattern|&#x2713;|\-|
-|MiKo_3006|'CancellationToken' parameter should be last method parameter|&#x2713;|\-|
-|MiKo_3007|Do not use LINQ method and declarative query syntax in same method|&#x2713;|\-|
-|MiKo_3008|Method should not return collections that can be changed from outside|&#x2713;|\-|
-|MiKo_3009|Commands should invoke only named methods and no lambda expressions|&#x2713;|\-|
+|MiKo_3001|Do not use custom delegates|&#x2713;|\-|
+|MiKo_3002|Limit class dependencies|&#x2713;|\-|
+|MiKo_3003|Follow .NET Framework Design Guidelines for events|&#x2713;|\-|
+|MiKo_3004|Make EventArgs property setters private|&#x2713;|\-|
+|MiKo_3005|Follow Trier-Doer-Pattern for methods named 'Try'|&#x2713;|\-|
+|MiKo_3006|Place 'CancellationToken' parameter last in method parameters|&#x2713;|\-|
+|MiKo_3007|Do not mix LINQ method and declarative query syntax in same method|&#x2713;|\-|
+|MiKo_3008|Return immutable collections|&#x2713;|\-|
+|MiKo_3009|Use named methods instead of lambda expressions with commands|&#x2713;|\-|
 |MiKo_3010|Do not create or throw reserved exception types|&#x2713;|\-|
-|MiKo_3011|Thrown ArgumentExceptions (or its subtypes) shall provide the correct parameter name|&#x2713;|&#x2713;|
-|MiKo_3012|Thrown ArgumentOutOfRangeExceptions (or its subtypes) shall provide the actual value that causes the exception to be thrown|&#x2713;|&#x2713;|
-|MiKo_3013|The 'default' clause in 'switch' statements should throw an ArgumentOutOfRangeException (or subtype), but no ArgumentException|&#x2713;|&#x2713;|
-|MiKo_3014|InvalidOperationException, NotImplementedException and NotSupportedException should have a reason as message|&#x2713;|&#x2713;|
-|MiKo_3015|Throw InvalidOperationExceptions (instead of ArgumentExceptions or its subtypes) to indicate inappropriate states of parameterless methods|&#x2713;|&#x2713;|
-|MiKo_3016|Do not throw ArgumentNullException for inappropriate states of property return values|&#x2713;|&#x2713;|
-|MiKo_3017|Do not swallow exceptions when throwing new exceptions|&#x2713;|&#x2713;|
-|MiKo_3018|Throw ObjectDisposedExceptions on publicly visible methods of disposable types|&#x2713;|\-|
+|MiKo_3011|Provide correct parameter name for ArgumentExceptions|&#x2713;|&#x2713;|
+|MiKo_3012|Provide actual value when throwing ArgumentOutOfRangeExceptions|&#x2713;|&#x2713;|
+|MiKo_3013|Throw ArgumentOutOfRangeException (not ArgumentException) in 'switch' default clauses|&#x2713;|&#x2713;|
+|MiKo_3014|Include reason in InvalidOperationException, NotImplementedException and NotSupportedException messages|&#x2713;|&#x2713;|
+|MiKo_3015|Use InvalidOperationExceptions for inappropriate states of parameterless methods|&#x2713;|&#x2713;|
+|MiKo_3016|Do not throw ArgumentNullException for property return values|&#x2713;|&#x2713;|
+|MiKo_3017|Include original exception when throwing new exceptions|&#x2713;|&#x2713;|
+|MiKo_3018|Throw ObjectDisposedExceptions on public methods of disposable types|&#x2713;|\-|
 |MiKo_3020|Use 'Task.CompletedTask' instead of 'Task.FromResult'|&#x2713;|&#x2713;|
-|MiKo_3021|Do not use 'Task.Run' in the implementation|&#x2713;|\-|
+|MiKo_3021|Do not use 'Task.Run' in implementation|&#x2713;|\-|
 |MiKo_3022|Do not return Task&lt;IEnumerable&gt; or Task&lt;IEnumerable&lt;T&gt;&gt;|&#x2713;|\-|
 |MiKo_3023|Do not use 'CancellationTokenSource' as parameter|&#x2713;|\-|
-|MiKo_3024|Do not use the [ref] keyword on reference parameters|&#x2713;|\-|
+|MiKo_3024|Do not use [ref] keyword on reference parameters|&#x2713;|\-|
 |MiKo_3025|Do not re-assign method parameters|&#x2713;|\-|
-|MiKo_3026|Unused parameters should be removed|&#x2713;|\-|
-|MiKo_3027|Parameters should not be marked to be reserved for future usage|&#x2713;|\-|
+|MiKo_3026|Remove unused parameters|&#x2713;|\-|
+|MiKo_3027|Do not reserve parameters for future use|&#x2713;|\-|
 |MiKo_3028|Do not assign null to lambda parameters|&#x2713;|\-|
-|MiKo_3029|Event registrations should not cause memory leaks|&#x2713;|\-|
-|MiKo_3030|Methods should follow the Law of Demeter|\-|\-|
-|MiKo_3031|ICloneable.Clone() should not be implemented|&#x2713;|\-|
-|MiKo_3032|Use 'nameof' instead of Cinch for names of properties for created 'PropertyChangedEventArgs' instances|&#x2713;|&#x2713;|
-|MiKo_3033|Use 'nameof' for names of properties for created 'PropertyChangingEventArgs' and 'PropertyChangedEventArgs' instances|&#x2713;|&#x2713;|
-|MiKo_3034|PropertyChanged event raiser shall use [CallerMemberName] attribute|&#x2713;|&#x2713;|
-|MiKo_3035|Do not invoke 'WaitOne' methods without timeouts|&#x2713;|\-|
-|MiKo_3036|Prefer to use 'TimeSpan' factory methods instead of constructors|&#x2713;|&#x2713;|
+|MiKo_3029|Prevent memory leaks in event registrations|&#x2713;|\-|
+|MiKo_3030|Follow Law of Demeter in methods|\-|\-|
+|MiKo_3031|Do not implement ICloneable.Clone()|&#x2713;|\-|
+|MiKo_3032|Use 'nameof' instead of Cinch for PropertyChangedEventArgs property names|&#x2713;|&#x2713;|
+|MiKo_3033|Use 'nameof' for property names in PropertyChangingEventArgs and PropertyChangedEventArgs|&#x2713;|&#x2713;|
+|MiKo_3034|Use [CallerMemberName] attribute for PropertyChanged event raisers|&#x2713;|&#x2713;|
+|MiKo_3035|Always specify timeouts with 'WaitOne' methods|&#x2713;|\-|
+|MiKo_3036|Use 'TimeSpan' factory methods instead of constructors|&#x2713;|&#x2713;|
 |MiKo_3037|Do not use magic numbers for timeouts|&#x2713;|\-|
 |MiKo_3038|Do not use magic numbers|&#x2713;|\-|
-|MiKo_3039|Properties should not use Linq or yield|&#x2713;|\-|
-|MiKo_3040|Do not use Booleans unless you are absolutely sure that you will never ever need more than 2 values|&#x2713;|\-|
-|MiKo_3041|EventArgs shall not use delegates|&#x2713;|\-|
-|MiKo_3042|EventArgs shall not implement interfaces|&#x2713;|\-|
+|MiKo_3039|Do not use Linq or yield in properties|&#x2713;|\-|
+|MiKo_3040|Use enums instead of booleans when more than 2 values might be needed|&#x2713;|\-|
+|MiKo_3041|Do not use delegates in EventArgs|&#x2713;|\-|
+|MiKo_3042|Do not implement interfaces in EventArgs|&#x2713;|\-|
 |MiKo_3043|Use 'nameof' for WeakEventManager event (de-)registrations|&#x2713;|&#x2713;|
-|MiKo_3044|Use 'nameof' to compare property names of 'PropertyChangingEventArgs' and 'PropertyChangedEventArgs'|&#x2713;|&#x2713;|
+|MiKo_3044|Use 'nameof' to compare property names of PropertyChangingEventArgs and PropertyChangedEventArgs|&#x2713;|&#x2713;|
 |MiKo_3045|Use 'nameof' for EventManager event registrations|&#x2713;|&#x2713;|
-|MiKo_3046|Use 'nameof' for property names of property raising methods|&#x2713;|&#x2713;|
+|MiKo_3046|Use 'nameof' for property names in property raising methods|&#x2713;|&#x2713;|
 |MiKo_3047|Use 'nameof' for applied [ContentProperty] attributes|&#x2713;|&#x2713;|
-|MiKo_3048|ValueConverters shall have the [ValueConversion] attribute applied|&#x2713;|\-|
-|MiKo_3049|Enum members shall have the [Description] attribute applied|&#x2713;|\-|
-|MiKo_3050|DependencyProperty fields should be 'public static readonly'|&#x2713;|&#x2713;|
-|MiKo_3051|DependencyProperty fields should be properly registered|&#x2713;|&#x2713;|
-|MiKo_3052|DependencyPropertyKey fields should be non-public 'static readonly'|&#x2713;|&#x2713;|
-|MiKo_3053|DependencyPropertyKey fields should be properly registered|&#x2713;|\-|
-|MiKo_3054|A read-only DependencyProperty should have an exposed DependencyProperty identifier|&#x2713;|&#x2713;|
-|MiKo_3055|ViewModels should implement INotifyPropertyChanged|&#x2713;|\-|
-|MiKo_3060|Debug.Assert or Trace.Assert shall not be used|&#x2713;|&#x2713;|
-|MiKo_3061|Loggers shall use a proper log category|&#x2713;|\-|
-|MiKo_3062|End log messages for exceptions with a colon|&#x2713;|&#x2713;|
+|MiKo_3048|Apply [ValueConversion] attribute to ValueConverters|&#x2713;|\-|
+|MiKo_3049|Apply [Description] attribute to enum members|&#x2713;|\-|
+|MiKo_3050|Declare DependencyProperty fields as 'public static readonly'|&#x2713;|&#x2713;|
+|MiKo_3051|Register DependencyProperty fields properly|&#x2713;|&#x2713;|
+|MiKo_3052|Declare DependencyPropertyKey fields as non-public 'static readonly'|&#x2713;|&#x2713;|
+|MiKo_3053|Register DependencyPropertyKey fields properly|&#x2713;|\-|
+|MiKo_3054|Expose DependencyProperty identifier for read-only DependencyProperties|&#x2713;|&#x2713;|
+|MiKo_3055|Implement INotifyPropertyChanged in ViewModels|&#x2713;|\-|
+|MiKo_3060|Do not use Debug.Assert or Trace.Assert|&#x2713;|&#x2713;|
+|MiKo_3061|Use proper log categories with loggers|&#x2713;|\-|
+|MiKo_3062|End exception log messages with a colon|&#x2713;|&#x2713;|
 |MiKo_3063|End non-exceptional log messages with a dot|&#x2713;|&#x2713;|
-|MiKo_3064|Log messages should not use the contraction "n't"|&#x2713;|&#x2713;|
-|MiKo_3065|Microsoft Logging calls should not use interpolated strings|&#x2713;|&#x2713;|
-|MiKo_3070|Do not return null for an IEnumerable|&#x2713;|\-|
-|MiKo_3071|Do not return null for a Task|&#x2713;|\-|
-|MiKo_3072|Non-private methods should not return 'List&lt;&gt;' or 'Dictionary&lt;&gt;'|&#x2713;|\-|
-|MiKo_3073|Do not leave objects partially initialized|&#x2713;|\-|
+|MiKo_3064|Do not use contraction "n't" in log messages|&#x2713;|&#x2713;|
+|MiKo_3065|Do not use interpolated strings with Microsoft Logging calls|&#x2713;|&#x2713;|
+|MiKo_3070|Do not return null for IEnumerable|&#x2713;|\-|
+|MiKo_3071|Do not return null for Task|&#x2713;|\-|
+|MiKo_3072|Do not return 'List&lt;&gt;' or 'Dictionary&lt;&gt;' from non-private methods|&#x2713;|\-|
+|MiKo_3073|Fully initialize objects|&#x2713;|\-|
 |MiKo_3074|Do not define 'ref' or 'out' parameters on constructors|&#x2713;|\-|
-|MiKo_3075|Internal and private types should be either static or sealed unless derivation from them is required|&#x2713;|&#x2713;|
-|MiKo_3076|Do not initialize static member with static member below or in other type part|&#x2713;|\-|
-|MiKo_3077|Properties that return an Enum should have a default value|&#x2713;|&#x2713;|
-|MiKo_3078|Enum members should have a default value|&#x2713;|&#x2713;|
-|MiKo_3079|HResults should be written in hexadecimal|&#x2713;|&#x2713;|
-|MiKo_3080|Use 'switch ... return' instead of 'switch ... break' when assigning variables|&#x2713;|\-|
-|MiKo_3081|Prefer pattern matching over a logical NOT condition|&#x2713;|&#x2713;|
-|MiKo_3082|Prefer pattern matching over a logical comparison with 'true' or 'false'|&#x2713;|&#x2713;|
-|MiKo_3083|Prefer pattern matching for null checks|&#x2713;|&#x2713;|
-|MiKo_3084|Do not place constants on the left side for comparisons|&#x2713;|&#x2713;|
-|MiKo_3085|Conditional statements should be short|&#x2713;|&#x2713;|
+|MiKo_3075|Mark internal and private types as static or sealed unless derivation is needed|&#x2713;|&#x2713;|
+|MiKo_3076|Do not initialize static members with static members below or in other type parts|&#x2713;|\-|
+|MiKo_3077|Provide default values for Enum-returning properties|&#x2713;|&#x2713;|
+|MiKo_3078|Provide default values for enum members|&#x2713;|&#x2713;|
+|MiKo_3079|Write HResults in hexadecimal|&#x2713;|&#x2713;|
+|MiKo_3080|Use 'switch ... return' instead of 'switch ... break' for variable assignments|&#x2713;|\-|
+|MiKo_3081|Use pattern matching instead of logical NOT conditions|&#x2713;|&#x2713;|
+|MiKo_3082|Use pattern matching instead of comparing with 'true' or 'false'|&#x2713;|&#x2713;|
+|MiKo_3083|Use pattern matching for null checks|&#x2713;|&#x2713;|
+|MiKo_3084|Place variables, not constants, on the left side of comparisons|&#x2713;|&#x2713;|
+|MiKo_3085|Keep conditional statements short|&#x2713;|&#x2713;|
 |MiKo_3086|Do not nest conditional statements|&#x2713;|\-|
 |MiKo_3087|Do not use negative complex conditions|&#x2713;|\-|
-|MiKo_3088|Prefer pattern matching for not-null checks|&#x2713;|&#x2713;|
-|MiKo_3089|Do not use simple constant property patterns as conditions of 'if' statements|&#x2713;|&#x2713;|
+|MiKo_3088|Use pattern matching for not-null checks|&#x2713;|&#x2713;|
+|MiKo_3089|Do not use simple constant property patterns as conditions in 'if' statements|&#x2713;|&#x2713;|
 |MiKo_3090|Do not throw exceptions in finally blocks|&#x2713;|\-|
 |MiKo_3091|Do not raise events in finally blocks|&#x2713;|\-|
 |MiKo_3092|Do not raise events in locks|&#x2713;|\-|
 |MiKo_3093|Do not invoke delegates inside locks|&#x2713;|\-|
 |MiKo_3094|Do not invoke methods or properties of parameters inside locks|&#x2713;|\-|
-|MiKo_3095|Code blocks should not be empty|&#x2713;|\-|
+|MiKo_3095|Do not use empty code blocks|&#x2713;|\-|
 |MiKo_3096|Use dictionaries instead of large switch statements|&#x2713;|\-|
 |MiKo_3097|Do not cast to type and return object|&#x2713;|\-|
-|MiKo_3098|Justifications of suppressed messages shall explain|&#x2713;|\-|
+|MiKo_3098|Provide meaningful explanations for suppressed messages|&#x2713;|\-|
 |MiKo_3099|Do not compare enum values with null|&#x2713;|&#x2713;|
-|MiKo_3100|Test classes and types under test belong in same namespace|&#x2713;|\-|
-|MiKo_3101|Test classes should contain tests|&#x2713;|\-|
-|MiKo_3102|Test methods should not contain conditional statements (such as 'if', 'switch', etc.)|&#x2713;|\-|
-|MiKo_3103|Test methods should not use 'Guid.NewGuid()'|&#x2713;|&#x2713;|
-|MiKo_3104|Use NUnit's [Combinatorial] attribute properly|&#x2713;|&#x2713;|
-|MiKo_3105|Test methods should use NUnit's fluent Assert approach|&#x2713;|&#x2713;|
-|MiKo_3106|Assertions should not use equality or comparison operators|&#x2713;|\-|
-|MiKo_3107|Moq Mock condition matchers should be used on mocks only|&#x2713;|&#x2713;|
-|MiKo_3108|Test methods should use assertions|&#x2713;|\-|
-|MiKo_3109|Multiple assertions shall use assertion messages|&#x2713;|&#x2713;|
-|MiKo_3110|Assertions should not use 'Count' or 'Length'|&#x2713;|&#x2713;|
-|MiKo_3111|Assertions should use 'Is.Zero' instead of 'Is.EqualTo(0)'|&#x2713;|&#x2713;|
-|MiKo_3112|Assertions should use 'Is.Empty' instead of 'Has.Count.Zero'|&#x2713;|&#x2713;|
+|MiKo_3100|Place test classes in same namespace as types under test|&#x2713;|\-|
+|MiKo_3101|Include tests in test classes|&#x2713;|\-|
+|MiKo_3102|Do not use conditional statements in test methods|&#x2713;|\-|
+|MiKo_3103|Do not use 'Guid.NewGuid()' in test methods|&#x2713;|&#x2713;|
+|MiKo_3104|Apply NUnit's [Combinatorial] attribute properly|&#x2713;|&#x2713;|
+|MiKo_3105|Use NUnit's fluent Assert approach in test methods|&#x2713;|&#x2713;|
+|MiKo_3106|Do not use equality or comparison operators in assertions|&#x2713;|\-|
+|MiKo_3107|Use Moq Mock condition matchers only on mocks|&#x2713;|&#x2713;|
+|MiKo_3108|Include assertions in test methods|&#x2713;|\-|
+|MiKo_3109|Include assertion messages with multiple assertions|&#x2713;|&#x2713;|
+|MiKo_3110|Do not use 'Count' or 'Length' in assertions|&#x2713;|&#x2713;|
+|MiKo_3111|Use 'Is.Zero' instead of 'Is.EqualTo(0)' in assertions|&#x2713;|&#x2713;|
+|MiKo_3112|Use 'Is.Empty' instead of 'Has.Count.Zero' in assertions|&#x2713;|&#x2713;|
 |MiKo_3113|Do not use FluentAssertions|&#x2713;|&#x2713;|
 |MiKo_3114|Use 'Mock.Of&lt;T&gt;()' instead of 'new Mock&lt;T&gt;().Object'|&#x2713;|&#x2713;|
-|MiKo_3115|Test methods should contain code|&#x2713;|\-|
-|MiKo_3116|Test initialization methods should contain code|&#x2713;|\-|
-|MiKo_3117|Test cleanup methods should contain code|&#x2713;|\-|
-|MiKo_3118|Test methods should not use ambiguous Linq calls|&#x2713;|\-|
-|MiKo_3119|Test methods should not simply return completed task|&#x2713;|&#x2713;|
-|MiKo_3120|Moq mocks should use values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values|&#x2713;|&#x2713;|
-|MiKo_3121|Tests should test concrete implementations and no interfaces|&#x2713;|\-|
-|MiKo_3122|Test methods should not use more than 2 parameters|&#x2713;|\-|
-|MiKo_3123|Test methods should not catch exceptions|&#x2713;|\-|
-|MiKo_3124|Test methods should not assert in finally blocks|&#x2713;|\-|
-|MiKo_3201|If statements can be inverted in short methods|&#x2713;|&#x2713;|
+|MiKo_3115|Include code in test methods|&#x2713;|\-|
+|MiKo_3116|Include code in test initialization methods|&#x2713;|\-|
+|MiKo_3117|Include code in test cleanup methods|&#x2713;|\-|
+|MiKo_3118|Do not use ambiguous Linq calls in test methods|&#x2713;|\-|
+|MiKo_3119|Do not return only completed task in test methods|&#x2713;|&#x2713;|
+|MiKo_3120|Use direct values instead of 'It.Is&lt;&gt;(...)' condition matcher to verify exact values in Moq mocks|&#x2713;|&#x2713;|
+|MiKo_3121|Test concrete implementations instead of interfaces|&#x2713;|\-|
+|MiKo_3122|Limit test method parameters to 2 or fewer|&#x2713;|\-|
+|MiKo_3123|Do not catch exceptions in test methods|&#x2713;|&#x2713;|
+|MiKo_3124|Do not use assertions in finally blocks in test methods|&#x2713;|&#x2713;|
+|MiKo_3201|Invert if statements in short methods|&#x2713;|&#x2713;|
 |MiKo_3202|Use positive conditions when returning in all paths|&#x2713;|&#x2713;|
-|MiKo_3203|If-continue statements can be inverted when followed by single line|&#x2713;|&#x2713;|
-|MiKo_3204|Negative If statements can be inverted when they have an else clause|&#x2713;|&#x2713;|
-|MiKo_3210|Only the longest overloads should be virtual or abstract|&#x2713;|\-|
-|MiKo_3211|Public types should not have finalizers|&#x2713;|\-|
-|MiKo_3212|Do not confuse developers by providing other Dispose methods|&#x2713;|\-|
-|MiKo_3213|Parameterless Dispose method follows Basic Dispose pattern|&#x2713;|\-|
-|MiKo_3214|Interfaces do not contain 'Begin/End' or 'Enter/Exit' scope-defining methods|&#x2713;|\-|
-|MiKo_3215|Callbacks should be 'Func&lt;T, bool&gt;' instead of 'Predicate&lt;bool&gt;'|&#x2713;|&#x2713;|
-|MiKo_3216|Static fields with initializers should be read-only|&#x2713;|&#x2713;|
+|MiKo_3203|Invert if-continue statements when followed by single line|&#x2713;|&#x2713;|
+|MiKo_3204|Invert negative if statements when they have an else clause|&#x2713;|&#x2713;|
+|MiKo_3210|Make only the longest overloads virtual or abstract|&#x2713;|\-|
+|MiKo_3211|Do not use finalizers in public types|&#x2713;|\-|
+|MiKo_3212|Follow standard Dispose pattern without adding other Dispose methods|&#x2713;|\-|
+|MiKo_3213|Implement parameterless Dispose method using Basic Dispose pattern|&#x2713;|\-|
+|MiKo_3214|Remove 'Begin/End' or 'Enter/Exit' scope-defining methods from interfaces|&#x2713;|\-|
+|MiKo_3215|Use 'Func&lt;T, bool&gt;' instead of 'Predicate&lt;bool&gt;' for callbacks|&#x2713;|&#x2713;|
+|MiKo_3216|Mark static fields with initializers as read-only|&#x2713;|&#x2713;|
 |MiKo_3217|Do not use generic types that have other generic types as type arguments|&#x2713;|\-|
-|MiKo_3218|Do not define extension methods in unexpected places|&#x2713;|\-|
-|MiKo_3219|Public members should not be 'virtual'|&#x2713;|\-|
-|MiKo_3220|Logical '&amp;&amp;' or '&#124;&#124;' conditions using 'true' or 'false' should be simplified|&#x2713;|&#x2713;|
-|MiKo_3221|GetHashCode overrides should use 'HashCode.Combine'|&#x2713;|&#x2713;|
-|MiKo_3222|String comparisons can be simplified|&#x2713;|&#x2713;|
-|MiKo_3223|Reference comparisons can be simplified|&#x2713;|&#x2713;|
-|MiKo_3224|Value comparisons can be simplified|&#x2713;|&#x2713;|
-|MiKo_3225|Redundant comparisons can be simplified|&#x2713;|&#x2713;|
-|MiKo_3226|Read-only fields with initializers should be const|&#x2713;|&#x2713;|
-|MiKo_3227|Prefer pattern matching for equality checks|&#x2713;|&#x2713;|
-|MiKo_3228|Prefer pattern matching for inequality checks|&#x2713;|&#x2713;|
-|MiKo_3229|'KeyValuePair.Create' should be used instead of constructors|&#x2713;|&#x2713;|
+|MiKo_3218|Define extension methods in expected places|&#x2713;|\-|
+|MiKo_3219|Do not mark public members as 'virtual'|&#x2713;|\-|
+|MiKo_3220|Simplify logical '&amp;&amp;' or '&#124;&#124;' conditions using 'true' or 'false'|&#x2713;|&#x2713;|
+|MiKo_3221|Use 'HashCode.Combine' in GetHashCode overrides|&#x2713;|&#x2713;|
+|MiKo_3222|Simplify string comparisons|&#x2713;|&#x2713;|
+|MiKo_3223|Simplify reference comparisons|&#x2713;|&#x2713;|
+|MiKo_3224|Simplify value comparisons|&#x2713;|&#x2713;|
+|MiKo_3225|Simplify redundant comparisons|&#x2713;|&#x2713;|
+|MiKo_3226|Make read-only fields with initializers const|&#x2713;|&#x2713;|
+|MiKo_3227|Use pattern matching for equality checks|&#x2713;|&#x2713;|
+|MiKo_3228|Use pattern matching for inequality checks|&#x2713;|&#x2713;|
+|MiKo_3229|Use 'KeyValuePair.Create' instead of constructors|&#x2713;|&#x2713;|
 |MiKo_3230|Do not use 'Guid' as type for identifiers|&#x2713;|\-|
-|MiKo_3231|Prefer pattern matching for equality checks for ordinal string comparisons|&#x2713;|&#x2713;|
-|MiKo_3301|Favor lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
-|MiKo_3302|Favor simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
-|MiKo_3401|Namespace hierarchies should not be too deep|&#x2713;|\-|
+|MiKo_3231|Use pattern matching for ordinal string comparison equality checks|&#x2713;|&#x2713;|
+|MiKo_3301|Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
+|MiKo_3302|Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
+|MiKo_3401|Keep namespace hierarchies from becoming too deep|&#x2713;|\-|
 |MiKo_3501|Do not suppress nullable warnings on Null-conditional operators|&#x2713;|&#x2713;|
 |MiKo_3502|Do not suppress nullable warnings on Linq calls|&#x2713;|&#x2713;|
-|MiKo_3503|Do not assign variables in try-catch blocks and return them directly outside the block|&#x2713;|&#x2713;|
+|MiKo_3503|Do not assign variables in try-catch blocks that are returned directly outside|&#x2713;|&#x2713;|
 
 ### Ordering
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_4001|Methods with same name should be ordered based on the number of their parameters|&#x2713;|&#x2713;|
-|MiKo_4002|Methods with same name and accessibility should be placed side-by-side|&#x2713;|&#x2713;|
-|MiKo_4003|Dispose methods should be placed directly after constructors and finalizers|&#x2713;|&#x2713;|
-|MiKo_4004|Dispose methods should be placed before all other methods of the same accessibility|&#x2713;|&#x2713;|
-|MiKo_4005|The interface that gives a type its name should be placed directly after the type's declaration|&#x2713;|&#x2713;|
-|MiKo_4007|Operators should be placed before methods|&#x2713;|&#x2713;|
-|MiKo_4008|GetHashCode methods should be placed directly after Equals methods|&#x2713;|&#x2713;|
-|MiKo_4101|Test initialization methods should be ordered directly after One-Time methods|&#x2713;|&#x2713;|
-|MiKo_4102|Test cleanup methods should be ordered after test initialization methods and before test methods|&#x2713;|&#x2713;|
-|MiKo_4103|One-Time test initialization methods should be ordered before all other methods|&#x2713;|&#x2713;|
-|MiKo_4104|One-Time test cleanup methods should be ordered directly after One-Time test initialization methods|&#x2713;|&#x2713;|
-|MiKo_4105|Object under test fields should be ordered before all other fields|&#x2713;|&#x2713;|
+|MiKo_4001|Order methods with same name based on their parameter count|&#x2713;|&#x2713;|
+|MiKo_4002|Place methods with same name and accessibility side-by-side|&#x2713;|&#x2713;|
+|MiKo_4003|Place Dispose methods directly after constructors and finalizers|&#x2713;|&#x2713;|
+|MiKo_4004|Place Dispose methods before all other methods of the same accessibility|&#x2713;|&#x2713;|
+|MiKo_4005|Place the interface that gives a type its name directly after the type's declaration|&#x2713;|&#x2713;|
+|MiKo_4007|Place operators before methods|&#x2713;|&#x2713;|
+|MiKo_4008|Place GetHashCode methods directly after Equals methods|&#x2713;|&#x2713;|
+|MiKo_4101|Place test initialization methods directly after One-Time methods|&#x2713;|&#x2713;|
+|MiKo_4102|Place test cleanup methods after test initialization methods and before test methods|&#x2713;|&#x2713;|
+|MiKo_4103|Place One-Time test initialization methods before all other methods|&#x2713;|&#x2713;|
+|MiKo_4104|Place One-Time test cleanup methods directly after One-Time test initialization methods|&#x2713;|&#x2713;|
+|MiKo_4105|Place object under test fields before all other fields|&#x2713;|&#x2713;|
 
 ### Performance
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_5001|'Debug' and 'DebugFormat' methods should be invoked only after 'IsDebugEnabled'|&#x2713;|&#x2713;|
-|MiKo_5002|'xxxFormat' methods should be invoked with multiple arguments only|&#x2713;|&#x2713;|
-|MiKo_5003|Correct Log methods should be invoked for exceptions|&#x2713;|\-|
+|MiKo_5001|Invoke 'Debug' and 'DebugFormat' methods only after checking 'IsDebugEnabled'|&#x2713;|&#x2713;|
+|MiKo_5002|Use 'xxxFormat' methods only with multiple arguments|&#x2713;|&#x2713;|
+|MiKo_5003|Use appropriate Log methods for exceptions|&#x2713;|\-|
 |MiKo_5010|Do not use 'object.Equals()' on value types|&#x2713;|&#x2713;|
 |MiKo_5011|Do not concatenate strings with += operator|&#x2713;|\-|
 |MiKo_5012|Do not use 'yield return' for recursively defined structures|&#x2713;|\-|
 |MiKo_5013|Do not create empty arrays|&#x2713;|&#x2713;|
-|MiKo_5014|Do not create empty lists if the return value is read-only|&#x2713;|&#x2713;|
+|MiKo_5014|Do not create empty lists when return value is read-only|&#x2713;|&#x2713;|
 |MiKo_5015|Do not intern string literals|&#x2713;|&#x2713;|
-|MiKo_5016|Use a HashSet for lookups in 'List.RemoveAll'|&#x2713;|\-|
-|MiKo_5017|Fields or variables assigned with string literals should be constant|&#x2713;|&#x2713;|
-|MiKo_5019|Read-only struct parameters should have the [in] modifier|&#x2713;|&#x2713;|
+|MiKo_5016|Use HashSet for lookups in 'List.RemoveAll'|&#x2713;|\-|
+|MiKo_5017|Make fields or variables assigned with string literals constant|&#x2713;|&#x2713;|
+|MiKo_5019|Add [in] modifier to read-only struct parameters|&#x2713;|&#x2713;|
 
 ### Spacing
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
-|MiKo_6001|Log statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6002|Assertion statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6003|Local variable statements should be preceded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6004|Variable assignment statements should be preceded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6005|Return statements should be preceded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6006|Awaited statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6007|Test statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6008|Using directives should be preceded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6009|Try statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6010|If statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6011|Lock statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6012|foreach loops should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6013|for loops should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6014|while loops should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6015|do/while loops should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6016|using statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6017|switch statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6018|break statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6019|continue statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6020|throw statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6021|ArgumentNullException.ThrowIfNull statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6022|ArgumentException.ThrowIfNullOrEmpty statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6023|ArgumentOutOfRangeException.ThrowIf statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6024|ObjectDisposedException.ThrowIf statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6030|Open braces of initializers should be placed directly below the corresponding type definition|&#x2713;|&#x2713;|
-|MiKo_6031|Question and colon tokens of ternary operators should be placed directly below the corresponding condition|&#x2713;|&#x2713;|
-|MiKo_6032|Multi-line parameters are positioned outdented at end of method|&#x2713;|&#x2713;|
-|MiKo_6033|Braces of blocks below case sections should be placed directly below the corresponding case keyword|&#x2713;|&#x2713;|
-|MiKo_6034|Dots should be placed on same line(s) as invoked members|&#x2713;|&#x2713;|
-|MiKo_6035|Open parenthesis should be placed on same line(s) as invoked methods|&#x2713;|&#x2713;|
-|MiKo_6036|Lambda blocks should be placed directly below the corresponding arrow(s)|&#x2713;|&#x2713;|
-|MiKo_6037|Single arguments should be placed on same line(s) as invoked methods|&#x2713;|&#x2713;|
-|MiKo_6038|Casts should be placed on same line(s)|&#x2713;|&#x2713;|
-|MiKo_6039|Return values should be placed on same line(s) as return keywords|&#x2713;|&#x2713;|
-|MiKo_6040|Consecutive invocations spaning multiple lines should be aligned by their dots|&#x2713;|&#x2713;|
-|MiKo_6041|Assignments should be placed on same line(s)|&#x2713;|&#x2713;|
-|MiKo_6042|'new' keywords should be placed on same line(s) as the types|&#x2713;|&#x2713;|
-|MiKo_6043|Expression bodies of lambdas should be placed on same line as lambda itself when fitting|&#x2713;|&#x2713;|
-|MiKo_6044|Operators such as '&amp;&amp;' or '&#124;&#124;' should be placed on same line(s) as their (right) operands|&#x2713;|&#x2713;|
-|MiKo_6045|Comparisons using operators such as '==' or '!=' should be placed on same line(s)|&#x2713;|&#x2713;|
-|MiKo_6046|Calculations using operators such as '+' or '%' should be placed on same line(s)|&#x2713;|&#x2713;|
-|MiKo_6047|Braces of switch expressions should be placed directly below the corresponding switch keyword|&#x2713;|&#x2713;|
-|MiKo_6048|Logical conditions should be placed on a single line|&#x2713;|&#x2713;|
-|MiKo_6049|Event (un-)registrations should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6050|Multi-line arguments are positioned outdented at end of method call|&#x2713;|&#x2713;|
-|MiKo_6051|Colon of constructor call shall be placed on same line as constructor call|&#x2713;|&#x2713;|
-|MiKo_6052|Colon of list of base types shall be placed on same line as first base type|&#x2713;|&#x2713;|
-|MiKo_6053|Single-line arguments shall be placed on single line|&#x2713;|&#x2713;|
-|MiKo_6054|Lambda arrows shall be placed on same line as the parameter(s) of the lambda|&#x2713;|&#x2713;|
-|MiKo_6055|Assignment statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6056|Brackets of collection expressions should be placed directly at the same place collection initializer braces would be positioned|&#x2713;|&#x2713;|
-|MiKo_6057|Type parameter constraint clauses should be aligned vertically|&#x2713;|&#x2713;|
-|MiKo_6058|Type parameter constraint clauses should be indented below parameter list|&#x2713;|&#x2713;|
-|MiKo_6059|Multi-line conditions are positioned outdented below associated calls|&#x2713;|&#x2713;|
-|MiKo_6060|Switch case labels should be placed on same line|&#x2713;|&#x2713;|
-|MiKo_6061|Switch expression arms should be placed on same line|&#x2713;|&#x2713;|
-|MiKo_6062|Expressions within complex initializer expressions should be placed beside open brace|&#x2713;|&#x2713;|
-|MiKo_6063|Invocations should be placed on same line|&#x2713;|&#x2713;|
-|MiKo_6064|Identifier invocations should be placed on same line|&#x2713;|&#x2713;|
-|MiKo_6065|Consecutive invocations spanning multiple lines should be indented and not outdented|&#x2713;|&#x2713;|
-|MiKo_6066|Collection expression elements should be indented and not outdented|&#x2713;|&#x2713;|
-|MiKo_6067|Ternary operators should be placed on same lines as their respective expressions|&#x2713;|&#x2713;|
-|MiKo_6070|Console statements should be surrounded by blank lines|&#x2713;|&#x2713;|
-|MiKo_6071|Local using statements should be surrounded by blank lines|&#x2713;|&#x2713;|
+|MiKo_6001|Surround log statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6002|Surround assertion statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6003|Precede local variable statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6004|Precede variable assignment statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6005|Precede return statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6006|Surround awaited statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6007|Surround test statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6008|Precede using directives with blank lines|&#x2713;|&#x2713;|
+|MiKo_6009|Surround try statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6010|Surround if statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6011|Surround lock statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6012|Surround foreach loops with blank lines|&#x2713;|&#x2713;|
+|MiKo_6013|Surround for loops with blank lines|&#x2713;|&#x2713;|
+|MiKo_6014|Surround while loops with blank lines|&#x2713;|&#x2713;|
+|MiKo_6015|Surround do/while loops with blank lines|&#x2713;|&#x2713;|
+|MiKo_6016|Surround using statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6017|Surround switch statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6018|Surround break statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6019|Surround continue statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6020|Surround throw statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6021|Surround ArgumentNullException.ThrowIfNull statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6022|Surround ArgumentException.ThrowIfNullOrEmpty statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6023|Surround ArgumentOutOfRangeException.ThrowIf statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6024|Surround ObjectDisposedException.ThrowIf statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6030|Place open braces of initializers directly below the corresponding type definition|&#x2713;|&#x2713;|
+|MiKo_6031|Place question and colon tokens of ternary operators directly below the corresponding condition|&#x2713;|&#x2713;|
+|MiKo_6032|Position multi-line parameters outdented at end of method|&#x2713;|&#x2713;|
+|MiKo_6033|Place braces of blocks below case sections directly below the corresponding case keyword|&#x2713;|&#x2713;|
+|MiKo_6034|Place dots on same line(s) as invoked members|&#x2713;|&#x2713;|
+|MiKo_6035|Place open parenthesis on same line(s) as invoked methods|&#x2713;|&#x2713;|
+|MiKo_6036|Place lambda blocks directly below the corresponding arrow(s)|&#x2713;|&#x2713;|
+|MiKo_6037|Place single arguments on same line(s) as invoked methods|&#x2713;|&#x2713;|
+|MiKo_6038|Place casts on same line(s)|&#x2713;|&#x2713;|
+|MiKo_6039|Place return values on same line(s) as return keywords|&#x2713;|&#x2713;|
+|MiKo_6040|Align consecutive multi-line invocations by their dots|&#x2713;|&#x2713;|
+|MiKo_6041|Place assignments on same line(s)|&#x2713;|&#x2713;|
+|MiKo_6042|Place 'new' keywords on same line(s) as the types|&#x2713;|&#x2713;|
+|MiKo_6043|Place expression bodies of lambdas on same line as lambda when fitting|&#x2713;|&#x2713;|
+|MiKo_6044|Place operators such as '&amp;&amp;' or '&#124;&#124;' on same line(s) as their (right) operands|&#x2713;|&#x2713;|
+|MiKo_6045|Place comparisons using operators such as '==' or '!=' on same line(s)|&#x2713;|&#x2713;|
+|MiKo_6046|Place calculations using operators such as '+' or '%' on same line(s)|&#x2713;|&#x2713;|
+|MiKo_6047|Place braces of switch expressions directly below the corresponding switch keyword|&#x2713;|&#x2713;|
+|MiKo_6048|Place logical conditions on a single line|&#x2713;|&#x2713;|
+|MiKo_6049|Surround event (un-)registrations with blank lines|&#x2713;|&#x2713;|
+|MiKo_6050|Position multi-line arguments outdented at end of method call|&#x2713;|&#x2713;|
+|MiKo_6051|Place colon of constructor call on same line as constructor call|&#x2713;|&#x2713;|
+|MiKo_6052|Place colon of list of base types on same line as first base type|&#x2713;|&#x2713;|
+|MiKo_6053|Place single-line arguments on single line|&#x2713;|&#x2713;|
+|MiKo_6054|Place lambda arrows on same line as the parameter(s) of the lambda|&#x2713;|&#x2713;|
+|MiKo_6055|Surround assignment statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6056|Place brackets of collection expressions at the same position as collection initializer braces|&#x2713;|&#x2713;|
+|MiKo_6057|Align type parameter constraint clauses vertically|&#x2713;|&#x2713;|
+|MiKo_6058|Indent type parameter constraint clauses below parameter list|&#x2713;|&#x2713;|
+|MiKo_6059|Position multi-line conditions outdented below associated calls|&#x2713;|&#x2713;|
+|MiKo_6060|Place switch case labels on same line|&#x2713;|&#x2713;|
+|MiKo_6061|Place switch expression arms on same line|&#x2713;|&#x2713;|
+|MiKo_6062|Place expressions within complex initializer expressions beside open brace|&#x2713;|&#x2713;|
+|MiKo_6063|Place invocations on same line|&#x2713;|&#x2713;|
+|MiKo_6064|Place identifier invocations on same line|&#x2713;|&#x2713;|
+|MiKo_6065|Indent rather than outdent consecutive invocations spanning multiple lines|&#x2713;|&#x2713;|
+|MiKo_6066|Indent rather than outdent collection expression elements|&#x2713;|&#x2713;|
+|MiKo_6067|Place ternary operators on same lines as their respective expressions|&#x2713;|&#x2713;|
+|MiKo_6070|Surround Console statements with blank lines|&#x2713;|&#x2713;|
+|MiKo_6071|Surround local using statements with blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Made rule titles shorter, clearer, and more direct.

- Used action words like “Keep,” “Use,” and “Do not” for consistency.

- Improved readability and made guidance easier to follow.

- Updated test rules to give clear, actionable advice.

(resolves #1538)