### PR TITLE
'SingleLineCommentAnalyzer.FindTriviaToAnalyze' now attempts to ignore XML documentation

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -26,9 +27,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private IEnumerable<Diagnostic> AnalyzeComment(SyntaxNode node)
         {
-            foreach (var trivia in node.DescendantTrivia())
+            // TODO RKN: Consider to not include all descendants, especially 'SyntaxKind.SingleLineDocumentationCommentTrivia' as inspecting documentation might take a lot of time
+            foreach (var trivia in node.DescendantTrivia().Where(_ => _.IsSingleLineComment()))
             {
-                if (trivia.IsSingleLineComment() && CommentContainsSeparator(trivia.ToString().AsSpan()))
+                if (CommentContainsSeparator(trivia.ToString().AsSpan()))
                 {
                     yield return Issue(trivia);
                 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzerTests.cs
@@ -108,6 +108,18 @@ public class TestMe
 }
 ");
 
+        [Test, Combinatorial]
+        public void No_issue_is_reported_for_separator_comment_([Values("", " ")] string gap, [Values("----", "****", "====", "####")] string comment) => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public void DoSomething()
+    {
+        //" + gap + comment + @"
+    }
+}
+");
+
         [Test]
         public void No_issue_is_reported_for_correctly_commented_method() => No_issue_is_reported_for(@"
 
@@ -268,14 +280,60 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_separator_comment_([Values("", " ")] string gap, [Values("----", "****", "====", "####")] string comment) => No_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_small_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
 
 public class TestMe
 {
+    /// <summary>
+    /// Some summary.
+    /// </summary>
     public void DoSomething()
     {
         //" + gap + comment + @"
     }
+}
+");
+
+        [Test, Combinatorial]
+        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_long_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    /// <summary>
+    /// Some summary.
+    /// </summary>
+    public void DoSomething()
+    {
+        //" + gap + comment + @" in addition to something much longer
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_arrow_inside_comment_([Values("", " ")] string gap) => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    /// <summary>
+    /// Some summary.
+    /// </summary>
+    public void DoSomething()
+    {
+        //" + gap + @" in addition to something much longer -> there is the arrow
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_uncommented_field_within_region() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    #region Some region
+
+    private int _someField;
+
+    #endregion
 }
 ");
 


### PR DESCRIPTION
- Modify `SingleLineCommentAnalyzer.FindTriviaToAnalyze` to skip XML documentation trivia by checking for structured trivia and adjusting the analysis span

- Update `MiKo_2311_CommentIsSeparatorAnalyzer` to filter for single-line comments only, avoiding inspection of documentation comments

- Add comprehensive test cases covering separator comments and documented methods with various comment patterns
