### PR TITLE
Added cache for plural names to NamingAnalyzer

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzer.cs
@@ -51,7 +51,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     continue;
                 }
 
-                var pluralName = FindPluralName(originalName.AsSpan(), out var singularName);  // might return null in case there is none
+                var pluralName = FindPluralName(originalName, out var singularName);  // might return null in case there is none
 
                 if (pluralName is null)
                 {


### PR DESCRIPTION
- Introduce a cache for plural/singular name pairs.

- Add `FindPluralName(string, out string)` overload that uses the cache.

- Update callers to use the cached overload instead of span-based calls.
