### PR TITLE
MiKo_2016, MiKo_2012 and MiKo_2019 are now aware of 'This will' / 'This method will'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -551,12 +551,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("This method is called", "Gets called");
             yield return new Pair("This Method "); // typo in real-life scenario
             yield return new Pair("This method ");
+            yield return new Pair("This Method will "); // typo in real-life scenario
+            yield return new Pair("This method will ");
             yield return new Pair("This Class "); // typo in real-life scenario
             yield return new Pair("This class ");
-            yield return new Pair("This Callback ");
-            yield return new Pair("This Call-back ");
+            yield return new Pair("This Callback "); // typo in real-life scenario
+            yield return new Pair("This Call-back "); // typo in real-life scenario
             yield return new Pair("This callback ");
             yield return new Pair("This call-back ");
+            yield return new Pair("This Callback will "); // typo in real-life scenario
+            yield return new Pair("This Call-back will "); // typo in real-life scenario
+            yield return new Pair("This callback will ");
+            yield return new Pair("This call-back will ");
 
             yield return new Pair("This control ");
             yield return new Pair("This control will ");

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
@@ -12,34 +12,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2016_CodeFixProvider)), Shared]
     public sealed class MiKo_2016_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
-        private static readonly string[] ReplacementMapKeys =
-                                                              {
-                                                                  "A callback that is called ",
-                                                                  "A callback which is called ",
-                                                                  "A method that gets called ",
-                                                                  "A method that is called ",
-                                                                  "A method which gets called ",
-                                                                  "A method which is called ",
-                                                                  "Callback that is called ",
-                                                                  "Callback which is called ",
-                                                                  "Method that gets called ",
-                                                                  "Method that is called ",
-                                                                  "Method which gets called ",
-                                                                  "Method which is called ",
-                                                                  "The callback that is called ",
-                                                                  "The callback which is called ",
-                                                                  "The method gets called ",
-                                                                  "The method is called ",
-                                                                  "The method that gets called ",
-                                                                  "The method that is called ",
-                                                                  "The method which gets called ",
-                                                                  "The method which is called ",
-                                                                  "This method gets called ",
-                                                                  "This method is called ",
-                                                              };
+        private static readonly Pair[] ReplacementMap = { new Pair("Gets called to ") };
 
-        private static readonly Pair[] ReplacementMap = ReplacementMapKeys.Select(_ => new Pair(_, Constants.Comments.AsynchronouslyStartingPhrase + "invoked "))
-                                                                          .OrderDescendingByLengthAndText(_ => _.Key);
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
 
         public override string FixableDiagnosticId => "MiKo_2016";
 
