### PR TITLE
MiKo_2012 and MiKo_2019 are now aware of some more phrases on boolean properties

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -62,7 +62,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] EmptyReplacementsMapKeys = EmptyReplacementsMap.ToArray(_ => _.Key);
 
-        private static readonly string[] GetSetReplacementPhrases = CreateGetSetReplacementPhrases().Except(new[] { "Gets or sets a value ", "Gets or sets " })
+        private static readonly string[] GetSetReplacementPhrases = CreateGetSetReplacementPhrases().Distinct()
+                                                                                                    .Except(new[] { "Gets or sets a value ", "Gets or sets ", "Gets a value ", "Sets a value ", "gets a value ", "sets a value " })
                                                                                                     .OrderDescendingByLengthAndText();
 
         private static readonly Pair[] PreparationMap =
@@ -285,7 +286,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                             .ReplaceAllWithProbe(GetSetReplacementPhrases, " ");
 
             builder.ReplaceWithProbe("  ", " ");
-            builder.ReplaceWithProbe("indicating get or set ", "indicating ");
             builder.ReplaceWithProbe("indicating describes ", "indicating ");
             builder.ReplaceWithProbe("indicating describe ", "indicating ");
             builder.ReplaceWithProbe("indicating specifies ", "indicating ");
@@ -294,6 +294,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             builder.ReplaceWithProbe("indicating indicate ", "indicating ");
             builder.ReplaceWithProbe("indicating returns ", "indicating ");
             builder.ReplaceWithProbe("indicating return ", "indicating ");
+            builder.ReplaceWithProbe("indicating indicating", "indicating");
+            builder.ReplaceWithProbe("indicating for ", "indicating whether the ");
             builder.ReplaceWithProbe("bool indicating", "value indicating");
             builder.ReplaceWithProbe("bool that indicates", "value indicating");
             builder.ReplaceWithProbe("bool which indicates", "value indicating");
@@ -322,7 +324,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             builder.ReplaceWithProbe("indicating that", "indicating whether");
             builder.ReplaceWithProbe("indicating if ", "indicating whether ");
             builder.ReplaceWithProbe("indicating to", "indicating whether to");
-            builder.ReplaceWithProbe("indicating indicating", "indicating");
             builder.ReplaceWithProbe("whether to true if to", "whether to");
             builder.ReplaceWithProbe("whether to true to", "whether to");
             builder.ReplaceWithProbe("whether to true, to", "whether to");
@@ -344,12 +345,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             builder.ReplaceWithProbe("whether specify if", "whether");
             builder.ReplaceWithProbe("whether specify that", "whether");
             builder.ReplaceWithProbe("whether specify whether", "whether");
+            builder.ReplaceWithProbe("whether whether", "whether");
             builder.ReplaceWithProbe("ets get ", "ets ");
             builder.ReplaceWithProbe("ets set ", "ets ");
             builder.ReplaceWithProbe("gets returns", "gets");
             builder.ReplaceWithProbe("Gets returns", "Gets");
             builder.ReplaceWithProbe("sets returns", "sets");
             builder.ReplaceWithProbe("Sets returns", "Sets");
+            builder.ReplaceWithProbe(" the the ", " the ");
+            builder.ReplaceWithProbe(" the an ", " an ");
+            builder.ReplaceWithProbe(" the a ", " a ");
+            builder.ReplaceWithProbe(" to the ", " the ");
+            builder.ReplaceWithProbe(" to an ", " an ");
+            builder.ReplaceWithProbe(" to a ", " a ");
             builder.ReplaceWithProbe("  ", " ");
 
             var replacedFixedText = builder.ToStringAndRelease();
