### PR TITLE
MiKo_2050 is now aware of 'Represents an exception that occurs during' and nullable strings

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1620,14 +1620,24 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static bool IsException(this TypeSyntax value, Type exceptionType)
         {
-            if (value is PredefinedTypeSyntax)
+            while (true)
             {
-                return false;
+                switch (value)
+                {
+                    case PredefinedTypeSyntax _:
+                        return false;
+
+                    case NullableTypeSyntax nullable:
+                        value = nullable.ElementType;
+
+                        continue;
+
+                    default:
+                        var s = value.ToString();
+
+                        return s == exceptionType.Name || s == exceptionType.FullName;
+                }
             }
-
-            var s = value.ToString();
-
-            return s == exceptionType.Name || s == exceptionType.FullName;
         }
 
         /// <summary>
@@ -2059,19 +2069,30 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static bool IsString(this TypeSyntax value)
         {
-            if (value is PredefinedTypeSyntax predefined)
+            while (true)
             {
-                return predefined.Keyword.IsKind(SyntaxKind.StringKeyword);
-            }
+                switch (value)
+                {
+                    case PredefinedTypeSyntax predefined:
+                        return predefined.Keyword.IsKind(SyntaxKind.StringKeyword);
 
-            switch (value.ToString())
-            {
-                case nameof(String):
-                case nameof(System) + "." + nameof(String):
-                    return true;
-            }
+                    case NullableTypeSyntax nullable:
+                        value = nullable.ElementType;
 
-            return false;
+                        continue;
+
+                    default:
+                        switch (value.ToString())
+                        {
+                            case nameof(String):
+                            case nameof(System) + "." + nameof(String):
+                                return true;
+
+                            default:
+                                return false;
+                        }
+                }
+            }
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -15,9 +14,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2050_CodeFixProvider : OverallDocumentationCodeFixProvider
     {
 //// ncrunch: rdi off
-        private static readonly string[] TypeReplacementMapKeys = CreateTypePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase).ToArray();
+        private static readonly Pair[] TypeReplacementMap = CreateTypePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase).OrderDescendingByLengthAndText().ToArray(_ => new Pair(_));
 
-        private static readonly Pair[] TypeReplacementMap = TypeReplacementMapKeys.ToArray(_ => new Pair(_));
+        private static readonly string[] TypeReplacementMapKeys = TypeReplacementMap.ToArray(_ => _.Key);
+
+        private static readonly Pair[] TypeCleanupMap =
+                                                        {
+                                                            new Pair("when during", "when an error occurs during"),
+                                                        };
+
+        private static readonly string[] TypeCleanupMapKeys = TypeCleanupMap.ToArray(_ => _.Key);
+
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2050";
@@ -37,23 +44,23 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static DocumentationCommentTriviaSyntax FixTypeSummary(DocumentationCommentTriviaSyntax comment)
         {
-            const string Phrase = Constants.Comments.ExceptionTypeSummaryStartingPhrase;
-
             var summaries = comment.GetXmlSyntax(Constants.XmlTag.Summary);
 
             if (summaries.Count is 0)
             {
-                var newSummary = Comment(SyntaxFactory.XmlSummaryElement(), Phrase).WithTrailingXmlComment();
+                var newSummary = Comment(SyntaxFactory.XmlSummaryElement(), Constants.Comments.ExceptionTypeSummaryStartingPhrase).WithTrailingXmlComment();
 
                 return comment.InsertNodeAfter(comment.Content[0], newSummary);
             }
             else
             {
                 var summary = summaries[0];
-                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordAdjustment.StartLowerCase);
-                var newSummary = CommentStartingWith(preparedSummary, Phrase);
 
-                return comment.ReplaceNode(summary, newSummary);
+                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordAdjustment.StartLowerCase);
+                var newSummary = CommentStartingWith(preparedSummary, Constants.Comments.ExceptionTypeSummaryStartingPhrase);
+                var updatedSummary = Comment(newSummary, TypeCleanupMapKeys, TypeCleanupMap);
+
+                return comment.ReplaceNode(summary, updatedSummary);
             }
         }
 
@@ -80,18 +87,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return FixSerializationParamCtor(type, parameters[0], parameters[1]);
             }
 
