### PR TITLE
MiKo_2019 is now aware of 'get information about'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -945,23 +945,29 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var continuation in continuations)
                 {
-                    yield return start + continuation;
+                    var phrase = start + continuation;
+
+                    yield return phrase;
+                    yield return phrase + "about ";
                 }
             }
 
-            foreach (var getter in gets)
+            foreach (var continuation in continuations)
             {
-                foreach (var continuation in continuations)
+                foreach (var getter in gets)
                 {
-                    yield return getter + " " + continuation;
-                }
-            }
+                    var phrase = getter + " " + continuation;
 
-            foreach (var setter in sets)
-            {
-                foreach (var continuation in continuations)
+                    yield return phrase;
+                    yield return phrase + "about ";
+                }
+
+                foreach (var setter in sets)
                 {
-                    yield return setter + " " + continuation;
+                    var phrase = setter + " " + continuation;
+
+                    yield return phrase;
+                    yield return phrase + "about ";
                 }
             }
         }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -665,6 +665,7 @@ public interface TestMe
         [TestCase("This property returns")]
         [TestCase("This Property will return")]
         [TestCase("This Property returns")]
+        [TestCase("get information about")]
         public void Code_gets_fixed_for_non_boolean_property_text_(string originalText)
         {
             const string Template = @"


### PR DESCRIPTION
- Property getter and setter starting phrases now include variations with "about"

- Add test case to verify handling of "get information about" phrase