### PR TITLE
MiKo_1063 now ignores parameters of implemented interfaces

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -31,12 +31,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(IParameterSymbol symbol)
         {
-            if (symbol.ContainingSymbol is IMethodSymbol method && method.IsExtern)
+            if (base.ShallAnalyze(symbol))
             {
-                return false;
+                if (symbol.ContainingSymbol is IMethodSymbol method)
+                {
+                    if (method.IsExtern)
+                    {
+                        return false;
+                    }
+
+                    if (method.IsInterfaceImplementation())
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
-            return base.ShallAnalyze(symbol);
+            return false;
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeName(INamespaceSymbol symbol, Compilation compilation) => AnalyzeName(symbol);

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.Prefixes.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.Prefixes.cs
@@ -77,6 +77,48 @@ namespace Bla
 }");
 
         [Test]
+        public void No_issue_is_reported_for_parameters_of_implemented_interfaces_([ValueSource(nameof(BadPrefixes))] string part) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+#pragma warning disable MiKo_1063
+
+    public interface ITestMe
+    {
+        int DoSomething(int " + part + @"Parameter);
+    }
+
+#pragma warning restore MiKo_1063
+
+    public class TestMe : ITestMe
+    {
+        public int DoSomething(int " + part + @"Parameter) => 42;
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_parameters_of_implemented_interfaces_on_abstract_class_([ValueSource(nameof(BadPrefixes))] string part) => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+#pragma warning disable MiKo_1063
+
+    public interface ITestMe
+    {
+        int DoSomething(int " + part + @"Parameter);
+    }
+
+#pragma warning restore MiKo_1063
+
+    public abstract class TestMe : ITestMe
+    {
+        public abstract int DoSomething(int " + part + @"Parameter);
+    }
+}");
+
+        [Test]
         public void An_issue_is_reported_for_local_variable_with_prefix_([ValueSource(nameof(BadPrefixes))] string prefix) => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Modify `ShallAnalyze` to check if a method implements an interface and skip analysis for its parameters

- Add tests for interface implementation scenarios in both regular and abstract classes
