### PR TITLE
MiKo_2019 codefix is now aware of ctor of generic type

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.CodeFixes.cs
@@ -19,6 +19,31 @@ namespace MiKoSolutions.Analyzers
     internal static partial class SyntaxNodeExtensions
     {
         /// <summary>
+        /// Converts the specified <see cref="TypeDeclarationSyntax"/> to a <see cref="TypeSyntax"/>.
+        /// </summary>
+        /// <param name="value">
+        /// The type declaration syntax to convert.
+        /// </param>
+        /// <returns>
+        /// A <see cref="TypeSyntax"/> representing the type declaration.
+        /// </returns>
+        public static TypeSyntax AsTypeSyntax(this TypeDeclarationSyntax value)
+        {
+            var name = value.GetName();
+
+            if (value.TypeParameterList is TypeParameterListSyntax typeParameters)
+            {
+                var arguments = typeParameters.Parameters
+                                              .Select(_ => SyntaxFactory.ParseTypeName(_.GetName()))
+                                              .ToSeparatedSyntaxList();
+
+                return SyntaxFactory.GenericName(SyntaxFactory.Identifier(name), SyntaxFactory.TypeArgumentList(arguments));
+            }
+
+            return SyntaxFactory.ParseTypeName(name);
+        }
+
+        /// <summary>
         /// Gets the first XML element that is NOT empty (has some content) and matches the given tag.
         /// </summary>
         /// <param name="syntaxNodes">

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -684,6 +684,17 @@ namespace MiKoSolutions.Analyzers
         internal static string GetName(this TypeParameterConstraintClauseSyntax value) => value?.Name.GetName() ?? string.Empty;
 
         /// <summary>
+        /// Gets the name of the specified <see cref="TypeParameterSyntax"/>.
+        /// </summary>
+        /// <param name="value">
+        /// The type syntax.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the name of the type parameter; or the <see cref="string.Empty"/> string ("") if no name is found.
+        /// </returns>
+        internal static string GetName(this TypeParameterSyntax value) => value?.Identifier.ValueText ?? string.Empty;
+
+        /// <summary>
         /// Gets the name of the specified <see cref="TypeSyntax"/>.
         /// </summary>
         /// <param name="value">

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -114,15 +114,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         continuation = " class from being created";
                     }
 
-                    string commentEnd = continuation.AsCachedBuilder()
-                                                    .Append(startText)
-                                                    .Without(ConstructorPhrases)
-                                                    .Append(' ')
-                                                    .Replace(" for ", " with ")
-                                                    .TrimmedEnd()
-                                                    .ToStringAndRelease();
+                    var commentEnd = continuation.AsCachedBuilder()
+                                                 .Append(startText)
+                                                 .Without(ConstructorPhrases)
+                                                 .Append(' ')
+                                                 .Replace(" for ", " with ")
+                                                 .TrimmedEnd()
+                                                 .ToStringAndRelease();
 
-                    return Comment(summary, start, SeeCref(constructor.Identifier.ValueText), commentEnd);
+                    var seeCref = constructor.Parent is TypeDeclarationSyntax type
+                                  ? SeeCref(type.AsTypeSyntax())
+                                  : SeeCref(constructor.Identifier.ValueText);
+
+                    return Comment(summary, start, seeCref, commentEnd);
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OperatorAnalyzer.cs
@@ -117,7 +117,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private Diagnostic AnalyzeParameter(DocumentationCommentTriviaSyntax comment, IParameterSymbol parameter, string phrase)
         {
             var parameterName = parameter.Name;
-            string paramName = Constants.XmlTag.Param + " name=\"" + parameterName + "\"";
+            var paramName = Constants.XmlTag.Param + " name=\"" + parameterName + "\"";
 
             var parameterComment = comment.GetParameterComment(parameterName);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -705,6 +705,26 @@ public interface TestMe
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", """Prevents a default instance of the <see cref="TestMe"/> class from being created"""));
         }
 
+        [Test]
+        public void Code_gets_fixed_for_public_constructor_for_generic_type_([ValueSource(nameof(Constructors))] string originalText)
+        {
+            const string Template = """
+
+                                    using System;
+
+                                    public class TestMe<T1, T2>
+                                    {
+                                        /// <summary>
+                                        /// ###.
+                                        /// </summary>
+                                        public TestMe() { }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", """Initializes a new instance of the <see cref="TestMe{T1,T2}"/> class"""));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzerTests.cs
@@ -74,7 +74,7 @@ public sealed class TestMe { }
 ";
 
             var wrongText = wrongId.Trim();
-            string correctText = ToCorrectText(wrongText);
+            var correctText = ToCorrectText(wrongText);
 
             VerifyCSharpFix(Template.Replace("###", wrongText), Template.Replace("###", correctText));
         }
@@ -90,7 +90,7 @@ public sealed class TestMe { }
 ";
 
             var wrongText = wrongId.Trim();
-            string correctText = ToCorrectText(wrongText);
+            var correctText = ToCorrectText(wrongText);
 
             VerifyCSharpFix(Template.Replace("###", wrongText), Template.Replace("###", correctText));
         }
@@ -113,7 +113,7 @@ public sealed class TestMe { }
 ";
 
             var wrongText = wrongId.Trim();
-            string correctText = ToCorrectText(wrongText);
+            var correctText = ToCorrectText(wrongText);
 
             VerifyCSharpFix(OriginalTemplate.Replace("###", wrongText), FixedTemplate.Replace("###", correctText));
         }


### PR DESCRIPTION
- Add `TypeDeclaration` to `TypeSyntax` conversion

- Support generic type ctor cref in comments

- Add tests for generic constructor fixes

- Minor `var` refactoring in code and tests
