### PR TITLE
MiKo_6044 is now aware of invocations followed by suppressed  nullable warning

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.cs
@@ -81,8 +81,14 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 case PostfixUnaryExpressionSyntax unary:
                 {
                     var operatorToken = unary.OperatorToken;
+                    var expression = unary.Operand;
 
-                    return operatorToken.IsOnSameLineAs(unary.Operand) ? null : Issue(operatorToken);
+                    if (expression is InvocationExpressionSyntax i && i.Expression is MemberAccessExpressionSyntax maes)
+                    {
+                        expression = maes.Name;
+                    }
+
+                    return operatorToken.IsOnSameLineAs(expression) ? null : Issue(operatorToken);
                 }
 
                 default:

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzerTests.cs
@@ -337,6 +337,25 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void No_issue_is_reported_for_SuppressNullableWarningExpression_at_end_of_line() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    TestMe _testee;
+
+    public TestMe DoSomething()
+    {
+        _testee
+            .DoSomething()!
+            .DoSomething();
+
+        return _testee;
+    }
+}
+");
+
         protected override string GetDiagnosticId() => MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6044_BooleanOperatorsAreOnSameLineAsRightOperandAnalyzer();


### PR DESCRIPTION
- Add logic to handle invocation expressions with member access when checking operator positioning

- Add test case to verify the fix for suppressed nullable warnings at end of lines
