### PR TITLE
MiKo_2019 (and MiKo_2012) are now aware of some more boolean property starting phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -130,9 +130,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                         "set/Get a value ",
                                                                         "Set/get a value ",
                                                                         "Set/Get a value ",
+                                                                        "get/set ",
                                                                         "get/Set ",
                                                                         "Get/set ",
                                                                         "Get/Set ",
+                                                                        "set/get ",
                                                                         "set/Get ",
                                                                         "Set/get ",
                                                                         "Set/Get ",
@@ -315,18 +317,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                             .ReplaceWithProbe("Sets a value indicating set to true ", "Sets a value indicating ")
                                             .ReplaceWithProbe("Sets a value indicating set ", "Sets a value indicating ")
                                             .ReplaceWithProbe("Sets set ", "Sets ")
+                                            .ReplaceWithProbe("  ", " ")
                                             .ReplaceWithProbe("value indicating the value indicating", "value indicating the")
-                                            .ReplaceWithProbe("indicating  that indicates", "indicating")
-                                            .ReplaceWithProbe("indicating  which indicates", "indicating")
+                                            .ReplaceWithProbe("indicating that indicates", "indicating")
+                                            .ReplaceWithProbe("indicating which indicates", "indicating")
                                             .ReplaceWithProbe("indicating to true,", "indicating")
                                             .ReplaceWithProbe("indicating to true", "indicating")
                                             .ReplaceWithProbe("indicating to", "indicating whether to")
                                             .ReplaceWithProbe("indicating if to", "indicating whether to")
                                             .ReplaceWithProbe("indicating that to", "indicating whether to")
-                                            .ReplaceWithProbe("indicating  to", "indicating whether to")
-                                            .ReplaceWithProbe("indicating  indicating", "indicating")
                                             .ReplaceWithProbe("indicating indicating", "indicating")
-                                            .ReplaceWithProbe("a value indicating  a value indicating", "a value indicating");
+                                            .ReplaceWithProbe("a value indicating a value indicating", "a value indicating");
 
             var replacedFixedText = builder.ToStringAndRelease();
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -618,6 +618,29 @@ public interface TestMe
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", "Gets or sets a value indicating whether"));
         }
 
+        [TestCase("Get/Set")]
+        [TestCase("Get/set")]
+        [TestCase("get/Set")]
+        [TestCase("Set/Get")]
+        [TestCase("Set/get")]
+        [TestCase("set/Get")]
+        public void Code_gets_fixed_for_non_boolean_property_text_(string originalText)
+        {
+            const string Template = @"
+using System;
+
+public interface TestMe
+{
+    /// <summary>
+    /// ### some text to inform about something
+    /// </summary>
+    public string SomeProperty { get; set; }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", "Gets or sets"));
+        }
+
         [TestCase("Called to inform about something", "Informs about something")]
         [TestCase("Called to save something", "Saves something")]
         [TestCase("Save something", "Saves something")]


### PR DESCRIPTION
- Add support for various case combinations of "Get/Set", "Set/Get", "Gets/Sets", and "Sets/Gets" phrases

- Extend pattern matching for "flag" and "value" variations with articles ("a flag", "a value")
