### PR TITLE
MiKo_2012 no longer reports 'available to' as it contains 'able to'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -15,9 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2012_CodeFixProvider)), Shared]
     public sealed class MiKo_2012_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
-        //// ncrunch: rdi off
-        private const FirstWordAdjustment StartAdjustment = FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace;
-
+//// ncrunch: rdi off
         private static readonly string[] DefaultPhrases =
                                                           {
                                                               "A default impl",
@@ -130,7 +128,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (text.StartsWithAny(EmptyReplacementsMapKeys))
             {
-                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, StartAdjustment);
+                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
             }
 
             if (text.StartsWith("Called"))
@@ -148,9 +146,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static ReadOnlySpan<char> GetUpdatedSyntax(ref XmlElementSyntax comment, XmlTextSyntax textSyntax, in ReadOnlySpan<char> text)
         {
-            if (text.StartsWithAny(ReplacementMapKeys))
+            if (text.ContainsAny(ReplacementMapKeys))
             {
-                comment = GetUpdatedSyntax(comment, StartAdjustment);
+                var adjustment = FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace;
+
+                if (text.StartsWithAny(ReplacementMapKeys))
+                {
+                    adjustment |= FirstWordAdjustment.MakeThirdPersonSingular;
+                }
+
+                comment = GetUpdatedSyntax(comment, adjustment);
 
                 if (comment.Content.First() is XmlTextSyntax t && ReferenceEquals(t, textSyntax) is false)
                 {
@@ -810,6 +815,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 yield return new Pair(beginning + " specialized in ");
                 yield return new Pair(beginning + " used for checking ", "Determines ");
                 yield return new Pair(beginning + " used for ");
+
+                yield return new Pair(" used to ", " to ");
+                yield return new Pair(" able to ", " to ");
+                yield return new Pair(" capable to ", " to ");
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -132,6 +132,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             continue;
                         }
 
+                        if (phrase is "able to" && summary.Contains("vailable", StringComparison.Ordinal) && summary.Replace("vailable", "vail").Contains(phrase, StringComparison.OrdinalIgnoreCase) is false)
+                        {
+                            // ignore phrase 'available'
+                            continue;
+                        }
+
                         return ReportIssueContainsPhrase(symbol, phrase.AsSpan());
                     }
                 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_documentation_([Values("that is used in", "which is used in")] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_documentation_([Values("that is used in", "which is used in", "available to", "unavailable to")] string phrase) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -852,6 +852,10 @@ public class TestMe
         [TestCase("This handler will handle", "Handles")]
         [TestCase("This Handler handles", "Handles")]
         [TestCase("This handler handles", "Handles")]
+        [TestCase("Something able to do stuff that is available to anybody", "Something to do stuff that is available to anybody")]
+        [TestCase("Something able to do stuff that is available tonight", "Something to do stuff that is available tonight")]
+        [TestCase("Something able to do stuff that is unavailable to anybody", "Something to do stuff that is unavailable to anybody")]
+        [TestCase("Something able to do stuff that is unavailable tonight", "Something to do stuff that is unavailable tonight")]
         public void Code_gets_fixed_for_class_(string originalCode, string fixedCode)
         {
             const string Template = @"


### PR DESCRIPTION
Codefix now fixes 'able to' in the middle of a sentence