-            var summary = Comment(SyntaxFactory.XmlSummaryElement(), "Determines whether the specified ", SeeCref(type), " instances are considered not equal.").WithTrailingXmlComment();
-            var param1 = ParameterComment(parameters[0], "The first value to compare.").WithTrailingXmlComment();
-            var param2 = ParameterComment(parameters[1], "The second value to compare.").WithTrailingXmlComment();
-
-            var returns = SyntaxFactory.XmlReturnsElement(
-                                                      SeeLangword_True().WithLeadingXmlComment(),
-                                                      XmlText(" if both instances are considered not equal; otherwise, "),
-                                                      SeeLangword_False(),
-                                                      XmlText(".").WithTrailingXmlComment())
-                                       .WithEndOfLine();
-
-            return SyntaxFactory.DocumentationComment(summary, param1, param2, returns);
+            return FixParameterlessCtor(type);
         }
 
         private static DocumentationCommentTriviaSyntax FixParameterlessCtor(TypeSyntax type)
@@ -191,7 +187,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                  "A general exception", "An general exception", "The general exception", "This general exception", "General exception",
                                  "A most general exception", "An most general exception", "The most general exception", "This most general exception", "Most general exception",
                              };
-            var verbs = new[] { "that is thrown", "which is thrown", "is thrown", "thrown", "to throw", "that is fired", "which is fired", "fired", "to fire" };
+            var verbs = new[] { "that is thrown", "which is thrown", "is thrown", "thrown", "to throw", "that is fired", "which is fired", "fired", "to fire", "that occurs", "which occurs" };
             var conditions = new[] { "if", "when", "in case" };
 
             var results = new HashSet<string>();
@@ -216,6 +212,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 results.Add(start + " that indicates that ");
                 results.Add(start + " which indicates that ");
                 results.Add(start + " indicating that ");
+                results.Add(start + " that occurs ");
+                results.Add(start + " which occurs ");
 
                 foreach (var verb in verbs)
                 {
@@ -223,6 +221,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var begin = string.Concat(start, middle);
                     var beginLowerCase = begin.ToLowerCaseAt(0);
+
+                    results.Add(string.Concat("Represent ", beginLowerCase));
+                    results.Add(string.Concat("Represents ", beginLowerCase));
 
                     foreach (var condition in conditions)
                     {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
@@ -17,621 +17,675 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] StartingPhrases = [.. CreatePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase.Trim())];
 
         [Test]
