### PR TITLE
MiKo_2220 is now aware of 'to inspect for' in the middle of a text

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -12,9 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = Constants.Comments.FindTerms.Select(_ => new Pair(_, Constants.Comments.ToSeekTerm))
-                                                                 .ConcatenatedWith(new Pair(" to inspect for ", " " + Constants.Comments.ToSeekTerm + " for "))
-                                                                 .OrderDescendingByLengthAndText(_ => _.Key);
+        private static readonly Pair[] ReplacementMap = Constants.Comments.FindTerms.ToArray(_ => new Pair(_, Constants.Comments.ToSeekTerm));
 
 //// ncrunch: rdi default
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_CodeFixProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Composition;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -11,7 +12,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = Constants.Comments.FindTerms.ToArray(_ => new Pair(_, Constants.Comments.ToSeekTerm));
+        private static readonly Pair[] ReplacementMap = Constants.Comments.FindTerms.Select(_ => new Pair(_, Constants.Comments.ToSeekTerm))
+                                                                 .ConcatenatedWith(new Pair(" to inspect for ", " " + Constants.Comments.ToSeekTerm + " for "))
+                                                                 .OrderDescendingByLengthAndText(_ => _.Key);
 
 //// ncrunch: rdi default
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2220";
 
-        private static readonly string[] FindTermsWithDelimiters = Constants.Comments.FindTerms.WithDelimiters();
+        private static readonly string[] FindTermsWithDelimiters = Constants.Comments.FindTerms.WithDelimiters().Except(" to inspect for ").ToArray();
 
         public MiKo_2220_DocumentationShouldUseToSeekAnalyzer() : base(Id)
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
@@ -16,7 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly Dictionary<string, string> Map = new()
                                                                      {
                                                                          { "to find", "to seek" },
-                                                                         { "to inspect for ", "to seek for " },
                                                                          { "to look for", "to seek" },
                                                                          { "to test for", "to seek" },
 
@@ -45,9 +44,18 @@ public class TestMe
 }");
 
         [Test]
+        public void No_issue_is_reported_for_correct_comment_with_to_inspect_for() => No_issue_is_reported_for(@"
+/// <summary>
+/// Some summary to inspect for more details.
+/// </summary>
+public class TestMe
+{
+}");
+
+        [Test]
         public void An_issue_is_reported_for_wrong_text_in_documentation_([ValueSource(nameof(WrongPhrases))] string phrase) => An_issue_is_reported_for(@"
 /// <summary>
-/// It is used " + phrase.Trim() + @" something.
+/// It is used " + phrase + @" something.
 /// </summary>
 public class TestMe
 {
@@ -64,7 +72,7 @@ public class TestMe
 {
 }";
 
-            VerifyCSharpFix(Template.Replace("###", phrase.Trim()), Template.Replace("###", Map[phrase].Trim()));
+            VerifyCSharpFix(Template.Replace("###", phrase), Template.Replace("###", Map[phrase]));
         }
 
         protected override string GetDiagnosticId() => MiKo_2220_DocumentationShouldUseToSeekAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly Dictionary<string, string> Map = new()
                                                                      {
                                                                          { "to find", "to seek" },
-                                                                         { "to inspect for", "to seek" },
+                                                                         { "to inspect for ", "to seek for " },
                                                                          { "to look for", "to seek" },
                                                                          { "to test for", "to seek" },
 
@@ -47,7 +47,7 @@ public class TestMe
         [Test]
         public void An_issue_is_reported_for_wrong_text_in_documentation_([ValueSource(nameof(WrongPhrases))] string phrase) => An_issue_is_reported_for(@"
 /// <summary>
-/// It " + phrase + @" do something.
+/// It is used " + phrase.Trim() + @" something.
 /// </summary>
 public class TestMe
 {
@@ -58,13 +58,13 @@ public class TestMe
         {
             const string Template = @"
 /// <summary>
-/// It ### do something.
+/// It is used ### something.
 /// </summary>
 public class TestMe
 {
 }";
 
-            VerifyCSharpFix(Template.Replace("###", phrase), Template.Replace("###", Map[phrase]));
+            VerifyCSharpFix(Template.Replace("###", phrase.Trim()), Template.Replace("###", Map[phrase].Trim()));
         }
 
         protected override string GetDiagnosticId() => MiKo_2220_DocumentationShouldUseToSeekAnalyzer.Id;


### PR DESCRIPTION
- Handle 'to inspect for' mid-sentence

- Update replacement map and ordering

- Ensure correct 'to seek' insertion

(resolves #1606)