### PR TITLE
Added new rule MiKo_2241 that reports on 'empty string' and fixes it to '<see cref="String.Empty"/> string ("")'

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -155,6 +155,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2237_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2241_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2244_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2245_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -172,6 +172,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2238_MakeSureToCallThisAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2244_DocumentationShallUseListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -9663,6 +9663,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;empty string&apos; with &apos;&lt;see cref=&quot;string.Empty&quot;/&gt; string (&quot;&quot;)&apos;.
+        /// </summary>
+        internal static string MiKo_2241_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2241_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XML documentation shall not use the phrase &apos;empty string&apos;. Instead, use the phrase &apos;&lt;see cref=&quot;string.Empty&quot;/&gt; string (&quot;&quot;)&apos; to clearly express the concept and provide hyperlink support. This improves readability and developer understanding..
+        /// </summary>
+        internal static string MiKo_2241_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2241_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace phrase &apos;empty string&apos; with &apos;&lt;see cref=&quot;string.Empty&quot;/&gt; string (&quot;&quot;)&apos;.
+        /// </summary>
+        internal static string MiKo_2241_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2241_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use &apos;empty string&apos; in documentation.
+        /// </summary>
+        internal static string MiKo_2241_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2241_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items.
         /// </summary>
         internal static string MiKo_2244_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3405,6 +3405,18 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
   <data name="MiKo_2240_Title" xml:space="preserve">
     <value>Do not start &lt;response&gt; documentation with 'Returns'</value>
   </data>
+  <data name="MiKo_2241_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'empty string' with '&lt;see cref="string.Empty"/&gt; string ("")'</value>
+  </data>
+  <data name="MiKo_2241_Description" xml:space="preserve">
+    <value>XML documentation shall not use the phrase 'empty string'. Instead, use the phrase '&lt;see cref="string.Empty"/&gt; string ("")' to clearly express the concept and provide hyperlink support. This improves readability and developer understanding.</value>
+  </data>
+  <data name="MiKo_2241_MessageFormat" xml:space="preserve">
+    <value>Replace phrase 'empty string' with '&lt;see cref="string.Empty"/&gt; string ("")'</value>
+  </data>
+  <data name="MiKo_2241_Title" xml:space="preserve">
+    <value>Do not use 'empty string' in documentation</value>
+  </data>
   <data name="MiKo_2244_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;list&gt; to list items</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// The diagnostic issue containing the starting phrase proposal.
         /// </param>
         /// <returns>
-        /// A <see cref="string"/> that contains the starting phrase proposal, or an empty string if not found.
+        /// A <see cref="string"/> that contains the starting phrase proposal, or the <see cref="string.Empty"/> string ("") if not found.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static string GetStartingPhraseProposal(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.StartingPhrase, out var s) ? s : string.Empty;
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// The diagnostic issue containing the ending phrase proposal.
         /// </param>
         /// <returns>
-        /// A <see cref="string"/> that contains the ending phrase proposal, or an empty string if not found.
+        /// A <see cref="string"/> that contains the ending phrase proposal, or the <see cref="string.Empty"/> string ("") if not found.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static string GetEndingPhraseProposal(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.EndingPhrase, out var s) ? s : string.Empty;
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// The diagnostic issue containing the phrase proposal.
         /// </param>
         /// <returns>
