### PR TITLE
MiKo_2310 is now aware of reasoning via 'so that'

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1040,7 +1040,7 @@ namespace MiKoSolutions.Analyzers
                                                                         "doesnt matter", // be able to detect typos
                                                                     };
 
-            internal static readonly string[] ReasoningPhrases = { "because", "reason" };
+            internal static readonly string[] ReasoningPhrases = { "because", "reason", "so that" };
 
             internal static readonly string[] LangwordReferences = { "true", "false", "null" };
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
@@ -78,6 +78,16 @@ public class TestMe
 }");
 
         [Test]
+        public void No_issue_is_reported_for_intentionally_comment_with_so_that_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        // " + comment + @" so that we like it this way
+    }
+}");
+
+        [Test]
         public void No_issue_is_reported_for_intentionally_comment_with_reason_in_catch_block_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {


### PR DESCRIPTION
- Add "so that" to the list of recognized reasoning phrases

- Add test coverage for the new "so that" reasoning pattern
