### PR TITLE
MiKo_2060 is now aware of 'Creates ' as factory type XML documentation start

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -320,6 +320,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                 new Pair(" type with type.", " type with default values."),
                                                 new Pair(" type with that ", " type with default values that "),
                                                 new Pair(" type with which ", " type with default values which "),
+                                                new Pair(" creating creates ", " creating "),
+                                                new Pair(" creating create ", " creating "),
                                             };
                 CleanupReplacementMapKeys = CleanupReplacementMap.ToArray(_ => _.Key);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -779,10 +779,12 @@ internal interface IFactory
 
             results.RemoveWhere(_ => _.ContainsAny(strangePhrases));
 
-            results.Add("Implementations create ");
-            results.Add("Implementations construct ");
-            results.Add("Implementations build ");
-            results.Add("Implementations provide ");
+            results.Add("Implementations create");
+            results.Add("Implementations construct");
+            results.Add("Implementations build");
+            results.Add("Implementations provide");
+            results.Add("Create");
+            results.Add("Creates");
 
             return results;
         }


### PR DESCRIPTION
- Add "Create" and "Creates" to the list of recognized factory documentation starting phrases

- Add cleanup rules to handle redundant "creating creates/create" patterns in documentation
