### PR TITLE
MiKo_2076 is now aware of default values such as 'int.MaxValue'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -603,7 +603,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type) => Cref(Constants.XmlTag.See, type);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static XmlEmptyElementSyntax SeeCref(string typeName, string member) => SeeCref(typeName.AsTypeSyntax(), member);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static XmlEmptyElementSyntax SeeCref(string typeName, NameSyntax member) => SeeCref(typeName.AsTypeSyntax(), member);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type, string member) => SeeCref(type, SyntaxFactory.ParseName(member));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static XmlEmptyElementSyntax SeeCref(TypeSyntax type, NameSyntax member) => Cref(Constants.XmlTag.See, type, member);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
@@ -5,7 +5,6 @@ using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -24,12 +23,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (symbol is INamedTypeSymbol typeSymbol && typeSymbol.IsEnum())
             {
                 var defaultValue = typeSymbol.GetFields()[0];
-                var nameSyntax = SyntaxFactory.ParseName(defaultValue.Name);
 
                 return new XmlNodeSyntax[]
                            {
                                XmlText(Constants.Comments.DefaultStartingPhrase),
-                               SeeCref(returnType, nameSyntax),
+                               SeeCref(returnType, defaultValue.Name),
                                XmlText("."),
                            };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_CodeFixProvider.cs
@@ -53,7 +53,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.DefaultSeeCrefValue, out var defaultCrefValue))
             {
-                return SeeCref(defaultCrefValue);
+                if (defaultCrefValue != null)
+                {
+                    var dotIndex = defaultCrefValue.LastIndexOf('.');
+
+                    if (dotIndex is -1)
+                    {
+                        return SeeCref(defaultCrefValue);
+                    }
+
+                    return SeeCref(defaultCrefValue.Substring(0, dotIndex), defaultCrefValue.Substring(dotIndex + 1));
+                }
             }
 
             if (issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.DefaultCodeValue, out var defaultCodeValue))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzer.cs
@@ -58,6 +58,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 case SyntaxKind.IdentifierName:
                     return new Pair(Constants.AnalyzerCodeFixSharedData.DefaultSeeCrefValue, defaultValue.ToString()); // seems like some field or property, so simply use that one
 
+                case SyntaxKind.SimpleMemberAccessExpression:
+                    return new Pair(Constants.AnalyzerCodeFixSharedData.DefaultSeeCrefValue, defaultValue.ToString()); // seems like some field or property, so simply use that one
+
                 case SyntaxKind.UnaryPlusExpression:
                 case SyntaxKind.UnaryMinusExpression:
                 case SyntaxKind.BitwiseNotExpression:

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Documentation
@@ -15,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
 //// ncrunch: rdi default
 
-        protected static XmlEmptyElementSyntax SeeCrefTaskResult() => SeeCref("Task<TResult>", SyntaxFactory.ParseName(nameof(Task<object>.Result)));
+        protected static XmlEmptyElementSyntax SeeCrefTaskResult() => SeeCref("Task<TResult>", nameof(Task<object>.Result));
 
         protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2076_OptionalParameterDefaultPhraseAnalyzerTests.cs
@@ -313,6 +313,49 @@ public namespace Bla
         }
 
         [Test]
+        public void Code_gets_fixed_for_documented_method_in_namespace_with_optional_value_with_missing_default_documentation_for_integer_type_constant()
+        {
+            const string OriginalCode = @"
+public namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        /// <param name=""value"">
+        /// Some value.
+        /// </param>
+        public bool DoSomething(int value = int.MaxValue)
+        {
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+public namespace Bla
+{
+    public class TestMe
+    {
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        /// <param name=""value"">
+        /// Some value.
+        /// The default is <see cref=""int.MaxValue""/>.
+        /// </param>
+        public bool DoSomething(int value = int.MaxValue)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_documented_method_in_namespace_with_optional_value_with_missing_default_documentation_for_enum()
         {
             const string OriginalCode = @"


### PR DESCRIPTION
- Add string overloads for `SeeCref` helpers

- Support `TypeCref` in XML cref matching

- Recognize member access default values

- Add test for `int.MaxValue` handling