-        public void No_issue_is_reported_for_non_exception_class() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_exception_class() => No_issue_is_reported_for("""
 
-/// <summary>
-/// Something...
-/// </summary>
-[Serializable]
-public sealed class BlaBla
-{
-    /// <overloads>
-    /// <summary>
-    /// Ctor.
-    /// </summary>
-    /// </overloads>
-    /// <summary>
-    /// Ctor.
-    /// </summary>
-    public BlaBla()
-    {
-    }
+            using System;
+            using System.Runtime.Serialization;
 
-    /// <summary>
-    /// Ctor.
-    /// </summary>
-    /// <param name=""message"">
-    /// whatever
-    /// </param>
-    public BlaBla(string message)
-        : base(message)
-    {
-    }
+            /// <summary>
+            /// Something...
+            /// </summary>
+            [Serializable]
+            public sealed class BlaBla
+            {
+                /// <overloads>
+                /// <summary>
+                /// Ctor.
+                /// </summary>
+                /// </overloads>
+                /// <summary>
+                /// Ctor.
+                /// </summary>
+                public BlaBla()
+                {
+                }
 
-    /// <summary>
-    /// Ctor.
-    /// </summary>
-    /// <param name=""message"">
-    /// whatever
-    /// </param>
-    /// <param name=""innerException"">
-    /// Some stuff.
-    /// </param>
-    public BlaBla(string message, Exception innerException) : base(message, innerException)
-    {
-    }
+                /// <summary>
+                /// Ctor.
+                /// </summary>
+                /// <param name="message">
+                /// whatever
+                /// </param>
+                public BlaBla(string message)
+                    : base(message)
+                {
+                }
 
-    /// <summary>
-    /// Ctor.
-    /// </summary>
-    /// <param name=""info"">
-    /// p1
-    /// </param>
-    /// <param name=""context"">
-    /// p2
-    /// </param>
-    /// <remarks>
-    /// Unimportant.
-    /// </remarks>
-    private BlaBla(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+                /// <summary>
+                /// Ctor.
+                /// </summary>
+                /// <param name="message">
+                /// whatever
+                /// </param>
+                /// <param name="innerException">
+                /// Some stuff.
+                /// </param>
+                public BlaBla(string message, Exception innerException) : base(message, innerException)
+                {
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-/// <summary>
-/// The exception that is thrown when ...
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <overloads>
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    /// </overloads>
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    public BlaBlaException()
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    public BlaBlaException(string message)
-        : base(message)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception that is the cause of the current exception.
-    /// <para />
-    /// If the <paramref name=""innerException"" /> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+                /// <summary>
+                /// Ctor.
+                /// </summary>
+                /// <param name="info">
+                /// p1
+                /// </param>
+                /// <param name="context">
+                /// p2
+                /// </param>
+                /// <remarks>
+                /// Unimportant.
+                /// </remarks>
+                private BlaBla(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_type() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception() => No_issue_is_reported_for("""
 
-/// <summary>
-/// The exception that is thrown when ...
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void No_issue_is_reported_for_non_documented_exception_type() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+            /// <summary>
+            /// The exception that is thrown when ...
+            /// </summary>
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <overloads>
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                /// </overloads>
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                public BlaBlaException()
+                {
+                }
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}");
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                public BlaBlaException(string message)
+                    : base(message)
+                {
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_without_params() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                /// <param name="innerException">
+                /// The exception that is the cause of the current exception.
+                /// <para />
+                /// If the <paramref name="innerException" /> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                /// </param>
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <overloads>
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    /// </overloads>
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    public BlaBlaException()
-    {
-    }
-}");
-
-        [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_without_params() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    public BlaBlaException()
-    {
-    }
-}");
-
-        [Test]
-        public void No_issue_is_reported_for_correctly_documented_but_missing_overloads_exception_ctor_without_params() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    public BlaBlaException()
-    {
-    }
-}");
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                /// <remarks>
+                /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception_type() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    public BlaBlaException(string message)
-        : base(message)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            /// <summary>
+            /// The exception that is thrown when ...
+            /// </summary>
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_documented_exception_type() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    public BlaBlaException(string message)
-        : base(message)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception_ctor_without_params() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception that is the cause of the current exception.
-    /// <para />
-    /// If the <paramref name=""innerException"" /> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <overloads>
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                /// </overloads>
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                public BlaBlaException()
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_documented_exception_ctor_without_params() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                public BlaBlaException()
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_but_missing_overloads_exception_ctor_without_params() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void No_issue_is_reported_for_correctly_documented_but_missing_remarks_exception_ctor_with_serialization_param() => No_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                public BlaBlaException()
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_exception_type() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for("""
 
-/// <summary>
-/// Thrown ...
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_overloads_on_exception_ctor_without_params() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <overloads>
-    /// <summary>
-    /// Some overload.
-    /// </summary>
-    /// </overloads>
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    public BlaBlaException()
-    {
-    }
-}");
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                public BlaBlaException(string message)
+                    : base(message)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    public BlaBlaException(string message)
-        : base(message)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                public BlaBlaException(string message)
+                    : base(message)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message.
-    /// </param>
-    public BlaBlaException(string message)
-        : base(message)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception that is the cause of the current exception.
-    /// <para />
-    /// If the <paramref name=""innerException"" /> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                /// <param name="innerException">
+                /// The exception that is the cause of the current exception.
+                /// <para />
+                /// If the <paramref name="innerException" /> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                /// </param>
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception that is the cause of the current exception.
-    /// <para />
-    /// If the <paramref name=""innerException"" /> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_exception_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception.
-    /// <para />
-    /// If the <paramref name=""innerException"" /> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
 
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
-
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}");
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                /// <remarks>
+                /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_SerializationInfo_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_non_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The serialization info.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_StreamingContext_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void No_issue_is_reported_for_correctly_documented_but_missing_remarks_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The streaming context.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_remarks_on_exception_ctor_with_serialization_param() => An_issue_is_reported_for(@"
-using System;
-using System.Runtime.Serialization;
+        public void An_issue_is_reported_for_incorrectly_documented_exception_type() => An_issue_is_reported_for("""
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// Some remarks.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}");
+            using System;
+            using System.Runtime.Serialization;
+
+            /// <summary>
+            /// Thrown ...
+            /// </summary>
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_overloads_on_exception_ctor_without_params() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <overloads>
+                /// <summary>
+                /// Some overload.
+                /// </summary>
+                /// </overloads>
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                public BlaBlaException()
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                public BlaBlaException(string message)
+                    : base(message)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                /// </summary>
+                /// <param name="message">
+                /// The error message.
+                /// </param>
+                public BlaBlaException(string message)
+                    : base(message)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                /// <param name="innerException">
+                /// The exception that is the cause of the current exception.
+                /// <para />
+                /// If the <paramref name="innerException" /> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                /// </param>
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                /// </summary>
+                /// <param name="message">
+                /// The error message.
+                /// </param>
+                /// <param name="innerException">
+                /// The exception that is the cause of the current exception.
+                /// <para />
+                /// If the <paramref name="innerException" /> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                /// </param>
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_exception_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                /// </summary>
+                /// <param name="message">
+                /// The error message that explains the reason for the exception.
+                /// </param>
+                /// <param name="innerException">
+                /// The exception.
+                /// <para />
+                /// If the <paramref name="innerException" /> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                /// </param>
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                /// <remarks>
+                /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+                public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_SerializationInfo_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The serialization info.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                /// <remarks>
+                /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_StreamingContext_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The streaming context.
+                /// </param>
+                /// <remarks>
+                /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_remarks_on_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Runtime.Serialization;
+
+            [Serializable]
+            public sealed class BlaBlaException : Exception
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                /// </summary>
+                /// <param name="info">
+                /// The object that holds the serialized object data.
+                /// </param>
+                /// <param name="context">
+                /// The contextual information about the source or destination.
+                /// </param>
+                /// <remarks>
+                /// Some remarks.
+                /// </remarks>
+                private BlaBlaException(SerializationInfo info, StreamingContext context)
+                    : base(info, context)
+                {
+                }
+            }
+            """);
 
         [Test]
         public void Code_gets_fixed_for_exception_type_with_empty_summary_on_same_line()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-/// <summary></summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                /// <summary></summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
-/// <summary>
-/// The exception that is thrown when 
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when 
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -639,28 +693,32 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_exception_type_with_empty_summary_on_different_lines()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-/// <summary>
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                /// <summary>
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
-/// <summary>
-/// The exception that is thrown when 
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when 
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -668,29 +726,33 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_exception_type_with_summary_on_different_lines()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-/// <summary>
-/// Something is done.
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                /// <summary>
+                /// Something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
-/// <summary>
-/// The exception that is thrown when something is done.
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -698,29 +760,35 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_exception_type_with_summary_on_different_lines_([ValueSource(nameof(StartingPhrases))] string message)
         {
-            var originalCode = @"
-using System;
-using System.Runtime.Serialization;
+            var originalCode = """
 
