### PR TITLE
MiKo_1041 is now aware of 'xyzMap' as plural name

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -95,6 +95,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return pluralName;
             }
 
+            if (originalName.EndsWith("Map"))
+            {
+                singularName = originalName.ToString();
+
+                return null; // seems the original name is already the plural name, so we do not report that
+            }
+
             var index = originalName.IndexOfAny(Splitters);
 
             if (index > 0)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -32,6 +32,7 @@ public class TestMe
         [TestCase("IQueryable<int> query")]
         [TestCase("IOrderedQueryable query")]
         [TestCase("IOrderedQueryable<int> query")]
+        [TestCase("int[] replacementMap")]
         public void No_issue_is_reported_for_field_(string field) => No_issue_is_reported_for(@"
 using System.Linq;
 
@@ -42,7 +43,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue")] string field)
+        public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue", "replacementMap")] string field)
             => No_issue_is_reported_for(@"
 
 public class TestMe


### PR DESCRIPTION
- Add logic to treat "Map" suffix as an acceptable plural form for collection fields

- Add test coverage for the new "Map" suffix handling
