### PR TITLE
MiKo_5019 now ignores 'StreamingContext' parameters

### DIFF
--- a/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5019_InParameterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5019_InParameterAnalyzerTests.cs
@@ -219,6 +219,17 @@ public class TestMe : EqualityComparer<int>
 ");
 
         [Test]
+        public void No_issue_gets_reported_for_StreamingContext() => No_issue_is_reported_for(@"
+using System;
+using System.Runtime.Serialization;
+
+public class TestMe
+{
+    public bool DoSomething(StreamingContext context) => true;
+}
+");
+
+        [Test]
         public void No_issue_gets_reported_for_readonly_struct_as_parameter_with_in_modifier() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Ignore `StreamingContext` parameters in analyzer

- Prevent false positives on constructors

- Add test covering `StreamingContext` case

(resolves #1618)
