### PR TITLE
MiKo_1054 is now also aware of 'Helper' suffixed with a number

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1054_HelperClassNameAnalyzer.cs
@@ -49,12 +49,15 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             if (typeName.Length > SpecialNameHandle.Length && typeName.StartsWith(SpecialNameHandle))
             {
-                return typeName.WithoutSuffix(wrongName)
+                return typeName.WithoutNumberSuffix()
+                               .WithoutSuffix(wrongName)
                                .Slice(SpecialNameHandle.Length)
                                .ConcatenatedWith(SpecialNameHandler);
             }
 
-            return typeName.WithoutSuffix(wrongName).ToString();
+            return typeName.WithoutNumberSuffix()
+                           .WithoutSuffix(wrongName)
+                           .ToString();
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
@@ -18,6 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] WrongSuffixes =
                                                          [
                                                              "Helper",
+                                                             "Helper42",
                                                              "Helpers",
                                                              "Misc",
                                                              "Miscellaneous",


### PR DESCRIPTION
- Add logic to strip numeric suffixes from type names before removing the "Helper" suffix

- Add test coverage for the new "Helper{number}" pattern