### PR TITLE
Code-fixes switched to 'XmlTextDocumentationCodeFixProvider'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2015_CodeFixProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2015_CodeFixProvider)), Shared]
-    public sealed class MiKo_2015_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2015_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private static readonly Pair[] EventReplacementMap =
                                                              {
@@ -21,8 +21,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                  new Pair("Fire", "Raise"),
                                                              };
 
-        private static readonly string[] EventReplacementMapKeys = EventReplacementMap.ToArray(_ => _.Key);
-
         private static readonly Pair[] ExceptionReplacementMap =
                                                                  {
                                                                      new Pair("fired", "thrown"),
@@ -35,18 +33,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                      new Pair("Fire", "Throw"),
                                                                  };
 
-        private static readonly string[] ExceptionReplacementMapKeys = ExceptionReplacementMap.ToArray(_ => _.Key);
-
         public override string FixableDiagnosticId => "MiKo_2015";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            var text = syntax.ToString();
+            var text = syntax.GetTextTrimmed();
 
             // inspect comment for 'event' or exception
-            return text.Contains("xception")
-                   ? Comment(syntax, ExceptionReplacementMapKeys, ExceptionReplacementMap)
-                   : Comment(syntax, EventReplacementMapKeys, EventReplacementMap);
+            var map = text.Contains("xception") ? ExceptionReplacementMap : EventReplacementMap;
+
+            return GetUpdatedSyntax(syntax, issue, map);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_CodeFixProvider.cs
@@ -12,7 +12,7 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2049_CodeFixProvider)), Shared]
-    public sealed class MiKo_2049_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2049_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private const string IsPhrase = "is";
         private const string ArePhrase = "are";
@@ -21,16 +21,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2049";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            var location = issue.Location;
             var properties = issue.Properties;
             var textToReplace = properties[Constants.AnalyzerCodeFixSharedData.TextKey];
             var textToReplaceWith = properties[Constants.AnalyzerCodeFixSharedData.TextReplacementKey];
 
-            var affectedNodes = syntax.DescendantNodes<XmlTextSyntax>(_ => _.GetLocation().Contains(location));
-
-            return syntax.ReplaceNodes(affectedNodes, (_, rewritten) => GetBetterText(rewritten, textToReplace, textToReplaceWith));
+            return GetBetterText(syntax, textToReplace, textToReplaceWith);
         }
 
         private static XmlTextSyntax GetBetterText(XmlTextSyntax node, string textToReplace, string textToReplaceWith)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
@@ -7,16 +7,14 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2075_CodeFixProvider)), Shared]
-    public sealed class MiKo_2075_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2075_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
-        private static readonly string[] ReplacementMapKeys = Constants.Comments.ActionTerms;
-
-        private static readonly Pair[] ReplacementMap = ReplacementMapKeys.ToArray(_ => new Pair(_, Constants.Comments.CallbackTerm));
+        private static readonly Pair[] ReplacementMap = Constants.Comments.ActionTerms.ToArray(_ => new Pair(_, Constants.Comments.CallbackTerm));
 
         public override string FixableDiagnosticId => "MiKo_2075";
 
         protected override string Title => Resources.MiKo_2075_CodeFixTitle.FormatWith(Constants.Comments.CallbackTerm);
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2202_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            return GetUpdatedXmlText(syntax, Constants.Comments.IdTermWithDelimiters, Constants.Comments.IdTerm, ReplacementMap, ReplacementTerm);
+            return GetUpdatedSyntax(syntax, issue, ReplacementMap, Constants.Comments.IdTerm, ReplacementTerm);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2203_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            return GetUpdatedXmlText(syntax, Constants.Comments.GuidTermsWithDelimiters, Constants.Comments.Guids[0], ReplacementMap, ReplacementTerm);
+            return GetUpdatedSyntax(syntax, issue, ReplacementMap, Constants.Comments.Guids[0], ReplacementTerm);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
@@ -8,38 +8,21 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2208_CodeFixProvider)), Shared]
-    public sealed class MiKo_2208_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2208_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
 //// ncrunch: rdi off
 
-        private static readonly Dictionary<string, string> ReplacementMap = CreateReplacementMap();
+        private static readonly Pair[] ReplacementMap = CreateReplacementMap();
 
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2208";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
-        {
-            var token = syntax.FindToken(issue);
-
-            return syntax.ReplaceToken(token, token.WithText(ReplaceText(token.Text)));
-        }
-
-        private static string ReplaceText(string originalText)
-        {
-            var result = originalText.AsCachedBuilder();
-
-            foreach (var pair in ReplacementMap)
-            {
-                result.ReplaceWithProbe(pair.Key, pair.Value);
-            }
-
-            return result.ToStringAndRelease();
-        }
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
 
 //// ncrunch: rdi off
 
-        private static Dictionary<string, string> CreateReplacementMap()
+        private static Pair[] CreateReplacementMap()
         {
             var dictionary = new Dictionary<string, string>();
 
@@ -52,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 dictionary.Add(phrase, phrase.FirstWord() + " ");
             }
 
-            return dictionary;
+            return dictionary.ToArray(_ => new Pair(_.Key, _.Value));
         }
 
 //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2209_CodeFixProvider.cs
@@ -7,11 +7,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2209_CodeFixProvider)), Shared]
-    public sealed class MiKo_2209_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2209_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_2209";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
             var token = syntax.FindToken(issue);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2210_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            return GetUpdatedXmlText(syntax, Constants.Comments.InfoTermWithDelimiters, Constants.Comments.InfoTerm, ReplacementMap, ReplacementTerm);
