### PR TITLE
MiKo_3105 now ignores 'Assert.EnterMultipleScope' and 'Assert.MultipleAsync'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzer.cs
@@ -23,6 +23,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                   "Catch",
                                                                                   "ThrowsAsync",
                                                                                   "Multiple",
+                                                                                  "MultipleAsync",
+                                                                                  "EnterMultipleScope",
                                                                               };
 
         public MiKo_3105_TestMethodsUseAssertThatAnalyzer() : base(Id)

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3105_TestMethodsUseAssertThatAnalyzerTests.cs
@@ -145,6 +145,42 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_a_AssertMultipleAsync() => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Test]
+        public async Task DoSomethingAsync()
+        {
+            await Assert.MultipleAsync(() => { });
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_a_AssertEnterMultipleScope() => No_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+            }
+        }
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_a_AssertThatAsync() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 


### PR DESCRIPTION
- Extend ignored NUnit Assert methods

- Add tests for `MultipleAsync`, `EnterMultipleScope`

- Update analyzer allowlist entries

