### PR TITLE
Dogfooding own spacing and performance rules

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -436,6 +436,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var tokens = textTokens.ToList();
                     tokens.RemoveAt(0);
+
                     tokens[0] = tokens[0].WithLeadingTrivia();
 
                     text = XmlText(tokens);
@@ -889,6 +890,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                              .WithTrailingTriviaFrom(firstToken);
 
                         currentTextTokens[count - 1] = token;
+
                         currentTextTokens.AddRange(nextTextTokens.Skip(1));
 
                         var newText = currentText.WithTextTokens(currentTextTokens.ToTokenList());

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -194,8 +194,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         if (constraints.OfType<ClassOrStructConstraintSyntax>().FirstOrDefault() is ClassOrStructConstraintSyntax classConstraint)
                         {
                             return classConstraint.IsKind(SyntaxKind.ClassConstraint)
-                                    ? "object"
-                                    : "value"; // it is a struct
+                                   ? "object"
+                                   : "value"; // it is a struct
                         }
                     }
                 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                    && m.GetIdentifierName() is nameof(StringComparison)
                                                                                    && m.GetName() is nameof(StringComparison.Ordinal);
 
-        private static bool IsStringComparisonOrdinal(SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             switch (arguments.Count)
             {


### PR DESCRIPTION
- Minor performance tweaks and refactors

- Improve parameter passing with 'in'

- Clean up trivia handling in XML tokens

- Align ternary operator indentation
