### PR TITLE
MiKo_1040 now ignores 'this' parameter and situation where another parameter would have the same name

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
@@ -37,13 +37,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             foreach (var parameter in symbol.Parameters)
             {
+                if (parameter.Ordinal is 0 && symbol.IsExtensionMethod)
+                {
+                    // this is a 'this' parameter
+                    continue;
+                }
+
                 if (ShallAnalyze(parameter))
                 {
-                    var diagnostic = AnalyzeCollectionSuffix(parameter);
+                    var issue = AnalyzeCollectionSuffix(parameter);
 
-                    if (diagnostic != null)
+                    if (issue != null)
                     {
-                        yield return diagnostic;
+                        yield return issue;
                     }
                 }
             }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -103,6 +103,18 @@ public static class TestMeExtensions
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_better_parameter_name_that_would_match_an_existing_parameter() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public void DoSomething(List<int> value, int[] values)
+    { }
+}
+");
+
         [TestCase("string blaEnumList")]
         [TestCase("string blaList")]
         [TestCase("string blaCollection")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -61,24 +61,6 @@ public class TestMe
 }
 ");
 
-        [TestCase("string blaEnumList")]
-        [TestCase("string blaList")]
-        [TestCase("string blaCollection")]
-        [TestCase("string blaObservableCollection")]
-        [TestCase("string blaArray")]
-        [TestCase("string blaHashSet")]
-        [TestCase("string blaDictionary")]
-        [TestCase("string blaDict")]
-        [TestCase("string blaDic")]
-        public void An_issue_is_reported_for_incorrectly_named_parameter_(string parameter) => An_issue_is_reported_for(@"
-
-public class TestMe
-{
-    public void DoSomething(" + parameter + @")
-    { }
-}
-");
-
         [Test] // this situation is covered by CA 1725 so we do not report that as well
         public void No_issue_is_reported_for_incorrectly_named_parameter_of_method_that_implements_interface() => No_issue_is_reported_for(@"
 using System;
@@ -104,6 +86,37 @@ using System.Collections.Generic;
 public class TestMe : ITestMe
 {
     public void DoSomething(bool refreshList)
+    { }
+}
+");
+
+        [TestCase("value")]
+        [TestCase("source")]
+        public void No_issue_is_reported_for_extension_method_parameter_(string parameter) => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+public static class TestMeExtensions
+{
+    public static void DoSomething(this List<int> " + parameter + @")
+    { }
+}
+");
+
+        [TestCase("string blaEnumList")]
+        [TestCase("string blaList")]
+        [TestCase("string blaCollection")]
+        [TestCase("string blaObservableCollection")]
+        [TestCase("string blaArray")]
+        [TestCase("string blaHashSet")]
+        [TestCase("string blaDictionary")]
+        [TestCase("string blaDict")]
+        [TestCase("string blaDic")]
+        public void An_issue_is_reported_for_incorrectly_named_parameter_(string parameter) => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public void DoSomething(" + parameter + @")
     { }
 }
 ");


### PR DESCRIPTION
- Ignore `this` parameter in extension methods

- Skip rename when better name collides

- Add tests for extension `this` exclusions

- Add tests for collision avoidance

(resolves #1589)