### PR TITLE
Codefixes changed to lazy load their data

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -57,10 +57,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
-        static MiKo_2023_CodeFixProvider() => LoadData(); // ensure that we have the object available
-#endif
-
         public override string FixableDiagnosticId => "MiKo_2023";
 
         public static void LoadData() => GC.KeepAlive(MappedData.Value);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -52,10 +52,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] TaskParts = Constants.Comments.GenericTaskReturnTypeStartingPhraseTemplate.FormatWith("task", "|").Split('|');
 
-#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
-        static MiKo_2035_CodeFixProvider() => LoadData(); // ensure that we have the object available
-#endif
-
         public override string FixableDiagnosticId => "MiKo_2035";
 
         public static void LoadData() => GC.KeepAlive(MappedData.Value);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -17,10 +17,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
-        static MiKo_2060_CodeFixProvider() => LoadData(); // ensure that we have the object available
-#endif
-
         public override string FixableDiagnosticId => "MiKo_2060";
 
         public static void LoadData() => GC.KeepAlive(MappedData.Value);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -16,10 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
-#if !NCRUNCH // do not define a static ctor to speed up tests in NCrunch
-        static MiKo_2080_CodeFixProvider() => LoadData(); // ensure that we have the object available
-#endif
-
         public override string FixableDiagnosticId => "MiKo_2080";
 
         public static void LoadData() => GC.KeepAlive(MappedData.Value);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -58,12 +58,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
 //// ncrunch: no coverage end
 
-#if NCRUNCH
-
         [OneTimeSetUp]
         public static void PrepareTestEnvironment() => MiKo_2023_CodeFixProvider.LoadData();
-
-#endif
 
         [Test]
         public void No_issue_is_reported_for_undocumented_parameter() => No_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -36,12 +36,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] StartingPhrases = [.. Enumerable.ToHashSet(CreateStartingPhrases().Take(TestLimit))];
 
-#if NCRUNCH
-
         [OneTimeSetUp]
         public static void PrepareTestEnvironment() => MiKo_2035_CodeFixProvider.LoadData();
-
-#endif
 
         [Test]
         public void No_issue_is_reported_for_uncommented_method_([ValueSource(nameof(ReturnTypes))] string returnType) => No_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -19,12 +19,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] InterfaceSummaryStartingPhrases = [.. ClassSummaryStartingPhrases.Take(100)];
         private static readonly string[] MethodStartingPhrases = [.. CreateMethodSummaryPhrases()];
 
-#if NCRUNCH
-
         [OneTimeSetUp]
         public static void PrepareTestEnvironment() => MiKo_2060_CodeFixProvider.LoadData();
-
-#endif
 
         [Test]
         public void No_issue_is_reported_for_undocumented_non_factory_class() => No_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -17,12 +17,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly string[] WrongBooleanPhrases = [.. CreateWrongBooleanPhrases().Take(TestLimit)];
 
-#if NCRUNCH
-
         [OneTimeSetUp]
         public static void PrepareTestEnvironment() => MiKo_2080_CodeFixProvider.LoadData();
-
-#endif
 
         [Test]
         public void No_issue_is_reported_for_uncommented_field() => No_issue_is_reported_for(@"


### PR DESCRIPTION
- Switch code fixes to lazy data loading

- Remove static constructors for providers

- Initialize data via explicit `LoadData`

- Update tests to preload mapping data
