### PR TITLE
Added 'GetLineSpan' helper methods

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Runtime.CompilerServices;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 // ncrunch: rdi off
@@ -15,16 +17,22 @@ namespace MiKoSolutions.Analyzers
             return node.GetEnclosingSymbol(semanticModel) as T;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetStartPosition(this Location value) => value.GetLineSpan().StartLinePosition;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetEndPosition(this Location value) => value.GetLineSpan().EndLinePosition;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinStartLine(this Location value) => value.GetStartPosition().Character;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinEndLine(this Location value) => value.GetEndPosition().Character;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetStartingLine(this Location value) => value.GetStartPosition().Line;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetEndingLine(this Location value) => value.GetEndPosition().Line;
 
         internal static string GetText(this Location value) => value.SourceTree?.GetText().ToString(value.SourceSpan);

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -319,6 +319,8 @@ namespace MiKoSolutions.Analyzers
                                                                                                                                            .Select(_ => _.ArgumentList.Arguments)
                                                                                                                                            .FirstOrDefault(_ => _.Count > 0);
 
+        internal static FileLinePositionSpan GetLineSpan(this ISymbol value) => value.Locations.First(_ => _.IsInSource).GetLineSpan();
+
         internal static IReadOnlyList<TSymbol> GetMembers<TSymbol>(this ITypeSymbol value) where TSymbol : ISymbol
         {
             var members = value.GetMembers();

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,18 +19,25 @@ namespace MiKoSolutions.Analyzers
     /// </summary>
     internal static partial class SyntaxNodeExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinStartLine(this SyntaxNode value) => value.GetLocation().GetPositionWithinStartLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinEndLine(this SyntaxNode value) => value.GetLocation().GetPositionWithinEndLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetStartingLine(this SyntaxNode value) => value.GetLocation().GetStartingLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetEndingLine(this SyntaxNode value) => value.GetLocation().GetEndingLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetStartPosition(this SyntaxNode value) => value.GetLocation().GetStartPosition();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetEndPosition(this SyntaxNode value) => value.GetLocation().GetEndPosition();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool HasTrailingEndOfLine(this SyntaxNode value) => value != null && value.GetTrailingTrivia().HasEndOfLine();
 
         internal static bool IsOnSameLineAs(this SyntaxNode value, SyntaxNode other) => value?.GetStartingLine() == other?.GetStartingLine();
@@ -90,8 +98,10 @@ namespace MiKoSolutions.Analyzers
             return value.WithLeadingTrivia(trivia);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithIndentation<T>(this T value) where T : SyntaxNode => value.WithFirstLeadingTrivia(SyntaxFactory.ElasticMarker); // use elastic one to allow formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithAdditionalLeadingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithAdditionalLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
         internal static bool HasLeadingEmptyLine(this SyntaxNode value)
@@ -114,14 +124,19 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithLeadingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithFirstLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed); // do not use elastic one to prevent formatting it away again
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithLeadingEndOfLine<T>(this T value) where T : SyntaxNode => value.WithFirstLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed); // use elastic one to allow formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithLeadingSpace<T>(this T value) where T : SyntaxNode => value.WithLeadingTrivia(SyntaxFactory.ElasticSpace); // use elastic one to allow formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithTrailingSpace<T>(this T value) where T : SyntaxNode => value.WithTrailingTrivia(SyntaxFactory.ElasticSpace); // use elastic one to allow formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithTrailingSpaces<T>(this T value, in int spaces) where T : SyntaxNode => value.WithTrailingTrivia(Enumerable.Repeat(SyntaxFactory.ElasticSpace, spaces)); // use elastic one to allow formatting to be done automatically
 
         internal static T WithAdditionalLeadingSpaces<T>(this T value, in int additionalSpaces) where T : SyntaxNode
