### PR TITLE
MiKo_2023 and MiKo_2024 are now aware of primary constructors

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -217,6 +217,15 @@ namespace MiKoSolutions.Analyzers
 
                     case IndexerDeclarationSyntax indexer:
                         return indexer.ParameterList.Parameters.ToArray();
+#if VS2022
+                    case ClassDeclarationSyntax c when c.ParameterList is ParameterListSyntax parameters:
+                        return parameters.Parameters.ToArray();
+
+                    case StructDeclarationSyntax s when s.ParameterList is ParameterListSyntax parameters:
+                        return parameters.Parameters.ToArray();
+#endif
+                    case RecordDeclarationSyntax r when r.ParameterList is ParameterListSyntax parameters:
+                        return parameters.Parameters.ToArray();
 
                     case BaseTypeDeclarationSyntax _:
                         return Array.Empty<ParameterSyntax>();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -969,6 +969,102 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_on_primary_class_constructor()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        /// <summary></summary>
+                                        /// <param name="condition">Determines whether something is done.</param>
+                                        public class TestMe(bool condition)
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     /// <summary></summary>
+                                     /// <param name="condition">
+                                     /// <see langword="true"/> to indicate that something is done; otherwise, <see langword="false"/>.
+                                     /// </param>
+                                     public class TestMe(bool condition)
+                                     {
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_on_primary_struct_constructor()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        /// <summary></summary>
+                                        /// <param name="condition">Determines whether something is done.</param>
+                                        public struct TestMe(bool condition)
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     /// <summary></summary>
+                                     /// <param name="condition">
+                                     /// <see langword="true"/> to indicate that something is done; otherwise, <see langword="false"/>.
+                                     /// </param>
+                                     public struct TestMe(bool condition)
+                                     {
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_on_primary_record_constructor()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+
+                                        /// <summary></summary>
+                                        /// <param name="condition">Determines whether something is done.</param>
+                                        public record TestMe(bool condition)
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     /// <summary></summary>
+                                     /// <param name="condition">
+                                     /// <see langword="true"/> to indicate that something is done; otherwise, <see langword="false"/>.
+                                     /// </param>
+                                     public record TestMe(bool condition)
+                                     {
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_2023_BooleanParamDefaultPhraseAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2023_BooleanParamDefaultPhraseAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
@@ -257,6 +257,87 @@ public class TestMe
         }
 
         [Test]
+        public void Code_gets_fixed_for_primary_class_ctor()
+        {
+            const string OriginalCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>Whatever it is.</param>
+public class TestMe(StringComparison o)
+{
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>
+/// One of the enumeration members that specifies whatever it is.
+/// </param>
+public class TestMe(StringComparison o)
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_primary_struct_ctor()
+        {
+            const string OriginalCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>Whatever it is.</param>
+public struct TestMe(StringComparison o)
+{
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>
+/// One of the enumeration members that specifies whatever it is.
+/// </param>
+public struct TestMe(StringComparison o)
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_primary_record_ctor()
+        {
+            const string OriginalCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>Whatever it is.</param>
+public record TestMe(StringComparison o)
+{
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+/// <summary />
+/// <param name='o'>
+/// One of the enumeration members that specifies whatever it is.
+/// </param>
+public record TestMe(StringComparison o)
+{
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_when_on_different_lines()
         {
             const string OriginalCode = @"


### PR DESCRIPTION
- Handle primary constructors in parameter lookup

- Extend analyzers to class/struct/record primaries

- Add tests for MiKo_2023 primary constructors

- Add tests for MiKo_2024 primary constructors

(resolves #1625)