### PR TITLE
Added rudimentary codefix for MiKo_2223 that can fix 'string.Empty'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -139,6 +139,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2218_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2220_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2222_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2223_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2224_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2225_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2229_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -8926,6 +8926,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;&lt;see cref=&quot;...&quot;/&gt;&apos;.
+        /// </summary>
+        internal static string MiKo_2223_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2223_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to XML documentation should link references like methods or types using &lt;see cref=&quot;...&quot;/&gt; instead of plain text. This approach ensures refactoring tools can update these references during renames, preventing the documentation from pointing to non-existent code..
         /// </summary>
         internal static string MiKo_2223_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3154,6 +3154,9 @@ This ensures clarity and usability in your documentation, making it straightforw
   <data name="MiKo_2222_Title" xml:space="preserve">
     <value>Use term 'identification' instead of 'ident' in documentation</value>
   </data>
+  <data name="MiKo_2223_CodeFixTitle" xml:space="preserve">
+    <value>Use '&lt;see cref="..."/&gt;'</value>
+  </data>
   <data name="MiKo_2223_Description" xml:space="preserve">
     <value>XML documentation should link references like methods or types using &lt;see cref="..."/&gt; instead of plain text. This approach ensures refactoring tools can update these references during renames, preventing the documentation from pointing to non-existent code.</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -31,6 +31,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected static Pair[] CreatePhraseProposal(string phrase) => new[] { new Pair(Constants.AnalyzerCodeFixSharedData.Phrase, phrase) };
 
+        protected static Pair[] CreateReplacementProposal(string text, string replacement) => new[]
+                                                                                                  {
+                                                                                                      new Pair(Constants.AnalyzerCodeFixSharedData.TextKey, text),
+                                                                                                      new Pair(Constants.AnalyzerCodeFixSharedData.TextReplacementKey, replacement),
+                                                                                                  };
+
         protected static Location GetFirstLocation(in SyntaxToken textToken, string value, in StringComparison comparison = StringComparison.Ordinal, in int startOffset = 0, in int endOffset = 0)
         {
             return CreateLocation(value, textToken.SyntaxTree, textToken.SpanStart, textToken.ValueText.IndexOf(value, comparison), startOffset, endOffset);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -62,13 +62,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 replacement = replacement.ToUpperCaseAt(0);
             }
 
-            var properties = new[]
-                                 {
-                                     new Pair(Constants.AnalyzerCodeFixSharedData.TextKey, text),
-                                     new Pair(Constants.AnalyzerCodeFixSharedData.TextReplacementKey, replacement),
-                                 };
-
-            return Issue(location, replacement, properties);
+            return Issue(location, replacement, CreateReplacementProposal(text, replacement));
         }
 
         protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_CodeFixProvider.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2223_CodeFixProvider)), Shared]
+    public sealed class MiKo_2223_CodeFixProvider : XmlTextDocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2223";
+
+        protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => syntax;
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (syntax is XmlTextSyntax xmlText && issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.TextReplacementKey, out var replacement) && replacement != null)
+            {
+                var token = xmlText.FindToken(issue);
+
+                var span = issue.Location.SourceSpan;
+                var offset = token.SpanStart;
+
+                var valueText = token.ValueText;
+                var partBefore = valueText.Substring(0, span.Start - offset);
+                var partAfter = valueText.Substring(span.End - offset);
+
+                // we need to split at the specific token and place all other tokens into the new XML text
+                var textTokens = xmlText.TextTokens;
+                var tokenIndex = textTokens.IndexOf(token);
+
+                var firstPart = textTokens.Take(tokenIndex).ToTokenList().Add(token.WithText(partBefore));
+
+                var updatedXmlText = xmlText.WithTextTokens(firstPart);
+                var seeCref = SeeCref(SyntaxFactory.ParseName(replacement));
+
+                var newNodes = new List<SyntaxNode> { updatedXmlText, seeCref };
+
+                if (partAfter.Length is 0)
+                {
+                    var lastPart = textTokens.Skip(tokenIndex + 1).ToTokenList();
+
+                    if (lastPart.Count > 0)
+                    {
+                        newNodes.Add(XmlText(lastPart));
+                    }
+                }
+                else
+                {
+                    var lastPart = textTokens.Replace(token, partAfter.AsToken()) // replace the original text token with a completely new text token, to avoid any preceding '///' characters
+                                             .Skip(tokenIndex)
+                                             .ToTokenList();
+
+                    newNodes.Add(XmlText(lastPart));
+                }
+
+                return root.ReplaceNode(xmlText, newNodes);
+            }
+
+            return base.GetUpdatedSyntaxRoot(document, root, syntax, annotationOfSyntax, issue);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.cs
@@ -324,7 +324,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     // we found a special text, so report that
                     var location = CreateLocation(token, index, index + stringEmpty.Length);
 
