### PR TITLE
BenchmarkDotNet bumped to v0.15.4

### DIFF
--- a/BenchmarkConsole/BenchmarkConsole.csproj
+++ b/BenchmarkConsole/BenchmarkConsole.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Bump `BenchmarkDotNet ` to v0.15.4
