### PR TITLE
MiKo_2035 code fix is now aware of some more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -304,9 +304,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                              };
 
                 PreparationMap = new[]
-                                 {
-                                     new Pair("trivia array", "#1#"),
-                                 };
+                                     {
+                                         new Pair("trivia array", "#1#"),
+                                     };
 
                 PreparationMapKeys = PreparationMap.ToArray(_ => _.Key);
 
@@ -319,6 +319,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                      new Pair("an the", "the"),
                                      new Pair(" of gets ", " of "),
                                      new Pair(" of get ", " of "),
+                                     new Pair(" contains gets ", " contains "),
+                                     new Pair(" contains get ", " contains "),
                                  };
 
                 CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -624,14 +624,16 @@ public class TestMe
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
-        [Test]
-        public void Code_gets_fixed_for_generic_collection_with_non_primitive_type()
+        [TestCase("Some data", "A collection of my items that contains some data")]
+        [TestCase("Gets the information.", "A collection of my items that contains the information.")]
+        [TestCase("Get the information.", "A collection of my items that contains the information.")]
+        public void Code_gets_fixed_for_generic_collection_with_non_primitive_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = @"
 using System;
 using System.Collections.Generic;
 
-public record GroupedRow
+public record MyItem
 {
 }
 
@@ -643,11 +645,11 @@ public class TestMe
     /// <returns>
     /// ###.
     /// </returns>
-    public ICollection<GroupedRow> DoSomething { get; set; }
+    public ICollection<MyItem> DoSomething { get; set; }
 }
 ";
 
-            VerifyCSharpFix(Template.Replace("###", "Some data"), Template.Replace("###", "A collection of grouped rows that contains some data"));
+            VerifyCSharpFix(Template.Replace("###", originalPhrase), Template.Replace("###", fixedPhrase));
         }
 
         [Test]


### PR DESCRIPTION
- Expand cleanup phrases for "contains get(s)"

- Refactor test to parameterized cases

- Generalize test record/type naming

- Minor formatting/indentation fixes