@@ -354,10 +369,13 @@ namespace MiKoSolutions.Analyzers
             return value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithAdditionalTrailingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithAdditionalTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithTrailingEmptyLine<T>(this T value) where T : SyntaxNode => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T WithTrailingNewLine<T>(this T value) where T : SyntaxNode => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed); // do not use an elastic one to enforce the line break
 
         internal static T WithoutTrailingSpaces<T>(this T value) where T : SyntaxNode
@@ -422,6 +440,7 @@ namespace MiKoSolutions.Analyzers
             return finalTrivia;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(' ', count));
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -87,6 +87,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static AccessorDeclarationSyntax GetSetter(this PropertyDeclarationSyntax value) => value?.AccessorList?.FirstChild<AccessorDeclarationSyntax>(SyntaxKind.SetAccessorDeclaration);
 
+        internal static FileLinePositionSpan GetLineSpan(this SyntaxNode value) => value.GetLocation().GetLineSpan();
+
         internal static XmlElementSyntax GetParameterComment(this DocumentationCommentTriviaSyntax value, string parameterName) => value.FirstDescendant<XmlElementSyntax>(_ => _.GetName() is Constants.XmlTag.Param && _.GetParameterName() == parameterName);
 
         internal static ExpressionSyntax GetPropertyExpression(this PropertyDeclarationSyntax value)
@@ -961,7 +963,7 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool IsSpanningMultipleLines(this SyntaxNode value)
         {
-            var lineSpan = value.GetLocation().GetLineSpan();
+            var lineSpan = value.GetLineSpan();
 
             var startingLine = lineSpan.StartLinePosition.Line;
             var endingLine = lineSpan.EndLinePosition.Line;

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -31,6 +31,8 @@ namespace MiKoSolutions.Analyzers
 
         internal static T GetEnclosing<T>(this in SyntaxToken value) where T : SyntaxNode => value.Parent.GetEnclosing<T>();
 
+        internal static FileLinePositionSpan GetLineSpan(this in SyntaxToken value) => value.GetLocation().GetLineSpan();
+
         internal static int GetPositionWithinStartLine(this in SyntaxToken value) => value.GetLocation().GetPositionWithinStartLine();
 
         internal static int GetPositionWithinEndLine(this in SyntaxToken value) => value.GetLocation().GetPositionWithinEndLine();

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -31,10 +31,13 @@ namespace MiKoSolutions.Analyzers
 
         internal static T GetEnclosing<T>(this in SyntaxToken value) where T : SyntaxNode => value.Parent.GetEnclosing<T>();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FileLinePositionSpan GetLineSpan(this in SyntaxToken value) => value.GetLocation().GetLineSpan();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinStartLine(this in SyntaxToken value) => value.GetLocation().GetPositionWithinStartLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinEndLine(this in SyntaxToken value) => value.GetLocation().GetPositionWithinEndLine();
 
         internal static LinePosition GetPositionAfterEnd(this in SyntaxToken value)
@@ -44,12 +47,16 @@ namespace MiKoSolutions.Analyzers
             return new LinePosition(position.Line, position.Character + 1);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetStartPosition(this in SyntaxToken value) => value.GetLocation().GetStartPosition();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetEndPosition(this in SyntaxToken value) => value.GetLocation().GetEndPosition();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetStartingLine(this in SyntaxToken value) => value.GetLocation().GetStartingLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetEndingLine(this in SyntaxToken value) => value.GetLocation().GetEndingLine();
 
         internal static ISymbol GetSymbol(this in SyntaxToken value, Compilation compilation)
@@ -160,14 +167,19 @@ namespace MiKoSolutions.Analyzers
 
         internal static bool HasComment(this in SyntaxToken value) => value.HasLeadingComment() || value.HasTrailingComment();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool HasLeadingComment(this in SyntaxToken value) => value.LeadingTrivia.HasComment();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool HasTrailingComment(this in SyntaxToken value) => value.TrailingTrivia.HasComment();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool HasTrailingEndOfLine(this in SyntaxToken value) => value.TrailingTrivia.HasEndOfLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsDefaultValue(this in SyntaxToken value) => value.IsKind(SyntaxKind.None);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsAnyKind(this in SyntaxToken value, ISet<SyntaxKind> kinds) => kinds.Contains(value.Kind());
 
         internal static bool IsAnyKind(this in SyntaxToken value, in ReadOnlySpan<SyntaxKind> kinds)
@@ -185,6 +197,7 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsLocatedAt(this in SyntaxToken value, Location location) => value.GetLocation().Equals(location);
 
         internal static bool IsOnSameLineAs(this in SyntaxToken value, SyntaxNode other) => value.GetStartingLine() == other?.GetStartingLine();
@@ -271,8 +284,10 @@ namespace MiKoSolutions.Analyzers
 
         internal static SyntaxTokenList ToTokenList(this IEnumerable<SyntaxKind> source) => source.Select(_ => _.AsToken()).ToTokenList();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithEndOfLine(this in SyntaxToken value) => value.WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed); // use elastic one to allow formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithLeadingEmptyLine(this in SyntaxToken value) => value.WithLeadingEmptyLines(1);
 
         internal static SyntaxToken WithLeadingEmptyLines(this in SyntaxToken value, in int lines)
