### PR TITLE
MiKo_2035 is now able to fix more collection phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -257,7 +257,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var startingWords = new[] { "a", "an", "the" };
                 var modifications = new[] { "readonly", "read-only", "read only" };
-                var collections = new[] { "array", "list", "dictionary", "enumerable", "hash set", "hash table", "hashed set", "hashed table", "hashing set", "hashing table", "hashset", "hashSet", "hashtable", "hashTable", "map", "queue", "stack" };
+                var collections = new[]
+                                      {
+                                          "array", "list", "dictionary", "enumerable", "enumerable collection", "syntax list", "separated syntax list", "immutable array",
+                                          "hash set", "hash table", "hashed set", "hashed table", "hashing set", "hashing table", "hashset", "hashSet", "hashtable", "hashTable",
+                                          "map", "queue", "stack",
+                                      };
                 var prepositions = new[] { "of", "with", "that contains", "which contains", "that holds", "which holds", "containing", "holding" };
 
                 foreach (var collection in collections)

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -936,7 +936,11 @@ public class TestMe
         {
             string[] startingWords = ["a", "an", "the"];
             string[] modifications = ["readonly", "read-only", "read only"];
-            string[] collections = ["array", "list", "dictionary", "enumerable", "queue", "stack", "map", "hashset", "hashSet", "hashtable", "hashTable", "hash set", "hashed set", "hash table", "hashed table", "hashing set", "hashing table"];
+            string[] collections = [
+                                       "array", "list", "dictionary", "enumerable", "queue", "stack", "map",
+                                       "hashset", "hashSet", "hashtable", "hashTable", "hash set", "hashed set", "hash table", "hashed table", "hashing set", "hashing table",
+                                       "syntax list", "enumerable collection", "separated syntax list", "immutable array",
+                                   ];
             string[] prepositions = ["of", "with", "that contains", "which contains", "that holds", "which holds", "containing", "holding"];
 
             foreach (var collection in collections)


### PR DESCRIPTION
- Extend collection phrase coverage
  - "enumerable collection"
  - "syntax list"
  - "separated syntax list"
  - "immutable array"

- Add tests for new phrases

- Keep analyzer and tests in sync