### PR TITLE
Refactored MiKo_2245 analyzer and codefix to avoid unnecessary string creations

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -2771,7 +2771,15 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if the string is a number; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool IsNumber(this string value) => OnlyNumberRegex.IsMatch(value);
+        public static bool IsNumber(this string value)
+        {
+            switch (value.Length)
+            {
+                case 0: return false;
+                case 1: return value[0].IsNumber();
+                default: return OnlyNumberRegex.IsMatch(value);
+            }
+        }
 
         /// <summary>
         /// Determines whether the string is in <c>PascalCasing</c> format.

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -1587,7 +1587,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// The empty XML text with a new line and leading XML comment.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static XmlTextSyntax NewLineXmlText() => XmlText(string.Empty).WithLeadingXmlComment();
+        protected static XmlTextSyntax NewLineXmlText() => XmlText().WithLeadingXmlComment();
 
         /// <summary>
         /// Creates an empty XML text with trailing XML comment trivia.
@@ -1596,19 +1596,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// The empty XML text with trailing XML comment.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static XmlTextSyntax TrailingNewLineXmlText() => XmlText(string.Empty).WithTrailingXmlComment();
+        protected static XmlTextSyntax TrailingNewLineXmlText() => XmlText().WithTrailingXmlComment();
 
         /// <summary>
         /// Creates an XML text with the specified text.
         /// </summary>
         /// <param name="text">
         /// The text value.
+        /// The default is the <see cref="string.Empty"/> string ("").
         /// </param>
         /// <returns>
         /// The XML text.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static XmlTextSyntax XmlText(string text) => SyntaxFactory.XmlText(text);
+        protected static XmlTextSyntax XmlText(string text = "") => SyntaxFactory.XmlText(text);
 
         /// <summary>
         /// Creates an XML text with the specified syntax token list.

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -131,7 +131,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             switch (count)
             {
                 case 0:
-                    return FixEmptyComment(comment.WithContent(XmlText(string.Empty)));
+                    return FixEmptyComment(comment.WithContent(XmlText()));
 
                 case 1 when contents[0] is XmlTextSyntax t:
                 {
@@ -266,7 +266,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var finalCommentContinuation = StringBuilderCache.GetStringAndRelease(commentContinuation);
 
-            var prepared = comment.ReplaceNode(originalText, XmlText(string.Empty));
+            var prepared = comment.ReplaceNode(originalText, XmlText());
 
             return FixComment(prepared, info.Keys, info.Map, finalCommentContinuation);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var newContent = comment.Content
                                     .AddRange(texts)
-                                    .Add(XmlText(string.Empty).WithLeadingXmlComment());
+                                    .Add(XmlText().WithLeadingXmlComment());
 
             return comment.WithContent(newContent);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
@@ -113,7 +113,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (textToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                 {
                     // keep new line
-                    result.Add(XmlText(string.Empty).WithLeadingXmlComment());
+                    result.Add(XmlText().WithLeadingXmlComment());
 
                     // we do not need to inspect further
                     newLineTokenJustSkipped = true;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_CodeFixProvider.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (textToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                 {
                     // keep new line
-                    result.Add(XmlText(string.Empty).WithLeadingXmlComment());
+                    result.Add(XmlText().WithLeadingXmlComment());
 
                     // we do not need to inspect further
                     newLineTokenJustSkipped = true;


### PR DESCRIPTION
- Avoids unnecessary string allocations

- Optimizes number checks for short strings

- Streamlines XML text creation defaults

- Refactors analyzer loop for efficiency
