### PR TITLE
MiKo_1040, MiKo_1041 and MiKo_1070 now ignore 'IGrouping'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
@@ -31,6 +31,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
+            if (parameterType.IsIGrouping())
+            {
+                return false;
+            }
+
             return parameterType.IsEnumerable();
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
@@ -34,6 +34,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
+            if (type.IsIGrouping())
+            {
+                return false;
+            }
+
             return type.IsEnumerable();
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -43,6 +43,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
+            if (symbol.IsIGrouping())
+            {
+                return false;
+            }
+
             return symbol.IsEnumerable();
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -115,6 +115,17 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_IGrouping_parameter() => No_issue_is_reported_for(@"
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething(IGrouping<int, string> group)
+    { }
+}
+");
+
         [TestCase("string blaEnumList")]
         [TestCase("string blaList")]
         [TestCase("string blaCollection")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -28,6 +28,16 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_correctly_IGrouping_named_field() => No_issue_is_reported_for(@"
+using System.Linq;
+
+public class TestMe
+{
+    private IGrouping<int, string> _group;
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue")] string field)
             => No_issue_is_reported_for(@"
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -376,6 +376,27 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_IGrouping_node() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(IEnumerable<TestMe> items)
+    {
+        var itemsGroupedByName = items.GroupBy(_ => _.Name);
+
+        foreach (var itemGroup in itemsGroupedByName)
+        {
+        }
+    }
+}
+");
+
         [TestCase("number", "numbers")]
         [TestCase("resultOfSomething", "resultsOfSomething")]
         [TestCase("resultToShow", "resultsToShow")]


### PR DESCRIPTION
- Ignore `IGrouping` in collection analyzers

- Add tests for `IGrouping` exemptions

- Prevent false positives on grouping variables


(resolves #1609)