### PR TITLE
MiKo_3109 codefix now ignores 'Assert.EnterMultipleScope' and 'Assert.MultipleAsync'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -60,6 +60,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case "Inconclusive":
                 case "Ignore":
                 case "Multiple":
+                case "MultipleAsync":
+                case "EnterMultipleScope":
                     return args; // do not adjust
 
                 case "Less":

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzerTests.cs
@@ -316,6 +316,9 @@ namespace Bla
         [TestCase("Assert.Ignore()", @"Assert.Ignore()")]
         [TestCase("Assert.Inconclusive()", @"Assert.Inconclusive()")]
         [TestCase("Assert.Fail()", @"Assert.Fail()")]
+        [TestCase("Assert.Multiple()", @"Assert.Multiple()")]
+        [TestCase("Assert.MultipleAsync()", @"Assert.MultipleAsync()")]
+        [TestCase("Assert.EnterMultipleScope()", @"Assert.EnterMultipleScope()")]
         public void Code_is_not_fixed_for_assertion_(string originalCode, string fixedCode)
         {
             const string Template = @"


### PR DESCRIPTION
- Skip adjusting `MultipleAsync` and `EnterMultipleScope`

- Extend do-not-fix list in codefix

- Add unit tests for non-fix assertions
