### PR TITLE
MiKo_2012 is now aware of some more phrases reg. 'use this class'

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -547,7 +547,7 @@ namespace MiKoSolutions.Analyzers
                                                                               "The ",
                                                                               "This ",
                                                                               "To ",
-                                                                              "Use this ",
+                                                                              "Use ",
                                                                               "Used ",
                                                                               "Uses ",
                                                                               "View", // includes 'ViewModel'

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -625,6 +625,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("Use this Class to "); // typo in real-life scenario
             yield return new Pair("Use this Class, to "); // typo in real-life scenario
 
+            yield return new Pair("Use a instance of the class to ");
+            yield return new Pair("Use an instance of the class to ");
+            yield return new Pair("Use the instance of the class to ");
+            yield return new Pair("Use a instance of this class to ");
+            yield return new Pair("Use an instance of this class to ");
+            yield return new Pair("Use the instance of this class to ");
+            yield return new Pair("Use instances of the class to ");
+            yield return new Pair("Use instances of this class to ");
+            yield return new Pair("Use the instances of the class to ");
+            yield return new Pair("Use the instances of this class to ");
+            yield return new Pair("Use the class to ");
+            yield return new Pair("Use this class to ");
+            yield return new Pair("Use a this class to "); // typo
+            yield return new Pair("Use an this class to "); // typo
+            yield return new Pair("Use the this class to "); // typo
+            yield return new Pair("Use a the class to "); // typo
+            yield return new Pair("Use an the class to "); // typo
+            yield return new Pair("Use the the class to "); // typo
+
             yield return new Pair("The Method will be called", "Gets called"); // typo in real-life scenario
             yield return new Pair("The method will be called", "Gets called");
             yield return new Pair("The Method is called", "Gets called"); // typo in real-life scenario

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -686,6 +686,24 @@ public class TestMe
         [TestCase("The class would be used to")]
         [TestCase("This class is used to")]
         [TestCase("Used to")]
+        [TestCase("Use a instance of the class to")]
+        [TestCase("Use an instance of the class to")]
+        [TestCase("Use the instance of the class to")]
+        [TestCase("Use a instance of this class to")]
+        [TestCase("Use an instance of this class to")]
+        [TestCase("Use the instance of this class to")]
+        [TestCase("Use instances of the class to")]
+        [TestCase("Use instances of this class to")]
+        [TestCase("Use the instances of the class to")]
+        [TestCase("Use the instances of this class to")]
+        [TestCase("Use the class to")]
+        [TestCase("Use this class to")]
+        [TestCase("Use a this class to")] // typo
+        [TestCase("Use an this class to")] // typo
+        [TestCase("Use the this class to")] // typo
+        [TestCase("Use a the class to")] // typo
+        [TestCase("Use an the class to")] // typo
+        [TestCase("Use the the class to")] // typo
         public void Code_gets_fixed_for_class_(string startingPhrase)
         {
             const string Template = @"


### PR DESCRIPTION
- Extend phrase detection to cover instance-based patterns ("Use an instance of the class to", etc.)

- Add detection for grammatically incorrect typos ("Use a this class to", "Use the the class to", etc.)

- Simplify the prefix matching pattern from "Use this " to "Use " to catch broader variations
