### PR TITLE
MiKo_1040, MiKo_1041 and MiKo_1070 now ignore 'IQueryable'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -1807,30 +1807,6 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsByteArray(this ITypeSymbol value) => value is IArrayTypeSymbol array && array.ElementType.IsByte();
 
         /// <summary>
-        /// Determines whether a type is an <see cref="IGrouping"/> interface.
-        /// </summary>
-        /// <param name="value">
-        /// The type to inspect.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if the type is an <see cref="IGrouping"/> interface; otherwise, <see langword="false"/>.
-        /// </returns>
-        internal static bool IsIGrouping(this ITypeSymbol value)
-        {
-            if (value.TypeKind is TypeKind.Interface)
-            {
-                switch (value.Name)
-                {
-                    case "IGrouping":
-                    case "System.Linq.IGrouping":
-                        return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Determines whether a type is a <see cref="CancellationToken"/>.
         /// </summary>
         /// <param name="value">
@@ -2129,18 +2105,54 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Determines whether a type is a Prism event.
+        /// Determines whether a type is an <see cref="IGrouping{TKey,TElement}"/> interface.
         /// </summary>
         /// <param name="value">
         /// The type to inspect.
         /// </param>
         /// <returns>
-        /// <see langword="true"/> if the type is a Prism event; otherwise, <see langword="false"/>.
+        /// <see langword="true"/> if the type is an <see cref="IGrouping{TKey,TElement}"/> interface; otherwise, <see langword="false"/>.
         /// </returns>
-        internal static bool IsPrismEvent(this ITypeSymbol value) => value.TypeKind is TypeKind.Class
-                                                                  && value.SpecialType is SpecialType.None
-                                                                  && value.ToString() != "Microsoft.Practices.Prism.Events.EventBase"
-                                                                  && value.InheritsFrom("Microsoft.Practices.Prism.Events.EventBase");
+        internal static bool IsIGrouping(this ITypeSymbol value)
+        {
+            if (value.TypeKind is TypeKind.Interface)
+            {
+                switch (value.Name)
+                {
+                    case "IGrouping":
+                    case "System.Linq.IGrouping":
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether a type is an <see cref="IQueryable"/> interface.
+        /// </summary>
+        /// <param name="value">
+        /// The type to inspect.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the type is an <see cref="IQueryable"/> interface; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsIQueryable(this ITypeSymbol value)
+        {
+            if (value.TypeKind is TypeKind.Interface)
+            {
+                switch (value.Name)
+                {
+                    case nameof(IQueryable):
+                    case nameof(IOrderedQueryable):
+                    case "System.Linq.IQueryable":
+                    case "System.Linq.IOrderedQueryable":
+                        return true;
+                }
+            }
+
+            return value.Implements<IQueryable>();
+        }
 
         /// <summary>
         /// Determines whether a type inherits from <see cref="EventArgs"/>.
@@ -2618,6 +2630,20 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsPartial(this IMethodSymbol value) => value.HasModifier(SyntaxKind.PartialKeyword);
+
+        /// <summary>
+        /// Determines whether a type is a Prism event.
+        /// </summary>
+        /// <param name="value">
+        /// The type to inspect.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the type is a Prism event; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsPrismEvent(this ITypeSymbol value) => value.TypeKind is TypeKind.Class
+                                                                     && value.SpecialType is SpecialType.None
+                                                                     && value.ToString() != "Microsoft.Practices.Prism.Events.EventBase"
+                                                                     && value.InheritsFrom("Microsoft.Practices.Prism.Events.EventBase");
 
         /// <summary>
         /// Determines whether a symbol is publicly visible.

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzer.cs
@@ -36,7 +36,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            return parameterType.IsEnumerable();
+            if (parameterType.IsEnumerable())
+            {
+                return parameterType.IsIQueryable() is false;
+            }
+
+            return false;
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzer.cs
@@ -39,7 +39,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            return type.IsEnumerable();
+            if (type.IsEnumerable())
+            {
+                return type.IsIQueryable() is false;
+            }
+
+            return false;
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -48,7 +48,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            return symbol.IsEnumerable();
+            if (symbol.IsEnumerable())
+            {
+                return symbol.IsIQueryable() is false;
+            }
+
+            return false;
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -115,13 +115,17 @@ public class TestMe
 }
 ");
 
-        [Test]
-        public void No_issue_is_reported_for_IGrouping_parameter() => No_issue_is_reported_for(@"
+        [TestCase("IGrouping<int, string> group")]
+        [TestCase("IQueryable query")]
+        [TestCase("IQueryable<int> query")]
+        [TestCase("IOrderedQueryable query")]
+        [TestCase("IOrderedQueryable<int> query")]
+        public void No_issue_is_reported_for_parameter_(string parameter) => No_issue_is_reported_for(@"
 using System.Linq;
 
 public class TestMe
 {
-    public void DoSomething(IGrouping<int, string> group)
+    public void DoSomething("" + parameter + @"")
     { }
 }
 ");

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -27,13 +27,17 @@ public class TestMe
 }
 ");
 
-        [Test]
-        public void No_issue_is_reported_for_correctly_IGrouping_named_field() => No_issue_is_reported_for(@"
+        [TestCase("IGrouping<int, string> group")]
+        [TestCase("IQueryable query")]
+        [TestCase("IQueryable<int> query")]
+        [TestCase("IOrderedQueryable query")]
+        [TestCase("IOrderedQueryable<int> query")]
+        public void No_issue_is_reported_for_field_(string field) => No_issue_is_reported_for(@"
 using System.Linq;
 
 public class TestMe
 {
-    private IGrouping<int, string> _group;
+    private " + field + @";
 }
 ");
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -184,16 +184,19 @@ public class TestMe
 }
 ");
 
-        [Test]
-        public void No_issue_is_reported_for_method_with_IGrouping() => No_issue_is_reported_for(@"
-using System;
+        [TestCase("IGrouping<int, string> group")]
+        [TestCase("IQueryable query")]
+        [TestCase("IQueryable<int> query")]
+        [TestCase("IOrderedQueryable query")]
+        [TestCase("IOrderedQueryable<int> query")]
+        public void No_issue_is_reported_for_method_with_(string variable) => No_issue_is_reported_for(@"
 using System.Linq;
 
 public class TestMe
 {
     public void DoSomething()
     {
-        IGrouping<string, string> group = null;
+        " + variable + @" = null;
     }
 }
 ");


### PR DESCRIPTION
- Add `IQueryable` type detection helper

- Exclude `IQueryable` from collection naming rules

- Add tests for `IQueryable` exclusions

- Adjust `IGrouping` helper placement

(resolves #1611)