### PR TITLE
Enhanced MiKo_2223 to also fix 'string' or 'int'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -3785,6 +3785,24 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A <see cref="WordsReadOnlySpanEnumerator"/> for the span of characters.
         /// </returns>
+        public static WordsReadOnlySpanEnumerator WordsAsSpan(this string value, in WordBoundary boundary = WordBoundary.UpperCaseCharacters)
+        {
+            return value.AsSpan().WordsAsSpan(boundary);
+        }
+
+        /// <summary>
+        /// Converts the string to a <see cref="WordsReadOnlySpanEnumerator"/> for word enumeration.
+        /// </summary>
+        /// <param name="value">
+        /// The span of characters to enumerate words from.
+        /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.UpperCaseCharacters"/>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="WordsReadOnlySpanEnumerator"/> for the span of characters.
+        /// </returns>
         public static WordsReadOnlySpanEnumerator WordsAsSpan(this in ReadOnlySpan<char> value, in WordBoundary boundary = WordBoundary.UpperCaseCharacters) => new WordsReadOnlySpanEnumerator(value, boundary);
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2020_InheritdocSummaryAnalyzer.cs
@@ -92,7 +92,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             else
                             {
                                 // inspect first and last word
-                                var words = text.AsSpan().WordsAsSpan();
+                                var words = text.WordsAsSpan();
 
                                 if (words.First().Text.StartsWithAny(InheritMarkerTexts, StringComparison.OrdinalIgnoreCase)
                                  || words.Last().Text.ContainsAny(InheritMarkerTexts, StringComparison.OrdinalIgnoreCase))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2223_CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var firstPart = textTokens.Take(tokenIndex).ToTokenList().Add(token.WithText(partBefore));
 
                 var updatedXmlText = xmlText.WithTextTokens(firstPart);
-                var seeCref = SeeCref(SyntaxFactory.ParseName(replacement));
+                var seeCref = SeeCref(SyntaxFactory.ParseTypeName(replacement));
 
                 var newNodes = new List<SyntaxNode> { updatedXmlText, seeCref };
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     var text = token.ValueText;
 
-                    foreach (ReadOnlySpan<char> word in text.AsSpan().WordsAsSpan(WordBoundary.WhiteSpaces))
+                    foreach (ReadOnlySpan<char> word in text.WordsAsSpan(WordBoundary.WhiteSpaces))
                     {
                         if (word.Length is 0 || (word.Length is 1 && word.IsNumber() is false))
                         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -107,8 +107,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var foundSuffix = string.Empty;
 
             var text = GetText(arguments[index].Expression);
-            var finalText = text.AsSpan()
-                                .WordsAsSpan()
+            var finalText = text.WordsAsSpan()
                                 .Select(_ => _.Text.Trim(Constants.Underscores).ToLowerCaseAt(0))
                                 .Select(_ =>
                                             {

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -132,13 +132,13 @@ namespace MiKoSolutions.Analyzers.Extensions
         }
 
         [Test]
-        public static void WordsAsSpan_returns_words_in_method_name() => Assert.That("GetHashCode".AsSpan().WordsAsSpan().Select(_ => _.ToString()), Is.EquivalentTo(["Get", "Hash", "Code"]));
+        public static void WordsAsSpan_returns_words_in_method_name() => Assert.That("GetHashCode".WordsAsSpan().Select(_ => _.ToString()), Is.EquivalentTo(["Get", "Hash", "Code"]));
 
         [Test]
-        public static void WordsAsSpan_returns_words_in_text_with_leading_whitespaces() => Assert.That(" This is some text for -1. Just to be sure.".AsSpan().WordsAsSpan(WordBoundary.WhiteSpaces).Select(_ => _.ToString()), Is.EquivalentTo(["This", "is", "some", "text", "for", "-1", "Just", "to", "be", "sure"]));
+        public static void WordsAsSpan_returns_words_in_text_with_leading_whitespaces() => Assert.That(" This is some text for -1. Just to be sure.".WordsAsSpan(WordBoundary.WhiteSpaces).Select(_ => _.ToString()), Is.EquivalentTo(["This", "is", "some", "text", "for", "-1", "Just", "to", "be", "sure"]));
 
         [Test]
-        public static void WordsAsSpan_returns_words_in_text_without_leading_whitespaces() => Assert.That("This is some text for -1. Just to be sure.".AsSpan().WordsAsSpan(WordBoundary.WhiteSpaces).Select(_ => _.ToString()), Is.EquivalentTo(["This", "is", "some", "text", "for", "-1", "Just", "to", "be", "sure"]));
+        public static void WordsAsSpan_returns_words_in_text_without_leading_whitespaces() => Assert.That("This is some text for -1. Just to be sure.".WordsAsSpan(WordBoundary.WhiteSpaces).Select(_ => _.ToString()), Is.EquivalentTo(["This", "is", "some", "text", "for", "-1", "Just", "to", "be", "sure"]));
 
         [TestCase(' ', "", ExpectedResult = " ")]
         [TestCase('-', "", ExpectedResult = "-")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using System;
+
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -30,6 +32,32 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                               "Microsoft",
                                                               "Outlook",
                                                           ];
+
+        private static readonly string[] NonCompoundWords =
+                                                            [
+                                                                 "bool",
+                                                                 "byte",
+                                                                 "char",
+                                                                 "float",
+                                                                 "int",
+                                                                 "string",
+                                                                 "uint",
+                                                                 "ushort",
+                                                                 "ulong",
+                                                                 nameof(String),
+                                                                 nameof(Int16),
+                                                                 nameof(Int32),
+                                                                 nameof(Int64),
+                                                                 nameof(UInt16),
+                                                                 nameof(UInt32),
+                                                                 nameof(UInt64),
+                                                                 nameof(Single),
+                                                                 nameof(Double),
+                                                                 nameof(Boolean),
+                                                                 nameof(Byte),
+                                                                 nameof(Char),
+                                                                 nameof(Type),
+                                                           ];
 
         [Test]
         public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
@@ -700,6 +728,22 @@ public class TestMe
 ");
 
         [Test]
+        public void An_issue_is_reported_for_incorrectly_documented_method_with_([ValueSource(nameof(NonCompoundWords))] string type) => An_issue_is_reported_for(@"
+using System;
+using System.IO;
+
+public class TestMe
+{
+    /// <summary>
+    /// Does something with " + type + @" to see.
+    /// </summary>
+    public void DoSomething()
+    {
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_incorrectly_documented_method_with_(
                                                                              [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
                                                                              [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
@@ -717,6 +761,29 @@ public class TestMe
     }
 }
 ");
+
+        [Test]
+        public void Code_gets_fixed_for_incorrectly_documented_method_with_([ValueSource(nameof(NonCompoundWords))] string type)
+        {
+            const string Template = """
+
+                                    using System;
+                                    using System.IO;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>
+                                        /// Does something with ### to see.
+                                        /// </summary>
+                                        public void DoSomething()
+                                        {
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", type), Template.Replace("###", "<see cref=\"" + type + "\"/>"));
+        }
 
         [Test]
         public void Code_gets_fixed_for_incorrectly_documented_method_with_(


### PR DESCRIPTION
- Add word-based detection for primitive types

- Update code fix to parse type names

- Introduce WordsAsSpan overload for string

- Expand tests for new word handling

(resolves #1670)