### PR TITLE
MiKo_2033 is now aware of 'the string result'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -53,6 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                         new Pair("that contains the formatted string", "that contains the formatted result"),
                                                         new Pair("that contains a ", "that contains the "),
                                                         new Pair("that contains value ", "that contains the value "),
+                                                        new Pair(" string result ", " result "),
                                                     };
 
         private static readonly string[] CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -50,174 +50,192 @@ public class TestMe
         public void No_issue_is_reported_for_method_that_returns_a_(
                                                                 [Values("returns", "value")] string xmlTag,
                                                                 [Values("void", "int", "Task", "Task<int>", "Task<bool>")] string returnType)
-            => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => No_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// Something.
-    /// </" + xmlTag + @">
-    public " + returnType + @" DoSomething(object o) => throw new NotSupportedException();
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// Something.
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} DoSomething(object o) => throw new NotSupportedException();
+                                          }
+
+                                          """);
 
         [Test, Combinatorial]
         public void No_issue_is_reported_for_correctly_commented_String_only_method_(
                                                                                  [Values("returns", "value")] string xmlTag,
                                                                                  [Values("", " ")] string space,
                                                                                  [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
-            => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => No_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// A " + "<see cref=\"" + returnType + "\"" + space + @"/> that contains something.
-    /// </" + xmlTag + @">
-    public " + returnType + @" DoSomething(object o) => null;
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// A <see cref="{{returnType}}"{{space}}/> that contains something.
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} DoSomething(object o) => null;
+                                          }
+
+                                          """);
 
         [Test, Combinatorial]
         public void No_issue_is_reported_for_correctly_commented_consist_String_only_method_(
                                                                                          [Values("returns", "value")] string xmlTag,
                                                                                          [Values("", " ")] string space,
                                                                                          [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
-            => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => No_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// A " + "<see cref=\"" + returnType + "\"" + space + @"/> that consists of something.
-    /// </" + xmlTag + @">
-    public " + returnType + @" DoSomething(object o) => null;
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// A <see cref="{{returnType}}"{{space}}/> that consists of something.
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} DoSomething(object o) => null;
+                                          }
+
+                                          """);
 
         [Test, Combinatorial]
         public void No_issue_is_reported_for_correctly_commented_ToString_method_(
                                                                               [Values("returns")] string xmlTag,
                                                                               [Values("", " ")] string space,
                                                                               [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
-            => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => No_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// A " + "<see cref=\"" + returnType + "\"" + space + @"/> that represents the current object.
-    /// </" + xmlTag + @">
-    public " + returnType + @" ToString() => null;
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// A <see cref="{{returnType}}"{{space}}/> that represents the current object.
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} ToString() => null;
+                                          }
+
+                                          """);
 
         [Test, Combinatorial]
         public void No_issue_is_reported_for_correctly_commented_String_Task_method_(
                                                                                  [Values("returns", "value")] string xmlTag,
                                                                                  [Values("", " ")] string space,
                                                                                  [ValueSource(nameof(StringTaskReturnValues))] string returnType)
