### PR TITLE
GetLocalFunctions now ignores abstract and partial methods

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -224,6 +224,16 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static IReadOnlyList<LocalFunctionStatementSyntax> GetLocalFunctions(this IMethodSymbol value)
         {
+            if (value.IsAbstract)
+            {
+                return Array.Empty<LocalFunctionStatementSyntax>();
+            }
+
+            if (value.IsPartialDefinition)
+            {
+                return Array.Empty<LocalFunctionStatementSyntax>();
+            }
+
             var node = value.GetSyntaxNodeInSource();
 
             if (node is null)


### PR DESCRIPTION
- Skip syntax-node retrieval for abstract methods and for partial method definitions

