### PR TITLE
Tests limited to speed up test run

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -363,7 +363,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             private static IEnumerable<string> CreatePhrases()
             {
                 var startingWords = new[] { "a", "an", "the", "a new", "the new" };
-                var modifications = new[] { "readonly", "read-only", "read only", "filtered", "concurrent" };
+                var modifications = new[] { "readonly", "read-only", "read only", "filtered", "concurrent", "single" };
                 var collections = new[]
                                       {
                                           "array", "arraylist", "array list", "list",  "collection", "dictionary", "enumerable", "enumerable collection", "syntax list", "separated syntax list", "immutable array",

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -1147,26 +1147,26 @@ public class TestMe
 
             string[] verbs =
                              [
-                                 "controling", // be aware of typo
+                                 //// commented out to limit tests: "controling", // be aware of typo
                                  "controlling",
                                  "defining",
                                  "determining",
-                                 "determinating", // be aware of typo
+                                 //// commented out to limit tests: "determinating", // be aware of typo
                                  "indicating",
                                  "specifying",
                                  "that controls",
-                                 "that defined", // be aware of typo
+                                 //// commented out to limit tests: "that defined", // be aware of typo
                                  "that defines",
-                                 "that determined", // be aware of typo
+                                 //// commented out to limit tests: "that determined", // be aware of typo
                                  "that determines",
-                                 "that indicated", // be aware of typo
+                                 //// commented out to limit tests: "that indicated", // be aware of typo
                                  "that indicates",
                                  "that specifies",
                                  "which controls",
                                  "which defines",
                                  "which determines",
                                  "which indicates",
-                                 "which specified", // be aware of typo
+                                 //// commented out to limit tests: "which specified", // be aware of typo
                                  "which specifies",
                              ];
 
@@ -1186,20 +1186,20 @@ public class TestMe
             string[] startingVerbs =
                                      [
                                          "Controls",
-                                         "Controling", // be aware of typo
+                                         //// commented out to limit tests: "Controling", // be aware of typo
                                          "Controlling",
                                          "Defines",
                                          "Defined",
                                          "Defining",
                                          "Determines",
-                                         "Determined",
+                                         //// commented out to limit tests: "Determined",
                                          "Determining",
-                                         "Determinating", // be aware of typo
+                                         //// commented out to limit tests: "Determinating", // be aware of typo
                                          "Indicates",
-                                         "Indicated",
+                                         //// commented out to limit tests: "Indicated",
                                          "Indicating",
                                          "Specifies",
-                                         "Specified",
+                                         //// commented out to limit tests: "Specified",
                                          "Specifying",
                                      ];
 
@@ -1218,32 +1218,32 @@ public class TestMe
         [ExcludeFromCodeCoverage]
         private static HashSet<string> CreateOptionalPhrases()
         {
-            string[] starts = ["A optional", "An optional", "The optional", "An (optional)", "The (optional)", "Optional", "(Optional)"];
+            string[] starts = ["A optional", "An optional", "The optional", "Optional"]; // commented out to limit tests: "An (optional)", "The (optional)", "(Optional)"];
             string[] conditions = ["if", "whether", "whether or not", "if to", "whether to", "whether or not to"];
             string[] booleans = ["bool ", "Boolean ", string.Empty];
             string[] values = ["parameter", "flag", "value"];
 
             string[] verbs =
                              [
-                                 "controling", // be aware of typo
+                                 //// commented out to limit tests: "controling", // be aware of typo
                                  "controlling",
                                  "defining",
                                  "determining",
                                  "indicating",
                                  "specifying",
                                  "that controls",
-                                 "that defined", // be aware of typo
+                                 //// commented out to limit tests: "that defined", // be aware of typo
                                  "that defines",
                                  "that determined",
                                  "that determines",
-                                 "that indicated", // be aware of typo
+                                 //// commented out to limit tests: "that indicated", // be aware of typo
                                  "that indicates",
                                  "that specifies",
                                  "which controls",
                                  "which defines",
                                  "which determines",
                                  "which indicates",
-                                 "which specified", // be aware of typo
+                                 //// commented out to limit tests: "which specified", // be aware of typo
                                  "which specifies",
                              ];
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -1244,10 +1244,10 @@ public class TestMe
         private static IEnumerable<string> CreateStartingPhrases()
         {
             string[] startingWords = ["a", "an", "the", "a new", "the new"];
-            string[] modifications = ["read-only", "filtered", "concurrent"];
+            string[] modifications = ["read-only", /* commented out to limit tests: "filtered", "concurrent", "single" */];
             string[] collections = [
                                        "array", "arraylist", "array list", "list", "dictionary", "enumerable", "queue", "stack", "map", "bag",
-                                       "hashset", "hashSet", "hashtable", "hashTable", "hash set", "hashed set", "hash table", "hashed table", "hashing set", "hashing table",
+                                       //// commented out to limit tests: "hashset", "hashSet", "hashtable", "hashTable", "hash set", "hashed set", "hash table", "hashed table", "hashing set", "hashing table",
                                        "syntax list", "enumerable collection", "separated syntax list", "immutable array",
                                    ];
             string[] prepositions = ["of", "with", "that contains", "which contains", "containing"];


### PR DESCRIPTION
- Add "single" to collection modifiers

- Reduce test permutations to speed runs

- Comment out typo and rare variants

- Narrow optional phrase and collections sets
