### PR TITLE
MiKo_3070 now ignores types that inherit from 'IEnumerable' but end with 'Object'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System.Xml;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -33,12 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return false;
             }
 
-            if (returnType.IsEnumerable())
-            {
-                return returnType.InheritsFrom<XmlNode>() is false;
-            }
-
-            return false;
+            return returnType.IsCollection(returnType.Name);
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3070_EnumerableMethodReturnsNullAnalyzerTests.cs
@@ -371,6 +371,45 @@ namespace Bla
 }");
 
         [Test]
+        public void No_issue_is_reported_for_method_that_returns_null_for_specific_type_with_number_at_the_end() => No_issue_is_reported_for(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bla
+{
+    public interface IXyzObject42 : IEnumerable<string>, IEnumerable
+    {
+    }
+
+    public class TestMe
+    {
+        public IXyzObject42 Create()
+        {
+            return null;
+        }
+    }
+}");
+
+        [Test]
+        public void No_issue_is_reported_for_expression_body_method_that_returns_null_for_specific_type_with_number_at_the_end() => No_issue_is_reported_for(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bla
+{
+    public interface IXyzObject42 : IEnumerable<string>, IEnumerable
+    {
+    }
+
+    public class TestMe
+    {
+        public IXyzObject42 Create() => null;
+    }
+}");
+
+        [Test]
         public void No_issue_is_reported_for_incomplete_method() => No_issue_is_reported_for(@"
 using System.Collections.Generic;
 


### PR DESCRIPTION
- Refactor `ShallAnalyze` to use `IsCollection` method that considers type names

- Added test coverage for types ending with 'Object' followed by numbers (e.g., `IXyzObject42`)
