### PR TITLE
Detection for Local variable (designations) enhanced

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -792,14 +792,29 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static ITypeSymbol GetTypeSymbol(this SyntaxNode value, SemanticModel semanticModel)
         {
-            if (value is null)
+            switch (value)
             {
-                return null;
+                case null: return null;
+                case ArgumentSyntax a: return a.GetTypeSymbol(semanticModel);
+                case MemberAccessExpressionSyntax m: return m.GetTypeSymbol(semanticModel);
+                case ClassDeclarationSyntax c: return c.GetTypeSymbol(semanticModel);
+                case RecordDeclarationSyntax r: return r.GetTypeSymbol(semanticModel);
+                case BaseTypeSyntax b: return b.GetTypeSymbol(semanticModel);
+                case TypeSyntax t: return t.GetTypeSymbol(semanticModel);
+                case VariableDeclarationSyntax declaration: return declaration.GetTypeSymbol(semanticModel);
+                case ParenthesizedVariableDesignationSyntax p: return p.Parent.GetTypeSymbol(semanticModel); // TODO RKN: seems we have an parenthesize around
+                case VariableDesignationSyntax designation: return designation.GetTypeSymbol(semanticModel);
+                case DeclarationPatternSyntax dp: return dp.Type.GetTypeSymbol(semanticModel);
+                case DeclarationExpressionSyntax de: return de.Type.GetTypeSymbol(semanticModel);
+                case ExpressionSyntax e: return e.GetTypeSymbol(semanticModel);
+
+                default:
+                {
+                    var typeInfo = semanticModel.GetTypeInfo(value);
+
+                    return typeInfo.Type;
+                }
             }
-
-            var typeInfo = semanticModel.GetTypeInfo(value);
-
-            return typeInfo.Type;
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
@@ -13,14 +13,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         protected override void InitializeCore(CompilationStartAnalysisContext context)
         {
             context.RegisterSyntaxNodeAction(AnalyzeLocalDeclarationStatement, SyntaxKind.LocalDeclarationStatement);
-            context.RegisterSyntaxNodeAction(AnalyzeDeclarationPattern, SyntaxKind.DeclarationPattern);
-            context.RegisterSyntaxNodeAction(AnalyzeDeclarationExpression, SyntaxKind.DeclarationExpression);
             context.RegisterSyntaxNodeAction(AnalyzeForEachStatement, SyntaxKind.ForEachStatement);
             context.RegisterSyntaxNodeAction(AnalyzeForStatement, SyntaxKind.ForStatement);
 
             // TODO RKN: Renaming tuples currently does not work, see https://github.com/dotnet/roslyn/issues/14115
             // context.RegisterSyntaxNodeAction(AnalyzeTupleElement, SyntaxKind.TupleElement);
             context.RegisterSyntaxNodeAction(AnalyzeTupleExpression, SyntaxKind.TupleExpression);
+            context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.SingleVariableDesignation);
+            context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.ParenthesizedVariableDesignation);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1026_LocalVariableNameLengthAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1026_LocalVariableNameLengthAnalyzer.cs
@@ -21,7 +21,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
             // local variables in 'for' and 'foreach' statements are covered by MiKo_1027 rule
             context.RegisterSyntaxNodeAction(AnalyzeLocalDeclarationStatement, SyntaxKind.LocalDeclarationStatement);
-            context.RegisterSyntaxNodeAction(AnalyzeDeclarationPattern, SyntaxKind.DeclarationPattern);
+            context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.ParenthesizedVariableDesignation);
+            context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.SingleVariableDesignation);
         }
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1108_MockNamingAnalyzer : NamingAnalyzer // NamingLocalVariableAnalyzer
+    public sealed class MiKo_1108_MockNamingAnalyzer : LocalVariableNamingAnalyzer
     {
         public const string Id = "MiKo_1108";
 
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private static readonly string[] MockNames = { "Mocked", "mocked", "Mock", MockName, "Stub", "stub", "Faked", "Fake", "faked", "fake", "Shim", "shim" };
 
-        public MiKo_1108_MockNamingAnalyzer() : base(Id, (SymbolKind)(-1))
+        public MiKo_1108_MockNamingAnalyzer() : base(Id)
         {
         }
 
@@ -29,19 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             context.RegisterSyntaxNodeAction(AnalyzePropertyDeclaration, SyntaxKind.PropertyDeclaration);
             context.RegisterSyntaxNodeAction(AnalyzeFieldDeclaration, SyntaxKind.FieldDeclaration);
 
-            context.RegisterSyntaxNodeAction(AnalyzeVariableDeclaration, SyntaxKind.VariableDeclaration);
-            context.RegisterSyntaxNodeAction(AnalyzeDeclarationPattern, SyntaxKind.DeclarationPattern);
-            context.RegisterSyntaxNodeAction(AnalyzeForEachStatement, SyntaxKind.ForEachStatement);
-        }
-
-        protected override void AnalyzeDeclarationPattern(SyntaxNodeAnalysisContext context)
-        {
-            var type = context.FindContainingType();
-
-            if (ShallAnalyze(type))
-            {
-                base.AnalyzeDeclarationPattern(context);
-            }
+            base.InitializeCore(context);
         }
 
         protected override void AnalyzeForEachStatement(SyntaxNodeAnalysisContext context)
