### PR TITLE
MiKo_2019 is now able to fix some boolean properties

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -62,7 +62,27 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] EmptyReplacementsMapKeys = EmptyReplacementsMap.ToArray(_ => _.Key);
 
-//// ncrunch: rdi default
+        private static readonly string[] PropertyStartingPhrases =
+                                                                   {
+                                                                       "Gets/Sets ",
+                                                                       "Gets or Sets ",
+                                                                       "Gets Or Sets ",
+                                                                       "Gets OR Sets ",
+                                                                       "Gets and Sets ",
+                                                                       "Gets And Sets ",
+                                                                       "Gets AND Sets ",
+                                                                       "Get ",
+                                                                       "Set ",
+                                                                       "Get/Set ",
+                                                                       "Get or Set ",
+                                                                       "Get Or Set ",
+                                                                       "Get OR Set ",
+                                                                       "Get and Set ",
+                                                                       "Get And Set ",
+                                                                       "Get AND Set ",
+                                                                   };
+
+        //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2012";
 
@@ -163,6 +183,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             return CommentStartingWith(comment, "Represents ");
                     }
                 }
+
+                if (text.StartsWithAny(PropertyStartingPhrases))
+                {
+                    if (member is PropertyDeclarationSyntax property)
+                    {
+                        return GetUpdatedProperty(comment, property, text);
+                    }
+                }
             }
 
             return comment;
@@ -209,17 +237,32 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var builder = StringBuilderCache.Acquire(startingPhrase.Length + remainingText.Length)
                                             .Append(startingPhrase)
                                             .Append(remainingText.ToLowerCaseAt(0))
+                                            .ReplaceWithProbe("get/Set flag ", " ")
+                                            .ReplaceWithProbe("get/Set ", " ")
                                             .ReplaceWithProbe("Gets or sets a value indicating get or set ", "Gets or sets a value indicating ")
+                                            .ReplaceWithProbe("Gets or sets a value indicating to true ", "Gets or sets a value indicating ")
                                             .ReplaceWithProbe("Gets or sets a value indicating get ", "Gets or sets a value indicating ")
                                             .ReplaceWithProbe("Gets or sets a value indicating set ", "Gets or sets a value indicating ")
                                             .ReplaceWithProbe("Gets or sets get or set ", "Gets or sets ")
                                             .ReplaceWithProbe("Gets or sets get ", "Gets or sets ")
                                             .ReplaceWithProbe("Gets or sets set ", "Gets or sets ")
                                             .ReplaceWithProbe("Gets a value indicating get ", "Gets a value indicating ")
+                                            .ReplaceWithProbe("Gets a value indicating set to true ", "Gets a value indicating ")
                                             .ReplaceWithProbe("Gets get ", "Gets ")
+                                            .ReplaceWithProbe("Sets a value indicating set to true ", "Sets a value indicating ")
                                             .ReplaceWithProbe("Sets a value indicating set ", "Sets a value indicating ")
                                             .ReplaceWithProbe("Sets set ", "Sets ")
-                                            .ReplaceWithProbe("value indicating the value indicating", "value indicating the");
+                                            .ReplaceWithProbe("value indicating the value indicating", "value indicating the")
+                                            .ReplaceWithProbe("indicating  that indicates", "indicating")
+                                            .ReplaceWithProbe("indicating  which indicates", "indicating")
+                                            .ReplaceWithProbe("indicating to true,", "indicating")
+                                            .ReplaceWithProbe("indicating to true", "indicating")
+                                            .ReplaceWithProbe("indicating to", "indicating whether to")
+                                            .ReplaceWithProbe("indicating if to", "indicating whether to")
+                                            .ReplaceWithProbe("indicating that to", "indicating whether to")
+                                            .ReplaceWithProbe("indicating  to", "indicating whether to")
+                                            .ReplaceWithProbe("indicating  indicating", "indicating")
+                                            .ReplaceWithProbe("indicating indicating", "indicating");
 
             var replacedFixedText = builder.ToStringAndRelease();
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -532,6 +532,36 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
         }
 
+        [TestCase("Set to true")]
+        [TestCase("Set to true,")]
+        [TestCase("Set to true if")]
+        [TestCase("Get/Set flag that indicates if")]
+        [TestCase("Get/Set flag that indicates whether")]
+        [TestCase("Get/Set flag that indicates that")]
+        [TestCase("Get/Set flag which indicates if")]
+        [TestCase("Get/Set flag which indicates whether")]
+        [TestCase("Get/Set flag which indicates that")]
+        [TestCase("Get/Set flag indicating if")]
+        [TestCase("Get/Set flag indicating whether")]
+        [TestCase("Get/Set flag indicating that")]
+        [TestCase("Get/Set")]
+        public void Code_gets_fixed_for_boolean_property_text_(string originalText)
+        {
+            const string Template = @"
+using System;
+
+public interface TestMe
+{
+    /// <summary>
+    /// ### to inform about something
+    /// </summary>
+    public bool SomeProperty { get; set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", "Gets or sets a value indicating whether"));
+        }
+
         [TestCase("Called to inform about something", "Informs about something")]
         [TestCase("Called to save something", "Saves something")]
         [TestCase("Save something", "Saves something")]


### PR DESCRIPTION
- Normalize boolean property summary phrases

- Add replacements for awkward "indicating" patterns

- Handle various "Get/Set" starting phrases

- Add tests for boolean summary auto-fixes

