### PR TITLE
MiKo_2226 and MiKo_2310 now ignore "with indent"

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -999,7 +999,7 @@ namespace MiKoSolutions.Analyzers
                                                                         "by indention", // be able to detect typos
                                                                         "with indention", // be able to detect typos
                                                                         "by indent", // be able to detect typos
-                                                                        "with indent", // be able to detect typos
+                                                                        //// to not use "with indent" because "with indentation" is a correct phrase that has no reference to "intentionally"
                                                                         "on purpose",
                                                                         "purposely",
                                                                         "purposly", // be able to detect typos

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzerTests.cs
@@ -26,7 +26,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   "purposely left empty",
                                                                   "purposly left empty", // check for typo
                                                                   "by indent", // check for typo
-                                                                  "empty with indent", // check for typo
                                                                   "empty with indention", // check for typo
                                                                   "indentionally", // check for typo
                                                                   "indentionaly", // check for typo

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
@@ -26,7 +26,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   "purposely left empty",
                                                                   "purposly left empty", // check for typo
                                                                   "by indent", // check for typo
-                                                                  "empty with indent", // check for typo
                                                                   "empty with indention", // check for typo
                                                                   "indentionally", // check for typo
                                                                   "indentionaly", // check for typo


### PR DESCRIPTION
- Exclude "with indent" from intent patterns (to not report valid phrases such as "with indentation")

- Update analyzers' test expectations

