### PR TITLE
MiKo_6030 and MiKo_6062 now update ComplexElementInitializer indentations in similar way

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -9,6 +9,7 @@ namespace MiKoSolutions.Analyzers
     internal static class Constants
     {
         internal const int Indentation = 4;
+        internal const int IndentationForComplexElementInitializerExpression = 2;
         internal const int MinimumCharactersThreshold = 4;
 
         internal const string Core = "Core";

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6062_ComplexInitializerElementExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6062_ComplexInitializerElementExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var expressionPosition = expression.GetStartPosition();
                 var openBracePosition = initializer.OpenBraceToken.GetStartPosition();
 
-                var expectedPosition = openBracePosition.Character + 2;
+                var expectedPosition = openBracePosition.Character + Constants.IndentationForComplexElementInitializerExpression;
 
                 if (expressionPosition.Line > openBracePosition.Line && expressionPosition.Character != expectedPosition)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingCodeFixProvider.cs
@@ -63,8 +63,6 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             var openBraceToken = syntax.OpenBraceToken;
             var closeBraceToken = syntax.CloseBraceToken;
 
-            var closeBraceTokenSpaces = openBraceToken.IsOnSameLineAs(closeBraceToken) ? 0 : spaces;
-
             var updatedOpenBraceToken = openBraceToken.WithLeadingSpaces(spaces);
 
             if (syntax.Parent is BaseObjectCreationExpressionSyntax parent)
@@ -84,8 +82,21 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 }
             }
 
+            int closeBraceTokenSpaces, indentation;
+
+            if (syntax.IsKind(SyntaxKind.ComplexElementInitializerExpression))
+            {
+                indentation = Constants.IndentationForComplexElementInitializerExpression;
+                closeBraceTokenSpaces = syntax.Expressions.LastOrDefault()?.IsOnSameLineAs(closeBraceToken) is true ? 0 : spaces;
+            }
+            else
+            {
+                indentation = Constants.Indentation;
+                closeBraceTokenSpaces = openBraceToken.IsOnSameLineAs(closeBraceToken) ? 0 : spaces;
+            }
+
             return syntax.WithOpenBraceToken(updatedOpenBraceToken)
-                         .WithExpressions(GetUpdatedSyntax(syntax.Expressions, openBraceToken, spaces + Constants.Indentation))
+                         .WithExpressions(GetUpdatedSyntax(syntax.Expressions, openBraceToken, spaces + indentation))
                          .WithCloseBraceToken(closeBraceToken.WithLeadingSpaces(closeBraceTokenSpaces));
         }
 
@@ -116,7 +127,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     }
 
                     updatedSyntax = syntax.WithArgumentList(argumentList.WithOpenParenToken(openParenToken.WithoutTrivia()).WithCloseParenToken(updatedCloseParenToken))
-                                          .WithInitializer(GetUpdatedSyntax(initializer, spaces + Constants.Indentation));
+                                              .WithInitializer(GetUpdatedSyntax(initializer, spaces + Constants.Indentation));
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzerTests.cs
@@ -1401,7 +1401,7 @@ public class TestMe
                              Headers = new Dictionary(string, string[])
                                            {
                                                {
-                                                   ""key"", [""value""]
+                                                 ""key"", [""value""]
                                                },
                                            },
                          };
@@ -1639,6 +1639,57 @@ public class TestMe
                                      { ""some"", ""value"" },
                                      { ""another"", ""item"" },
                                      { ""third"", ""entry"" }
+                                 }
+                         };
+    }
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_list_of_dictionary_with_explicit_dictionary_creation_and_element_expressions_are_on_separate_lines()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var result = new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object>() {
+                {
+                    ""some"", ""value"" },
+                {
+                    ""another"", ""item"" },
+                {
+                    ""third"", ""entry"" }
+            }
+        };
+    }
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var result = new List<Dictionary<string, object>>
+                         {
+                             new Dictionary<string, object>()
+                                 {
+                                     {
+                                       ""some"", ""value"" },
+                                     {
+                                       ""another"", ""item"" },
+                                     {
+                                       ""third"", ""entry"" }
                                  }
                          };
     }


### PR DESCRIPTION
- Standardize indentations for `ComplexElementInitializerExpression` across analyzers MiKo_6030 and MiKo_6062