@@ -304,12 +319,16 @@ namespace MiKoSolutions.Analyzers
             return value.WithLeadingTrivia(trivia);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithLeadingEndOfLine(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed); // do not use elastic one to prevent formatting it away again
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithAdditionalLeadingTrivia(this in SyntaxToken value, in SyntaxTrivia trivia) => value.WithLeadingTrivia(value.LeadingTrivia.Add(trivia));
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithAdditionalLeadingTrivia(this in SyntaxToken value, in SyntaxTriviaList trivia) => value.WithLeadingTrivia(value.LeadingTrivia.AddRange(trivia));
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithAdditionalLeadingTrivia(this in SyntaxToken value, IEnumerable<SyntaxTrivia> trivia) => value.WithLeadingTrivia(value.LeadingTrivia.AddRange(trivia));
 
         internal static SyntaxToken WithAdditionalLeadingTriviaFrom(this in SyntaxToken value, SyntaxNode node)
@@ -330,6 +349,7 @@ namespace MiKoSolutions.Analyzers
                    : value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithLeadingSpace(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxFactory.ElasticSpace); // use elastic one to allow formatting to be done automatically
 
         internal static SyntaxToken WithLeadingSpaces(this in SyntaxToken value, in int count)
@@ -391,8 +411,10 @@ namespace MiKoSolutions.Analyzers
             return value.WithAdditionalLeadingTrivia(WhiteSpaces(additionalSpaces));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithLeadingXmlComment(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentStart);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithLeadingXmlCommentExterior(this in SyntaxToken value) => value.WithLeadingTrivia(SyntaxNodeExtensions.XmlCommentExterior);
 
         internal static SyntaxToken WithTriviaFrom(this in SyntaxToken value, SyntaxNode node) => value.WithLeadingTriviaFrom(node)
