### PR TITLE
MiKo_2050 is now aware of phrase 'Represents errors that occur during'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -186,8 +186,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                  "A exception", "An exception", "The exception", "This exception", "Exception",
                                  "A general exception", "An general exception", "The general exception", "This general exception", "General exception",
                                  "A most general exception", "An most general exception", "The most general exception", "This most general exception", "Most general exception",
+                                 "A error", "An error", "The error", "This error", "Error", "Errors", "errors",
                              };
-            var verbs = new[] { "that is thrown", "which is thrown", "is thrown", "thrown", "to throw", "that is fired", "which is fired", "fired", "to fire", "that occurs", "which occurs" };
+            var verbs = new[] { "that is thrown", "which is thrown", "is thrown", "thrown", "to throw", "that is fired", "which is fired", "fired", "to fire", "that occurs", "which occurs", "that occur", "which occur" };
             var conditions = new[] { "if", "when", "in case" };
 
             var results = new HashSet<string>();
@@ -214,6 +215,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 results.Add(start + " indicating that ");
                 results.Add(start + " that occurs ");
                 results.Add(start + " which occurs ");
+                results.Add(start + " that occur ");
+                results.Add(start + " which occur ");
 
                 foreach (var verb in verbs)
                 {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
@@ -863,6 +863,10 @@ public sealed class BlaBlaException : Exception
         [TestCase("The exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
         [TestCase("Exception that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
         [TestCase("Exception which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Represents errors that occur during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Represents errors which occur during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Represents an error that occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
+        [TestCase("Represents an error which occurs during some operations", "The exception that is thrown when an error occurs during some operations")]
         public void Code_gets_fixed_for_exception_type_with_special_summary_on_same_line_(string originalMessage, string fixedMessage)
         {
             var originalCode = @"


### PR DESCRIPTION
- Extend phrase detection to include "error(s)"

- Support plural "occur" verb forms

- Generate additional phrase variants

- Add tests for new summaries

(resolves #1623)