### PR TITLE
Added new rules MiKo_1518 and MiKo_1519 that report on 'reference' in parameter or variable names

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -353,6 +353,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1515_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1516_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1517_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1518_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1519_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -509,6 +509,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1515_PropertiesWithAbilityNameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1516_ParametersWithAbilityNameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1517_FieldsWithAbilityNameAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1518_ReferenceVariablesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1519_ReferenceParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5355,6 +5355,78 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;reference&apos; from name.
+        /// </summary>
+        internal static string MiKo_1518_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1518_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reference types in .NET are already references, so adding &apos;Reference&apos; to variable names is redundant. Use names that describe the object&apos;s role, not its implementation detail..
+        /// </summary>
+        internal static string MiKo_1518_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1518_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1518_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1518_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix or suffix local variables with &apos;reference&apos;.
+        /// </summary>
+        internal static string MiKo_1518_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1518_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;reference&apos; from name.
+        /// </summary>
+        internal static string MiKo_1519_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1519_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reference types in .NET are already references, so adding &apos;Reference&apos; to parameter names is redundant. Use names that describe the object&apos;s role, not its implementation detail..
+        /// </summary>
+        internal static string MiKo_1519_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1519_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1519_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1519_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix or suffix parameters with &apos;reference&apos;.
+        /// </summary>
+        internal static string MiKo_1519_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1519_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1937,6 +1937,30 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
   <data name="MiKo_1517_Title" xml:space="preserve">
     <value>Express binary conditions clearly in boolean field names</value>
   </data>
+  <data name="MiKo_1518_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'reference' from name</value>
+  </data>
+  <data name="MiKo_1518_Description" xml:space="preserve">
+    <value>Reference types in .NET are already references, so adding 'Reference' to variable names is redundant. Use names that describe the object's role, not its implementation detail.</value>
+  </data>
+  <data name="MiKo_1518_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1518_Title" xml:space="preserve">
+    <value>Do not prefix or suffix local variables with 'reference'</value>
+  </data>
+  <data name="MiKo_1519_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'reference' from name</value>
+  </data>
+  <data name="MiKo_1519_Description" xml:space="preserve">
+    <value>Reference types in .NET are already references, so adding 'Reference' to parameter names is redundant. Use names that describe the object's role, not its implementation detail.</value>
+  </data>
+  <data name="MiKo_1519_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1519_Title" xml:space="preserve">
+    <value>Do not prefix or suffix parameters with 'reference'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1518_CodeFixProvider)), Shared]
+    public sealed class MiKo_1518_CodeFixProvider : LocalVariableNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1518";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1518_ReferenceVariablesAnalyzer : LocalVariableNamingAnalyzer
+    {
+        public const string Id = "MiKo_1518";
+
+        public MiKo_1518_ReferenceVariablesAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+
+                    if (name.Contains("Reference", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var betterName = FindBetterName(name);
+
+                        if (betterName != name)
+                        {
+                            yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string FindBetterName(string name) => name.Length > 9
+                                                             ? name.AsCachedBuilder().Without("reference").Without("Reference").ToLowerCaseAt(0).ToStringAndRelease() // simply remove both as we need to check them anyway (so we save some calls)
+                                                             : name;
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1519_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1519_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1519_CodeFixProvider)), Shared]
+    public sealed class MiKo_1519_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1519";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1519_ReferenceParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1519_ReferenceParametersAnalyzer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1519_ReferenceParametersAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1519";
+
+        public MiKo_1519_ReferenceParametersAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+
+            if (name.Contains("Reference", StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = FindBetterName(name);
+
+                if (betterName != name)
+                {
+                    return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string name) => name.Length > 9
+                                                             ? name.AsCachedBuilder().Without("reference").Without("Reference").ToLowerCaseAt(0).ToStringAndRelease() // simply remove both as we need to check them anyway (so we save some calls)
+                                                             : name;
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzerTests.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1518_ReferenceVariablesAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_variable_without_reference_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test] // currently, we do not know how to rename such variable 'reference'
+        public void No_issue_is_reported_for_variable_named_reference() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int reference = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_named_([Values("referenceSomething", "someReference")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int " + name + @" = 42;
+        }
+    }
+}
+");
+
+        [TestCase("referenceSomething", "something")]
+        [TestCase("someReference", "some")]
+        [TestCase("someReferenceStuff", "someStuff")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int ### = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1518_ReferenceVariablesAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1518_ReferenceVariablesAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1518_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1519_ReferenceParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1519_ReferenceParametersAnalyzerTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1519_ReferenceParametersAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_parameter_without_reference_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test] // currently, we do not know how to rename such parameter 'reference'
+        public void No_issue_is_reported_for_parameter_named_reference() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int reference)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_named_([Values("referenceSomething", "someReference")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int " + name + @")
+        {
+        }
+    }
+}
+");
+
+        [TestCase("referenceSomething", "something")]
+        [TestCase("someReference", "some")]
+        [TestCase("someReferenceStuff", "someStuff")]
+        public void Code_gets_fixed_for_parameter_with_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int ###)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1519_ReferenceParametersAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1519_ReferenceParametersAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1519_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 521 rules that are currently provided by the analyzer.
+The following tables lists all the 523 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -177,6 +177,8 @@ The following tables lists all the 521 rules that are currently provided by the 
 |MiKo_1515|Express binary conditions clearly in boolean property names|&#x2713;|&#x2713;|
 |MiKo_1516|Express binary conditions clearly in boolean parameter names|&#x2713;|&#x2713;|
 |MiKo_1517|Express binary conditions clearly in boolean field names|&#x2713;|&#x2713;|
+|MiKo_1518|Do not prefix or suffix local variables with 'reference'|&#x2713;|&#x2713;|
+|MiKo_1519|Do not prefix or suffix parameters with 'reference'|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add analyzers for 'Reference' in names

- Provide code fixes for renaming

- Localize titles, messages, descriptions

- Update docs and project includes

(resolves #1551)