-        /// A <see cref="string"/> that contains the phrase proposal, or an empty string if not found.
+        /// A <see cref="string"/> that contains the phrase proposal, or the <see cref="string.Empty"/> string ("") if not found.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static string GetPhraseProposal(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.Phrase, out var s) ? s : string.Empty;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_CodeFixProvider.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2241_CodeFixProvider)), Shared]
+    public sealed class MiKo_2241_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2241";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<XmlTextSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => syntax;
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (syntax is XmlTextSyntax text)
+            {
+                return root.ReplaceNode(syntax, GetReplacements(text));
+            }
+
+            return root;
+        }
+
+        private static List<SyntaxNode> GetReplacements(XmlTextSyntax node)
+        {
+            var textTokens = node.TextTokens;
+            var result = new List<SyntaxNode>(textTokens.Count * 2);
+
+            var newLineTokenJustSkipped = false;
+
+            const string Splitter = "###";
+            var splitters = new[] { Splitter };
+
+            foreach (var textToken in textTokens)
+            {
+                // special handling of new lines
+                if (textToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                {
+                    // keep new line
+                    result.Add(XmlText().WithLeadingXmlComment());
+
+                    // we do not need to inspect further
+                    newLineTokenJustSkipped = true;
+
+                    continue;
+                }
+
+                var valueText = textToken.ValueText
+                                         .AsCachedBuilder()
+                                         .ReplaceWithProbe("an empty string", "the empty string")
+                                         .ReplaceWithProbe("An empty string", "The empty string")
+                                         .ReplaceWithProbe("empty string", @"empty string ("""")")
+                                         .ReplaceWithProbe("empty string", Splitter + " string")
+                                         .ToString();
+
+                var text = valueText.AsSpan();
+
+                // get rid of leading whitespace characters caused by '/// '
+                if (newLineTokenJustSkipped)
+                {
+                    text = text.TrimStart();
+                }
+
+                newLineTokenJustSkipped = false;
+
+                var parts = text.SplitBy(splitters);
+
+                foreach (var part in parts)
+                {
+                    if (part is Splitter)
+                    {
+                        result.Add(SeeCref(PredefinedType(SyntaxKind.StringKeyword), nameof(string.Empty)));
+                    }
+                    else
+                    {
+                        result.Add(XmlText(part));
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2241_DocumentationUsesEmptyStringAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2241";
+
+        private const string Phrase = "empty string";
+
+        public MiKo_2241_DocumentationUsesEmptyStringAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            List<Diagnostic> issues = null;
+
+            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
+            {
+                var textTokens = xmlText.TextTokens;
+
+                // keep in local variable to avoid multiple requests (see Roslyn implementation)
+                var textTokensCount = textTokens.Count;
+
+                if (textTokensCount is 0)
+                {
+                    continue;
+                }
+
+                var parent = xmlText.Parent;
+
+                if (parent.IsCode())
+                {
+                    continue;
+                }
+
+                for (var index = 0; index < textTokensCount; index++)
+                {
+                    var token = textTokens[index];
+
+                    if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                    {
+                        continue;
+                    }
+
+                    var locations = GetAllLocations(token, Phrase);
+
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(locations.Count);
+                    }
+
+                    foreach (var location in locations)
+                    {
+                        issues.Add(Issue(location));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzerTests.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2241_DocumentationUsesEmptyStringAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_no_empty_string_in_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some text.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_string_in_code_in_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some text for <code> some empty string </code>. Just to be sure.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void An_issue_is_reported_for_empty_string_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some empty string inside text.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void Code_gets_fixed_for_an_empty_string()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// This is an empty string here.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// This is the <see cref="string.Empty"/> string ("") here.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_empty_string()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// This is some empty string here.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// This is some <see cref="string.Empty"/> string ("") here.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_the_empty_string()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// This is the empty string here.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// This is the <see cref="string.Empty"/> string ("") here.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_an_empty_string_as_start()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// An empty string here.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// The <see cref="string.Empty"/> string ("") here.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_the_empty_string_as_start()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// The empty string here.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// The <see cref="string.Empty"/> string ("") here.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2241_DocumentationUsesEmptyStringAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2241_DocumentationUsesEmptyStringAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2241_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzerTests.cs
@@ -44,7 +44,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void An_issue_is_reported_with_a_number_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_a_number_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 /// <" + tag + @">
 /// This is some text for -1. Just to be sure.
 /// </" + tag + @">
@@ -52,7 +52,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void An_issue_is_reported_with_a_number_followed_by_a_colon_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_a_number_followed_by_a_colon_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 /// <" + tag + @">
 /// This is some text for -1, just to be sure.
 /// </" + tag + @">

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 527 rules that are currently provided by the analyzer.
+The following tables lists all the 528 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -301,6 +301,7 @@ The following tables lists all the 527 rules that are currently provided by the 
 |MiKo_2238|Do not start &lt;summary&gt; documentation with 'Make sure to call this'|&#x2713;|\-|
 |MiKo_2239|Use '///' instead of '/** */' for documentation|&#x2713;|&#x2713;|
 |MiKo_2240|Do not start &lt;response&gt; documentation with 'Returns'|&#x2713;|&#x2713;|
+|MiKo_2241|Do not use 'empty string' in documentation|&#x2713;|&#x2713;|
 |MiKo_2244|Use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt; in documentation|&#x2713;|&#x2713;|
 |MiKo_2245|Wrap numbers with &lt;c&gt; in documentation|&#x2713;|&#x2713;|
 |MiKo_2300|Explain the 'Why' instead of the 'How' in comments|&#x2713;|\-|


### PR DESCRIPTION
- Add analyzer for 'empty string' phrase

- Add code fix to use see cref

- Update resources and rule listing

- Add comprehensive unit tests

(resolves #1661)