### PR TITLE
MiKo_2035 codefix is now aware of "A new ..."

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -322,7 +322,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             private static IEnumerable<string> CreatePhrases()
             {
-                var startingWords = new[] { "a", "an", "the" };
+                var startingWords = new[] { "a", "an", "the", "a new", "the new" };
                 var modifications = new[] { "readonly", "read-only", "read only", "filtered", "concurrent" };
                 var collections = new[]
                                       {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -1078,7 +1078,7 @@ public class TestMe
         [ExcludeFromCodeCoverage]
         private static IEnumerable<string> CreateStartingPhrases()
         {
-            string[] startingWords = ["a", "an", "the"];
+            string[] startingWords = ["a", "an", "the", "a new", "the new"];
             string[] modifications = ["read-only", "filtered", "concurrent"];
             string[] collections = [
                                        "array", "arraylist", "array list", "list", "dictionary", "enumerable", "queue", "stack", "map", "bag",
@@ -1110,6 +1110,12 @@ public class TestMe
                             if (shortStartingPhrase.StartsWith("a i", StringComparison.Ordinal) || shortStartingPhrase.StartsWith("a a", StringComparison.Ordinal))
                             {
                                 // do not test "a array" or "a immutable array", to limit tests
+                                continue;
+                            }
+
+                            if (shortStartingPhrase.StartsWith("an ", StringComparison.Ordinal) && shortStartingPhrase[3] != 'a' && shortStartingPhrase[3] != 'i')
+                            {
+                                // do not test "an dictionary" or "an hashset", to limit tests
                                 continue;
                             }
 


### PR DESCRIPTION
- Recognize "a new"/"the new" starts

- Extend test starting phrases set

- Add test filter for invalid "an"
