### PR TITLE
MiKo_2236 is now also aware of 'p.ex.' (abbreviation of "per exemplum")

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_CodeFixProvider.cs
@@ -13,15 +13,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                         {
                                                             new Pair("e.g.", "for example"),
                                                             new Pair("i.e.", "for example"),
+                                                            new Pair("p.ex.", "for example"),
                                                             new Pair("e. g.", "for example"),
                                                             new Pair("i. e.", "for example"),
+                                                            new Pair("p. ex.", "for example"),
                                                             new Pair("eg.", "for example"),
 
                                                             // upper-case terms
                                                             new Pair("E.g.", "For example"),
                                                             new Pair("I.e.", "For example"),
+                                                            new Pair("P.ex.", "For example"),
                                                             new Pair("E. g.", "For example"),
                                                             new Pair("I. e.", "For example"),
+                                                            new Pair("P. ex.", "For example"),
                                                             new Pair("Eg.", "For example"),
                                                         };
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzer.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2236";
 
-        private static readonly string[] Phrases = { "e.g.", "i.e.", "e. g.", "i. e.", "eg." };
+        private static readonly string[] Phrases = { "e.g.", "i.e.", "e. g.", "i. e.", "eg.", "p.ex.", "p. ex." };
 
         public MiKo_2236_ExampleAbbreviationAnalyzer() : base(Id)
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
@@ -20,6 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                        "(E.g. something)",
                                                        "(e.g. something)",
                                                        "It is eg. something.",
+                                                       "It's p.ex. something.",
+                                                       "It is p.ex. something.",
                                                    ];
 
         [Test]
@@ -78,11 +80,15 @@ public class TestMe
         [TestCase("It's i.e. something", "It's for example something")]
         [TestCase("It's e. g. something", "It's for example something")]
         [TestCase("It's i. e. something", "It's for example something")]
+        [TestCase("It's p.ex. something", "It's for example something")]
+        [TestCase("It's p. ex. something", "It's for example something")]
         [TestCase("It's something (i.e. whatever)", "It's something (for example whatever)")]
         [TestCase("E.g. something", "For example something")]
         [TestCase("I.e. something", "For example something")]
+        [TestCase("P.ex. something", "For example something")]
         [TestCase("E. g. something", "For example something")]
         [TestCase("I. e. something", "For example something")]
+        [TestCase("P. ex. something", "For example something")]
         public void Code_gets_fixed_(string originalPhrase, string fixedPhrase)
         {
             const string Template = @"


### PR DESCRIPTION
- Add "p.ex." and "p. ex." to the list of detected abbreviations

- Add code fix replacements for all variants of "p.ex." to "for example"

- Extend test coverage with multiple test cases for the new abbreviation patterns
