### PR TITLE
Added new rule MiKo_1523 that reports if methods names contain 'Helper' or 'HelpingMethod'

### DIFF
--- a/Documentation/MiKo_1523.md
+++ b/Documentation/MiKo_1523.md
@@ -1,0 +1,65 @@
+﻿# MiKo_1523: Do not name methods 'Helper'
+
+## Cause
+
+A method has a name that contains the terms 'Helper' or 'HelpingMethod'.
+
+## Rule description
+
+Method names should describe the specific behavior they provide, not label the method as a generic helper.
+
+Names like 'Helper', 'HelpingMethod', or 'XxxHelper' are vague and add no meaningful semantic information. Whether a method "helps" is already implied by how and where it's used.
+
+Using action‑oriented, descriptive names that communicate intent and effect makes the code clearer and easier to understand.
+
+### Rationale behind
+
+Generic names like 'Helper' provide no information about what a method actually does.
+They make it difficult for developers to understand the purpose of a method without reading its implementation.
+
+Avoiding vague helper names and using descriptive, action-oriented names provides several important benefits:
+
+- **Improved Readability**:
+  Descriptive method names immediately tell what the method does.
+  Developers can understand the code without having to dig into the implementation details.
+
+- **Better Maintainability**:
+  When method names clearly describe their purpose, it is easier to find the right method when fixing bugs or adding features.
+  This reduces the time spent searching through the codebase.
+
+- **Enhanced Self-Documentation**:
+  Action-oriented names make the code self-explanatory.
+  Well-named methods reduce the need for additional comments and documentation.
+
+- **Reduced Confusion**:
+  Generic names like 'Helper' do not convey what the method actually helps with.
+  Specific names eliminate ambiguity and make the code flow more logical.
+
+- **Easier Code Reviews**:
+  Reviewers can quickly understand what each method is supposed to do based on its name.
+  This makes code reviews faster and more effective.
+
+- **Better Code Organization**:
+  Descriptive names encourage developers to think about what a method really does.
+  This often leads to better separation of concerns and cleaner code structure.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the method to describe what it actually does.
+
+Replace generic terms like 'Helper' with action verbs that explain the specific operation being performed.
+
+For example:
+
+- Instead of `StringHelper`, use `FormatString`, `ValidateInput`, or `ParseValue`
+- Instead of `DataHelper`, use `LoadData`, `SaveRecord`, or `TransformData`
+- Instead of `CalculationHelper`, use `ComputeTotal`, `CalculateDiscount`, or `SumValues`
+
+Choose names that clearly communicate the method's intent and what it returns or modifies.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1523
+#pragma warning restore MiKo_1523
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -522,6 +522,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1520_ToCopyVariablesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1521_ToCopyParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1522_VoidGetMethodAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1523_HelperMethodAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5456,6 +5456,35 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Method names should describe the specific behavior they provide, not label the method as a generic helper.
+        ///Names like &apos;Helper&apos;, &apos;HelpingMethod&apos;, or &apos;XxxHelper&apos; are vague and add no meaningful semantic information. Whether a method &quot;helps&quot; is already implied by how and where it&apos;s used.
+        ///Using action‑oriented, descriptive names that communicate intent and effect makes the code clearer and easier to understand..
+        /// </summary>
+        internal static string MiKo_1523_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1523_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;{1}&apos; from method name.
+        /// </summary>
+        internal static string MiKo_1523_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1523_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not name methods &apos;Helper&apos;.
+        /// </summary>
+        internal static string MiKo_1523_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1523_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1972,6 +1972,17 @@ This makes your code clearer and follows common .NET naming conventions.</value>
   <data name="MiKo_1522_Title" xml:space="preserve">
     <value>Do not start void methods with 'Get'</value>
   </data>
+  <data name="MiKo_1523_Description" xml:space="preserve">
+    <value>Method names should describe the specific behavior they provide, not label the method as a generic helper.
+Names like 'Helper', 'HelpingMethod', or 'XxxHelper' are vague and add no meaningful semantic information. Whether a method "helps" is already implied by how and where it's used.
+Using action‑oriented, descriptive names that communicate intent and effect makes the code clearer and easier to understand.</value>
+  </data>
+  <data name="MiKo_1523_MessageFormat" xml:space="preserve">
+    <value>Remove '{1}' from method name</value>
+  </data>
+  <data name="MiKo_1523_Title" xml:space="preserve">
+    <value>Do not name methods 'Helper'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1523_HelperMethodAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1523_HelperMethodAnalyzer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1523_HelperMethodAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1523";
+
+        private static readonly string[] Terms = { "Helper", "HelpingMethod" };
+
+        public MiKo_1523_HelperMethodAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            var symbolName = symbol.Name;
+
+            for (int index = 0, count = Terms.Length; index < count; index++)
+            {
+                var term = Terms[index];
+
+                if (symbolName.Contains(term, StringComparison.Ordinal))
+                {
+                    return new[] { Issue(symbol, term) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1523_HelperMethodAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1523_HelperMethodAnalyzerTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1523_HelperMethodAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] WrongTerms = ["Helper", "HelpingMethod"];
+
+        [Test]
+        public void No_issue_is_reported_for_method_with_correct_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_starting_with_([ValueSource(nameof(WrongTerms))] string term) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void " + term + @"Something(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_method_ending_with_([ValueSource(nameof(WrongTerms))] string term) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void Something" + term + @"(int something)
+        {
+        }
+    }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_1523_HelperMethodAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1523_HelperMethodAnalyzer();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables lists all the 535 rules that are currently provided by the analyzer.
+The following tables lists all the 536 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -187,6 +187,7 @@ The following tables lists all the 535 rules that are currently provided by the 
 |[MiKo_1520](/Documentation/MiKo_1520.md)|Do not prefix or suffix local variables with 'toCopy'|&#x2713;|&#x2713;|
 |[MiKo_1521](/Documentation/MiKo_1521.md)|Do not prefix or suffix parameters with 'toCopy'|&#x2713;|&#x2713;|
 |[MiKo_1522](/Documentation/MiKo_1522.md)|Do not start void methods with 'Get'|&#x2713;|\-|
+|[MiKo_1523](/Documentation/MiKo_1523.md)|Do not name methods 'Helper'|&#x2713;|\-|
 
 ### Documentation
 


### PR DESCRIPTION
- Add new analyzer to detect and report methods with 'Helper' or 'HelpingMethod' in their names

- Add comprehensive test coverage for the new analyzer

- Create documentation explaining the rule, rationale, and examples

(resolves #1785)