### PR TITLE
Enhanced MiKo_1072 by additional allowed names, updated messages for MiKo_1071/2/3

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -2746,7 +2746,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Formulate question as statement.
+        ///   Looks up a localized string similar to Formulate question &apos;{0}&apos; as statement.
         /// </summary>
         internal static string MiKo_1071_MessageFormat {
             get {
@@ -2781,7 +2781,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Formulate question as statement.
+        ///   Looks up a localized string similar to Formulate question &apos;{0}&apos; as statement.
         /// </summary>
         internal static string MiKo_1072_MessageFormat {
             get {
@@ -2816,7 +2816,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Formulate question as statement.
+        ///   Looks up a localized string similar to Formulate question &apos;{0}&apos; as statement.
         /// </summary>
         internal static string MiKo_1073_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1033,7 +1033,7 @@ Example:
    'if (deviceIsOnline) DoSomething();' is more fluent to read.</value>
   </data>
   <data name="MiKo_1071_MessageFormat" xml:space="preserve">
-    <value>Formulate question as statement</value>
+    <value>Formulate question '{0}' as statement</value>
   </data>
   <data name="MiKo_1071_Title" xml:space="preserve">
     <value>Name local boolean variables as statements, not questions</value>
@@ -1050,7 +1050,7 @@ Example:
    'if (DeviceIsOnline) DoSomething();' is more fluent to read.</value>
   </data>
   <data name="MiKo_1072_MessageFormat" xml:space="preserve">
-    <value>Formulate question as statement</value>
+    <value>Formulate question '{0}' as statement</value>
   </data>
   <data name="MiKo_1072_Title" xml:space="preserve">
     <value>Name boolean properties or methods as statements, not questions</value>
@@ -1067,7 +1067,7 @@ Example:
    'if (DeviceIsOnline) DoSomething();' is more fluent to read.</value>
   </data>
   <data name="MiKo_1073_MessageFormat" xml:space="preserve">
-    <value>Formulate question as statement</value>
+    <value>Formulate question '{0}' as statement</value>
   </data>
   <data name="MiKo_1073_Title" xml:space="preserve">
     <value>Name boolean fields as statements, not questions</value>

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzerTests.cs
@@ -16,30 +16,58 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             "CanBeConnected",
                                                             "Connected",
                                                             "HasConnectionEstablished",
+                                                            "IsAllLowerCase",
+                                                            "IsAllUpperCase",
+                                                            "IsAnyKind",
+                                                            "IsAssignableFrom",
+                                                            "IsAssignableTo",
+                                                            "IsByteArray",
+                                                            "IsCancellationToken",
                                                             "IsCompleted",
                                                             "IsConnected",
+                                                            "IsContainedInData",
+                                                            "IsDefault",
                                                             "IsDefaultValue",
                                                             "IsDigitsOnly",
                                                             "IsDragSource",
+                                                            "IsDroppedOverSomething",
                                                             "IsDropTarget",
+                                                            "IsEmptyArray",
+                                                            "IsExcludedFromData",
+                                                            "IsFirstChild",
+                                                            "IsIncludedInData",
                                                             "IsInCode",
                                                             "IsInDesign",
                                                             "IsInDesignerMode",
                                                             "IsInDesignMode",
+                                                            "IsInheritedFromSomething",
+                                                            "IsInsideOfSomething",
+                                                            "IsLastChild",
                                                             "IsLowerCase",
                                                             "IsLowerCaseLetter",
+                                                            "IsNameOf",
                                                             "IsNavigationTarget",
+                                                            "IsNextChild",
                                                             "IsNotCompleted",
+                                                            "IsOfName",
+                                                            "IsOfType",
                                                             "IsOfTypeWhatever",
                                                             "IsOnSameLineLine",
+                                                            "IsPreviousChild",
+                                                            "IsPrimaryConstructor",
                                                             "IsReadOnly",
                                                             "IsReadWrite",
                                                             "IsSame",
                                                             "IsSameKey",
+                                                            "IsShownAs",
                                                             "IsShownAsText",
+                                                            "IsShownIn",
                                                             "IsShownInMenu",
+                                                            "IsSingleWord",
                                                             "IsSolutionWide",
+                                                            "IsTest",
                                                             "IsTestMethod",
+                                                            "IsTypeOf",
                                                             "IsUpperCase",
                                                             "IsUpperCaseLetter",
                                                             "IsValueConverter",
@@ -86,6 +114,22 @@ using System;
 public class TestMe
 {
     public int IsDoingSomething { get; set; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_Boolean_return_type_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+using System;
+using System.Threading;
+
+[TestFixture]
+public class TestMe
+{
+    [Test]
+    public bool " + name + @"()
+    {
+        return false;
+    }
 }
 ");
 


### PR DESCRIPTION
- Add 20+ new well-known Boolean method/property names to the allowed list

- Exclude test methods from Boolean naming analysis

- Update diagnostic message formats to include the specific name that violates the rule
