### PR TITLE
Added rules MiKo_1520 and MiKo_1521 for local variables and parameters named 'toCopy'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -357,6 +357,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1517_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1518_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1519_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1520_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -511,6 +511,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1517_FieldsWithAbilityNameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1518_ReferenceVariablesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1519_ReferenceParametersAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1520_ToCopyVariablesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5427,6 +5427,78 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;toCopy&apos; into &apos;original&apos;.
+        /// </summary>
+        internal static string MiKo_1520_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1520_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;original&apos; as a variable name when providing an object to be copied, because it clearly indicates that it&apos;s the source of the data. Avoid names like &apos;toCopy&apos;, which can be misleading and suggest it&apos;s the target instead. Clear and conventional naming improves readability and reduces confusion..
+        /// </summary>
+        internal static string MiKo_1520_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1520_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1520_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1520_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix or suffix local variables with &apos;toCopy&apos;.
+        /// </summary>
+        internal static string MiKo_1520_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1520_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;toCopy&apos; into &apos;original&apos;.
+        /// </summary>
+        internal static string MiKo_1521_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1521_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;original&apos; as a parameter name when passing an object to be copied, because it clearly indicates that it&apos;s the source of the data. Avoid names like &apos;toCopy&apos;, which can be misleading and suggest it&apos;s the target instead. Clear and conventional naming improves readability and reduces confusion..
+        /// </summary>
+        internal static string MiKo_1521_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1521_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1521_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1521_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix or suffix parameters with &apos;toCopy&apos;.
+        /// </summary>
+        internal static string MiKo_1521_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1521_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {
@@ -7802,7 +7874,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Comment is obvious and provides no value.
+        ///   Looks up a localized string similar to Remove obvious comment.
         /// </summary>
         internal static string MiKo_2079_MessageFormat {
             get {
@@ -11097,7 +11169,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use &apos;{1}&apos; instead.
+        ///   Looks up a localized string similar to Change to &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_3032_MessageFormat {
             get {
@@ -18020,7 +18092,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place ternary operator and colon on the same lines as their respective expressions.
+        ///   Looks up a localized string similar to Place ? and : on the same lines as their expressions.
         /// </summary>
         internal static string MiKo_6067_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1961,6 +1961,30 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
   <data name="MiKo_1519_Title" xml:space="preserve">
     <value>Do not prefix or suffix parameters with 'reference'</value>
   </data>
+  <data name="MiKo_1520_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'toCopy' into 'original'</value>
+  </data>
+  <data name="MiKo_1520_Description" xml:space="preserve">
+    <value>Use 'original' as a variable name when providing an object to be copied, because it clearly indicates that it's the source of the data. Avoid names like 'toCopy', which can be misleading and suggest it's the target instead. Clear and conventional naming improves readability and reduces confusion.</value>
+  </data>
+  <data name="MiKo_1520_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1520_Title" xml:space="preserve">
+    <value>Do not prefix or suffix local variables with 'toCopy'</value>
+  </data>
+  <data name="MiKo_1521_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'toCopy' into 'original'</value>
+  </data>
+  <data name="MiKo_1521_Description" xml:space="preserve">
+    <value>Use 'original' as a parameter name when passing an object to be copied, because it clearly indicates that it's the source of the data. Avoid names like 'toCopy', which can be misleading and suggest it's the target instead. Clear and conventional naming improves readability and reduces confusion.</value>
+  </data>
+  <data name="MiKo_1521_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1521_Title" xml:space="preserve">
+    <value>Do not prefix or suffix parameters with 'toCopy'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1520_CodeFixProvider)), Shared]
+    public sealed class MiKo_1520_CodeFixProvider : LocalVariableNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1520";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1520_ToCopyVariablesAnalyzer : LocalVariableNamingAnalyzer
+    {
+        public const string Id = "MiKo_1520";
+
+        public MiKo_1520_ToCopyVariablesAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+                    var nameSpan = name.AsSpan();
+
+                    if (nameSpan.StartsWith("toCopy") || nameSpan.EndsWith("ToCopy"))
+                    {
+                        var betterName = FindBetterName(name);
+
+                        yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                    }
+                }
+            }
+        }
+
+        private static string FindBetterName(string name)
+        {
+            var builder = name.AsCachedBuilder()
+                              .Insert(0, "original")
+                              .Without("toCopy")
+                              .Without("ToCopy");
+
+            if (builder.Length > 8)
+            {
+                builder.ToUpperCaseAt(8);
+            }
+
+            return builder.ToStringAndRelease();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1521_CodeFixProvider)), Shared]
+    public sealed class MiKo_1521_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1521";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1521_ToCopyParametersAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1521";
+
+        public MiKo_1521_ToCopyParametersAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+            var nameSpan = name.AsSpan();
+
+            if (nameSpan.StartsWith("toCopy") || nameSpan.EndsWith("ToCopy"))
+            {
+                var betterName = FindBetterName(name);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static string FindBetterName(string name)
+        {
+            var builder = name.AsCachedBuilder()
+                                              .Insert(0, "original")
+                                              .Without("toCopy")
+                                              .Without("ToCopy");
+
+            if (builder.Length > 8)
+            {
+                builder.ToUpperCaseAt(8);
+            }
+
+            return builder.ToStringAndRelease();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzerTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1520_ToCopyVariablesAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_variable_without_toCopy_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_named_([Values("toCopySomething", "somethingToCopy", "toCopy")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int " + name + @" = 42;
+        }
+    }
+}
+");
+
+        [TestCase("toCopy", "original")]
+        [TestCase("toCopySomething", "originalSomething")]
+        [TestCase("somethingToCopy", "originalSomething")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int ### = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1520_ToCopyVariablesAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1520_ToCopyVariablesAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1520_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzerTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1521_ToCopyParametersAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_parameter_without_toCopy_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_named_([Values("toCopySomething", "somethingToCopy", "toCopy")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int " + name + @")
+        {
+        }
+    }
+}
+");
+
+        [TestCase("toCopy", "original")]
+        [TestCase("toCopySomething", "originalSomething")]
+        [TestCase("somethingToCopy", "originalSomething")]
+        public void Code_gets_fixed_for_parameter_with_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int ###)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1521_ToCopyParametersAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1521_ToCopyParametersAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1521_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 523 rules that are currently provided by the analyzer.
+The following tables lists all the 525 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -179,6 +179,8 @@ The following tables lists all the 523 rules that are currently provided by the 
 |MiKo_1517|Express binary conditions clearly in boolean field names|&#x2713;|&#x2713;|
 |MiKo_1518|Do not prefix or suffix local variables with 'reference'|&#x2713;|&#x2713;|
 |MiKo_1519|Do not prefix or suffix parameters with 'reference'|&#x2713;|&#x2713;|
+|MiKo_1520|Do not prefix or suffix local variables with 'toCopy'|&#x2713;|&#x2713;|
+|MiKo_1521|Do not prefix or suffix parameters with 'toCopy'|&#x2713;|&#x2713;|
 
 ### Documentation
 |ID|Title|Enabled by default|CodeFix available|


### PR DESCRIPTION
- Add analyzers for 'toCopy' naming

- Provide code fixes suggesting 'original'

- Include comprehensive unit tests

- Update resources and README

(resolves #1616)