### PR TITLE
Microsoft.AspNetCore.Mvc.Abstractions bumped to v2.3.8

### DIFF
--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.10" />
     <PackageReference Include="log4net" Version="3.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.8" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Bumped `Microsoft.AspNetCore.Mvc.Abstractions` version from `2.3.0` to `2.3.8`