### PR TITLE
MiKo_1107 is now aware of 'HTTP' (client/response/request) and 'ActiveMQ'

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
@@ -280,6 +280,9 @@ namespace MiKoSolutions.Analyzers.Linguistics
                            .ReplaceWithProbe("Keep", "Keeps")
                            .ReplaceWithProbe("Keepss", "Keeps") // fix typo
                            .ReplaceWithProbe("Wont", "Does_Not_")
+                           .ReplaceWithProbe("HTTPClient", "HTTP_client")
+                           .ReplaceWithProbe("HTTPResponse", "HTTP_response")
+                           .ReplaceWithProbe("HTTPRequest", "HTTP_request")
                            .ReplaceWithProbe("ArgumentExceptionThrown", "ThrowsArgumentException")
                            .ReplaceWithProbe("ArgumentsExceptionThrown", "ThrowsArgumentException")
                            .ReplaceWithProbe("ArgumentNullExceptionThrown", "ThrowsArgumentNullException")
@@ -298,7 +301,9 @@ namespace MiKoSolutions.Analyzers.Linguistics
                            .ReplaceWithProbe("ValidationExceptionThrown", "ThrowsValidationException")
                            .ReplaceWithProbe("UnauthorizedAccessExceptionThrown", "ThrowsUnauthorizedAccessException")
                            .ReplaceWithProbe("ExceptionThrown", "ThrowsException")
+                           .ReplaceWithProbe("ActiveMQ", "<0>")
                            .SeparateWords(Constants.Underscore)
+                           .ReplaceWithProbe("<_0>", "ActiveMQ")
                            .ReplaceWithProbe("argument_exception", "ArgumentException")
                            .ReplaceWithProbe("argument_null_exception", "ArgumentNullException") // fix some corrections, such as for known exceptions
                            .ReplaceWithProbe("argument_out_of_range_exception", "ArgumentOutOfRangeException")

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
@@ -122,6 +122,11 @@ public class TestMe
         [TestCase("DoSomething_ThrowException_DoesNotKeepSomething", "Do_something_throws_exception_does_not_keep_something")]
         [TestCase("DoSomething_ThrowException_WillKeepSomething", "Do_something_throws_exception_keeps_something")]
         [TestCase("DoSomething_ThrowException_ToKeepSomething", "Do_something_throws_exception_to_keep_something")]
+        [TestCase("ClientThrow_ActiveMQException", "Client_throws_ActiveMQ_exception")]
+        [TestCase("Client_SendsHTTPRequest_WithData", "Client_sends_HTTP_request_with_data")]
+        [TestCase("Client_ReceivesHTTPRequest_WithData", "Client_receives_HTTP_request_with_data")]
+        [TestCase("HTTPClient_SendsHTTPRequest_WithData", "HTTP_client_sends_HTTP_request_with_data")]
+        [TestCase("HTTPClient_ReceivesHTTPRequest_WithData", "HTTP_client_receives_HTTP_request_with_data")]
         public void Code_gets_fixed_for_test_method_(string original, string fix)
         {
             const string Template = @"


### PR DESCRIPTION
- Add support for HTTP-prefixed terms (HTTPClient, HTTPResponse, HTTPRequest) to be converted to snake_case format (HTTP_client, HTTP_response, HTTP_request)

- Add special handling for ActiveMQ to preserve its capitalization during word separation

- Add comprehensive test cases validating the new HTTP and ActiveMQ formatting rules
