### PR TITLE
MiKo_2219 now ignores ? and ! inside <c> tags

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.cs
@@ -18,6 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly HashSet<string> AllowedTags = new HashSet<string>
                                                                   {
+                                                                      Constants.XmlTag.C,
                                                                       Constants.XmlTag.Code,
                                                                       Constants.XmlTag.Note,
                                                                   };

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
@@ -49,6 +49,18 @@ public class TestMe
 }");
 
         [Test]
+        public void No_issue_is_reported_for_text_inside_c_tag() => No_issue_is_reported_for(@"
+/// <summary>
+/// Some text.
+/// </summary>
+/// <remarks>
+/// <c>a != b</c> or <c>some?.ToString()</c>
+/// </remarks>
+public class TestMe
+{
+}");
+
+        [Test]
         public void No_issue_is_reported_for_text_inside_code_tag() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some text.


### PR DESCRIPTION
- Allow '?' and '!' inside `<c>` tags

- Add tests covering `<c>` tag scenarios

- Maintain behavior for `<code>` and `<note>`
