### PR TITLE
MiKo_1041 is now aware of terms starting with 'For'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     /// </summary>
     public abstract class NamingAnalyzer : Analyzer
     {
-        private static readonly string[] Splitters = { "Of", "With", "To", "In", "From" };
+        private static readonly string[] Splitters = { "Of", "With", "To", "In", "From", "For" };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NamingAnalyzer"/> class with the unique identifier of the diagnostic and the kind of symbol to analyze.

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -33,6 +33,8 @@ public class TestMe
         [TestCase("IOrderedQueryable query")]
         [TestCase("IOrderedQueryable<int> query")]
         [TestCase("int[] replacementMap")]
+        [TestCase("string[] WrongNamesForConcreteLookup")]
+        [TestCase("string[] WrongNamesForLookup")]
         public void No_issue_is_reported_for_field_(string field) => No_issue_is_reported_for(@"
 using System.Linq;
 


### PR DESCRIPTION
- Add "For" as a word splitter in the naming analyzer

- Add test cases to verify fields with "For" prefixes are handled correctly

(eg. 'ForLookup')