@@ -506,20 +528,27 @@ namespace MiKoSolutions.Analyzers
             return values;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithSurroundingSpace(this in SyntaxToken value) => value.WithLeadingSpace().WithTrailingSpace();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithText(this in SyntaxToken value, string text) => SyntaxFactory.Token(value.LeadingTrivia, value.Kind(), text, text, value.TrailingTrivia);
 
         internal static SyntaxToken WithText(this in SyntaxToken value, in ReadOnlySpan<char> text) => value.WithText(text.ToString());
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithTrailingEmptyLine(this in SyntaxToken value) => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithTrailingNewLine(this in SyntaxToken value) => value.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithTrailingSpace(this in SyntaxToken value) => value.WithTrailingTrivia(SyntaxFactory.Space); // use non-elastic one to prevent formatting to be done automatically
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static SyntaxToken WithTrailingXmlComment(this in SyntaxToken value) => value.WithTrailingTrivia(SyntaxNodeExtensions.XmlCommentStart);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(' ', count));
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -15,6 +15,8 @@ namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxTriviaExtensions
     {
+        internal static FileLinePositionSpan GetLineSpan(this in SyntaxTrivia value) => value.GetLocation().GetLineSpan();
+
         internal static int GetPositionWithinStartLine(this in SyntaxTrivia value) => value.GetLocation().GetPositionWithinStartLine();
 
         internal static int GetStartingLine(this in SyntaxTrivia value) => value.GetLocation().GetStartingLine();

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTriviaExtensions.cs
@@ -15,16 +15,22 @@ namespace MiKoSolutions.Analyzers
 {
     internal static class SyntaxTriviaExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static FileLinePositionSpan GetLineSpan(this in SyntaxTrivia value) => value.GetLocation().GetLineSpan();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetPositionWithinStartLine(this in SyntaxTrivia value) => value.GetLocation().GetPositionWithinStartLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetStartingLine(this in SyntaxTrivia value) => value.GetLocation().GetStartingLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetEndingLine(this in SyntaxTrivia value) => value.GetLocation().GetEndingLine();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetStartPosition(this in SyntaxTrivia value) => value.GetLocation().GetStartPosition();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static LinePosition GetEndPosition(this in SyntaxTrivia value) => value.GetLocation().GetEndPosition();
 
         internal static bool HasEndOfLine(this in SyntaxTriviaList value)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzer.cs
@@ -120,7 +120,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     continue;
                 }
 
-                var span = token.GetLocation().GetLineSpan();
+                var span = token.GetLineSpan();
 
                 if (lines.Contains(span.StartLinePosition.Line) || lines.Contains(span.EndLinePosition.Line))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3076_StaticMemberInitializerRefersToStaticMemberBelowOrInOtherPartAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3076_StaticMemberInitializerRefersToStaticMemberBelowOrInOtherPartAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (identifierNames.Count != 0)
             {
-                var fieldLocation = fieldSyntax.GetLocation().GetLineSpan();
+                var fieldLocation = fieldSyntax.GetLineSpan();
 
                 // get all fields
                 var problematicFields = GetStaticFieldsFromBelowOrFromOtherPart(symbol, fieldLocation);
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             foreach (var otherField in otherFields)
             {
-                var lineSpan = otherField.GetLocation().GetLineSpan();
+                var lineSpan = otherField.GetLineSpan();
 
                 if (lineSpan.Path != fieldLocation.Path || lineSpan.StartLinePosition >= fieldLocation.StartLinePosition)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
         private Diagnostic[] AnalyzeTestType(INamedTypeSymbol symbol, IFieldSymbol field)
         {
-            var path = field.Locations.First(_ => _.IsInSource).GetLineSpan().Path;
+            var path = field.GetLineSpan().Path;
 
             var fields = GetFieldsOrderedByLocation(symbol, path);
             var firstField = fields[0];

--- a/MiKo.Analyzer.Shared/Rules/Ordering/OrderingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/OrderingAnalyzer.cs
@@ -11,16 +11,16 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
         {
         }
 
-        protected static IReadOnlyList<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, MethodKind kind = MethodKind.Ordinary) => GetMethodsOrderedByLocation(type, type.Locations.First(_ => _.IsInSource).GetLineSpan().Path, kind);
+        protected static IReadOnlyList<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, MethodKind kind = MethodKind.Ordinary) => GetMethodsOrderedByLocation(type, type.GetLineSpan().Path, kind);
 
         protected static IReadOnlyList<IMethodSymbol> GetMethodsOrderedByLocation(INamedTypeSymbol type, string path, MethodKind kind = MethodKind.Ordinary) => type.GetMethods(kind)
-                                                                                                                                                                    .Where(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().Path == path)
-                                                                                                                                                                    .OrderBy(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().StartLinePosition)
+                                                                                                                                                                    .Where(_ => _.GetLineSpan().Path == path)
+                                                                                                                                                                    .OrderBy(_ => _.GetLineSpan().StartLinePosition)
                                                                                                                                                                     .ToList();
 
         protected static IReadOnlyList<IFieldSymbol> GetFieldsOrderedByLocation(INamedTypeSymbol type, string path) => type.GetFields()
-                                                                                                                           .Where(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().Path == path)
-                                                                                                                           .OrderBy(_ => _.Locations.First(__ => __.IsInSource).GetLineSpan().StartLinePosition)
+                                                                                                                           .Where(_ => _.GetLineSpan().Path == path)
+                                                                                                                           .OrderBy(_ => _.GetLineSpan().StartLinePosition)
                                                                                                                            .ToList();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Ordering/TestMethodsOrderingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Ordering/TestMethodsOrderingAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Ordering
 
         private Diagnostic[] AnalyzeTestType(INamedTypeSymbol symbol, IMethodSymbol method)
         {
-            var path = method.Locations.First(_ => _.IsInSource).GetLineSpan().Path;
+            var path = method.GetLineSpan().Path;
 
             var methods = GetMethodsOrderedByLocation(symbol, path).ToList();
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/CallSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/CallSurroundedByBlankLinesAnalyzer.cs
@@ -111,7 +111,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeSimpleMemberAccessExpression(in SyntaxList<StatementSyntax> statements, MemberAccessExpressionSyntax call, SemanticModel semanticModel)
         {
-            var callLineSpan = call.GetLocation().GetLineSpan();
+            var callLineSpan = call.GetLineSpan();
 
             var noBlankLinesBefore = statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _))
                                                .Any(_ => IsAlsoCall(_, semanticModel) is false);

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6003_LocalVariableDeclarationPrecededByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6003_LocalVariableDeclarationPrecededByBlankLinesAnalyzer.cs
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeLocalDeclarationStatement(in SyntaxList<StatementSyntax> statements, LocalDeclarationStatementSyntax declaration)
         {
-            var callLineSpan = declaration.GetLocation().GetLineSpan();
+            var callLineSpan = declaration.GetLineSpan();
 
             var noBlankLinesBefore = statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _))
                                                .Any(_ => IsDeclaration(_) is false);

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6004_VariableAssignmentPrecededByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6004_VariableAssignmentPrecededByBlankLinesAnalyzer.cs
@@ -121,7 +121,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic Analyze(AssignmentExpressionSyntax assignment, in SyntaxList<StatementSyntax> statements)
         {
-            var callLineSpan = assignment.GetLocation().GetLineSpan();
+            var callLineSpan = assignment.GetLineSpan();
 
             var noBlankLinesBefore = statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _))
                                                .Any(_ => IsAssignmentOrDeclaration(assignment, _) is false);

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6005_ReturnStatementPrecededByBlankLinesAnalyzer.cs
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 return null;
             }
 