-/// <summary>
-/// " + message + @" something is done.
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                /// <summary>
+                /// 
+                """ + message + """
+                 something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
-/// <summary>
-/// The exception that is thrown when something is done.
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
             VerifyCSharpFix(originalCode, FixedCode);
         }
@@ -728,27 +796,31 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_exception_type_with_a_filled_summary_on_same_line()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-/// <summary>Something is done.</summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                /// <summary>Something is done.</summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
-/// <summary>
-/// The exception that is thrown when something is done.
-/// </summary>
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -766,51 +838,92 @@ public sealed class BlaBlaException : Exception
 {
 }";
 
-            const string FixedCode = @"
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                /// <summary>
+                /// The exception that is thrown when something is done.
+                /// </summary>
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                }
+                """;
+
+            VerifyCSharpFix(originalCode, FixedCode);
+        }
+
+        [TestCase("Represents an exception that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Represents an exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("An exception that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("An exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("The exception that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("The exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Exception that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        public void Code_gets_fixed_for_exception_type_with_special_summary_on_same_line_(string originalMessage, string fixedMessage)
+        {
+            var originalCode = @"
+using System;
+using System.Runtime.Serialization;
+
+/// <summary>" + originalMessage + @".</summary>
+[Serializable]
+public sealed class BlaBlaException : Exception
+{
+}";
+
+            var fixedCode = @"
 using System;
 using System.Runtime.Serialization;
 
 /// <summary>
-/// The exception that is thrown when something is done.
+/// " + fixedMessage + @".
 /// </summary>
 [Serializable]
 public sealed class BlaBlaException : Exception
 {
 }";
 
-            VerifyCSharpFix(originalCode, FixedCode);
+            VerifyCSharpFix(originalCode, fixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_parameterless_ctor()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary></summary>
-    public BlaBlaException()
-    {
-    }
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException()
+                    {
+                    }
+                }
+                """;
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class.
-    /// </summary>
-    public BlaBlaException()
-    {
-    }
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class.
+                    /// </summary>
+                    public BlaBlaException()
+                    {
+                    }
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -818,36 +931,40 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_message_only_ctor_lower_case()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary></summary>
-    public BlaBlaException(string message)
-    {
-    }
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException(string message)
+                    {
+                    }
+                }
+                """;
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    public BlaBlaException(string message)
-    {
-    }
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    public BlaBlaException(string message)
+                    {
+                    }
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -855,36 +972,122 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_message_only_ctor_upper_case()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary></summary>
-    public BlaBlaException(String message)
-    {
-    }
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException(String message)
+                    {
+                    }
+                }
+                """;
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    public BlaBlaException(String message)
-    {
-    }
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    public BlaBlaException(String message)
+                    {
+                    }
+                }
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nullable_message_only_ctor_lower_case()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException(string? message)
+                    {
+                    }
+                }
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    public BlaBlaException(string? message)
+                    {
+                    }
+                }
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nullable_message_only_ctor_upper_case()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException(String? message)
+                    {
+                    }
+                }
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    public BlaBlaException(String? message)
+                    {
+                    }
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -892,41 +1095,93 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_message_exception_ctor()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary></summary>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                    {
+                    }
+                }
+                """;
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
-    /// </summary>
-    /// <param name=""message"">
-    /// The error message that explains the reason for the exception.
-    /// </param>
-    /// <param name=""innerException"">
-    /// The exception that is the cause of the current exception.
-    /// <para/>
-    /// If the <paramref name=""innerException""/> parameter is not <see langword=""null""/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
-    /// </param>
-    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    /// <param name="innerException">
+                    /// The exception that is the cause of the current exception.
+                    /// <para/>
+                    /// If the <paramref name="innerException"/> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                    /// </param>
+                    public BlaBlaException(string message, Exception innerException) : base(message, innerException)
+                    {
+                    }
+                }
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nullable_message_exception_ctor()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// 
+                    /// </summary>
+                    public BlaBlaException(string? message, Exception? innerException) : base(message, innerException)
+                    {
+                    }
+                }
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+                    /// </summary>
+                    /// <param name="message">
+                    /// The error message that explains the reason for the exception.
+                    /// </param>
+                    /// <param name="innerException">
+                    /// The exception that is the cause of the current exception.
+                    /// <para/>
+                    /// If the <paramref name="innerException"/> parameter is not <see langword="null"/>, the current exception is raised in a <b>catch</b> block that handles the inner exception.
+                    /// </param>
+                    public BlaBlaException(string? message, Exception? innerException) : base(message, innerException)
+                    {
+                    }
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -934,44 +1189,48 @@ public sealed class BlaBlaException : Exception
         [Test]
         public void Code_gets_fixed_for_serialization_ctor()
         {
-            const string OriginalCode = @"
-using System;
-using System.Runtime.Serialization;
+            const string OriginalCode = """
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary></summary>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}";
+                using System;
+                using System.Runtime.Serialization;
 