-            => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => No_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// A task that represents the asynchronous operation. The value of the <see cref=""System.Threading.Tasks.Task{TResult}.Result" + "\"" + space + @" /> parameter returns a <see cref=""System.String" + "\"" + space + @"/> that contains something.
-    /// </" + xmlTag + @">
-    public " + returnType + @" DoSomething(object o) => null;
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// A task that represents the asynchronous operation. The value of the <see cref="System.Threading.Tasks.Task{TResult}.Result"{{space}}/> parameter returns a <see cref="System.String"{{space}}/> that contains something.
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} DoSomething(object o) => null;
+                                          }
+
+                                          """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_String_interned_method() => No_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+        public void No_issue_is_reported_for_correctly_commented_String_interned_method() => No_issue_is_reported_for("""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// An interned copy of the <see cref=""string""/> that contains something.
-    /// </returns>
-    public string DoSomething(object o) => null;
-}
-");
+                                                                                                                      using System;
+                                                                                                                      using System.Threading.Tasks;
+
+                                                                                                                      public class TestMe
+                                                                                                                      {
+                                                                                                                          /// <summary>
+                                                                                                                          /// Does something.
+                                                                                                                          /// </summary>
+                                                                                                                          /// <returns>
+                                                                                                                          /// An interned copy of the <see cref="string"/> that contains something.
+                                                                                                                          /// </returns>
+                                                                                                                          public string DoSomething(object o) => null;
+                                                                                                                      }
+
+                                                                                                                      """);
 
         [Test, Combinatorial]
         public void An_issue_is_reported_for_wrong_commented_method_(
                                                                  [Values("returns", "value")] string xmlTag,
                                                                  [Values("A whatever", "An whatever", "The whatever")] string comment,
                                                                  [ValueSource(nameof(StringReturnValues))] string returnType)
-            => An_issue_is_reported_for(@"
-using System;
-using System.Threading.Tasks;
+            => An_issue_is_reported_for($$"""
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <" + xmlTag + @">
-    /// " + comment + @"
-    /// </" + xmlTag + @">
-    public " + returnType + @" DoSomething(object o) => null;
-}
-");
+                                          using System;
+                                          using System.Threading.Tasks;
+
+                                          public class TestMe
+                                          {
+                                              /// <summary>
+                                              /// Does something.
+                                              /// </summary>
+                                              /// <{{xmlTag}}>
+                                              /// {{comment}}
+                                              /// </{{xmlTag}}>
+                                              public {{returnType}} DoSomething(object o) => null;
+                                          }
+
+                                          """);
 
         [Test]
         public void Code_gets_fixed_for_non_generic_method()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>Something.</returns>
-    public string DoSomething(object o) => null;
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>Something.</returns>
+                                            public string DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains something.
-    /// </returns>
-    public string DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that contains something.
+                                         /// </returns>
+                                         public string DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -225,35 +243,39 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_non_generic_method_with_line_break()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// Something.
-    /// </returns>
-    public string DoSomething(object o) => null;
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>
+                                            /// Something.
+                                            /// </returns>
+                                            public string DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains something.
-    /// </returns>
-    public string DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that contains something.
+                                         /// </returns>
+                                         public string DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -341,20 +363,22 @@ public class TestMe
 }
 ";
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains the text.
-    /// </returns>
-    public string DoSomething(object o) => null;
-}
-";
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that contains the text.
+                                         /// </returns>
+                                         public string DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(originalCode, FixedCode);
         }
@@ -412,35 +436,39 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_generic_method()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>Something.</returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>Something.</returns>
+                                            public Task<string> DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> that contains something.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A task that represents the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> that contains something.
+                                         /// </returns>
+                                         public Task<string> DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -448,37 +476,41 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_almost_correct_generic_method()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The Result is something.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>
+                                            /// A task that represents the asynchronous operation. The Result is something.
+                                            /// </returns>
+                                            public Task<string> DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> that contains something.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A task that represents the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> that contains something.
+                                         /// </returns>
+                                         public Task<string> DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -486,37 +518,41 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_almost_correct_phrase()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The <see cref=""Task{TResult}.Result""/> property on the task object returns a <see cref=""string""/> that contains something.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>
+                                            /// A task that represents the asynchronous operation. The <see cref="Task{TResult}.Result"/> property on the task object returns a <see cref="string"/> that contains something.
+                                            /// </returns>
+                                            public Task<string> DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> that contains something.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A task that represents the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> that contains something.
+                                         /// </returns>
+                                         public Task<string> DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -524,53 +560,57 @@ public class TestMe
         [Test(Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/366")]
         public void Code_gets_fixed_for_issue_366()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets the literal ""Foo"".
-    /// </summary>
-    /// <value>
-    /// The Foo.
-    /// </value>
-    public string Foo => ""Foo"";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-    /// <summary>
-    /// Gets the literal ""Bar"".
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains the Bar.
-    /// </returns>
-    public string Bar() => ""Bar"";
-}
-";
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Gets the literal "Foo".
+                                            /// </summary>
+                                            /// <value>
+                                            /// The Foo.
+                                            /// </value>
+                                            public string Foo => "Foo";
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                            /// <summary>
+                                            /// Gets the literal "Bar".
+                                            /// </summary>
+                                            /// <returns>
+                                            /// A <see cref="string"/> that contains the Bar.
+                                            /// </returns>
+                                            public string Bar() => "Bar";
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets the literal ""Foo"".
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains the Foo.
-    /// </value>
-    public string Foo => ""Foo"";
+                                        """;
 
