### PR TITLE
Added new rule MiKo_2242 that reports "string representation" and fixes it to "textual representation"

### DIFF
--- a/Documentation/MiKo_2242.md
+++ b/Documentation/MiKo_2242.md
@@ -1,0 +1,43 @@
+﻿# MiKo_2242: Use 'textual representation' instead of 'string representation' in documentation
+
+## Cause
+
+The documentation contains the phrase "string representation" instead of "textual representation".
+
+## Rule description
+
+Documentation should use "textual representation" instead of "string representation".
+
+Developers care about the content being represented (the text), not the technical type (string).
+This makes documentation clearer and more focused on what matters.
+
+### Rationale behind
+
+Using "textual representation" in documentation provides several important benefits:
+
+- **Improved clarity**:
+  The focus shifts from the technical implementation detail (the `string` type) to the actual purpose (representing something as text).
+  This helps developers understand what the method or property does without getting distracted by type information.
+
+- **Better readability**:
+  Documentation becomes more natural to read.
+  "Textual representation" sounds more like plain English, while "string representation" sounds overly technical.
+
+- **Reduced cognitive load**:
+  Developers can focus on the concept being represented rather than the data type.
+  This is especially helpful when reading multiple pieces of documentation in succession.
+
+- **Consistency with terminology**:
+  The .NET Framework documentation often uses "textual representation" when describing conversion methods like `ToString()`.
+  Following this convention creates consistency across the ecosystem.
+
+## How to fix violations
+
+Replace "string representation" with "textual representation" in the documentation.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_2242
+#pragma warning restore MiKo_2242
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -157,6 +157,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2241_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2242_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2244_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2245_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2301_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -174,6 +174,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2239_DocumentationUsesSingleLineDocumentationCommentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2240_ResponseTypeDefaultPhraseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2244_DocumentationShallUseListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2300_MeaninglessCommentAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -9583,6 +9583,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;string representation&apos; with &apos;textual representation&apos;.
+        /// </summary>
+        internal static string MiKo_2242_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2242_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation should use &quot;textual representation&quot; instead of &quot;string representation&quot;. Developers care about the content being represented (the text), not the technical type (string). This makes documentation clearer and more focused on what matters..
+        /// </summary>
+        internal static string MiKo_2242_Description {
+            get {
+                return ResourceManager.GetString("MiKo_2242_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;string representation&apos; with &apos;textual representation&apos;.
+        /// </summary>
+        internal static string MiKo_2242_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_2242_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;textual representation&apos; instead of &apos;string representation&apos; in documentation.
+        /// </summary>
+        internal static string MiKo_2242_Title {
+            get {
+                return ResourceManager.GetString("MiKo_2242_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use &lt;list&gt; to list items.
         /// </summary>
         internal static string MiKo_2244_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -3379,6 +3379,18 @@ Such documentation also undermines tool integration and usability, as IDEs rely 
   <data name="MiKo_2241_Title" xml:space="preserve">
     <value>Do not use 'empty string' in documentation</value>
   </data>
+  <data name="MiKo_2242_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'string representation' with 'textual representation'</value>
+  </data>
+  <data name="MiKo_2242_Description" xml:space="preserve">
+    <value>Documentation should use "textual representation" instead of "string representation". Developers care about the content being represented (the text), not the technical type (string). This makes documentation clearer and more focused on what matters.</value>
+  </data>
+  <data name="MiKo_2242_MessageFormat" xml:space="preserve">
+    <value>Replace 'string representation' with 'textual representation'</value>
+  </data>
+  <data name="MiKo_2242_Title" xml:space="preserve">
+    <value>Use 'textual representation' instead of 'string representation' in documentation</value>
+  </data>
   <data name="MiKo_2244_CodeFixTitle" xml:space="preserve">
     <value>Use &lt;list&gt; to list items</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_CodeFixProvider.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2242_CodeFixProvider)), Shared]
+    public sealed class MiKo_2242_CodeFixProvider : DocumentationCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_2242";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<XmlTextSyntax>().FirstOrDefault();
+
+        protected override SyntaxNode GetUpdatedSyntax(Document document, SyntaxNode syntax, Diagnostic issue) => syntax;
+
+        protected override SyntaxNode GetUpdatedSyntaxRoot(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue)
+        {
+            if (syntax is XmlTextSyntax text)
+            {
+                return root.ReplaceNode(syntax, GetReplacement(text));
+            }
+
+            return root;
+        }
+
+        private static XmlTextSyntax GetReplacement(XmlTextSyntax node)
+        {
+            var textTokens = node.TextTokens.ToList();
+
+            for (var index = 0; index < textTokens.Count; index++)
+            {
+                var textToken = textTokens[index];
+
+                if (textToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                {
+                    continue;
+                }
+
+                var valueText = textToken.ValueText
+                                         .AsCachedBuilder()
+                                         .ReplaceWithProbe("string representation", "textual representation")
+                                         .ReplaceWithProbe("String representation", "textual representation")
+                                         .ToStringAndRelease();
+
+                textTokens[index] = textToken.WithText(valueText);
+            }
+
+            return node.WithTextTokens(textTokens.ToTokenList());
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer : OverallDocumentationAnalyzer
+    {
+        public const string Id = "MiKo_2242";
+
+        private const string Phrase = "string representation";
+
+        public MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IReadOnlyList<Diagnostic> AnalyzeComment(DocumentationCommentTriviaSyntax comment, ISymbol symbol, SemanticModel semanticModel)
+        {
+            List<Diagnostic> issues = null;
+
+            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
+            {
+                var textTokens = xmlText.TextTokens;
+
+                // keep in local variable to avoid multiple requests (see Roslyn implementation)
+                var textTokensCount = textTokens.Count;
+
+                if (textTokensCount is 0)
+                {
+                    continue;
+                }
+
+                var parent = xmlText.Parent;
+
+                if (parent.IsCode())
+                {
+                    continue;
+                }
+
+                for (var index = 0; index < textTokensCount; index++)
+                {
+                    var token = textTokens[index];
+
+                    if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                    {
+                        continue;
+                    }
+
+                    var locations = GetAllLocations(token, Phrase, StringComparison.OrdinalIgnoreCase);
+
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(locations.Count);
+                    }
+
+                    foreach (var location in locations)
+                    {
+                        issues.Add(Issue(location));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzerTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [TestFixture]
+    public sealed class MiKo_2242_DocumentationUsesTextualRepresentationAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_no_string_representation_in_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some text.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void No_issue_is_reported_for_textual_representation_in_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some textual representation of something.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void An_issue_is_reported_for_string_representation_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+/// <" + tag + @">
+/// This is some string representation of something.
+/// </" + tag + @">
+public sealed class TestMe { }
+");
+
+        [Test]
+        public void Code_gets_fixed_for_string_representation()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// This is some string representation of something.
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// This is some textual representation of something.
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_String_representation()
+        {
+            const string OriginalCode = """
+
+                                        /// <summary>
+                                        /// This is some String representation of something
+                                        /// </summary>
+                                        public sealed class TestMe { }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     /// <summary>
+                                     /// This is some textual representation of something
+                                     /// </summary>
+                                     public sealed class TestMe { }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2242_CodeFixProvider();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 533 rules that are currently provided by the analyzer.
+The following tables lists all the 534 rules that are currently provided by the analyzer.
 
 ### Metrics
 |ID|Title|Enabled by default|CodeFix available|
@@ -303,6 +303,7 @@ The following tables lists all the 533 rules that are currently provided by the 
 |[MiKo_2239](/Documentation/MiKo_2239.md)|Use '///' instead of '/** */' for documentation|&#x2713;|&#x2713;|
 |[MiKo_2240](/Documentation/MiKo_2240.md)|Do not start &lt;response&gt; documentation with 'Returns'|&#x2713;|&#x2713;|
 |[MiKo_2241](/Documentation/MiKo_2241.md)|Do not use 'empty string' in documentation|&#x2713;|&#x2713;|
+|[MiKo_2242](/Documentation/MiKo_2242.md)|Use 'textual representation' instead of 'string representation' in documentation|&#x2713;|&#x2713;|
 |[MiKo_2244](/Documentation/MiKo_2244.md)|Use &lt;list&gt; instead of &lt;ul&gt; or &lt;ol&gt; in documentation|&#x2713;|&#x2713;|
 |[MiKo_2245](/Documentation/MiKo_2245.md)|Wrap numbers with &lt;c&gt; in documentation|&#x2713;|&#x2713;|
 |[MiKo_2300](/Documentation/MiKo_2300.md)|Explain the 'Why' instead of the 'How' in comments|&#x2713;|\-|


### PR DESCRIPTION
- Add new rule `MiKo_2242` with analyzer, code fix provider, and comprehensive test coverage

- Update README.md

- Include detailed documentation explaining the rationale behind preferring "textual representation"

(resolves #1686)