### PR TITLE
ReportGenerator bumped to v5.4.16

### DIFF
--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="5.4.14" />
+    <PackageReference Include="ReportGenerator" Version="5.4.16" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Bump `ReportGenerator` to v5.4.16

- Update test project dependency version
