### PR TITLE
MiKo_3226 and MiKo_5017 now ignore string literals assigned to different types

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzer.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
                         return Issue(localVariable);
                     }
 
-                    case FieldDeclarationSyntax field when field.IsConst() is false:
+                    case FieldDeclarationSyntax field when field.IsConst() is false && field.Declaration.Type.IsString():
                     {
                         return Issue(field);
                     }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3226_AssignedReadOnlyFieldsCanBeConstAnalyzerTests.cs
@@ -67,6 +67,17 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_static_readonly_field_of_string_type_when_assigned_to_different_type() => No_issue_is_reported_for(@"
+using System;
+using System.Xml.Linq;
+
+public class TestMe
+{
+    private static readonly XNamespace Value = ""test me"";
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_assigned_static_readonly_field_with_number_literal() => An_issue_is_reported_for(@"
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Performance/MiKo_5017_StringLiteralVariableAssignmentIsConstantAnalyzerTests.cs
@@ -22,6 +22,17 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_string_literal_as_static_readonly_field_if_assigned_to_different_type() => No_issue_is_reported_for(@"
+using System;
+using System.Xml.Linq;
+
+public class TestMe
+{
+    private static readonly XNamespace Value = ""test me"";
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_string_literal_as_local_constant() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Add type checking to ensure string literals are only flagged when assigned to string types

- Add test cases for both analyzers 
