### PR TITLE
MiKo_2012 and MiKo_2019 now fix text starting with 'Called'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -109,7 +109,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static SyntaxNode GetUpdatedSyntax(XmlElementSyntax comment, XmlTextSyntax textSyntax)
         {
-            var text = textSyntax.GetTextTrimmed().AsSpan();
+            var trimmedText = textSyntax.GetTextTrimmed();
+            var text = trimmedText.AsSpan();
 
             if (text.StartsWith("Interaction logic for"))
             {
@@ -120,6 +121,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (text.StartsWithAny(EmptyReplacementsMapKeys))
             {
                 return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, StartAdjustment);
+            }
+
+            if (text.StartsWith("Called"))
+            {
+                return Comment(comment, trimmedText.Replace("Called", "Gets called"));
             }
 
             if (comment.GetEnclosing(Declarations) is MemberDeclarationSyntax member)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -205,12 +205,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 // only adjust in case there is no single letter
                 if (firstWord.Length > 1)
                 {
-                    if (firstWord.EndsWith("alled"))
-                    {
-                        // currently we cannot adjust "Called" text properly
-                        return summary;
-                    }
-
                     var index = text.IndexOf(firstWord);
                     var remainingText = text.Slice(index + firstWord.Length);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -1194,6 +1194,8 @@ public class TestMe
         }
 
         [TestCase("Called to do", "Does")]
+        [TestCase("Called by someone to do", "Gets called by someone to do")]
+        [TestCase("Called if someone attempts to do", "Gets called if someone attempts to do")]
         public void Code_gets_fixed_for_method_text_(string originalComment, string fixedComment)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -747,6 +747,8 @@ public interface TestMe
         [TestCase("The method which is called", "Gets called")]
         [TestCase("This method gets called", "Gets called")]
         [TestCase("This method is called", "Gets called")]
+        [TestCase("Called by someone", "Gets called by someone")]
+        [TestCase("Called if someone tries", "Gets called if someone tries")]
         public void Code_gets_fixed_for_(string originalText, string fixedText)
         {
             const string Template = """


### PR DESCRIPTION
- Remove guard clause in MiKo_2019 that prevented fixing text starting with "Called"

- Add logic in MiKo_2012 to replace "Called" with "Gets called" at the start of documentation text

- Add test cases to verify the new behavior handles various "Called" scenarios correctly
