### PR TITLE
MiKo_2019 is now aware of text starting with 'Asynchronously' or 'Recursively'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -106,6 +106,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Pair[] CallbackReplacements = CallbackPhrases.ToArray(_ => new Pair(_, "Gets called"));
 
+        private static readonly Pair[] CallbackReplacementsWithLy =
+                                                                    {
+                                                                        new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "called", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
+                                                                        new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "invoked", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
+
+                                                                        new Pair(Constants.Comments.RecursivelyStartingPhrase + "called", Constants.Comments.RecursivelyStartingPhrase + "runs"),
+                                                                        new Pair(Constants.Comments.RecursivelyStartingPhrase + "invoked", Constants.Comments.RecursivelyStartingPhrase + "runs"),
+                                                                    };
+
+        private static readonly string[] CallbackPhrasesWithLy = CallbackReplacementsWithLy.ToArray(_ => _.Key);
+
         public override string FixableDiagnosticId => "MiKo_2019";
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
@@ -200,6 +211,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 if (ReferenceEquals(summary, updatedSyntax) is false)
                 {
                     return updatedSyntax;
+                }
+
+                if (text.StartsWith(Constants.Comments.AsynchronouslyStartingPhrase) || text.StartsWith(Constants.Comments.RecursivelyStartingPhrase))
+                {
+                    var updatedSummary = Comment(summary, CallbackPhrasesWithLy, CallbackReplacementsWithLy);
+
+                    if (ReferenceEquals(summary, updatedSummary) is false)
+                    {
+                        return updatedSummary;
+                    }
+
+                    firstWord = text.SecondWord();
                 }
 
                 // only adjust in case there is no single letter

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -646,6 +646,10 @@ public interface TestMe
         [TestCase("Save something", "Saves something")]
         [TestCase("Whether something is there", "Determines whether something is there")]
         [TestCase("If something is there", "Determines whether something is there")]
+        [TestCase("Asynchronously invoked at some time", "Asynchronously runs at some time")]
+        [TestCase("Asynchronously called at some time", "Asynchronously runs at some time")]
+        [TestCase("Recursively invoked at some time", "Recursively runs at some time")]
+        [TestCase("Recursively called at some time", "Recursively runs at some time")]
         public void Code_gets_fixed_for_method_text_(string originalText, string fixedText)
         {
             const string Template = @"


### PR DESCRIPTION
- Add specialized replacement patterns for "Asynchronously" and "Recursively" adverb-prefixed phrases

- Add test cases covering the new adverb-aware functionality