@@ -47,14 +22,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
         {
-            var preparedComment = Comment((XmlElementSyntax)syntax, ReplacementMapKeys, ReplacementMap);
-
-            if (ReferenceEquals(syntax, preparedComment))
+            if (syntax is XmlElementSyntax summary)
             {
+                var preparedComment = MiKo_2019_CodeFixProvider.GetUpdatedSyntax(summary) as XmlElementSyntax ?? summary;
+
+                preparedComment = Comment(preparedComment, ReplacementMapKeys, ReplacementMap);
+
                 return CommentStartingWith(preparedComment, Constants.Comments.AsynchronouslyStartingPhrase, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular);
             }
 
-            return preparedComment;
+            return syntax;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -119,7 +119,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2019";
 
-        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        internal static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax)
         {
             if (syntax is XmlElementSyntax summary)
             {
@@ -132,6 +132,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
 
             return syntax;
+        }
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue)
+        {
+            return GetUpdatedSyntax(syntax);
         }
 
         private static SyntaxNode GetUpdatedSyntaxForConstructor(XmlElementSyntax summary, ConstructorDeclarationSyntax constructor)

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
@@ -281,28 +281,33 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
-        [TestCase("A callback that is called", "Asynchronously invoked")]
-        [TestCase("A callback which is called", "Asynchronously invoked")]
-        [TestCase("A method that gets called", "Asynchronously invoked")]
-        [TestCase("A method that is called", "Asynchronously invoked")]
-        [TestCase("A method which gets called", "Asynchronously invoked")]
-        [TestCase("A method which is called", "Asynchronously invoked")]
-        [TestCase("Callback that is called", "Asynchronously invoked")]
-        [TestCase("Callback which is called", "Asynchronously invoked")]
-        [TestCase("Method that gets called", "Asynchronously invoked")]
-        [TestCase("Method that is called", "Asynchronously invoked")]
-        [TestCase("Method which gets called", "Asynchronously invoked")]
-        [TestCase("Method which is called", "Asynchronously invoked")]
-        [TestCase("The callback that is called", "Asynchronously invoked")]
-        [TestCase("The callback which is called", "Asynchronously invoked")]
-        [TestCase("The method gets called", "Asynchronously invoked")]
-        [TestCase("The method is called", "Asynchronously invoked")]
-        [TestCase("The method that gets called", "Asynchronously invoked")]
-        [TestCase("The method that is called", "Asynchronously invoked")]
-        [TestCase("The method which gets called", "Asynchronously invoked")]
-        [TestCase("The method which is called", "Asynchronously invoked")]
-        [TestCase("This method gets called", "Asynchronously invoked")]
-        [TestCase("This method is called", "Asynchronously invoked")]
+        [TestCase("A callback that is called to do", "Asynchronously does")]
+        [TestCase("A callback which is called to do", "Asynchronously does")]
+        [TestCase("A method that gets called to do", "Asynchronously does")]
+        [TestCase("A method that is called to do", "Asynchronously does")]
+        [TestCase("A method which gets called to do", "Asynchronously does")]
+        [TestCase("A method which is called to do", "Asynchronously does")]
+        [TestCase("Callback that is called to do", "Asynchronously does")]
+        [TestCase("Callback which is called to do", "Asynchronously does")]
+        [TestCase("Method that gets called to do", "Asynchronously does")]
+        [TestCase("Method that is called to do", "Asynchronously does")]
+        [TestCase("Method which gets called to do", "Asynchronously does")]
+        [TestCase("Method which is called to do", "Asynchronously does")]
+        [TestCase("The callback that is called to do", "Asynchronously does")]
+        [TestCase("The callback which is called to do", "Asynchronously does")]
+        [TestCase("The method gets called to do", "Asynchronously does")]
+        [TestCase("The method is called to do", "Asynchronously does")]
+        [TestCase("The method that gets called to do", "Asynchronously does")]
+        [TestCase("The method that is called to do", "Asynchronously does")]
+        [TestCase("The method which gets called to do", "Asynchronously does")]
+        [TestCase("The method which is called to do", "Asynchronously does")]
+        [TestCase("This method gets called to do", "Asynchronously does")]
+        [TestCase("This method is called to do", "Asynchronously does")]
+
+        [TestCase("This will execute", "Asynchronously executes")]
+        [TestCase("This method will execute", "Asynchronously executes")]
+        [TestCase("This Method will execute", "Asynchronously executes")]
+        [TestCase("Is responsible for collecting", "Asynchronously collects")]
         public void Code_gets_fixed_for_(string originalText, string fixedText)
         {
             const string Template = """
@@ -310,7 +315,7 @@ public class TestMe
                                     public class TestMe
                                     {
                                         /// <summary>
-                                        /// ### to do something.
+                                        /// ### something.
                                         /// </summary>
                                         public async Task DoSomethingAsync() { }
                                     }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -669,10 +669,16 @@ public interface TestMe
         [TestCase("This call-back cleans stuff", "Cleans stuff")]
         [TestCase("This Callback cleans stuff", "Cleans stuff")]
         [TestCase("This Call-back cleans stuff", "Cleans stuff")]
+        [TestCase("This callback will clean stuff", "Cleans stuff")]
+        [TestCase("This call-back will clean stuff", "Cleans stuff")]
+        [TestCase("This Callback will clean stuff", "Cleans stuff")]
+        [TestCase("This Call-back will clean stuff", "Cleans stuff")]
         [TestCase("Use this Method, to change something", "Changes something")]
         [TestCase("Use this Method to change something", "Changes something")]
         [TestCase("Use this method to change something", "Changes something")]
         [TestCase("Use this method, to change something", "Changes something")]
+        [TestCase("This will start to do something", "Starts to do something")]
+        [TestCase("This method will start to do something", "Starts to do something")]
         public void Code_gets_fixed_for_method_text_(string originalText, string fixedText)
         {
             const string Template = @"


### PR DESCRIPTION
- Extend pattern recognition in MiKo_2016, MiKo_2012, and MiKo_2019 analyzers to handle future tense ("will") variations (related to MiKo_2049)

- Refactor MiKo_2016 to reuse MiKo_2019's syntax transformation logic

- Add comprehensive test coverage for the new patterns