@@ -51,6 +39,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             if (ShallAnalyze(type))
             {
                 base.AnalyzeForEachStatement(context);
+            }
+        }
+
+        protected override void AnalyzeLocalDeclarationStatement(SyntaxNodeAnalysisContext context)
+        {
+            var type = context.FindContainingType();
+
+            if (ShallAnalyze(type))
+            {
+                base.AnalyzeLocalDeclarationStatement(context);
             }
         }
 
@@ -124,25 +122,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
 
             return false;
-        }
-
-        private void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var type = context.FindContainingType();
-
-            if (ShallAnalyze(type))
-            {
-                var variableDeclarationSyntax = (VariableDeclarationSyntax)context.Node;
-
-                if (variableDeclarationSyntax.Parent is FieldDeclarationSyntax)
-                {
-                    // nothing to do, we already analyzed the field separately
-                }
-                else
-                {
-                    AnalyzeIdentifiers(context, type, variableDeclarationSyntax);
-                }
-            }
         }
 
         private void AnalyzePropertyDeclaration(SyntaxNodeAnalysisContext context)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1521_ToCopyParametersAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -721,7 +721,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// <param name="context">
         /// The syntax node analysis context.
         /// </param>
-        protected void AnalyzeLocalDeclarationStatement(SyntaxNodeAnalysisContext context)
+        protected virtual void AnalyzeLocalDeclarationStatement(SyntaxNodeAnalysisContext context)
         {
             var node = (LocalDeclarationStatementSyntax)context.Node;
 
@@ -742,42 +742,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             if (ShallAnalyze(type))
             {
                 var issues = AnalyzeIdentifiers(semanticModel, type, node.Declaration.Variables.ToArray(_ => _.Identifier));
-
-                ReportDiagnostics(context, issues);
-            }
-        }
-
-        /// <summary>
-        /// Analyzes a declaration expression.
-        /// </summary>
-        /// <param name="context">
-        /// The syntax node analysis context.
-        /// </param>
-        protected void AnalyzeDeclarationExpression(SyntaxNodeAnalysisContext context)
-        {
-            var declaration = (DeclarationExpressionSyntax)context.Node;
-
-            var issues = Analyze(context.SemanticModel, declaration);
-
-            ReportDiagnostics(context, issues);
-        }
-
-        /// <summary>
-        /// Analyzes a declaration pattern.
-        /// </summary>
-        /// <param name="context">
-        /// The syntax node analysis context.
-        /// </param>
-        protected virtual void AnalyzeDeclarationPattern(SyntaxNodeAnalysisContext context)
-        {
-            var node = (DeclarationPatternSyntax)context.Node;
-
-            var semanticModel = context.SemanticModel;
-            var type = node.Type.GetTypeSymbol(semanticModel);
-
-            if (ShallAnalyze(type))
-            {
-                var issues = Analyze(semanticModel, type, node.Designation);
 
                 ReportDiagnostics(context, issues);
             }
@@ -834,6 +798,27 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                         ReportDiagnostics(context, issues);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Analyzes a single variable designation.
+        /// </summary>
+        /// <param name="context">
+        /// The syntax node analysis context.
+        /// </param>
+        protected virtual void AnalyzeVariableDesignation(SyntaxNodeAnalysisContext context)
+        {
+            var node = (VariableDesignationSyntax)context.Node;
+            var semanticModel = context.SemanticModel;
+
+            var type = node.Parent.GetTypeSymbol(semanticModel);
+
+            if (ShallAnalyze(type))
+            {
+                var issues = Analyze(semanticModel, type, node);
+
+                ReportDiagnostics(context, issues);
             }
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -660,6 +660,90 @@ namespace Bla
             VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
+        [TestCase("cert", "certificate")]
+        [TestCase("decl", "declaration")]
+        [TestCase("impl", "implementation")]
+        [TestCase("lang", "language")]
+        public void Code_gets_fixed_for_variable_in_is_declaration_pattern_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        private object Data;
+
+        public void DoSomething()
+        {
+            if (Data is { } ###)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        [TestCase("cert", "certificate")]
+        [TestCase("decl", "declaration")]
+        [TestCase("impl", "implementation")]
+        [TestCase("lang", "language")]
+        public void Code_gets_fixed_for_variable_in_list_pattern_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+using System.Collections.Generic;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        private List<int> Data;
+
+        public void DoSomething()
+        {
+            if (Data is not [ _, var ###, _ ])
+            {
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        [TestCase("cert", "certificate")]
+        [TestCase("decl", "declaration")]
+        [TestCase("impl", "implementation")]
+        [TestCase("lang", "language")]
+        public void Code_gets_fixed_for_variable_in_property_pattern_with_variable_declaration_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        private TestMe Data;
+
+        public int State { get; set; }
+
+        public void DoSomething()
+        {
+            if (Data is { State: var ### } state)
+            {
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
         protected override string GetDiagnosticId() => MiKo_1063_AbbreviationsInNameAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1063_AbbreviationsInNameAnalyzer();


### PR DESCRIPTION
- Replace declaration pattern/expression analysis with `VariableDesignationSyntax`-based analysis

- Refactor local-variable analyzers to register variable designation syntax actions.

- Add new analyzer test cases for abbreviations in variable designations within pattern matching constructs