-    /// <summary>
-    /// Gets the literal ""Bar"".
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains the Bar.
-    /// </returns>
-    public string Bar() => ""Bar"";
-}
-";
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets the literal "Foo".
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains the Foo.
+                                         /// </value>
+                                         public string Foo => "Foo";
+
+                                         /// <summary>
+                                         /// Gets the literal "Bar".
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that contains the Bar.
+                                         /// </returns>
+                                         public string Bar() => "Bar";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -578,53 +618,57 @@ public class TestMe
         [Test(Description = "Reverse-ordered Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/366")]
         public void Code_gets_fixed_for_issue_366_order_reversed()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets the literal ""Bar"".
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains the Bar.
-    /// </returns>
-    public string Bar() => ""Bar"";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-    /// <summary>
-    /// Gets the literal ""Foo"".
-    /// </summary>
-    /// <value>
-    /// The Foo.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Gets the literal "Bar".
+                                            /// </summary>
+                                            /// <returns>
+                                            /// A <see cref="string"/> that contains the Bar.
+                                            /// </returns>
+                                            public string Bar() => "Bar";
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                            /// <summary>
+                                            /// Gets the literal "Foo".
+                                            /// </summary>
+                                            /// <value>
+                                            /// The Foo.
+                                            /// </value>
+                                            public string Foo => "Foo";
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets the literal ""Bar"".
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that contains the Bar.
-    /// </returns>
-    public string Bar() => ""Bar"";
+                                        """;
 
-    /// <summary>
-    /// Gets the literal ""Foo"".
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains the Foo.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets the literal "Bar".
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that contains the Bar.
+                                         /// </returns>
+                                         public string Bar() => "Bar";
+
+                                         /// <summary>
+                                         /// Gets the literal "Foo".
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains the Foo.
+                                         /// </value>
+                                         public string Foo => "Foo";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -633,37 +677,41 @@ public class TestMe
         [TestCase("some ", Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/401")]
         public void Code_gets_fixed_for_non_generic_method_and_issue_401_when_phrase_is_almost_correct_(string phrase)
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> returning ###<c>Foo</c>.
-    /// <see cref=""TestMe"" /> for more details.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Gets something.
+                                            /// </summary>
+                                            /// <value>
+                                            /// A <see cref="string"/> returning ###<c>Foo</c>.
+                                            /// <see cref="TestMe" /> for more details.
+                                            /// </value>
+                                            public string Foo => "Foo";
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains ###<c>Foo</c>.
-    /// <see cref=""TestMe"" /> for more details.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains ###<c>Foo</c>.
+                                         /// <see cref="TestMe" /> for more details.
+                                         /// </value>
+                                         public string Foo => "Foo";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode.Replace("###", phrase), FixedCode.Replace("###", phrase));
         }
@@ -671,37 +719,41 @@ public class TestMe
         [Test(Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/401")]
         public void Code_gets_fixed_for_non_generic_method_and_issue_401_when_complete_phrase_gets_added()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// The <c>Foo</c>.
-    /// <see cref=""TestMe"" /> for more details.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Gets something.
+                                            /// </summary>
+                                            /// <value>
+                                            /// The <c>Foo</c>.
+                                            /// <see cref="TestMe" /> for more details.
+                                            /// </value>
+                                            public string Foo => "Foo";
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains the <c>Foo</c>.
-    /// <see cref=""TestMe"" /> for more details.
-    /// </value>
-    public string Foo => ""Foo"";
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains the <c>Foo</c>.
+                                         /// <see cref="TestMe" /> for more details.
+                                         /// </value>
+                                         public string Foo => "Foo";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -709,35 +761,39 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_generic_method_and_issue_401_when_phrase_is_almost_correct_variant_1()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>A task representing the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> containing the <c>Foo</c>.</returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>A task representing the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> containing the <c>Foo</c>.</returns>
+                                            public Task<string> DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> that contains the <c>Foo</c>.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A task that represents the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> that contains the <c>Foo</c>.
+                                         /// </returns>
+                                         public Task<string> DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -745,37 +801,41 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_generic_method_and_issue_401_when_phrase_is_almost_correct_variant_2()
         {
-            const string OriginalCode = @"
-using System;
-using System.Threading.Tasks;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task representing the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> containing the <c>Foo</c>.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        using System;
+                                        using System.Threading.Tasks;
 
-            const string FixedCode = @"
-using System;
-using System.Threading.Tasks;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Does something.
+                                            /// </summary>
+                                            /// <returns>
+                                            /// A task representing the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> containing the <c>Foo</c>.
+                                            /// </returns>
+                                            public Task<string> DoSomething(object o) => null;
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Does something.
-    /// </summary>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The value of the <see cref=""Task{TResult}.Result""/> parameter returns a <see cref=""string""/> that contains the <c>Foo</c>.
-    /// </returns>
-    public Task<string> DoSomething(object o) => null;
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Threading.Tasks;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Does something.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A task that represents the asynchronous operation. The value of the <see cref="Task{TResult}.Result"/> parameter returns a <see cref="string"/> that contains the <c>Foo</c>.
+                                         /// </returns>
+                                         public Task<string> DoSomething(object o) => null;
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -798,20 +858,22 @@ public class TestMe
 }
 ";
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains something.
-    /// </value>
-    public string Something => ""Something"";
-}
-";
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains something.
+                                         /// </value>
+                                         public string Something => "Something";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(originalCode, FixedCode);
         }
@@ -834,20 +896,22 @@ public class TestMe
 }
 ";
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains something.
-    /// </value>
-    public string Something => ""Something"";
-}
-";
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains something.
+                                         /// </value>
+                                         public string Something => "Something";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(originalCode, FixedCode);
         }
@@ -870,20 +934,22 @@ public class TestMe
 }
 ";
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Gets something.
-    /// </summary>
-    /// <value>
-    /// A <see cref=""string""/> that contains the <see cref=""int""/> and/or <see cref=""bool""/> value of the operation.
-    /// </value>
-    public string Something => ""Something"";
-}
-";
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains the <see cref="int"/> and/or <see cref="bool"/> value of the operation.
+                                         /// </value>
+                                         public string Something => "Something";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(originalCode, FixedCode);
         }
@@ -891,33 +957,77 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_overridden_ToString_method()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    /// <summary>
-    /// Returns a string that represents the current object.
-    /// </summary>
-    /// <returns>A string that represents the current object.</returns>
-    public override string ToString() => base.ToString();
-}
-";
+                                        using System;
 
-            const string FixedCode = @"
-using System;
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Returns a string that represents the current object.
+                                            /// </summary>
+                                            /// <returns>A string that represents the current object.</returns>
+                                            public override string ToString() => base.ToString();
+                                        }
 
-public class TestMe
-{
-    /// <summary>
-    /// Returns a string that represents the current object.
-    /// </summary>
-    /// <returns>
-    /// A <see cref=""string""/> that represents the current object.
-    /// </returns>
-    public override string ToString() => base.ToString();
-}
-";
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Returns a string that represents the current object.
+                                         /// </summary>
+                                         /// <returns>
+                                         /// A <see cref="string"/> that represents the current object.
+                                         /// </returns>
+                                         public override string ToString() => base.ToString();
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_phrase_The_string_result()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        public class TestMe
+                                        {
+                                            /// <summary>
+                                            /// Gets something.
+                                            /// </summary>
+                                            /// <value>
+                                            /// The string result of something.
+                                            /// </value>
+                                            public string Something => "Something";
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     public class TestMe
+                                     {
+                                         /// <summary>
+                                         /// Gets something.
+                                         /// </summary>
+                                         /// <value>
+                                         /// A <see cref="string"/> that contains the result of something.
+                                         /// </value>
+                                         public string Something => "Something";
+                                     }
+
+                                     """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }


### PR DESCRIPTION
- Handle phrase 'The string result'

- Add cleanup map entry for replacements

- Modernize tests with raw string literals

- Extend tests covering new phrase

(resolves #1624)