### PR TITLE
MiKo_2033 is now aware of text starting with 'value '

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -52,6 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                         new Pair("that contains a formatted string", "that contains the formatted result"),
                                                         new Pair("that contains the formatted string", "that contains the formatted result"),
                                                         new Pair("that contains a ", "that contains the "),
+                                                        new Pair("that contains value ", "that contains the value "),
                                                     };
 
         private static readonly string[] CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -374,6 +374,8 @@ public class TestMe
         [TestCase("A formatted string", "the formatted result")]
         [TestCase("The formatted string", "the formatted result")]
         [TestCase("A humanized concatenation of the strings", "the humanized concatenation of the strings")]
+        [TestCase("value of something", "the value of something")]
+        [TestCase("Value of something", "the value of something")]
         public void Code_gets_fixed_for_non_generic_method_starting_and_continuing_with_(string phrase, string continuation)
         {
             var originalCode = @"


### PR DESCRIPTION
- Add fix for phrases starting with `value `

- Extend cleanup map with 'value' handling

- Add unit tests covering new cases