-            const string FixedCode = @"
-using System;
-using System.Runtime.Serialization;
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary></summary>
+                    private BlaBlaException(SerializationInfo info, StreamingContext context)
+                        : base(info, context)
+                    {
+                    }
+                }
+                """;
 
-[Serializable]
-public sealed class BlaBlaException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref=""BlaBlaException""/> class with serialized data.
-    /// </summary>
-    /// <param name=""info"">
-    /// The object that holds the serialized object data.
-    /// </param>
-    /// <param name=""context"">
-    /// The contextual information about the source or destination.
-    /// </param>
-    /// <remarks>
-    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
-    /// </remarks>
-    private BlaBlaException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-}";
+            const string FixedCode = """
+
+                using System;
+                using System.Runtime.Serialization;
+
+                [Serializable]
+                public sealed class BlaBlaException : Exception
+                {
+                    /// <summary>
+                    /// Initializes a new instance of the <see cref="BlaBlaException"/> class with serialized data.
+                    /// </summary>
+                    /// <param name="info">
+                    /// The object that holds the serialized object data.
+                    /// </param>
+                    /// <param name="context">
+                    /// The contextual information about the source or destination.
+                    /// </param>
+                    /// <remarks>
+                    /// This constructor is invoked during deserialization to reconstitute the exception object transmitted over a stream.
+                    /// </remarks>
+                    private BlaBlaException(SerializationInfo info, StreamingContext context)
+                        : base(info, context)
+                    {
+                    }
+                }
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }


### PR DESCRIPTION
- Fix constructor comment for exception ctors

- Support nullable string and exception params

- Normalize "Represents ... occurs" summaries

- Expand phrase detection for exception types

(resolves #1617)
(resolves #1619)