@@ -866,40 +874,32 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static IEnumerable<string> CreateGetSetReplacementPhrases()
         {
-            var continuations = new[] { "flag ", "a flag ", "the flag ", "value ", "a value ", "the value " };
+            var continuations = new[]
+                                    {
+                                        "flag ", "a flag ", "the flag ",
+                                        "Flag ", "a Flag ", "the Flag ",
+                                        "value ", "a value ", "the value ",
+                                        "information ", "a information ", "an information ", "the information ",
+                                    };
 
-            var starts = new[]
-                             {
-                                 "Get and Set ",
-                                 "Get And Set ",
-                                 "Get AND Set ",
-                                 "Get or Set ",
-                                 "Get Or Set ",
-                                 "Get OR Set ",
-                                 "get/set ",
-                                 "get/Set ",
-                                 "Get/set ",
-                                 "Get/Set ",
-                                 "Gets and Sets ",
-                                 "Gets And Sets ",
-                                 "Gets AND Sets ",
-                                 "Gets or sets ",
-                                 "Gets or Sets ",
-                                 "Gets Or Sets ",
-                                 "Gets OR Sets ",
-                                 "gets/sets ",
-                                 "gets/Sets ",
-                                 "Gets/sets ",
-                                 "Gets/Sets ",
-                                 "set/get ",
-                                 "set/Get ",
-                                 "Set/get ",
-                                 "Set/Get ",
-                                 "sets/gets ",
-                                 "sets/Gets ",
-                                 "Sets/gets ",
-                                 "Sets/Gets ",
-                             };
+            var gets = new[] { "Get", "get", "Gets", "gets", "GET", "GETS" };
+            var sets = new[] { "Set", "set", "Sets", "sets", "SET", "SETS" };
+
+            var conjunctions = new[] { "/", " and ", " And ", " AND ", " or ", " Or ", " OR " };
+
+            var starts = new HashSet<string>();
+
+            foreach (var conjunction in conjunctions)
+            {
+                foreach (var getter in gets)
+                {
+                    foreach (var setter in sets)
+                    {
+                        starts.Add(getter + conjunction + setter + " ");
+                        starts.Add(setter + conjunction + getter + " ");
+                    }
+                }
+            }
 
             foreach (var start in starts)
             {
@@ -910,8 +910,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     yield return start + continuation;
                 }
             }
+
+            foreach (var getter in gets)
+            {
+                foreach (var continuation in continuations)
+                {
+                    yield return getter + " " + continuation;
+                }
+            }
+
+            foreach (var setter in sets)
+            {
+                foreach (var continuation in continuations)
+                {
+                    yield return setter + " " + continuation;
+                }
+            }
         }
 
-        //// ncrunch: rdi default
+//// ncrunch: rdi default
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -1544,6 +1544,17 @@ public class TestMe
         [TestCase("Used to get or set", "Gets or sets a value indicating")]
         [TestCase("Used to get", "Gets or sets a value indicating")]
         [TestCase("Used to set", "Gets or sets a value indicating")]
+        [TestCase("get information if it is", "Gets or sets a value indicating whether it is")]
+        [TestCase("get information if parameter is", "Gets or sets a value indicating whether parameter is")]
+        [TestCase("Get set whether to create", "Gets or sets a value indicating whether to create")]
+        [TestCase("Get set whether to a parameter should be always mapped to", "Gets or sets a value indicating whether a parameter should be always mapped to")]
+        [TestCase("Get set whether to an parameter should be always mapped to", "Gets or sets a value indicating whether an parameter should be always mapped to")]
+        [TestCase("Get set whether to the parameter should be always mapped to", "Gets or sets a value indicating whether the parameter should be always mapped to")]
+        [TestCase("get the flag for system record of the trace manager", "Gets or sets a value indicating whether the system record of the trace manager")]
+        [TestCase("get the flag for a system record of the trace manager", "Gets or sets a value indicating whether a system record of the trace manager")]
+        [TestCase("get the flag for an system record of the trace manager", "Gets or sets a value indicating whether an system record of the trace manager")]
+        [TestCase("get the flag for the system record of the trace manager", "Gets or sets a value indicating whether the system record of the trace manager")]
+        [TestCase("Get information whether this element is a compound type", "Gets or sets a value indicating whether this element is a compound type")]
         public void Code_gets_fixed_for_boolean_property_text_(string originalComment, string fixedComment)
         {
             const string Template = @"


### PR DESCRIPTION
- Expand phrase detection to include patterns like "get information if", "Get set whether to", and "get the flag for"

- Refactor phrase generation logic to use dynamic construction with loops instead of static arrays

- Add cleanup rules to handle duplicate words and article corrections in generated documentation
