### PR TITLE
MiKo_1117 is now aware of 'acceptable' as vague term

### DIFF
--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -4223,7 +4223,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test names must show the scenario and the exact outcome, including the event, exception type, or returned value.
+        ///   Looks up a localized string similar to Do not use vague term &apos;{1}&apos; in test name.
         /// </summary>
         internal static string MiKo_1117_MessageFormat {
             get {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -1550,7 +1550,7 @@ This forces readers to inspect the test body to understand the behavior.
 Precise and descriptive names make tests self‑explanatory, improve debugging, and enhance the quality of test documentation.</value>
   </data>
   <data name="MiKo_1117_MessageFormat" xml:space="preserve">
-    <value>Test names must show the scenario and the exact outcome, including the event, exception type, or returned value</value>
+    <value>Do not use vague term '{1}' in test name</value>
   </data>
   <data name="MiKo_1117_Title" xml:space="preserve">
     <value>Make test method names more precise</value>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzer.cs
@@ -12,38 +12,39 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1117";
 
-        private static readonly string[] UnclearTerms =
-                                                        {
-                                                            "_exception_thrown",
-                                                            "_throws_exception",
-                                                            "correct",
-                                                            "done",
-                                                            "Event_Is_Raised",
-                                                            "EventFired",
-                                                            "EventIsFired",
-                                                            "EventIsRaised",
-                                                            "EventOccured",
-                                                            "EventOccurred",
-                                                            "EventRaised",
-                                                            "ExceptionThrown",
-                                                            "finished",
-                                                            "FiresEvent",
-                                                            "graceful",
-                                                            "handle",
-                                                            "normal",
-                                                            "not_handle",
-                                                            "NotHandle",
-                                                            "OccuredEvent",
-                                                            "OccurredEvent",
-                                                            "proper",
-                                                            "Raised_Event",
-                                                            "RaisedEvent",
-                                                            "Raises_Event",
-                                                            "RaisesEvent",
-                                                            "successful",
-                                                            "ThrowsException",
-                                                            "works",
-                                                        };
+        private static readonly string[] VagueTerms =
+                                                      {
+                                                          "_exception_thrown",
+                                                          "_throws_exception",
+                                                          "acceptable",
+                                                          "correct",
+                                                          "done",
+                                                          "Event_Is_Raised",
+                                                          "EventFired",
+                                                          "EventIsFired",
+                                                          "EventIsRaised",
+                                                          "EventOccured",
+                                                          "EventOccurred",
+                                                          "EventRaised",
+                                                          "ExceptionThrown",
+                                                          "finished",
+                                                          "FiresEvent",
+                                                          "graceful",
+                                                          "handle",
+                                                          "normal",
+                                                          "not_handle",
+                                                          "NotHandle",
+                                                          "OccuredEvent",
+                                                          "OccurredEvent",
+                                                          "proper",
+                                                          "Raised_Event",
+                                                          "RaisedEvent",
+                                                          "Raises_Event",
+                                                          "RaisesEvent",
+                                                          "successful",
+                                                          "ThrowsException",
+                                                          "works",
+                                                      };
 
         private static readonly string[] KnownExceptions =
                                                            {
@@ -74,10 +75,21 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol) && symbol.IsTestMethod();
 
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => HasIssue(symbol.Name.AsCachedBuilder().ReplaceAllWithProbe(KnownExceptions, "#").ToStringAndRelease())
-                                                                                                                 ? new[] { Issue(symbol) }
-                                                                                                                 : Array.Empty<Diagnostic>();
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            var preparedTestName = symbol.Name.AsCachedBuilder()
+                                         .ReplaceAllWithProbe(KnownExceptions, "#")
+                                         .ToStringAndRelease();
 
-        private static bool HasIssue(string symbolName) => symbolName.ContainsAny(UnclearTerms, StringComparison.OrdinalIgnoreCase);
+            foreach (var vagueTerm in VagueTerms)
+            {
+                if (preparedTestName.Contains(vagueTerm, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new[] { Issue(symbol, vagueTerm) };
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
@@ -50,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                   "Something_with_an_uppercase_Property",
                                                               ];
 
-        private static readonly string[] WrongMethodNames =
+        private static readonly string[] VagueMethodNames =
                                                             [
                                                                 "Something_EventRaised",
                                                                 "Something_EventIsRaised",
@@ -87,6 +87,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                 "Something_improperly",
                                                                 "Something_incorrect",
                                                                 "Something_incorrectly",
+                                                                "Something_is_acceptable",
+                                                                "Something_is_inacceptable",
+                                                                "Something_is_unacceptable",
                                                                 "Something_normally",
                                                                 "Something_proper_way",
                                                                 "Something_properly",
@@ -96,6 +99,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                 "SomethingDoesNotHandle",
                                                                 "SomethingDoNotHandle",
                                                                 "SomethingHandles",
+                                                                "SomethingIsAcceptable",
                                                                 "SomethingIsCorrect",
                                                                 "SomethingIsCorrectly",
                                                                 "SomethingIsDone",
@@ -104,19 +108,21 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                 "SomethingIsGracefully",
                                                                 "SomethingIsImproper",
                                                                 "SomethingIsImproperly",
+                                                                "SomethingIsInacceptable",
                                                                 "SomethingIsIncorrect",
                                                                 "SomethingIsIncorrectly",
                                                                 "SomethingIsNormal",
                                                                 "SomethingIsNormally",
                                                                 "SomethingIsProperly",
                                                                 "SomethingIsProperWay",
-                                                                "SomethingIsSuccessfully",
                                                                 "SomethingIsSuccessful",
+                                                                "SomethingIsSuccessfully",
+                                                                "SomethingIsUnacceptable",
                                                                 "SomethingWorks",
                                                             ];
 
         [Test]
-        public void No_issue_is_reported_for_non_test_class_([ValueSource(nameof(WrongMethodNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_test_class_([ValueSource(nameof(VagueMethodNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -139,7 +145,7 @@ public class TestMe
 
         [Test]
         public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(WrongMethodNames))] string methodName,
+                                                                      [ValueSource(nameof(VagueMethodNames))] string methodName,
                                                                       [ValueSource(nameof(TestFixtures))] string fixture,
                                                                       [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"


### PR DESCRIPTION
- Add "acceptable", "inacceptable", and "unacceptable" to list of vague terms

- Update the diagnostic message to include the specific vague term found

- Refactor analysis logic to iterate through vague terms and report triggering specific term
