### PR TITLE
Added hyperlinks for documentation

### DIFF
--- a/Documentation/MiKo_1001.md
+++ b/Documentation/MiKo_1001.md
@@ -16,7 +16,7 @@ This convention is used throughout the .NET Framework and should be followed in 
 
 ### Rationale behind
 
-Naming `EventArgs` parameters `e` is a deeply ingrained .NET convention that creates instant familiarity and consistency across all event handlers.
+Naming `EventArgs` parameters `e` is a deeply ingrained [.NET convention that creates instant familiarity and consistency across all event handlers](https://learn.microsoft.com/en-us/dotnet/standard/events/).
 This pattern appears in every event handler throughout the .NET Framework, from Windows Forms to WPF to ASP.NET, making it one of the most universally recognized conventions in .NET development.
 
 When developers see an event handler signature, the expectation is `(object sender, SomeEventArgs e)`, and deviating from this causes unnecessary cognitive friction.

--- a/Documentation/MiKo_1002.md
+++ b/Documentation/MiKo_1002.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-The parameters of an event handler do not follow the standard naming convention.
+The parameters of an event handler do not follow the [.NET Framework naming conventions for event handlers](https://learn.microsoft.com/en-us/dotnet/standard/events/).
 
 ## Rule description
 

--- a/Documentation/MiKo_1003.md
+++ b/Documentation/MiKo_1003.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-An event handler method does not follow the standard naming convention.
+An event handler method does not follow the [.NET Framework naming conventions for event handlers](https://learn.microsoft.com/en-us/dotnet/standard/events/).
 
 ## Rule description
 

--- a/Documentation/MiKo_1046.md
+++ b/Documentation/MiKo_1046.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-An asynchronous method using the Task-based Asynchronous Pattern does not end with the suffix `Async`.
+An asynchronous method using the [Task-based Asynchronous Pattern (TAP)](https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap) does not end with the suffix `Async`.
 
 ## Rule description
 

--- a/Documentation/MiKo_1047.md
+++ b/Documentation/MiKo_1047.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-A method ends with the suffix `Async` but does not follow the Task-based Asynchronous Pattern.
+A method ends with the suffix `Async` but does not follow the [Task-based Asynchronous Pattern (TAP)](https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap).
 
 ## Rule description
 

--- a/Documentation/MiKo_1055.md
+++ b/Documentation/MiKo_1055.md
@@ -15,7 +15,7 @@ This aligns with the naming conventions in the .NET Framework.
 Without a consistent naming convention, it becomes difficult to distinguish these special fields from regular fields.
 
 The .NET Framework establishes the convention of suffixing `DependencyProperty` fields with `Property`.
-Following this convention ensures code consistency and makes the codebase easier to understand for developers familiar with WPF.
+Following [this convention](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/how-to-implement-a-dependency-property) ensures code consistency and makes the codebase easier to understand for developers familiar with WPF.
 
 Using the `Property` suffix for dependency properties provides several important benefits:
 

--- a/Documentation/MiKo_1056.md
+++ b/Documentation/MiKo_1056.md
@@ -15,7 +15,7 @@ This aligns with the naming conventions in the .NET Framework.
 Without a clear naming relationship between the field and the property, it becomes difficult to understand which field belongs to which property.
 
 The .NET Framework establishes the convention that a `DependencyProperty` field should be named by combining the property name with the `Property` suffix.
-Following this convention ensures the relationship between fields and properties is immediately obvious.
+Following [this convention](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/how-to-implement-a-dependency-property) ensures the relationship between fields and properties is immediately obvious.
 
 Using property name prefixes for dependency properties provides several important benefits:
 

--- a/Documentation/MiKo_1057.md
+++ b/Documentation/MiKo_1057.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-A field that backs a `DependencyPropertyKey` does not end with the suffix `Key`.
+A field that backs a [DependencyPropertyKey](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey) does not end with the suffix `Key`.
 
 ## Rule description
 

--- a/Documentation/MiKo_1058.md
+++ b/Documentation/MiKo_1058.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-A field that backs a `DependencyPropertyKey` is not prefixed with the associated property name.
+A field that backs a [DependencyPropertyKey](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey) is not prefixed with the associated property name.
 
 ## Rule description
 

--- a/Documentation/MiKo_1065.md
+++ b/Documentation/MiKo_1065.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-An operator overload parameter does not follow the standard naming convention.
+An operator overload parameter does not follow the [.NET Framework Design Guidelines for operator overloads](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters).
 
 ## Rule description
 

--- a/Documentation/MiKo_1400.md
+++ b/Documentation/MiKo_1400.md
@@ -11,7 +11,7 @@ This follows .NET naming conventions and makes namespaces more intuitive.
 
 ### Rationale behind
 
-Using plural forms for namespace names is a fundamental .NET convention that reflects the purpose of namespaces as containers for multiple related types.
+Using plural forms for namespace names is a [fundamental .NET convention](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces) that reflects the purpose of namespaces as containers for multiple related types.
 A namespace like `Controllers` indicates that it contains multiple controller classes, making the organizational structure immediately clear.
 
 This convention provides several important benefits:

--- a/Documentation/MiKo_2041.md
+++ b/Documentation/MiKo_2041.md
@@ -23,7 +23,7 @@ Keeping the `<summary>` focused and concise provides several important benefits:
 
 - **Better Tool Support**:
   Documentation tools and IntelliSense are designed to display different documentation sections appropriately.
-  When information is in the correct tags, tools can present it in the most useful way.
+  When information is in the [correct tags](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments), tools can present it in the most useful way.
 
 - **Improved Readability**:
   A brief summary is easier to read and understand than a long paragraph containing multiple types of information.
@@ -45,7 +45,7 @@ Keeping the `<summary>` focused and concise provides several important benefits:
 
 To fix a violation of this rule, move information that does not belong in the `<summary>` to the appropriate documentation tags.
 Keep the `<summary>` brief and focused on describing what the type or member does.
-Use `<remarks>` for additional details, `<param>` for parameter descriptions, `<returns>` for return value documentation, and other appropriate tags for their specific purposes.
+Use `<remarks>` for additional details, `<param>` for parameter descriptions, `<returns>` for return value documentation, and [other appropriate tags](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments) for their specific purposes.
 
 ## How to suppress violations
 

--- a/Documentation/MiKo_2042.md
+++ b/Documentation/MiKo_2042.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-The documentation uses `<p>` HTML tags instead of `<para>` XML tags.
+The documentation uses `<p>` HTML tags instead of [`<para>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#para) XML tags.
 
 ## Rule description
 
@@ -11,7 +11,7 @@ This ensures a consistent format, suitable for XML-based documentation tools and
 
 ### Rationale behind
 
-XML documentation comments in .NET are designed to use XML-specific tags, not HTML tags.
+XML documentation comments in .NET are designed to use [XML-specific tags](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags), not HTML tags.
 While some documentation tools may render HTML tags, using the proper XML tags ensures better compatibility and correctness across all documentation tools and scenarios.
 
 Using `<para>` XML tags instead of HTML `<p>` tags provides several important benefits:

--- a/Documentation/MiKo_2204.md
+++ b/Documentation/MiKo_2204.md
@@ -6,13 +6,17 @@ The documentation uses manual enumeration markers like `1.)`, `2.)`, etc., inste
 
 ## Rule description
 
-XML documentation should use the `<list>` tag for enumerating items. Avoid using terms like 1.), 2.), etc., directly because IntelliSense and XML documentation tools cannot recognize these and may format comments awkwardly. Using `<list>` allows IntelliSense to format content as tables, numbered lists, ordered lists, etc., making documentation clear and easy to read.
+XML documentation should use the `<list>` tag for enumerating items.
+Avoid using terms like 1.), 2.), etc., directly because IntelliSense and XML documentation tools cannot recognize these and may format comments awkwardly.
+Using `<list>` allows IntelliSense to format content as tables, numbered lists, ordered lists, etc., making documentation clear and easy to read.
 
 ### Rationale behind
 
-Documentation tools are designed to process XML tags and format them appropriately for different output formats. When plain text markers like `1.)` are used, these tools treat them as regular text and cannot apply proper formatting.
+Documentation tools are designed to process XML tags and format them appropriately for different output formats.
+When plain text markers like `1.)` are used, these tools treat them as regular text and cannot apply proper formatting.
 
-The `<list>` tag is specifically designed for structured lists and enables documentation tools to render them correctly in IntelliSense, generated HTML documentation, and other output formats. This results in much better visual presentation and readability.
+The `<list>` tag is [specifically designed for structured lists](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#list) and enables documentation tools to render them correctly in IntelliSense, generated HTML documentation, and other output formats.
+This results in much better visual presentation and readability.
 
 Following this rule provides several important benefits:
 

--- a/Documentation/MiKo_2217.md
+++ b/Documentation/MiKo_2217.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-The `<list>` documentation is not properly formatted according to the rules for list types.
+The `<list>` documentation is not properly formatted according to the [rules for list types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#list).
 
 ## Rule description
 

--- a/Documentation/MiKo_2225.md
+++ b/Documentation/MiKo_2225.md
@@ -12,10 +12,10 @@ This ensures the formatting is clear and the documentation remains organized and
 
 ### Rationale behind
 
-The `<c>` and `<code>` tags serve different purposes in XML documentation, and using them correctly ensures proper rendering in IntelliSense and documentation tools.
+The [`<c>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#c) and [`<code>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#code) tags serve different purposes in XML documentation, and using them correctly ensures proper rendering in IntelliSense and documentation tools.
 Misusing these tags leads to poorly formatted documentation that confuses readers.
 
