### PR TITLE
MiKo_2074 is now aware of ending 'to check'/'to check for'/'to check if contained'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
@@ -15,6 +15,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("to search for to seek", "to seek"),
                                                             new Pair("to look up to seek", "to seek"),
                                                             new Pair("to look-up to seek", "to seek"),
+                                                            new Pair("to check to seek", "to seek"),
+                                                            new Pair("to check for to seek", "to seek"),
+                                                            new Pair("to check if contained to seek", "to seek"),
                                                         };
 
         private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
@@ -185,6 +185,9 @@ public class TestMe
         [TestCase("The value to search for", "The value")]
         [TestCase("The value to look up", "The value")]
         [TestCase("The value to look-up", "The value")]
+        [TestCase("The value to check", "The value")]
+        [TestCase("The value to check for", "The value")]
+        [TestCase("The value to check if contained", "The value")]
         public void Code_gets_fixed_for_simple_text(string originalStartingPhrase, string fixedStartingPhrase)
         {
             var originalCode = @"


### PR DESCRIPTION
- Extend replacement map with "to check" variants

- Add unit tests for new phrases