-                    yield return Issue("String.Empty", location); // we use the side effect here that the name is the argument zero and gets used in the issue's message
+                    yield return Issue("String.Empty", location, CreateReplacementProposal(stringEmpty, "String.Empty")); // we use the side effect here that the name is the argument zero and gets used in the issue's message
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
 
@@ -662,7 +663,9 @@ public class TestMe
     /// <summary>
     /// You may want to call stream.Seek() before.
     /// </summary>
-    void DoSomething(Stream stream);
+    public void DoSomething(Stream stream)
+    {
+    }
 }
 ");
 
@@ -679,12 +682,112 @@ public class TestMe
     /// <summary>
     /// Does something with " + type + "." + property + @" to see.
     /// </summary>
-    void DoSomething();
+    public void DoSomething()
+    {
+    }
 }
 ");
+
+        [Test]
+        public void Code_gets_fixed_for_incorrectly_documented_method_with_(
+                                                                        [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                        [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        {
+            const string Template = """
+
+                                    using System;
+                                    using System.IO;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>
+                                        /// Does something with ### to see.
+                                        /// </summary>
+                                        public void DoSomething()
+                                        {
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", type + "." + property), Template.Replace("###", """<see cref="String.Empty"/>"""));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_incorrectly_documented_method_ending_with_(
+                                                                               [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                               [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        {
+            const string Template = """
+
+                                    using System;
+                                    using System.IO;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>
+                                        /// Does something with ###
+                                        /// </summary>
+                                        public void DoSomething()
+                                        {
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", type + "." + property), Template.Replace("###", """<see cref="String.Empty"/>"""));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_incorrectly_single_line_documented_method_with_(
+                                                                                    [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                                    [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        {
+            const string Template = """
+
+                                    using System;
+                                    using System.IO;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>Does something with ### to see.</summary>
+                                        public void DoSomething()
+                                        {
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", type + "." + property), Template.Replace("###", """<see cref="String.Empty"/>"""));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_incorrectly_single_line_documented_method_ending_with_(
+                                                                                           [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                                           [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        {
+            const string Template = """
+
+                                    using System;
+                                    using System.IO;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>Does something with ###</summary>
+                                        public void DoSomething()
+                                        {
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", type + "." + property), Template.Replace("###", """<see cref="String.Empty"/>"""));
+        }
 
         protected override string GetDiagnosticId() => MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2223_CodeFixProvider();
     }
 }

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ The following tables lists all the 523 rules that are currently provided by the 
 |MiKo_2220|Use 'to seek' instead of 'to look for', 'to inspect for' or 'to test for' in documentation|&#x2713;|&#x2713;|
 |MiKo_2221|Do not use empty XML tags in documentation|&#x2713;|\-|
 |MiKo_2222|Use term 'identification' instead of 'ident' in documentation|&#x2713;|&#x2713;|
-|MiKo_2223|Link references via &lt;see cref="..."/&gt; in documentation|&#x2713;|\-|
+|MiKo_2223|Link references via &lt;see cref="..."/&gt; in documentation|&#x2713;|&#x2713;|
 |MiKo_2224|Place XML tags and texts on separate lines in documentation|&#x2713;|&#x2713;|
 |MiKo_2225|Place code marked with &lt;c&gt; tags on single line|&#x2713;|&#x2713;|
 |MiKo_2226|Explain the 'Why' instead of the 'That' in documentation|&#x2713;|\-|


### PR DESCRIPTION
- Introduce code fix for MiKo_2223 regarding `string.Empty`

- Replace plain text with `<see cref="..."/>`

- Add comprehensive code fix tests

(resolves #1489)