### PR TITLE
Fixed exceptions that occur with de-obfuscated code and cannot be tested

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -25,7 +25,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             base.InitializeCore(context);
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => identifiers.Select(_ => _.GetSymbol(semanticModel)).SelectMany(AnalyzeName);
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => identifiers.Select(_ => _.GetSymbol(semanticModel))
+                                                                                                                                                                     .WhereNotNull() // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                                                                                                                                                                     .SelectMany(AnalyzeName);
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsExtern is false && base.ShallAnalyze(symbol);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
@@ -31,6 +31,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static bool HasIssue(string name, in char character)
         {
+            if (name.Length is 0)
+            {
+                // code seems to be obfuscated or contains no valid characters, so ignore it silently
+                return false;
+            }
+
             if (name.First() == character)
             {
                 var trimmed = name.AsSpan().TrimStart(character);

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -380,7 +380,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <returns>
         /// <see langword="true"/> if the namespace shall be analyzed; otherwise, <see langword="false"/>.
         /// </returns>
-        protected virtual bool ShallAnalyze(INamespaceSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsGlobalNamespace is false;
+        protected virtual bool ShallAnalyze(INamespaceSymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return symbol.CanBeReferencedByName && symbol.IsGlobalNamespace is false;
+        }
 
         /// <summary>
         /// Determines whether the specified type shall be analyzed.
@@ -391,7 +400,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <returns>
         /// <see langword="true"/> if the type shall be analyzed; otherwise, <see langword="false"/>.
         /// </returns>
-        protected virtual bool ShallAnalyze(ITypeSymbol symbol) => symbol.CanBeReferencedByName;
+        protected virtual bool ShallAnalyze(ITypeSymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return symbol.CanBeReferencedByName;
+        }
 
         /// <summary>
         /// Determines whether the specified method shall be analyzed.
@@ -404,6 +422,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// </returns>
         protected virtual bool ShallAnalyze(IMethodSymbol symbol)
         {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
             if (symbol.CanBeReferencedByName is false)
             {
                 return false;
@@ -436,7 +460,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <returns>
         /// <see langword="true"/> if the property shall be analyzed; otherwise, <see langword="false"/>.
         /// </returns>
-        protected virtual bool ShallAnalyze(IPropertySymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        protected virtual bool ShallAnalyze(IPropertySymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        }
 
         /// <summary>
         /// Determines whether the specified event shall be analyzed.
@@ -447,7 +480,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <returns>
         /// <see langword="true"/> if the event shall be analyzed; otherwise, <see langword="false"/>.
         /// </returns>
-        protected virtual bool ShallAnalyze(IEventSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        protected virtual bool ShallAnalyze(IEventSymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return symbol.CanBeReferencedByName && symbol.IsOverride is false && symbol.IsInterfaceImplementation() is false;
+        }
 
         /// <summary>
         /// Determines whether the specified field shall be analyzed.
@@ -458,7 +500,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <returns>
         /// <see langword="true"/> if the field shall be analyzed; otherwise, <see langword="false"/>.
         /// </returns>
-        protected virtual bool ShallAnalyze(IFieldSymbol symbol) => symbol.CanBeReferencedByName && symbol.IsOverride is false;
+        protected virtual bool ShallAnalyze(IFieldSymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return symbol.CanBeReferencedByName && symbol.IsOverride is false;
+        }
 
         /// <summary>
         /// Determines whether the specified parameter shall be analyzed.
@@ -471,6 +522,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// </returns>
         protected virtual bool ShallAnalyze(IParameterSymbol symbol)
         {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
             if (symbol.CanBeReferencedByName is false)
             {
                 return false;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is SwitchSectionSyntax section && section.Statements.First() is BlockSyntax block)
+            if (context.Node is SwitchSectionSyntax section && section.Statements.FirstOrDefault() is BlockSyntax block) // be aware of incomplete sections
             {
                 var caseToken = section.Labels.First().Keyword;
                 var openBraceToken = block.OpenBraceToken;


### PR DESCRIPTION
- Avoid exceptions on incomplete switch sections

- Add null/empty guards in multiple naming analyzers to skip analysis when symbols/text are invalid

- Update ctor-parameter analysis to avoid duplicate key exceptions when parameter names are duplicated
