### PR TITLE
MiKo_6061 is now aware of ternary operators (conditional expressions)

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -73,6 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 case BinaryExpressionSyntax binary: return PlacedOnSameLine(binary) as T;
                 case CasePatternSwitchLabelSyntax patternLabel: return PlacedOnSameLine(patternLabel) as T;
                 case CaseSwitchLabelSyntax label: return PlacedOnSameLine(label) as T;
+                case ConditionalExpressionSyntax conditional: return PlacedOnSameLine(conditional) as T;
                 case ConstantPatternSyntax constantPattern: return PlacedOnSameLine(constantPattern) as T;
                 case DeclarationPatternSyntax declaration: return PlacedOnSameLine(declaration) as T;
                 case InvocationExpressionSyntax invocation: return PlacedOnSameLine(invocation) as T;
@@ -116,6 +117,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                                                                                        .WithKeyword(syntax.Keyword.WithoutTrailingTrivia())
                                                                                                        .WithValue(PlacedOnSameLine(syntax.Value).WithLeadingSpace().WithoutTrailingTrivia())
                                                                                                        .WithColonToken(syntax.ColonToken.WithoutLeadingTrivia());
+
+        protected static ConditionalExpressionSyntax PlacedOnSameLine(ConditionalExpressionSyntax syntax) => syntax.WithoutTrivia()
+                                                                                                                   .WithCondition(PlacedOnSameLine(syntax.Condition).WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                                   .WithQuestionToken(syntax.QuestionToken.WithoutTrivia())
+                                                                                                                   .WithWhenTrue(PlacedOnSameLine(syntax.WhenTrue).WithLeadingSpace().WithoutTrailingTrivia())
+                                                                                                                   .WithColonToken(syntax.ColonToken.WithoutTrivia())
+                                                                                                                   .WithWhenFalse(PlacedOnSameLine(syntax.WhenFalse).WithLeadingSpace().WithoutTrailingTrivia());
 
         protected static ConstantPatternSyntax PlacedOnSameLine(ConstantPatternSyntax syntax) => syntax.WithoutTrivia()
                                                                                                        .WithExpression(PlacedOnSameLine(syntax.Expression));

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6061_SwitchExpressionArmsAreOnSameLineAnalyzerTests.cs
@@ -202,6 +202,46 @@ public class TestMe
         }
 
         [Test]
+        public void Code_gets_fixed_for_switch_expression_arm_if_it_has_a_conditional_expression_that_spans_multiple_lines()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison, bool inverse)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => inverse
+                                                                    ? false
+                                                                    : true,
+                                        _ => false,
+                                    };
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(StringComparison comparison, bool inverse)
+    {
+            return comparison switch
+                                    {
+                                        StringComparison.Ordinal => inverse ? false : true,
+                                        _ => false,
+                                    };
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_switch_expression_arm_throwing_an_exception_if_it_spans_multiple_lines()
         {
             const string OriginalCode = @"


### PR DESCRIPTION
- Add spacing support for conditional expressions

- Extend same-line placer to ternary nodes

- Add test for switch arm with ternary
