### PR TITLE
MiKo_2019 is now aware of text starting with 'Additional' and 'Health'

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -371,6 +371,9 @@ public class TestMe
         [TestCase("Classes implementing this interfaces, will be called with their something", "Provides a something")]
         [TestCase("Simple structure to do stuff", "Represents a simple structure to do stuff")]
         [TestCase("Complex structure to do stuff", "Represents a complex structure to do stuff")]
+        [TestCase("Health check to do stuff", "Represents a health check to do stuff")]
+        [TestCase("Additional information to do stuff", "Represents an additional information to do stuff")]
+        [TestCase("Addtional information to do stuff", "Represents an addtional information to do stuff")] // typo
         public void Code_gets_fixed_for_class_text_(string originalText, string fixedText)
         {
             const string Template = @"


### PR DESCRIPTION
- Expand summary fix candidate prefixes

- Use article based on first word

- Keep unfixable and "Called" safeguards

- Add tests for new prefixes
