### PR TITLE
Added rule Miko_2083 that reports on writable fields being documented as read-only

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -119,6 +119,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2080_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2081_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2082_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2083_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2090_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2091_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2100_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -125,6 +125,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2080_FieldSummaryDefaultPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2081_ReadOnlyFieldAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2082_EnumMemberAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2083_NonReadOnlyFieldAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2090_EqualityOperatorAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2091_InequalityOperatorAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2100_ExampleDefaultPhraseAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5742,7 +5742,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Append sealed text to comment.
+        ///   Looks up a localized string similar to Append sealed text to documention.
         /// </summary>
         internal static string MiKo_2010_CodeFixTitle {
             get {
@@ -5778,7 +5778,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove sealed text to comment.
+        ///   Looks up a localized string similar to Remove sealed text from documentation.
         /// </summary>
         internal static string MiKo_2011_CodeFixTitle {
             get {
@@ -7997,6 +7997,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_2082_Title {
             get {
                 return ResourceManager.GetString("MiKo_2082_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove read-only text from documentation.
+        /// </summary>
+        internal static string MiKo_2083_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2083_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Writable fields should not mention being read-only since they are not. This keeps things clear and straightforward for developers..
+        /// </summary>
+        internal static string MiKo_2083_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2083_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;summary&gt; should not contain: &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_2083_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2083_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not falsely document writable fields as read-only.
+        /// </summary>
+        internal static string MiKo_2083_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2083_Title", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2067,7 +2067,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Document routed events as done by the .NET Framework</value>
   </data>
   <data name="MiKo_2010_CodeFixTitle" xml:space="preserve">
-    <value>Append sealed text to comment</value>
+    <value>Append sealed text to documention</value>
   </data>
   <data name="MiKo_2010_Description" xml:space="preserve">
     <value>To simplify their use in inheritance scenarios, sealed classes should clearly document that they are sealed. This helps developers understand their constraints and usage better.</value>
@@ -2079,7 +2079,7 @@ This improves code clarity, avoids ambiguity, and helps developers immediately u
     <value>Document sealed classes as being sealed</value>
   </data>
   <data name="MiKo_2011_CodeFixTitle" xml:space="preserve">
-    <value>Remove sealed text to comment</value>
+    <value>Remove sealed text from documentation</value>
   </data>
   <data name="MiKo_2011_Description" xml:space="preserve">
     <value>Unsealed classes should not mention being sealed since they are not. This keeps things clear and straightforward for developers.</value>
@@ -2830,6 +2830,18 @@ This ensures the documentation is precise and informative, helping developers un
   </data>
   <data name="MiKo_2082_Title" xml:space="preserve">
     <value>Use distinct phrases for Enum member &lt;summary&gt; documentation</value>
+  </data>
+  <data name="MiKo_2083_CodeFixTitle" xml:space="preserve">
+    <value>Remove read-only text from documentation</value>
+  </data>
+  <data name="MiKo_2083_Description" xml:space="preserve">
+    <value>Writable fields should not mention being read-only since they are not. This keeps things clear and straightforward for developers.</value>
+  </data>
+  <data name="MiKo_2083_MessageFormat" xml:space="preserve">
+    <value>&lt;summary&gt; should not contain: '{1}'</value>
+  </data>
+  <data name="MiKo_2083_Title" xml:space="preserve">
+    <value>Do not falsely document writable fields as read-only</value>
   </data>
   <data name="MiKo_2090_CodeFixTitle" xml:space="preserve">
     <value>Apply standard comment</value>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2081_CodeFixProvider.cs
@@ -15,9 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var comment = (XmlElementSyntax)syntax;
 
-            const string Text = Constants.Comments.FieldIsReadOnly;
-
-            return CommentWithContent(comment, comment.WithoutText(Text).Add(XmlText(Text))); // place on new line
+            return CommentWithContent(comment, comment.WithoutText(Constants.Comments.FieldIsReadOnly).Add(XmlText(Constants.Comments.FieldIsReadOnly))); // place on new line
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2083_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2083_CodeFixProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2083_CodeFixProvider)), Shared]
+    public sealed class MiKo_2083_CodeFixProvider : SummaryDocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2083";
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            var comment = (XmlElementSyntax)syntax;
+
+            return CommentWithContent(comment, comment.WithoutText(Constants.Comments.FieldIsReadOnly));
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2083_NonReadOnlyFieldAnalyzer : SummaryDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2083";
+
+        public MiKo_2083_NonReadOnlyFieldAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IFieldSymbol field && field.IsReadOnly is false;
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeSummaries(
+                                                                  DocumentationCommentTriviaSyntax comment,
+                                                                  ISymbol symbol,
+                                                                  IReadOnlyList<XmlElementSyntax> summaryXmls,
+                                                                  Lazy<string> commentXml,
+                                                                  Lazy<string[]> summaries)
+        {
+            if (summaryXmls.Any(_ => _.GetTextTrimmed().EndsWith(Constants.Comments.FieldIsReadOnly, StringComparison.Ordinal)))
+            {
+                return new[] { Issue(symbol.Name, summaryXmls[0].EndTag, Constants.Comments.FieldIsReadOnly) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
@@ -12,12 +12,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2081_ReadOnlyFieldAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_readonly_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_uncommented_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
 {
     " + visibility + @" string m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_uncommented_readonly_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    " + visibility + @" readonly string m_field;
 }
 ");
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzerTests.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2083_NonReadOnlyFieldAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] Visibilities = ["protected", "public", "private", "internal"];
+
+        [Test]
+        public void No_issue_is_reported_for_uncommented_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    " + visibility + @" readonly string m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_uncommented_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    " + visibility + @" string m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_correctly_commented_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// The field.
+    /// This field is read-only.
+    /// </summary>
+    " + visibility + @" readonly string m_field;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_commented_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// The field.
+    /// This field is read-only.
+    /// </summary>
+    " + visibility + @" string m_field;
+}
+");
+
+        [Test]
+        public void Code_gets_fixed()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// Some text
+/// </summary>
+public sealed class TestMe
+{
+    /// <summary>
+    /// Bla bla bla.
+    /// This field is read-only.
+    /// </summary>
+    private string m_field;
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Some text
+/// </summary>
+public sealed class TestMe
+{
+    /// <summary>
+    /// Bla bla bla.
+    /// </summary>
+    private string m_field;
+}
+";
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2083_NonReadOnlyFieldAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2083_NonReadOnlyFieldAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2083_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 525 rules that are currently provided by the analyzer.
+The following tables lists all the 526 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -255,6 +255,7 @@ The following tables lists all the 525 rules that are currently provided by the 
 |MiKo_2080|Start field &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
 |MiKo_2081|End public-visible read-only field &lt;summary&gt; documentation with default phrase|&#x2713;|&#x2713;|
 |MiKo_2082|Use distinct phrases for Enum member &lt;summary&gt; documentation|&#x2713;|&#x2713;|
+|MiKo_2083|Do not falsely document writable fields as read-only|&#x2713;|&#x2713;|
 |MiKo_2090|Use default phrase for equality operator documentation|&#x2713;|&#x2713;|
 |MiKo_2091|Use default phrase for inequality operator documentation|&#x2713;|&#x2713;|
 |MiKo_2100|Start &lt;example&gt; documentation with descriptive default phrase|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add rule MiKo_2083 analyzer and fix

- Detect writable fields documented read-only (as opposite for MiKo_2081)

- Provide code fix to remove phrase

- Update resources and README entries

(resolves #1645)