+            return GetUpdatedSyntax(syntax, issue, ReplacementMap, Constants.Comments.InfoTerm, ReplacementTerm);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_CodeFixProvider.cs
@@ -7,11 +7,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2212_CodeFixProvider)), Shared]
-    public sealed class MiKo_2212_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2212_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_2212";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
             var token = syntax.FindToken(issue);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2213_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Composition;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -8,16 +7,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2213_CodeFixProvider)), Shared]
-    public sealed class MiKo_2213_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2213_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_2213";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            var token = syntax.FindToken(issue);
-            var text = token.ValueText.AsCachedBuilder().ReplaceAllWithProbe(Constants.Comments.NotContractionReplacementMap.AsSpan()).ToStringAndRelease();
-
-            return syntax.ReplaceToken(token, token.WithText(text));
+            return GetUpdatedSyntax(syntax, issue, Constants.Comments.NotContractionReplacementMap);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2218_CodeFixProvider.cs
@@ -9,20 +9,17 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2218_CodeFixProvider)), Shared]
-    public sealed class MiKo_2218_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2218_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_2218";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            var location = issue.Location;
             var properties = issue.Properties;
             var textToReplace = properties[Constants.AnalyzerCodeFixSharedData.TextKey];
             var textToReplaceWith = properties[Constants.AnalyzerCodeFixSharedData.TextReplacementKey];
 
-            var affectedNodes = syntax.DescendantNodes<XmlTextSyntax>(_ => _.GetLocation().Contains(location));
-
-            return syntax.ReplaceNodes(affectedNodes, (_, rewritten) => GetBetterText(rewritten, textToReplace, textToReplaceWith));
+            return GetBetterText(syntax, textToReplace, textToReplaceWith);
         }
 
         private static XmlTextSyntax GetBetterText(XmlTextSyntax node, string textToReplace, string textToReplaceWith)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
@@ -7,17 +7,16 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2220_CodeFixProvider)), Shared]
-    public sealed class MiKo_2220_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2220_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
 //// ncrunch: rdi off
 
-        private static readonly string[] ReplacementMapKeys = Constants.Comments.FindTerms;
-        private static readonly Pair[] ReplacementMap = ReplacementMapKeys.ToArray(_ => new Pair(_, Constants.Comments.ToSeekTerm));
+        private static readonly Pair[] ReplacementMap = Constants.Comments.FindTerms.ToArray(_ => new Pair(_, Constants.Comments.ToSeekTerm));
 
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2220";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2222_CodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
-            return GetUpdatedXmlText(syntax, Constants.Comments.IdentTermWithDelimiters, Constants.Comments.IdentTerm, ReplacementMap, ReplacementTerm);
+            return GetUpdatedSyntax(syntax, issue, ReplacementMap, Constants.Comments.IdentTerm, ReplacementTerm);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2229_CodeFixProvider.cs
@@ -7,11 +7,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2229_CodeFixProvider)), Shared]
-    public sealed class MiKo_2229_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2229_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_2229";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue)
         {
             var token = syntax.FindToken(issue);
             var fragment = issue.Location.GetText();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2234_CodeFixProvider.cs
@@ -7,33 +7,17 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2234_CodeFixProvider)), Shared]
-    public sealed class MiKo_2234_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2234_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private static readonly Pair[] ReplacementMap = CreateReplacementMap();
 
         public override string FixableDiagnosticId => "MiKo_2234";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue)
-        {
-            return Comment(syntax, Constants.Comments.WhichIsToTerms, ReplacementMap);
-        }
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
 
 //// ncrunch: rdi off
 
-        private static Pair[] CreateReplacementMap()
-        {
-            var terms = Constants.Comments.WhichIsToTerms;
-            var termsLength = terms.Length;
-
-            var result = new Pair[termsLength];
-
-            for (var index = 0; index < termsLength; index++)
-            {
-                result[index] = new Pair(terms[index], Constants.Comments.ToTerm);
-            }
-
-            return result;
-        }
+        private static Pair[] CreateReplacementMap() => Constants.Comments.WhichIsToTerms.ToArray(_ => new Pair(_, Constants.Comments.ToTerm));
 
 //// ncrunch: rdi default
     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_CodeFixProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2235_CodeFixProvider)), Shared]
-    public sealed class MiKo_2235_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2235_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private static readonly Pair[] ReplacementMap =
                                                         {
@@ -23,10 +23,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("Going to", "Will"),
                                                         };
 
-        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
-
         public override string FixableDiagnosticId => "MiKo_2235";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2236_CodeFixProvider)), Shared]
-    public sealed class MiKo_2236_CodeFixProvider : OverallDocumentationCodeFixProvider
+    public sealed class MiKo_2236_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private static readonly Pair[] ReplacementMap =
                                                         {
@@ -25,10 +25,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("Eg.", "For example"),
                                                         };
 
-        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
-
         public override string FixableDiagnosticId => "MiKo_2236";
 
-        protected override DocumentationCommentTriviaSyntax GetUpdatedSyntax(Document document, DocumentationCommentTriviaSyntax syntax, Diagnostic issue) => Comment(syntax, ReplacementMapKeys, ReplacementMap);
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -156,6 +156,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var end = offset + tokenText.Length;
                         var start = end - trimmedTerm.Length;
 
+                        if (trimmedTerm.StartsWith(' '))
+                        {
+                            start += Offset; // we do not want to underline the first char
+                        }
+
                         var location = CreateLocation(syntaxToken, start, end);
                         var issue = IssueLocal(location);
 


### PR DESCRIPTION
- Refactor code fixes to XML-text provider

- Simplify replacements via shared helper

- Remove redundant key arrays and dictionaries

- Standardize `GetUpdatedSyntax` signatures
