### PR TITLE
Added new rule MiKo_1119 that verifies that test method names do not contain term 'when_present'

### DIFF
--- a/Documentation/MiKo_1119.md
+++ b/Documentation/MiKo_1119.md
@@ -1,0 +1,69 @@
+﻿# MiKo_1119: Do not include 'when_present' in test method names
+
+## Cause
+
+A test method name contains terms such as 'when_present', 'if_present', 'when_not_present', or 'if_not_present' (in various casings).
+
+## Rule description
+
+Test method names should be clear and meaningful.
+The terms 'when_present' or 'if_present' do not add useful information and make tests harder to understand.
+Use descriptive names that explain the behavior being tested instead.
+
+### Rationale behind
+
+Using vague condition indicators in test names reduces the clarity and maintainability of the test suite.
+When tests fail, developers need to quickly understand what scenario is failing without having to read the test implementation.
+Generic terms like `when_present` force developers to investigate the test code to determine what is actually present.
+
+Often, the `when_present` suffix is entirely redundant because the test scenario inherently requires the element to exist.
+If a test is checking behavior on an element, that element must be present for the test to be meaningful.
+Adding `when_present` does not add information but instead clutters the test name.
+
+Clear and specific test names provide several important benefits:
+
+- **Improved Readability**:
+  Explicit test names immediately communicate what is being tested.
+  Developers can understand the test scenario at a glance without needing to examine the test implementation.
+
+- **Better Debugging**:
+  When a test fails, a descriptive name helps identify the exact scenario that is not working.
+  This reduces the time needed to locate and fix issues.
+
+- **Enhanced Documentation**:
+  Test names serve as living documentation for the system's behavior.
+  Specific names document what scenarios the code handles and what conditions are supported.
+
+- **Easier Maintenance**:
+  Clear test names make it easier to understand the test suite's coverage.
+  Developers can quickly identify gaps in testing or redundant tests.
+
+- **Reduced Cognitive Load**:
+  Descriptive names eliminate the need to remember what 'present' refers to in each context.
+  Each test name stands on its own without requiring additional context.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the test method to explicitly describe what element or condition is being tested and what behavior is expected.
+
+Replace generic presence indicators with specific terms that describe what is being checked.
+Focus on making the test name self-explanatory by including the relevant context.
+
+Common patterns to recognize:
+
+- `Method_does_something_when_present` → `Method_does_something` (when the presence is implied by the action)
+- `Method_acts_on_element_when_present` → `Method_acts_on_existing_element` (when emphasizing existence is important)
+- `Method_skips_when_not_present` → `Method_skips_for_missing_element` (when testing the absence scenario)
+
+Consider including information about:
+
+- What specific element exists or is present (if not already clear from the action)
+- What the expected behavior or outcome is
+- What condition or state is being verified
+
+## How to suppress violations
+
+```csharp
+# pragma warning disable MiKo_1119
+# pragma warning restore MiKo_1119
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -486,6 +486,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1116_TestMethodsShouldBeInPresentTenseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1118_TestMethodsButAsyncSuffixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1119_TestMethodsWhenPresentAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1200_ExceptionCatchBlockAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1201_ExceptionParameterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4274,6 +4274,33 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test method names should be clear and meaningful. The terms &apos;when_present&apos; or &apos;if_present&apos; do not add useful information and make tests harder to understand. Use descriptive names that explain the behavior being tested instead..
+        /// </summary>
+        internal static string MiKo_1119_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1119_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;{1}&apos; from test method name.
+        /// </summary>
+        internal static string MiKo_1119_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1119_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not include &apos;when_present&apos; in test method names.
+        /// </summary>
+        internal static string MiKo_1119_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1119_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rename exception.
         /// </summary>
         internal static string MiKo_1200_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1564,6 +1564,15 @@ Clear, descriptive names state the action and the specific expected result, maki
   <data name="MiKo_1118_Title" xml:space="preserve">
     <value>Do not end test method names with 'Async'</value>
   </data>
+  <data name="MiKo_1119_Description" xml:space="preserve">
+    <value>Test method names should be clear and meaningful. The terms 'when_present' or 'if_present' do not add useful information and make tests harder to understand. Use descriptive names that explain the behavior being tested instead.</value>
+  </data>
+  <data name="MiKo_1119_MessageFormat" xml:space="preserve">
+    <value>Remove '{1}' from test method name</value>
+  </data>
+  <data name="MiKo_1119_Title" xml:space="preserve">
+    <value>Do not include 'when_present' in test method names</value>
+  </data>
   <data name="MiKo_1200_CodeFixTitle" xml:space="preserve">
     <value>Rename exception</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1119_TestMethodsWhenPresentAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1119";
+
+        private static readonly string[] ProblematicTexts =
+                                                            {
+                                                                "if_present",
+                                                                "if_not_present",
+                                                                "when_present",
+                                                                "when_not_present",
+                                                                "IfPresent",
+                                                                "IfNotPresent",
+                                                                "If_Present",
+                                                                "If_Not_Present",
+                                                                "If_NotPresent",
+                                                                "WhenPresent",
+                                                                "WhenNotPresent",
+                                                                "When_Present",
+                                                                "When_Not_Present",
+                                                                "When_NotPresent",
+                                                            };
+
+        public MiKo_1119_TestMethodsWhenPresentAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod();
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name
+                                   .Replace("resentation", "###") // ignore 'presentation'
+                                   .Replace("resenting", "###");  // ignore 'presenting'
+
+            foreach (var text in ProblematicTexts)
+            {
+                if (symbolName.Contains(text, StringComparison.Ordinal))
+                {
+                    return new[] { Issue(symbol, text) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzerTests.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1119_TestMethodsWhenPresentAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] ProblematicTexts =
+                                                            [
+                                                                "if_present",
+                                                                "if_not_present",
+                                                                "when_present",
+                                                                "when_not_present",
+                                                                "IfPresent",
+                                                                "IfNotPresent",
+                                                                "If_Present",
+                                                                "If_Not_Present",
+                                                                "If_NotPresent",
+                                                                "WhenPresent",
+                                                                "WhenNotPresent",
+                                                                "When_Present",
+                                                                "When_Not_Present",
+                                                                "When_NotPresent",
+                                                            ];
+
+        private static readonly string[] UnproblematicNames =
+                                                              [
+                                                                  "DoSomething",
+                                                                  "DoSomethingIfPresentationIsShown",
+                                                                  "DoSomethingWhenPresentationIsShown",
+                                                                  "DoSomethingIfPresentingSomething",
+                                                                  "DoSomethingWhenPresentingSomething",
+                                                                  "DoSomethingIfNotPresentingSomething",
+                                                                  "DoSomethingWhenNotPresentingSomething",
+                                                                  "DoSomething_If_Presentation_Is_Shown",
+                                                                  "DoSomething_When_Presentation_Is_Shown",
+                                                                  "DoSomething_If_Presenting_Something",
+                                                                  "DoSomething_When_Presenting_Something",
+                                                                  "DoSomething_If_Not_Presenting_Something",
+                                                                  "DoSomething_When_Not_Presenting_Something",
+                                                                  "DoSomething_If_NotPresenting_Something",
+                                                                  "DoSomething_When_NotPresenting_Something",
+                                                                  "DoSomething_if_presentation_is_shown",
+                                                                  "DoSomething_when_presentation_is_shown",
+                                                                  "DoSomething_if_presenting_something",
+                                                                  "DoSomething_when_presenting_something",
+                                                                  "DoSomething_if_not_presenting_something",
+                                                                  "DoSomething_when_not_presenting_something",
+                                                              ];
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_correct_name_(
+                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                        [ValueSource(nameof(Tests))] string test,
+                                                                        [ValueSource(nameof(UnproblematicNames))] string unproblematicTest)
+            => No_issue_is_reported_for(@"
+[" + fixture + @"]
+public class TestMe
+{
+    [" + test + @"]
+    public void " + unproblematicTest + @"() { }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_ending_with_incorrect_name_(
+                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                 [ValueSource(nameof(Tests))] string test,
+                                                                                 [ValueSource(nameof(ProblematicTexts))] string problematicTest)
+            => An_issue_is_reported_for(@"
+[" + fixture + @"]
+public class TestMe
+{
+    [" + test + @"]
+    public void DoSomething" + problematicTest + @"() { }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1119_TestMethodsWhenPresentAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1119_TestMethodsWhenPresentAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # MiKo-Analyzers
+
 Provides analyzers that are based on the .NET Compiler Platform (Roslyn) and can be used inside Visual Studio 2019 (v16.11) or 2022 (v17.14).
 
 How to install an Roslyn analyzer is described [here](https://learn.microsoft.com/en-us/visualstudio/code-quality/install-roslyn-analyzers?view=vs-2022).
 
 Screenshots on how to use such analyzers can be found [here](https://learn.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022).
 
-
 ## Build / Project status
+
 [![Maintenance](https://img.shields.io/maintenance/yes/2026.svg)](https://github.com/RalfKoban/MiKo-Analyzers)
 [![Build status](https://ci.appveyor.com/api/projects/status/qanrqn7r4q9frr9m/branch/master?svg=true)](https://ci.appveyor.com/project/RalfKoban/miko-analyzers/branch/master)
 [![codecov](https://codecov.io/gh/RalfKoban/MiKo-Analyzers/branch/master/graph/badge.svg)](https://codecov.io/gh/RalfKoban/MiKo-Analyzers)
 [![Coverity Scan Build Status](https://img.shields.io/coverity/scan/18917.svg)](https://scan.coverity.com/projects/ralfkoban-miko-analyzers)
 
 ## Available Rules
-The following tables lists all the 534 rules that are currently provided by the analyzer.
+
+The following tables lists all the 535 rules that are currently provided by the analyzer.
 
 ### Metrics
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_0001](/Documentation/MiKo_0001.md)|Keep methods small|&#x2713;|\-|
@@ -27,6 +30,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_0007](/Documentation/MiKo_0007.md)|Limit local function parameters|&#x2713;|\-|
 
 ### Naming
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_1000](/Documentation/MiKo_1000.md)|Suffix 'System.EventArgs' types with 'EventArgs'|&#x2713;|&#x2713;|
@@ -147,6 +151,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_1116](/Documentation/MiKo_1116.md)|Use present tense for test method names|&#x2713;|&#x2713;|
 |[MiKo_1117](/Documentation/MiKo_1117.md)|Make test method names more precise|&#x2713;|\-|
 |[MiKo_1118](/Documentation/MiKo_1118.md)|Do not end test method names with 'Async'|&#x2713;|&#x2713;|
+|[MiKo_1119](/Documentation/MiKo_1119.md)|Do not include 'when_present' in test method names|&#x2713;|\-|
 |[MiKo_1200](/Documentation/MiKo_1200.md)|Name catch block exceptions consistently|&#x2713;|&#x2713;|
 |[MiKo_1201](/Documentation/MiKo_1201.md)|Name exception parameters consistently|&#x2713;|&#x2713;|
 |[MiKo_1300](/Documentation/MiKo_1300.md)|Name unimportant lambda parameters '_'|&#x2713;|&#x2713;|
@@ -184,6 +189,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_1522](/Documentation/MiKo_1522.md)|Do not start void methods with 'Get'|&#x2713;|\-|
 
 ### Documentation
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_2000](/Documentation/MiKo_2000.md)|Write valid XML documentation|&#x2713;|&#x2713;|
@@ -322,6 +328,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_2313](/Documentation/MiKo_2313.md)|Format plain documentation comments as XML documentation|&#x2713;|&#x2713;|
 
 ### Maintainability
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_3000](/Documentation/MiKo_3000.md)|Do not use empty regions|&#x2713;|\-|
@@ -475,6 +482,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_3503](/Documentation/MiKo_3503.md)|Do not assign variables in try-catch blocks that are returned directly outside|&#x2713;|&#x2713;|
 
 ### Ordering
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_4001](/Documentation/MiKo_4001.md)|Order methods with same name based on their parameter count|&#x2713;|&#x2713;|
@@ -493,6 +501,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_4107](/Documentation/MiKo_4107.md)|Place assembly-wide test cleanup methods directly after assembly-wide test initialization methods|&#x2713;|&#x2713;|
 
 ### Performance
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_5001](/Documentation/MiKo_5001.md)|Invoke 'Debug' and 'DebugFormat' methods only after checking 'IsDebugEnabled'|&#x2713;|&#x2713;|
@@ -509,6 +518,7 @@ The following tables lists all the 534 rules that are currently provided by the 
 |[MiKo_5019](/Documentation/MiKo_5019.md)|Add [in] modifier to read-only struct parameters|&#x2713;|&#x2713;|
 
 ### Spacing
+
 |ID|Title|Enabled by default|CodeFix available|
 |:-|:----|:----------------:|:---------------:|
 |[MiKo_6001](/Documentation/MiKo_6001.md)|Surround log statements with blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add analyzer `MiKo_1119` to discourage generic presence indicators in test method names

- Add comprehensive test coverage for the new analyzer

(resolves #1777)