-Using the correct tag for single-line and multi-line code provides several important benefits:
+Using the correct tag for [single-line](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#c) and [multi-line](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#code) code provides several important benefits:
 
 - **Proper Rendering**:
   Documentation tools and IntelliSense render `<c>` tags as inline code and `<code>` tags as code blocks.

--- a/Documentation/MiKo_2244.md
+++ b/Documentation/MiKo_2244.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-XML documentation uses HTML tags like `<ul>` or `<ol>` instead of the proper XML documentation tag `<list>`.
+XML documentation uses HTML tags like `<ul>` or `<ol>` instead of the [proper XML documentation tag `<list>`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#list).
 
 ## Rule description
 

--- a/Documentation/MiKo_3001.md
+++ b/Documentation/MiKo_3001.md
@@ -11,7 +11,7 @@ To ease maintenance, use the pre-defined .NET Framework delegate types such as `
 ### Rationale behind
 
 Custom delegates introduce unnecessary complexity and reduce code maintainability.
-The .NET Framework already provides generic delegate types that cover virtually all common scenarios.
+The [.NET Framework already provides generic delegate types](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks) that cover virtually all common scenarios.
 
 Using pre-defined delegate types provides several important benefits:
 

--- a/Documentation/MiKo_3003.md
+++ b/Documentation/MiKo_3003.md
@@ -2,7 +2,7 @@
 
 ## Cause
 
-An event does not follow the .NET Framework Design Guidelines for Event Design.
+An event does not follow the [.NET Framework Design Guidelines for Event Design](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event).
 
 ## Rule description
 

--- a/Documentation/MiKo_3010.md
+++ b/Documentation/MiKo_3010.md
@@ -39,7 +39,7 @@ Avoiding reserved exception types provides several important benefits:
 
 ## How to fix violations
 
-To fix a violation of this rule, use a more appropriate exception type for the specific error condition, such as `InvalidOperationException`, `ArgumentException`, or create a custom exception type.
+To fix a violation of this rule, use [a more appropriate exception type](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types) for the specific error condition, such as `InvalidOperationException`, `ArgumentException`, or create a custom exception type.
 
 ## How to suppress violations
 

--- a/Documentation/MiKo_3011.md
+++ b/Documentation/MiKo_3011.md
@@ -38,7 +38,7 @@ Including correct parameter names in `ArgumentException`s provides several impor
 
 ## How to fix violations
 
-To fix a violation of this rule, ensure that the `ArgumentException` constructor includes the correct parameter name using the `nameof` operator.
+To fix a violation of this rule, ensure that the `ArgumentException` constructor [includes the correct parameter name](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types#argumentexception-argumentnullexception-and-argumentoutofrangeexception) using the `nameof` operator.
 
 ## How to suppress violations
 

--- a/Documentation/MiKo_3015.md
+++ b/Documentation/MiKo_3015.md
@@ -15,7 +15,7 @@ This keeps exception handling logical and context-appropriate, making the code c
 `ArgumentException` is specifically designed for parameter validation failures.
 When a method has no parameters or when the failure is due to object state rather than parameter values, using `ArgumentException` is semantically incorrect.
 
-Using `InvalidOperationException` for state-related failures provides several important benefits:
+Using [`InvalidOperationException` for state-related failures](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types#invalidoperationexception) provides several important benefits:
 
 - **Correct Semantic Meaning**:
   `InvalidOperationException` indicates that the operation cannot be performed in the current state.

--- a/Documentation/MiKo_3016.md
+++ b/Documentation/MiKo_3016.md
@@ -18,7 +18,7 @@ This approach ensures that the exception thrown accurately reflects the nature o
 `ArgumentNullException` is designed to indicate that a parameter itself is null.
 When a parameter's property is null, the parameter is not null, so `ArgumentNullException` misrepresents the actual problem.
 
-Throwing the correct exception type provides several important benefits:
+Throwing [the correct exception type](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types) provides several important benefits:
 
 - **Accurate Error Reporting**:
   The exception type should match the actual problem.

--- a/Documentation/MiKo_3021.md
+++ b/Documentation/MiKo_3021.md
@@ -13,7 +13,7 @@ This approach aligns better with proper asynchronous programming practices and k
 ### Rationale behind
 
 Using `Task.Run` within method implementations hides the fact that work is being queued to the thread pool.
-This creates misleading APIs where callers cannot control whether operations run synchronously or asynchronously.
+This creates [misleading APIs where callers cannot control whether operations run synchronously or asynchronously](https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-dont-use.html).
 
 Avoiding `Task.Run` in implementations provides several important benefits:
 

--- a/Documentation/MiKo_3027.md
+++ b/Documentation/MiKo_3027.md
@@ -50,3 +50,7 @@ When future needs arise, create a new method overload or a new method with the a
 #pragma warning disable MiKo_3027
 #pragma warning restore MiKo_3027
 ```
+
+## Additional information
+For more information, see the [.NET Framework Design Guidelines about Parameter design](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design).
+

--- a/Documentation/MiKo_3030.md
+++ b/Documentation/MiKo_3030.md
@@ -12,7 +12,7 @@ This practice keeps methods focused, modular, and easier to maintain.
 
 ### Rationale behind
 
-Following the Law of Demeter reduces coupling between different parts of the codebase, making the system more flexible and easier to change.
+Following the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) reduces coupling between different parts of the codebase, making the system more flexible and easier to change.
 When code depends on the internal structure of objects it does not own, changes to those internal structures can cause widespread breaking changes.
 
 Adhering to the Law of Demeter provides several important benefits:

--- a/Documentation/MiKo_3040.md
+++ b/Documentation/MiKo_3040.md
@@ -53,3 +53,7 @@ Update the method signature and all callers to use the new enum type.
 #pragma warning disable MiKo_3040
 #pragma warning restore MiKo_3040
 ```
+
+## Additional information
+For more information, see the [.NET Framework Design Guidelines about Parameter design](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design#choosing-between-enum-and-boolean-parameters).
+

--- a/Documentation/MiKo_3050.md
+++ b/Documentation/MiKo_3050.md
@@ -24,7 +24,7 @@ Declaring dependency properties as public static readonly provides several impor
   The `readonly` modifier enforces this immutability, preventing accidental modifications.
 
 - **Convention Adherence**:
-  Public static readonly is the established convention for dependency properties across the .NET ecosystem.
+  `public static readonly` is the [established convention for dependency properties](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/how-to-implement-a-dependency-property) across the .NET ecosystem.
   Following conventions makes code immediately recognizable and understandable to other developers.
 
 - **Tool Support**:

--- a/Documentation/MiKo_3051.md
+++ b/Documentation/MiKo_3051.md
@@ -52,3 +52,6 @@ Verify that the registered name matches the CLR property wrapper name.
 #pragma warning disable MiKo_3051
 #pragma warning restore MiKo_3051
 ```
+
+## Additional information
+For more information, see [How to implement a dependency property](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/properties/how-to-implement-a-dependency-property).

--- a/Documentation/MiKo_3052.md
+++ b/Documentation/MiKo_3052.md
@@ -51,3 +51,6 @@ Ensure the field is not accessible outside the declaring class or its derived cl
 #pragma warning disable MiKo_3052
 #pragma warning restore MiKo_3052
 ```
+
+## Additional information
+For more information, see the remarks section of [DependencyPropertyKey](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey).

--- a/Documentation/MiKo_3053.md
+++ b/Documentation/MiKo_3053.md
@@ -42,7 +42,7 @@ Properly registering dependency property keys provides several important benefit
 
 ## How to fix violations
 
-To fix a violation of this rule, ensure the registration call uses `DependencyProperty.RegisterReadOnly()` with correct parameters.
+To fix a violation of this rule, ensure the registration call uses [`DependencyProperty.RegisterReadOnly()`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly) with correct parameters.
 Use `nameof` for the property name, specify the correct property type and owning type.
 Store the result in a non-public `DependencyPropertyKey` field.
 

--- a/Documentation/MiKo_3105.md
+++ b/Documentation/MiKo_3105.md
@@ -12,7 +12,7 @@ This helps developers avoid mixing up `actual` and `expected` values and makes t
 ### Rationale behind
 
 NUnit's fluent assertion syntax provides a more consistent and readable approach to writing test assertions.
-The constraint model uses natural language constructs that make test intentions clearer and reduce common mistakes.
+The [constraint model](https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html) uses natural language constructs that make test intentions clearer and reduce common mistakes.
 
 This rule provides several important benefits:
 

--- a/Documentation/MiKo_3215.md
+++ b/Documentation/MiKo_3215.md
@@ -37,7 +37,7 @@ Using `Func<T, bool>` instead of `Predicate<T>` provides several important benef
   There is no ambiguity about what the delegate does.
 
 - **Framework Alignment**:
-  Following .NET Framework Design Guidelines ensures the API feels native.
+  Following [.NET Framework Design Guidelines for events and callbacks](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks) ensures the API feels native.
   This makes the code more familiar to .NET developers.
 
 ## How to fix violations

--- a/Documentation/MiKo_5012.md
+++ b/Documentation/MiKo_5012.md
@@ -50,3 +50,6 @@ To fix a violation of this rule, refactor the recursive method to use an explici
 #pragma warning disable MiKo_5012
 #pragma warning restore MiKo_5012
 ```
+
+## Additional information
+For more information, see this discussion on [Stack Overflow](https://stackoverflow.com/questions/3969963/when-not-to-use-yield-return).

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -308,15 +308,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
-        /// </summary>
-        internal static string MiKo_1001_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1001_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_1001_MessageFormat {
@@ -353,15 +344,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
-        /// </summary>
-        internal static string MiKo_1002_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1002_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_1002_MessageFormat {
@@ -394,15 +376,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1003_Description {
             get {
                 return ResourceManager.GetString("MiKo_1003_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/event-pattern.
-        /// </summary>
-        internal static string MiKo_1003_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1003_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -1823,15 +1796,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.
-        /// </summary>
-        internal static string MiKo_1046_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1046_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_1046_MessageFormat {
@@ -1864,15 +1828,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1047_Description {
             get {
                 return ResourceManager.GetString("MiKo_1047_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.
-        /// </summary>
-        internal static string MiKo_1047_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1047_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -2167,15 +2122,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
-        /// </summary>
-        internal static string MiKo_1055_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1055_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_1055_MessageFormat {
@@ -2199,15 +2145,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1056_Description {
             get {
                 return ResourceManager.GetString("MiKo_1056_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
-        /// </summary>
-        internal static string MiKo_1056_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1056_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -2248,15 +2185,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
-        /// </summary>
-        internal static string MiKo_1057_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1057_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name it &apos;{1}&apos;.
         /// </summary>
         internal static string MiKo_1057_MessageFormat {
@@ -2280,15 +2208,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1058_Description {
             get {
                 return ResourceManager.GetString("MiKo_1058_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
-        /// </summary>
-        internal static string MiKo_1058_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1058_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -2535,15 +2454,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1065_Description {
             get {
                 return ResourceManager.GetString("MiKo_1065_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters.
-        /// </summary>
-        internal static string MiKo_1065_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1065_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -4476,15 +4386,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_1400_Description {
             get {
                 return ResourceManager.GetString("MiKo_1400_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces.
-        /// </summary>
-        internal static string MiKo_1400_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_1400_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -6881,15 +6782,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.
-        /// </summary>
-        internal static string MiKo_2041_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2041_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &lt;summary&gt; should not contain: &apos;&lt;{0}/&gt;&apos;.
         /// </summary>
         internal static string MiKo_2041_MessageFormat {
@@ -6922,15 +6814,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_2042_Description {
             get {
                 return ResourceManager.GetString("MiKo_2042_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/para.
-        /// </summary>
-        internal static string MiKo_2042_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2042_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -8335,15 +8218,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/list.
-        /// </summary>
-        internal static string MiKo_2204_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2204_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items in documentation.
         /// </summary>
         internal static string MiKo_2204_MessageFormat {
@@ -8785,15 +8659,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to http://www.blackwasp.co.uk/DocumentationLists.aspx.
-        /// </summary>
-        internal static string MiKo_2217_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2217_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &lt;description&gt; is missing.
         /// </summary>
         internal static string MiKo_2217_MessageArgument_MissingDescription {
@@ -9120,15 +8985,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_2225_Description {
             get {
                 return ResourceManager.GetString("MiKo_2225_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#c.
-        /// </summary>
-        internal static string MiKo_2225_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2225_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -9718,15 +9574,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/list.
-        /// </summary>
-        internal static string MiKo_2244_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_2244_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items in documentation.
         /// </summary>
         internal static string MiKo_2244_MessageFormat {
@@ -10284,15 +10131,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks.
-        /// </summary>
-        internal static string MiKo_3001_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3001_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use &apos;Action&apos;, &apos;Func&apos; or &apos;Expression&apos; instead.
         /// </summary>
         internal static string MiKo_3001_MessageFormat {
@@ -10343,15 +10181,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3003_Description {
             get {
                 return ResourceManager.GetString("MiKo_3003_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event.
-        /// </summary>
-        internal static string MiKo_3003_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3003_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -10548,15 +10377,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
-        /// </summary>
-        internal static string MiKo_3010_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3010_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Do not create a &apos;{0}&apos;.
         /// </summary>
         internal static string MiKo_3010_MessageFormat {
@@ -10589,15 +10409,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3011_Description {
             get {
                 return ResourceManager.GetString("MiKo_3011_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types#argumentexception-argumentnullexception-and-argumentoutofrangeexception.
-        /// </summary>
-        internal static string MiKo_3011_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3011_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -10747,15 +10558,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
-        /// </summary>
-        internal static string MiKo_3015_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3015_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Throw an &apos;InvalidOperationException&apos; instead.
         /// </summary>
         internal static string MiKo_3015_MessageFormat {
@@ -10793,15 +10595,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3016_Description {
             get {
                 return ResourceManager.GetString("MiKo_3016_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types.
-        /// </summary>
-        internal static string MiKo_3016_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3016_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -10869,15 +10662,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
-        /// </summary>
-        internal static string MiKo_3018_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3018_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Throw ObjectDisposedException if disposed.
         /// </summary>
         internal static string MiKo_3018_MessageFormat {
@@ -10937,15 +10721,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3021_Description {
             get {
                 return ResourceManager.GetString("MiKo_3021_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-dont-use.html.
-        /// </summary>
-        internal static string MiKo_3021_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3021_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -11115,15 +10890,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design.
-        /// </summary>
-        internal static string MiKo_3027_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3027_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Do not reserve &apos;{0}&apos; for future usage.
         /// </summary>
         internal static string MiKo_3027_MessageFormat {
@@ -11201,15 +10967,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3030_Description {
             get {
                 return ResourceManager.GetString("MiKo_3030_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://en.wikipedia.org/wiki/Law_of_Demeter.
-        /// </summary>
-        internal static string MiKo_3030_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3030_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -11524,15 +11281,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3040_Description {
             get {
                 return ResourceManager.GetString("MiKo_3040_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design.
-        /// </summary>
-        internal static string MiKo_3040_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3040_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -11861,15 +11609,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
-        /// </summary>
-        internal static string MiKo_3050_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3050_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Make it &apos;public static readonly&apos;.
         /// </summary>
         internal static string MiKo_3050_MessageFormat {
@@ -11902,15 +11641,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3051_Description {
             get {
                 return ResourceManager.GetString("MiKo_3051_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property.
-        /// </summary>
-        internal static string MiKo_3051_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3051_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -11951,15 +11681,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey.
-        /// </summary>
-        internal static string MiKo_3052_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3052_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Make it non-public &apos;static readonly&apos;.
         /// </summary>
         internal static string MiKo_3052_MessageFormat {
@@ -11983,15 +11704,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3053_Description {
             get {
                 return ResourceManager.GetString("MiKo_3053_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly.
-        /// </summary>
-        internal static string MiKo_3053_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3053_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -12029,15 +11741,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3054_Description {
             get {
                 return ResourceManager.GetString("MiKo_3054_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly.
-        /// </summary>
-        internal static string MiKo_3054_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3054_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -13410,15 +13113,6 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html.
-        /// </summary>
-        internal static string MiKo_3105_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3105_HelpLinkUri", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use &apos;Assert.That&apos; instead.
         /// </summary>
         internal static string MiKo_3105_MessageFormat {
@@ -14361,15 +14055,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_3215_Description {
             get {
                 return ResourceManager.GetString("MiKo_3215_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks.
-        /// </summary>
-        internal static string MiKo_3215_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_3215_HelpLinkUri", resourceCulture);
             }
         }
         
@@ -15774,15 +15459,6 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_5012_Description {
             get {
                 return ResourceManager.GetString("MiKo_5012_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to https://stackoverflow.com/questions/3969963/when-not-to-use-yield-return.
-        /// </summary>
-        internal static string MiKo_5012_HelpLinkUri {
-            get {
-                return ResourceManager.GetString("MiKo_5012_HelpLinkUri", resourceCulture);
             }
         }
         

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -202,9 +202,6 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   <data name="MiKo_1001_Description" xml:space="preserve">
     <value>To maintain consistency and clarity in code, parameters that inherit from 'System.EventArgs' should be named 'e'.</value>
   </data>
-  <data name="MiKo_1001_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event</value>
-  </data>
   <data name="MiKo_1001_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
   </data>
@@ -217,9 +214,6 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   <data name="MiKo_1002_Description" xml:space="preserve">
     <value>To follow the .NET Framework Design Guidelines, parameters of event handlers should be named 'sender' and 'e'.</value>
   </data>
-  <data name="MiKo_1002_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event</value>
-  </data>
   <data name="MiKo_1002_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
   </data>
@@ -231,9 +225,6 @@ Following code constructs increase the Cyclomatic Complexity (CC) by +1:
   </data>
   <data name="MiKo_1003_Description" xml:space="preserve">
     <value>Event handlers should be named starting with 'On' followed by the event name to show they handle events.</value>
-  </data>
-  <data name="MiKo_1003_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/event-pattern</value>
   </data>
   <data name="MiKo_1003_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
@@ -709,9 +700,6 @@ This naming convention helps ensure clarity and consistency in method functional
   <data name="MiKo_1046_Description" xml:space="preserve">
     <value>To make maintenance easier, methods using the Task-based Asynchronous Pattern (TAP) should end with the suffix 'Async.' This helps clearly identify them as asynchronous methods.</value>
   </data>
-  <data name="MiKo_1046_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap</value>
-  </data>
   <data name="MiKo_1046_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
   </data>
@@ -723,9 +711,6 @@ This naming convention helps ensure clarity and consistency in method functional
   </data>
   <data name="MiKo_1047_Description" xml:space="preserve">
     <value>To simplify maintenance, do not add the 'Async' suffix to methods that do not follow the Task-based Asynchronous Pattern (TAP). Using 'Async' implies they do follow the pattern, which would be misleading.</value>
-  </data>
-  <data name="MiKo_1047_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap</value>
   </data>
   <data name="MiKo_1047_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
@@ -825,9 +810,6 @@ Instead, use specific names that describe their exact purpose, making the code e
   <data name="MiKo_1055_Description" xml:space="preserve">
     <value>To show that fields are containers for specific dependency properties, add the suffix 'Property' to their names. This aligns with the naming conventions in the .NET Framework.</value>
   </data>
-  <data name="MiKo_1055_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property</value>
-  </data>
   <data name="MiKo_1055_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
   </data>
@@ -836,9 +818,6 @@ Instead, use specific names that describe their exact purpose, making the code e
   </data>
   <data name="MiKo_1056_Description" xml:space="preserve">
     <value>To show that fields are containers for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework.</value>
-  </data>
-  <data name="MiKo_1056_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property</value>
   </data>
   <data name="MiKo_1056_MessageFormat" xml:space="preserve">
     <value>Name it {1}</value>
@@ -852,9 +831,6 @@ Instead, use specific names that describe their exact purpose, making the code e
   <data name="MiKo_1057_Description" xml:space="preserve">
     <value>To show that fields are keys for specific dependency properties, add the suffix 'Key' to their names. This aligns with the naming conventions in the .NET Framework.</value>
   </data>
-  <data name="MiKo_1057_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey</value>
-  </data>
   <data name="MiKo_1057_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
   </data>
@@ -863,9 +839,6 @@ Instead, use specific names that describe their exact purpose, making the code e
   </data>
   <data name="MiKo_1058_Description" xml:space="preserve">
     <value>To show that fields are keys for specific dependency properties, they should be prefixed with the property name. This aligns with the naming conventions in the .NET Framework.</value>
-  </data>
-  <data name="MiKo_1058_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey</value>
   </data>
   <data name="MiKo_1058_MessageFormat" xml:space="preserve">
     <value>Name it {1}</value>
@@ -956,9 +929,6 @@ If their names are longer, it likely means they are misplaced and violate the Si
 - For unary operator overloads, use 'value'.
 
 This ensures clarity and consistency in your code.</value>
-  </data>
-  <data name="MiKo_1065_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters</value>
   </data>
   <data name="MiKo_1065_MessageFormat" xml:space="preserve">
     <value>Name it '{1}'</value>
@@ -1631,9 +1601,6 @@ To make them clearer and more descriptive, the names should include details abou
   </data>
   <data name="MiKo_1400_Description" xml:space="preserve">
     <value>Namespaces group functionalities, so their names should be plural. This makes it clear that they encompass multiple related functions or classes, enhancing readability and organization.</value>
-  </data>
-  <data name="MiKo_1400_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces</value>
   </data>
   <data name="MiKo_1400_MessageFormat" xml:space="preserve">
     <value>Use plural for namespace, such as '{1}'</value>
@@ -2449,9 +2416,6 @@ This format clearly describes the purpose of the class and its functionality, ma
   <data name="MiKo_2041_Description" xml:space="preserve">
     <value>The &lt;summary&gt; documentation should be concise and only contain a brief summary description. Other information should be included in the appropriate XML tags alongside the &lt;summary&gt;. This ensures clarity and organization in the documentation.</value>
   </data>
-  <data name="MiKo_2041_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments</value>
-  </data>
   <data name="MiKo_2041_MessageFormat" xml:space="preserve">
     <value>&lt;summary&gt; should not contain: '&lt;{0}/&gt;'</value>
   </data>
@@ -2463,9 +2427,6 @@ This format clearly describes the purpose of the class and its functionality, ma
   </data>
   <data name="MiKo_2042_Description" xml:space="preserve">
     <value>Documentation should use the '&lt;para&gt;' XML tags instead of '&lt;p&gt;' HTML tags. This ensures a consistent format, suitable for XML-based documentation tools and frameworks.</value>
-  </data>
-  <data name="MiKo_2042_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/para</value>
   </data>
   <data name="MiKo_2042_MessageFormat" xml:space="preserve">
     <value>Use '&lt;para&gt;' instead of '&lt;p&gt;'</value>
@@ -2943,9 +2904,6 @@ This ensures the documentation is precise and informative, helping developers un
     <value>XML documentation should use the &lt;list&gt; tag for enumerating items. Avoid using terms like 1.), 2.), etc., directly because IntelliSense and XML documentation tools cannot recognize these and may format comments awkwardly.
 Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lists, ordered lists, etc., making documentation clear and easy to read.</value>
   </data>
-  <data name="MiKo_2204_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/list</value>
-  </data>
   <data name="MiKo_2204_MessageFormat" xml:space="preserve">
     <value>Use &lt;list&gt; to list items in documentation</value>
   </data>
@@ -3103,9 +3061,6 @@ Instead, use &lt;para&gt; tags, which are designed to mark paragraphs properly, 
 
 This ensures your list documentation is clear and accurately structured.</value>
   </data>
-  <data name="MiKo_2217_HelpLinkUri" xml:space="preserve">
-    <value>http://www.blackwasp.co.uk/DocumentationLists.aspx</value>
-  </data>
   <data name="MiKo_2217_MessageArgument_MissingDescription" xml:space="preserve">
     <value>&lt;description&gt; is missing</value>
   </data>
@@ -3219,9 +3174,6 @@ This ensures clarity and usability in your documentation, making it straightforw
   </data>
   <data name="MiKo_2225_Description" xml:space="preserve">
     <value>Use the &lt;c&gt; tag to mark text within a description as code, but only for single lines. For multiple lines of code, you should use the &lt;code&gt; tag. This ensures the formatting is clear and the documentation remains organized and readable.</value>
-  </data>
-  <data name="MiKo_2225_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#c</value>
   </data>
   <data name="MiKo_2225_MessageFormat" xml:space="preserve">
     <value>Place '&lt;c&gt;' tag with its content on same line</value>
@@ -3424,9 +3376,6 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
     <value>XML documentation should use the &lt;list&gt; tag for enumerating items. Avoid using &lt;ul&gt; or &lt;ol&gt; because IntelliSense and XML documentation tools cannot recognize these and may format comments awkwardly.
 Using &lt;list&gt; allows IntelliSense to format content as tables, numbered lists, ordered lists, etc., making documentation clear and easy to read.</value>
   </data>
-  <data name="MiKo_2244_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/list</value>
-  </data>
   <data name="MiKo_2244_MessageFormat" xml:space="preserve">
     <value>Use &lt;list&gt; to list items in documentation</value>
   </data>
@@ -3618,9 +3567,6 @@ Instead, comments should enhance understanding, giving context and reasoning for
   <data name="MiKo_3001_Description" xml:space="preserve">
     <value>To ease maintenance, use the pre-defined .NET Framework delegate types such as 'Action', 'Func' or 'Expression' instead of custom delegates.</value>
   </data>
-  <data name="MiKo_3001_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks</value>
-  </data>
   <data name="MiKo_3001_MessageFormat" xml:space="preserve">
     <value>Use 'Action', 'Func' or 'Expression' instead</value>
   </data>
@@ -3638,9 +3584,6 @@ Instead, comments should enhance understanding, giving context and reasoning for
   </data>
   <data name="MiKo_3003_Description" xml:space="preserve">
     <value>To ease usage, events should follow the .NET Framework Design Guidelines for Event Design.</value>
-  </data>
-  <data name="MiKo_3003_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/event</value>
   </data>
   <data name="MiKo_3003_MessageFormat" xml:space="preserve">
     <value>Use 'EventHandler' or 'EventHandler&lt;T&gt;' instead</value>
@@ -3708,9 +3651,6 @@ This pattern keeps methods consistent and predictable, enhancing readability and
   <data name="MiKo_3010_Description" xml:space="preserve">
     <value>Certain exceptions are reserved for and thrown by the Common Language Runtime (CLR) and often signal bugs. Developers should not throw these exceptions themselves to maintain code cleanliness and avoid confusion. Following this principle ensures clear and robust code management.</value>
   </data>
-  <data name="MiKo_3010_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types</value>
-  </data>
   <data name="MiKo_3010_MessageFormat" xml:space="preserve">
     <value>Do not create a '{0}'</value>
   </data>
@@ -3722,9 +3662,6 @@ This pattern keeps methods consistent and predictable, enhancing readability and
   </data>
   <data name="MiKo_3011_Description" xml:space="preserve">
     <value>Thrown ArgumentExceptions (or its subtypes) should always include the name of the parameter that caused the exception. This practice helps other developers quickly identify the problematic argument, facilitating easier debugging and improving overall code maintainability.</value>
-  </data>
-  <data name="MiKo_3011_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types#argumentexception-argumentnullexception-and-argumentoutofrangeexception</value>
   </data>
   <data name="MiKo_3011_MessageFormat" xml:space="preserve">
     <value>Change 'paramName' parameter to {1}</value>
@@ -3775,9 +3712,6 @@ This practice ensures that developers understand why the exception was thrown an
   <data name="MiKo_3015_Description" xml:space="preserve">
     <value>Avoid throwing ArgumentException (or its subtypes) in parameterless methods. If a method does not take any arguments, or if the failure is not related to the arguments themselves, use InvalidOperationException instead. This keeps exception handling logical and context-appropriate, making the code cleaner and easier to maintain.</value>
   </data>
-  <data name="MiKo_3015_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types</value>
-  </data>
   <data name="MiKo_3015_MessageFormat" xml:space="preserve">
     <value>Throw an 'InvalidOperationException' instead</value>
   </data>
@@ -3794,9 +3728,6 @@ This practice ensures that developers understand why the exception was thrown an
 - If the problem isn't with the parameter itself, throw an InvalidOperationException instead.
 
 This approach ensures that the exception thrown accurately reflects the nature of the issue, making your code more robust and understandable.</value>
-  </data>
-  <data name="MiKo_3016_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types</value>
   </data>
   <data name="MiKo_3016_MessageFormat" xml:space="preserve">
     <value>Throw an 'ArgumentException' or 'InvalidOperationException' instead</value>
@@ -3819,9 +3750,6 @@ This approach ensures that the exception thrown accurately reflects the nature o
   <data name="MiKo_3018_Description" xml:space="preserve">
     <value>Already disposed instances of disposable types should throw ObjectDisposedExceptions when methods are invoked on them. This practice makes it easier to identify bugs, as user code should never access already disposed types. Ensuring this indication helps maintain code integrity and prevents unintended errors.</value>
   </data>
-  <data name="MiKo_3018_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose</value>
-  </data>
   <data name="MiKo_3018_MessageFormat" xml:space="preserve">
     <value>Throw ObjectDisposedException if disposed</value>
   </data>
@@ -3842,9 +3770,6 @@ This approach ensures that the exception thrown accurately reflects the nature o
   </data>
   <data name="MiKo_3021_Description" xml:space="preserve">
     <value>If you're using 'Task.Run' to return a Task for a long-running operation, you're likely making a mistake. Instead, use 'Task.Run' to actually call the long-running operation. This approach aligns better with proper asynchronous programming practices and keeps your code efficient and manageable.</value>
-  </data>
-  <data name="MiKo_3021_HelpLinkUri" xml:space="preserve">
-    <value>https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-dont-use.html</value>
   </data>
   <data name="MiKo_3021_MessageFormat" xml:space="preserve">
     <value>Use '{0}' to invoke method '{1}', but not inside</value>
@@ -3903,9 +3828,6 @@ Generally, this behavior is not desirable. The object reference should remain th
   <data name="MiKo_3027_Description" xml:space="preserve">
     <value>Marking parameters for future use results in poor design. It's uncertain if the parameter will ever be used or if its type will fit future needs. Instead, override methods and add new parameters as needed. This approach maintains clarity and adaptability in your code, avoiding unnecessary clutter and potential issues. Keeps your codebase clean and efficient.</value>
   </data>
-  <data name="MiKo_3027_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design</value>
-  </data>
   <data name="MiKo_3027_MessageFormat" xml:space="preserve">
     <value>Do not reserve '{0}' for future usage</value>
   </data>
@@ -3932,9 +3854,6 @@ Generally, this behavior is not desirable. The object reference should remain th
   </data>
   <data name="MiKo_3030_Description" xml:space="preserve">
     <value>To ease maintenance, methods should make minimal assumptions about the structure or properties of the objects they use. They should work only with objects they receive directly and avoid reaching through these objects to access other objects or their services. This practice keeps methods focused, modular, and easier to maintain.</value>
-  </data>
-  <data name="MiKo_3030_HelpLinkUri" xml:space="preserve">
-    <value>https://en.wikipedia.org/wiki/Law_of_Demeter</value>
   </data>
   <data name="MiKo_3030_MessageFormat" xml:space="preserve">
     <value>Avoid to violate the Law of Demeter</value>
@@ -4046,9 +3965,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   <data name="MiKo_3040_Description" xml:space="preserve">
     <value>To ease maintenance and improve readability, avoid using Booleans as parameters unless absolutely sure the value will never exceed two options. Instead, use an Enum. This practice ensures the code remains clear, flexible, and easier to maintain.</value>
   </data>
-  <data name="MiKo_3040_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design</value>
-  </data>
   <data name="MiKo_3040_MessageFormat" xml:space="preserve">
     <value>Use an Enum instead</value>
   </data>
@@ -4157,9 +4073,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   <data name="MiKo_3050_Description" xml:space="preserve">
     <value>Fields that are the back of a DependencyProperty should be made 'public static readonly' to allow the .NET framework and other clients to find and access those fields.</value>
   </data>
-  <data name="MiKo_3050_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property</value>
-  </data>
   <data name="MiKo_3050_MessageFormat" xml:space="preserve">
     <value>Make it 'public static readonly'</value>
   </data>
@@ -4171,9 +4084,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   </data>
   <data name="MiKo_3051_Description" xml:space="preserve">
     <value>To avoid typos, register fields backing a DependencyProperty using 'DependencyProperty.Register()' and the 'nameof' operator. Ensure you provide the correct property names, property types, and owning types.</value>
-  </data>
-  <data name="MiKo_3051_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-implement-a-dependency-property</value>
   </data>
   <data name="MiKo_3051_MessageFormat" xml:space="preserve">
     <value>Use '{1}' instead</value>
@@ -4187,9 +4097,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   <data name="MiKo_3052_Description" xml:space="preserve">
     <value>Make fields backing a DependencyPropertyKey non-public, static, and readonly. This prevents clients from finding and accessing these fields, ensuring your code stays secure and well-encapsulated.</value>
   </data>
-  <data name="MiKo_3052_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencypropertykey</value>
-  </data>
   <data name="MiKo_3052_MessageFormat" xml:space="preserve">
     <value>Make it non-public 'static readonly'</value>
   </data>
@@ -4198,9 +4105,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   </data>
   <data name="MiKo_3053_Description" xml:space="preserve">
     <value>To prevent typos, register fields that are the key of a DependencyProperty using 'DependencyProperty.RegisterReadOnly()' and the 'nameof' operator. Also, ensure you provide the correct property names, property types, and owning types.</value>
-  </data>
-  <data name="MiKo_3053_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly</value>
   </data>
   <data name="MiKo_3053_MessageFormat" xml:space="preserve">
     <value>Use '{1}' instead</value>
@@ -4214,9 +4118,6 @@ Instead, use methods to make it clear that the behavior might differ between cal
   <data name="MiKo_3054_Description" xml:space="preserve">
     <value>Read-only dependency properties are defined by DependencyPropertyKey fields and should remain non-public. To make them accessible, expose a dependency property identifier for the read-only property. Do this by exposing the value of 'DependencyPropertyKey.DependencyProperty' as a 'public static readonly' field in the specific class.
 This maintains encapsulation while allowing access to the property.</value>
-  </data>
-  <data name="MiKo_3054_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/api/system.windows.dependencyproperty.registerreadonly</value>
   </data>
   <data name="MiKo_3054_MessageFormat" xml:space="preserve">
     <value>Expose a DependencyProperty identifier for the read-only dependency property '{0}'</value>
@@ -4694,9 +4595,6 @@ This practice ensures clarity and transparency in your codebase.</value>
   <data name="MiKo_3105_Description" xml:space="preserve">
     <value>NUnit's constraint-based Assert model uses a single 'Assert.That' method for all assertions, making it easier to understand. This helps developers avoid mixing up 'actual' and 'expected' values and makes the code more readable and intuitive.</value>
   </data>
-  <data name="MiKo_3105_HelpLinkUri" xml:space="preserve">
-    <value>https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html</value>
-  </data>
   <data name="MiKo_3105_MessageFormat" xml:space="preserve">
     <value>Use 'Assert.That' instead</value>
   </data>
@@ -5024,9 +4922,6 @@ Instead, provide a method that returns an 'IDisposable'. This way, developers ca
   </data>
   <data name="MiKo_3215_Description" xml:space="preserve">
     <value>To standardize delegates and adhere to .NET Framework Design Guidelines, use 'Func&lt;T, bool&gt;' for callbacks instead of 'Predicate&lt;T&gt;'. This approach ensures consistency and aligns with best practices.</value>
-  </data>
-  <data name="MiKo_3215_HelpLinkUri" xml:space="preserve">
-    <value>https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/events-and-callbacks</value>
   </data>
   <data name="MiKo_3215_MessageFormat" xml:space="preserve">
     <value>Use 'Func&lt;{0}, bool&gt;' instead of 'Predicate&lt;{0}&gt;'</value>
@@ -5501,9 +5396,6 @@ This organization ensures clarity and makes the code easier to find, understand 
   </data>
   <data name="MiKo_5012_Description" xml:space="preserve">
     <value>To improve performance, avoid letting methods with yield call themselves recursively. This causes the underlying iterators to be called more times than expected, resulting in poor runtime performance.</value>
-  </data>
-  <data name="MiKo_5012_HelpLinkUri" xml:space="preserve">
-    <value>https://stackoverflow.com/questions/3969963/when-not-to-use-yield-return</value>
   </data>
   <data name="MiKo_5012_MessageFormat" xml:space="preserve">
     <value>Do not use yield recursively</value>

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -61,7 +61,7 @@ namespace MiKoSolutions.Analyzers.Rules
                                                                 Severity,
                                                                 IsEnabledByDefault,
                                                                 LocalizableResource(id, "Description"),
-                                                                LocalizableResource(id, "HelpLinkUri")?.ToString()));
+                                                                "https://github.com/RalfKoban/MiKo-Analyzers/blob/master/Documentation/" + id + ".md"));
         }
 
         /// <summary>


### PR DESCRIPTION
- Remove `HelpLinkUri` resource entries

- Construct help link URLs programmatically

- Add inline hyperlinks in markdown documentation files for better discoverability
