### PR TITLE
MiKo_2019 is now aware of phrases like "This method is called"

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -78,6 +78,34 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   "ctor",
                                                               };
 
+        private static readonly string[] CallbackPhrases =
+                                                           {
+                                                               "A callback that is called",
+                                                               "A callback which is called",
+                                                               "A method that gets called",
+                                                               "A method that is called",
+                                                               "A method which gets called",
+                                                               "A method which is called",
+                                                               "Callback that is called",
+                                                               "Callback which is called",
+                                                               "Method that gets called",
+                                                               "Method that is called",
+                                                               "Method which gets called",
+                                                               "Method which is called",
+                                                               "The callback that is called",
+                                                               "The callback which is called",
+                                                               "The method gets called",
+                                                               "The method is called",
+                                                               "The method that gets called",
+                                                               "The method that is called",
+                                                               "The method which gets called",
+                                                               "The method which is called",
+                                                               "This method gets called",
+                                                               "This method is called",
+                                                           };
+
+        private static readonly Pair[] CallbackReplacements = CallbackPhrases.ToArray(_ => new Pair(_, "Gets called"));
+
         public override string FixableDiagnosticId => "MiKo_2019";
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
@@ -160,6 +188,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (startText.StartsWithAny(RepresentsTheCandidates))
                 {
                     return CommentStartingWith(summary, "Represents the ");
+                }
+
+                if (startText.StartsWithAny(CallbackPhrases))
+                {
+                    return Comment(summary, CallbackPhrases, CallbackReplacements);
                 }
 
                 var updatedSyntax = MiKo_2012_CodeFixProvider.GetUpdatedSyntax(summary);

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -725,6 +725,44 @@ public interface TestMe
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", """Initializes a new instance of the <see cref="TestMe{T1,T2}"/> class"""));
         }
 
+        [TestCase("A callback that is called", "Gets called")]
+        [TestCase("A callback which is called", "Gets called")]
+        [TestCase("A method that gets called", "Gets called")]
+        [TestCase("A method that is called", "Gets called")]
+        [TestCase("A method which gets called", "Gets called")]
+        [TestCase("A method which is called", "Gets called")]
+        [TestCase("Callback that is called", "Gets called")]
+        [TestCase("Callback which is called", "Gets called")]
+        [TestCase("Method that gets called", "Gets called")]
+        [TestCase("Method that is called", "Gets called")]
+        [TestCase("Method which gets called", "Gets called")]
+        [TestCase("Method which is called", "Gets called")]
+        [TestCase("The callback that is called", "Gets called")]
+        [TestCase("The callback which is called", "Gets called")]
+        [TestCase("The method gets called", "Gets called")]
+        [TestCase("The method is called", "Gets called")]
+        [TestCase("The method that gets called", "Gets called")]
+        [TestCase("The method that is called", "Gets called")]
+        [TestCase("The method which gets called", "Gets called")]
+        [TestCase("The method which is called", "Gets called")]
+        [TestCase("This method gets called", "Gets called")]
+        [TestCase("This method is called", "Gets called")]
+        public void Code_gets_fixed_for_(string originalText, string fixedText)
+        {
+            const string Template = """
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>
+                                        /// ### to do something.
+                                        /// </summary>
+                                        public void DoSomething() { }
+                                    }
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer();


### PR DESCRIPTION
- Add detection for different passive voice phrase patterns (e.g., "This method is called", "A callback that is called")

- Implement automatic code fix to replace passive constructions with "Gets called"

- Add comprehensive test coverage for all added phrase variations