-            var callLineSpan = returnStatement.GetLocation().GetLineSpan();
+            var callLineSpan = returnStatement.GetLineSpan();
 
             var noBlankLinesBefore = statements.Where(_ => _.IsKind(SyntaxKind.YieldReturnStatement) is false)
                                                .Any(_ => HasNoBlankLinesBefore(callLineSpan, _));

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6006_AwaitStatementSurroundedByBlankLinesAnalyzer.cs
@@ -115,7 +115,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 case StatementSyntax _:
                 {
-                    var callLineSpan = node.GetLocation().GetLineSpan();
+                    var callLineSpan = node.GetLineSpan();
 
                     var noBlankLinesBefore = HasNonAwaitedStatement(statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _)));
                     var noBlankLinesAfter = HasNonAwaitedStatement(statements.Where(_ => HasNoBlankLinesAfter(callLineSpan, _)));
@@ -131,7 +131,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 case EqualsValueClauseSyntax _:
                 case AssignmentExpressionSyntax _:
                 {
-                    var callLineSpan = node.GetLocation().GetLineSpan();
+                    var callLineSpan = node.GetLineSpan();
 
                     var noBlankLinesBefore = HasNonAwaitedLocalAssignment(statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _)));
                     var noBlankLinesAfter = HasNonAwaitedLocalAssignment(statements.Where(_ => HasNoBlankLinesAfter(callLineSpan, _)));

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6007_ObjectUnderTestStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6007_ObjectUnderTestStatementSurroundedByBlankLinesAnalyzer.cs
@@ -91,7 +91,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeExpressionStatements(in SyntaxList<StatementSyntax> statements, CSharpSyntaxNode node)
         {
-            var callLineSpan = node.GetLocation().GetLineSpan();
+            var callLineSpan = node.GetLineSpan();
 
             var noBlankLinesBefore = HasNoOtherObjectUnderTestExpression(statements.Where(_ => HasNoBlankLinesBefore(callLineSpan, _)));
             var noBlankLinesAfter = HasNoOtherObjectUnderTestExpression(statements.Where(_ => HasNoBlankLinesAfter(callLineSpan, _)));

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6048_LogicalConditionsAreOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6048_LogicalConditionsAreOnSameLineAnalyzer.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private static bool IsOnSingleLineLocal(SyntaxNode s)
         {
-            var span = s.GetLocation().GetLineSpan();
+            var span = s.GetLineSpan();
 
             return span.StartLinePosition.Line == span.EndLinePosition.Line;
         }
@@ -54,8 +54,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             var leftCondition = binary.Left;
             var rightCondition = binary.Right;
 
-            var leftSpan = leftCondition.GetLocation().GetLineSpan();
-            var rightSpan = rightCondition.GetLocation().GetLineSpan();
+            var leftSpan = leftCondition.GetLineSpan();
+            var rightSpan = rightCondition.GetLineSpan();
 
             // let's see if both conditions are on same line
             if (leftSpan.EndLinePosition.Line == rightSpan.StartLinePosition.Line)
@@ -79,8 +79,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             if (IsOnSingleLine(parenthesized.Expression))
             {
                 // we have a parenthesized one, so let's check also the parenthesis
-                var openParenthesisSpan = parenthesized.OpenParenToken.GetLocation().GetLineSpan();
-                var closeParenthesisSpan = parenthesized.CloseParenToken.GetLocation().GetLineSpan();
+                var openParenthesisSpan = parenthesized.OpenParenToken.GetLineSpan();
+                var closeParenthesisSpan = parenthesized.CloseParenToken.GetLineSpan();
 
                 if (openParenthesisSpan.StartLinePosition.Line == closeParenthesisSpan.EndLinePosition.Line)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6049_EventRegistrationsSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6049_EventRegistrationsSurroundedByBlankLinesAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 if (assignment.Parent?.Parent is BlockSyntax block)
                 {
                     // we found an event
-                    var callLineSpan = assignment.GetLocation().GetLineSpan();
+                    var callLineSpan = assignment.GetLineSpan();
 
                     var noBlankLinesBefore = block.Statements
                                                   .Where(_ => HasNoBlankLinesBefore(callLineSpan, _))

--- a/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
@@ -101,8 +101,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
             if (otherStatements.Count > 0)
             {
-                var beforePosition = GetLocationOfNodeOrLeadingComment(node).GetLineSpan();
-                var afterPosition = GetLocationOfNodeOrTrailingComment(node).GetLineSpan();
+                var beforePosition = GetLineSpanOfNodeOrLeadingComment(node);
+                var afterPosition = GetLineSpanOfNodeOrTrailingComment(node);
 
                 var noBlankLinesBefore = HasNoBlankLinesBefore(otherStatements, beforePosition);
                 var noBlankLinesAfter = HasNoBlankLinesAfter(otherStatements, afterPosition);
@@ -118,8 +118,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeStatement(SwitchSectionSyntax section, T node)
         {
-            var beforePosition = GetLocationOfNodeOrLeadingComment(node).GetLineSpan();
-            var afterPosition = GetLocationOfNodeOrTrailingComment(node).GetLineSpan();
+            var beforePosition = GetLineSpanOfNodeOrLeadingComment(node);
+            var afterPosition = GetLineSpanOfNodeOrTrailingComment(node);
 
             var statements = section.Statements;
             var otherStatements = statements.Except(node).Where(ShallAnalyzeOtherStatement).ToList();

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SurroundedByBlankLinesAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
         }
 
-        protected static Location GetLocationOfNodeOrLeadingComment(SyntaxNode node)
+        protected static FileLinePositionSpan GetLineSpanOfNodeOrLeadingComment(SyntaxNode node)
         {
             var list = node.GetLeadingTrivia();
             var listCount = list.Count;
@@ -27,15 +27,15 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     if (trivia.IsComment())
                     {
-                        return trivia.GetLocation();
+                        return trivia.GetLineSpan();
                     }
                 }
             }
 
-            return node.GetLocation();
+            return node.GetLineSpan();
         }
 
-        protected static Location GetLocationOfNodeOrTrailingComment(SyntaxNode node)
+        protected static FileLinePositionSpan GetLineSpanOfNodeOrTrailingComment(SyntaxNode node)
         {
             var list = node.GetTrailingTrivia();
             var listCount = list.Count;
@@ -48,17 +48,17 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                     if (trivia.IsComment())
                     {
-                        return trivia.GetLocation();
+                        return trivia.GetLineSpan();
                     }
                 }
             }
 
-            return node.GetLocation();
+            return node.GetLineSpan();
         }
 
         protected static bool HasNoBlankLinesBefore(in FileLinePositionSpan callLineSpan, SyntaxNode other)
         {
-            var endingLine = GetLocationOfNodeOrTrailingComment(other).GetEndingLine();
+            var endingLine = GetLineSpanOfNodeOrTrailingComment(other).EndLinePosition.Line;
 
             var differenceBefore = callLineSpan.StartLinePosition.Line - endingLine;
 
@@ -67,12 +67,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected static bool HasNoBlankLinesBefore(SyntaxNode node, SyntaxNode other)
         {
-            return HasNoBlankLinesBefore(GetLocationOfNodeOrLeadingComment(node).GetLineSpan(), other);
+            return HasNoBlankLinesBefore(GetLineSpanOfNodeOrLeadingComment(node), other);
         }
 
         protected static bool HasNoBlankLinesAfter(in FileLinePositionSpan callLineSpan, SyntaxNode other)
         {
-            var startingLine = GetLocationOfNodeOrLeadingComment(other).GetStartingLine();
+            var startingLine = GetLineSpanOfNodeOrLeadingComment(other).StartLinePosition.Line;
 
             var differenceAfter = startingLine - callLineSpan.EndLinePosition.Line;
 
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected static bool HasNoBlankLinesAfter(SyntaxNode node, SyntaxNode other)
         {
-            return HasNoBlankLinesAfter(GetLocationOfNodeOrTrailingComment(node).GetLineSpan(), other);
+            return HasNoBlankLinesAfter(GetLineSpanOfNodeOrTrailingComment(node), other);
         }
 
         protected Diagnostic Issue(SyntaxNode call, in bool noBlankLinesBefore, in bool noBlankLinesAfter)


### PR DESCRIPTION
- Introduce `GetLineSpan` helpers across APIs

- Replace direct `GetLocation().GetLineSpan()` calls

- Add AggressiveInlining to frequently used extensions

- Minor refactoring for spacing utilities
