### PR TITLE
MiKo_2081 now squiggles the <summary> end tag

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzer.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            if (symbol.IsSealed && summaries.Value.None(_ => _.EndsWith(Constants.Comments.SealedClassPhrase, StringComparison.Ordinal)))
+            if (symbol.IsSealed && summaryXmls.None(_ => _.GetTextTrimmed().EndsWith(Constants.Comments.SealedClassPhrase, StringComparison.Ordinal)))
             {
                 return new[] { Issue(symbol.Name, summaryXmls[0].EndTag, Constants.Comments.SealedClassPhrase) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            if (symbol.IsSealed is false && summaries.Value.Any(_ => _.Contains(Constants.Comments.SealedClassPhrase)))
+            if (symbol.IsSealed is false && summaryXmls.Any(_ => _.GetTextTrimmed().Contains(Constants.Comments.SealedClassPhrase)))
             {
                 return new[] { Issue(symbol.Name, summaryXmls[0].EndTag, Constants.Comments.SealedClassPhrase) };
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzer.cs
@@ -38,9 +38,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   Lazy<string> commentXml,
                                                                   Lazy<string[]> summaries)
         {
-            if (summaries.Value.None(_ => _.EndsWith(Constants.Comments.FieldIsReadOnly, StringComparison.Ordinal)))
+            if (summaryXmls.None(_ => _.GetTextTrimmed().EndsWith(Constants.Comments.FieldIsReadOnly, StringComparison.Ordinal)))
             {
-                return new[] { Issue(symbol, Constants.Comments.FieldIsReadOnly) };
+                return new[] { Issue(symbol.Name, summaryXmls[0].EndTag, Constants.Comments.FieldIsReadOnly) };
             }
 
             return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
@@ -12,73 +12,87 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2011_UnsealedClassSummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void Struct_is_not_reported() => No_issue_is_reported_for(@"
-/// <summary>
-/// Something.
-/// </summary>
-public struct TestMe
-{
-}
-");
+        public void Struct_is_not_reported() => No_issue_is_reported_for("""
+
+                                                                         /// <summary>
+                                                                         /// Something.
+                                                                         /// </summary>
+                                                                         public struct TestMe
+                                                                         {
+                                                                         }
+
+                                                                         """);
 
         [Test]
-        public void Sealed_public_class_is_not_reported() => No_issue_is_reported_for(@"
-/// <summary>
-/// This class cannot be inherited.
-/// </summary>
-public sealed class TestMe
-{
-}
-");
+        public void Sealed_public_class_is_not_reported() => No_issue_is_reported_for("""
+
+                                                                                      /// <summary>
+                                                                                      /// This class cannot be inherited.
+                                                                                      /// </summary>
+                                                                                      public sealed class TestMe
+                                                                                      {
+                                                                                      }
+
+                                                                                      """);
 
         [Test]
-        public void Sealed_non_public_class_is_not_reported() => No_issue_is_reported_for(@"
-/// <summary>
-/// Something.
-/// </summary>
-private sealed class TestMe
-{
-}
-");
+        public void Sealed_non_public_class_is_not_reported() => No_issue_is_reported_for("""
+
+                                                                                          /// <summary>
+                                                                                          /// Something.
+                                                                                          /// </summary>
+                                                                                          private sealed class TestMe
+                                                                                          {
+                                                                                          }
+
+                                                                                          """);
 
         [Test]
-        public void No_documentation_is_not_reported() => No_issue_is_reported_for(@"
-public sealed class TestMe
-{
-}
-");
+        public void No_documentation_is_not_reported() => No_issue_is_reported_for("""
+
+                                                                                   public sealed class TestMe
+                                                                                   {
+                                                                                   }
+
+                                                                                   """);
 
         [Test]
-        public void Correct_documentation_is_not_reported() => No_issue_is_reported_for(@"
-/// <summary>
-/// Something.
-/// </summary>
-public class TestMe
-{
-}
-");
+        public void Correct_documentation_is_not_reported() => No_issue_is_reported_for("""
+
+                                                                                        /// <summary>
+                                                                                        /// Something.
+                                                                                        /// </summary>
+                                                                                        public class TestMe
+                                                                                        {
+                                                                                        }
+
+                                                                                        """);
 
         [Test]
-        public void Wrong_start_placed_documentation_is_reported() => An_issue_is_reported_for(@"
-/// <summary>
-/// This class cannot be inherited.
-/// Something.
-/// </summary>
-public class TestMe
-{
-}
-");
+        public void Wrong_start_placed_documentation_is_reported() => An_issue_is_reported_for("""
+
+                                                                                               /// <summary>
+                                                                                               /// This class cannot be inherited.
+                                                                                               /// Something.
+                                                                                               /// </summary>
+                                                                                               public class TestMe
+                                                                                               {
+                                                                                               }
+
+                                                                                               """);
 
         [Test]
-        public void Wrong_end_placed_documentation_is_reported() => An_issue_is_reported_for(@"
-/// <summary>
-/// Something.
-/// This class cannot be inherited.
-/// </summary>
-public class TestMe
-{
-}
-");
+        public void Wrong_end_placed_documentation_is_reported() => An_issue_is_reported_for("""
+
+                                                                                             /// <summary>
+                                                                                             /// Something.
+                                                                                             /// This class cannot be inherited.
+                                                                                             /// </summary>
+                                                                                             public class TestMe
+                                                                                             {
+                                                                                             }
+
+                                                                                             """);
 
         [Test]
         public void Wrong_documentation_is_not_reported_for_TestClass_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
@@ -93,133 +107,184 @@ public class TestMe
 ");
 
         [Test]
-        public void Malformed_documentation_is_not_reported() => No_issue_is_reported_for(@"
-/// <summary>
-/// Saves & Loads the relevant layout inforamtion of the ribbon within <see cref=""XmlRibbonLayout""/>
-/// This class cannot be inherited.
-/// </summary>
-public class TestMe
-{
-}
-");
+        public void Malformed_documentation_is_reported() => An_issue_is_reported_for("""
+
+                                                                                      /// <summary>
+                                                                                      /// Saves & Loads the relevant layout inforamtion of the ribbon within <see cref="XmlRibbonLayout"/>
+                                                                                      /// This class cannot be inherited.
+                                                                                      /// </summary>
+                                                                                      public class TestMe
+                                                                                      {
+                                                                                      }
+
+                                                                                      """);
 
         [Test]
         public void Code_gets_fixed_for_class()
         {
-            const string OriginalCode = @"
-/// <summary>
-/// Some documentation.
-/// This class cannot be inherited.
-/// </summary>
-public class TestMe
-{
-}
-";
+            const string OriginalCode = """
 
-            const string FixedCode = @"
-/// <summary>
-/// Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+                                        /// <summary>
+                                        /// Some documentation.
+                                        /// This class cannot be inherited.
+                                        /// </summary>
+                                        public class TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Some documentation.
+                                     /// </summary>
+                                     public class TestMe
+                                     {
+                                     }
+
+                                     """;
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_for_record()
         {
-            const string OriginalCode = @"
-/// <summary>
-/// Some documentation.
-/// This class cannot be inherited.
-/// </summary>
-public record TestMe
-{
-}
-";
+            const string OriginalCode = """
 
-            const string FixedCode = @"
-/// <summary>
-/// Some documentation.
-/// </summary>
-public record TestMe
-{
-}
-";
+                                        /// <summary>
+                                        /// Some documentation.
+                                        /// This class cannot be inherited.
+                                        /// </summary>
+                                        public record TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Some documentation.
+                                     /// </summary>
+                                     public record TestMe
+                                     {
+                                     }
+
+                                     """;
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text()
         {
-            const string OriginalCode = @"
-/// <summary>
-/// This class cannot be inherited.
-/// Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+            const string OriginalCode = """
 
-            const string FixedCode = @"
-/// <summary>
-/// Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+                                        /// <summary>
+                                        /// This class cannot be inherited.
+                                        /// Some documentation.
+                                        /// </summary>
+                                        public class TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Some documentation.
+                                     /// </summary>
+                                     public class TestMe
+                                     {
+                                     }
+
+                                     """;
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_on_single_line()
         {
-            const string OriginalCode = @"
-/// <summary>
-/// Some text. This class cannot be inherited.
-/// Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+            const string OriginalCode = """
 
-            const string FixedCode = @"
-/// <summary>
-/// Some text. 
-/// Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+                                        /// <summary>
+                                        /// Some text. This class cannot be inherited.
+                                        /// Some documentation.
+                                        /// </summary>
+                                        public class TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Some text. 
+                                     /// Some documentation.
+                                     /// </summary>
+                                     public class TestMe
+                                     {
+                                     }
+
+                                     """;
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
         public void Code_gets_fixed_with_wrong_placed_sealed_text_all_on_single_line()
         {
-            const string OriginalCode = @"
-/// <summary>
-/// Some text. This class cannot be inherited. Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+            const string OriginalCode = """
 
-            const string FixedCode = @"
-/// <summary>
-/// Some text. Some documentation.
-/// </summary>
-public class TestMe
-{
-}
-";
+                                        /// <summary>
+                                        /// Some text. This class cannot be inherited. Some documentation.
+                                        /// </summary>
+                                        public class TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Some text. Some documentation.
+                                     /// </summary>
+                                     public class TestMe
+                                     {
+                                     }
+
+                                     """;
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_malformed_documentation()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// Saves & Loads the relevant layout inforamtion of the ribbon within <see cref="XmlRibbonLayout"/>
+                                        /// This class cannot be inherited.
+                                        /// </summary>
+                                        public class TestMe
+                                        {
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// Saves & Loads the relevant layout inforamtion of the ribbon within <see cref="XmlRibbonLayout"/>
+                                     /// </summary>
+                                     public class TestMe
+                                     {
+                                     }
+
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 


### PR DESCRIPTION
- Analyze summaries via Xml elements

- Report issues at summary end tags

- Update tests to raw string literals

- Add malformed doc fix test
