### PR TITLE
MiKo_1040 no longer reports on non-collection fields

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
@@ -20,22 +20,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var parameterType = symbol.Type;
 
-            if (parameterType.IsXmlNode())
-            {
-                return false;
-            }
-
             if (parameterType.IsString())
             {
                 return symbol.Name.EndsWithAny(Constants.Markers.Collections);
             }
 
-            if (parameterType.IsEnumerable())
+            if (parameterType.IsXmlNode())
             {
-                return true;
+                return false;
             }
 
-            return false;
+            return parameterType.IsEnumerable();
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
@@ -24,17 +24,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var type = symbol.Type;
 
-            if (type.IsXmlNode())
-            {
-                return false;
-            }
-
             if (type.IsString())
             {
                 return symbol.Name.EndsWithAny(Constants.Markers.Collections);
             }
 
-            return true;
+            if (type.IsXmlNode())
+            {
+                return false;
+            }
+
+            return type.IsEnumerable();
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -22,28 +22,28 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             var symbolName = symbol.Name;
 
+            if (symbol.IsString())
+            {
+                return symbolName.EndsWithAny(Constants.Markers.Collections);
+            }
+
             if (IsCatalog(symbolName))
             {
                 // ignore stuff like the MEF aggregate catalog
                 return false;
             }
 
-            if (symbol.IsEnumerable())
+            if (IsDocument(symbolName))
             {
-                if (IsDocument(symbolName))
-                {
-                    return false;
-                }
-
-                if (symbol.IsXmlNode())
-                {
-                    return false;
-                }
-
-                return true;
+                return false;
             }
 
-            return false;
+            if (symbol.IsXmlNode())
+            {
+                return false;
+            }
+
+            return symbol.IsEnumerable();
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -11,6 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     [TestFixture]
     public sealed class MiKo_1040_ParameterCollectionSuffixAnalyzerTests : CodeFixVerifier
     {
+        [TestCase("object item")]
         [TestCase("string value")]
         [TestCase("string MyValue")]
         [TestCase("int[] numbers")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -19,6 +19,15 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
 
         [Test]
+        public void No_issue_is_reported_for_correctly_named_field() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    private object _item;
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue")] string field)
             => No_issue_is_reported_for(@"
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -82,6 +82,7 @@ public class TestMe
 }
 ");
 
+        [TestCase("object item")]
         [TestCase("string value")]
         [TestCase("string myValue")]
         [TestCase("XAttribute attribute")]


### PR DESCRIPTION
- Limit analysis to enumerables only

- Add tests for object scalar cases

- Prevent false positives on fields/parameters

(fixes #1563)