### PR TITLE
MiKo_2019 and MiKo_2039 are now aware of more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -553,6 +553,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("Every class that implements the interface can ", "Allows to ");
             yield return new Pair("Every class that implements this interface can ", "Allows to ");
             yield return new Pair("Extension of ", "Extends the ");
+            yield return new Pair("Extension interface for ", "Enhances ");
             yield return new Pair("Interface definition for ", "Represents ");
             yield return new Pair("Interface for a ", "Represents a ");
             yield return new Pair("Interface for an ", "Represents an ");
@@ -568,6 +569,52 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("The interface shall be implemented by classes that want to ");
             yield return new Pair("This interface shall be implemented by components that want to ");
             yield return new Pair("The interface shall be implemented by components that want to ");
+            yield return new Pair("Interface that can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("Interface that can optionally be implemented by ", "Enhances ");
+            yield return new Pair("Interface that can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("Interface which can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("Interface which can optionally be implemented by ", "Enhances ");
+            yield return new Pair("Interface which can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("A interface can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("A interface can optionally be implemented by ", "Enhances ");
+            yield return new Pair("A interface can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("An interface can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("An interface can optionally be implemented by ", "Enhances ");
+            yield return new Pair("An interface can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("The interface can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("The interface can optionally be implemented by ", "Enhances ");
+            yield return new Pair("The interface can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("This interface can be implemented optionally by implementations of ", "Enhances ");
+            yield return new Pair("This interface can optionally be implemented by ", "Enhances ");
+            yield return new Pair("This interface can optionally added to classes implementing ", "Enhances ");
+            yield return new Pair("Extension interface for ", "Enhances ");
+
+            yield return new Pair("Implementations of this class allow to ");
+            yield return new Pair("Implementations of this class allows to ");
+            yield return new Pair("Implementations of this class can be used to ");
+            yield return new Pair("Implementations of this interface allow to ");
+            yield return new Pair("Implementations of this interface allows to ");
+            yield return new Pair("Implementations of this interface can be used to ");
+            yield return new Pair("Implementations of this class can ");
+            yield return new Pair("Implementations of this interface can ");
+
+            yield return new Pair("Implementers of this class allow to ");
+            yield return new Pair("Implementers of this class allows to ");
+            yield return new Pair("Implementers of this class can be used to ");
+            yield return new Pair("Implementers of this interface allow to ");
+            yield return new Pair("Implementers of this interface allows to ");
+            yield return new Pair("Implementers of this interface can be used to ");
+            yield return new Pair("Implementers of this class can ");
+            yield return new Pair("Implementers of this interface can ");
+
+            yield return new Pair("Implementer of this class allow to ");
+            yield return new Pair("Implementer of this class allows to ");
+            yield return new Pair("Implementer of this class can be used to ");
+            yield return new Pair("Implementer of this interface allow to ");
+            yield return new Pair("Implementer of this interface allows to ");
+            yield return new Pair("Implementer of this interface can be used to ");
+            yield return new Pair("Implementer of this class can ");
+            yield return new Pair("Implementer of this interface can ");
 
             yield return new Pair("This class is responsible for ");
             yield return new Pair("This interface is responsible for ");
@@ -660,6 +707,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("Use an the class to "); // typo
             yield return new Pair("Use the the class to "); // typo
 
+            yield return new Pair("This Method should return", "Returns"); // typo in real-life scenario
+            yield return new Pair("This method should return", "Returns");
             yield return new Pair("The Method will be called", "Gets called"); // typo in real-life scenario
             yield return new Pair("The method will be called", "Gets called");
             yield return new Pair("The Method is called", "Gets called"); // typo in real-life scenario
@@ -708,6 +757,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             yield return new Pair("This will ");
             yield return new Pair("This ");
 
+            yield return new Pair("Helper inferface for", "Supports");
+            yield return new Pair("Helper interface for", "Supports");
+            yield return new Pair("Helper Inferface for", "Supports");
+            yield return new Pair("Helper Interface for", "Supports");
+            yield return new Pair("A helper inferface for", "Supports");
+            yield return new Pair("A helper interface for", "Supports");
+            yield return new Pair("A helper Inferface for", "Supports");
+            yield return new Pair("A helper inferface for", "Supports");
+            yield return new Pair("A helper Interface for", "Supports");
+            yield return new Pair("A helper interface for", "Supports");
+            yield return new Pair("An helper Inferface for", "Supports");
+            yield return new Pair("An helper inferface for", "Supports");
+            yield return new Pair("An helper Interface for", "Supports");
+            yield return new Pair("An helper interface for", "Supports");
+            yield return new Pair("The helper Inferface for", "Supports");
+            yield return new Pair("The helper inferface for", "Supports");
+            yield return new Pair("The helper Interface for", "Supports");
+            yield return new Pair("The helper interface for", "Supports");
+
             foreach (var phrase in CreatePhrases(verbs, thirdPersonVerbs, gerundVerbs))
             {
                 yield return phrase;
@@ -745,6 +813,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                            "A callback", "A Callback", "A call-back", "A Call-back",
                            "The callback", "The Callback", "The call-back", "The Call-back",
                            "This callback", "This Callback", "This call-back", "This Call-back",
+                           "Implementations of this class",
+                           "Implementations of this interface",
+                           "Implementers of this class",
+                           "Implementers of this interface",
+                           "Implementer of this class",
+                           "Implementer of this interface",
                        };
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzer.cs
@@ -44,12 +44,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             StringBuilderCache.Release(builder);
 
-            if (problematicText is "Is")
+            switch (problematicText)
             {
-                return true;
-            }
+                case "Classes":
+                case "Implementations":
+                case "Implementers":
+                case "Interfaces":
+                case "Is":
+                case "Types":
+                    return true;
 
-            return Verbalizer.IsThirdPersonSingularVerb(problematicText) is false;
+                default:
+                    return Verbalizer.IsThirdPersonSingularVerb(problematicText) is false;
+            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
@@ -119,6 +119,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
+            results.Add("Contains several basic helper functions for ");
+            results.Add("Provides several basic helper functions for ");
+            results.Add("Has several basic helper functions for ");
+            results.Add("Several basic helper functions for ");
+            results.Add("Basic helper functions for ");
+            results.Add("Helper functions for ");
+
             return results;
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -523,52 +523,56 @@ public class TestMeCommand
         [TestCase("This class contains methods for building", "Provides support for creating")]
         [TestCase("This class contains methods for constructing", "Provides support for creating")]
         [TestCase("Used to create something", "Provides support for creating something")]
-        [TestCase(@"Used to create <see cref=""string""/> instances", @"Provides support for creating <see cref=""string""/> instances")]
+        [TestCase("""Used to create <see cref="string"/> instances""", """Provides support for creating <see cref="string"/> instances""")]
         [TestCase("Used for creating something", "Provides support for creating something")]
-        [TestCase(@"Used for creating <see cref=""string""/> instances", @"Provides support for creating <see cref=""string""/> instances")]
+        [TestCase("""Used for creating <see cref="string"/> instances""", """Provides support for creating <see cref="string"/> instances""")]
         [TestCase("Is used to create something", "Provides support for creating something")]
-        [TestCase(@"Is used to create <see cref=""string""/> instances", @"Provides support for creating <see cref=""string""/> instances")]
+        [TestCase("""Is used to create <see cref="string"/> instances""", """Provides support for creating <see cref="string"/> instances""")]
         [TestCase("Is used for creating something", "Provides support for creating something")]
-        [TestCase(@"Is used for creating <see cref=""string""/> instances", @"Provides support for creating <see cref=""string""/> instances")]
+        [TestCase("""Is used for creating <see cref="string"/> instances""", """Provides support for creating <see cref="string"/> instances""")]
         public void Code_gets_fixed_for_factory_types_(string originalComment, string fixedComment)
         {
-            const string Template = @"
-/// <summary>
-/// ### something.
-/// </summary>
-public class TestMeFactory
-{
-}
-";
+            const string Template = """
+
+                                    /// <summary>
+                                    /// ### something.
+                                    /// </summary>
+                                    public class TestMeFactory
+                                    {
+                                    }
+
+                                    """;
 
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
 
         [TestCase("Handler for event", "Handles the event")]
         [TestCase("Handler for the event", "Handles the event")]
-        [TestCase(@"Handler for <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
-        [TestCase(@"Handler for the <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
+        [TestCase("""Handler for <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
+        [TestCase("""Handler for the <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
         [TestCase("EventHandler for event", "Handles the event")]
         [TestCase("EventHandler for the event", "Handles the event")]
-        [TestCase(@"EventHandler for <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
-        [TestCase(@"EventHandler for the <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
+        [TestCase("""EventHandler for <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
+        [TestCase("""EventHandler for the <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
         [TestCase("Event handler for event", "Handles the event")]
         [TestCase("Event handler for the event", "Handles the event")]
-        [TestCase(@"Event handler for <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
-        [TestCase(@"Event handler for the <see cref=""string""/> event", @"Handles the <see cref=""string""/> event")]
+        [TestCase("""Event handler for <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
+        [TestCase("""Event handler for the <see cref="string"/> event""", """Handles the <see cref="string"/> event""")]
         public void Code_gets_fixed_for_event_handler_(string originalComment, string fixedComment)
         {
-            const string Template = @"
-using System;
+            const string Template = """
 
-public class TestMe
-{
-    /// <summary>
-    /// ###
-    /// </summary>
-    void OnSomething(object sender, EventArgs e);
-}
-";
+                                    using System;
+
+                                    public class TestMe
+                                    {
+                                        /// <summary>
+                                        /// ###
+                                        /// </summary>
+                                        void OnSomething(object sender, EventArgs e);
+                                    }
+
+                                    """;
 
             VerifyCSharpFix(Template.Replace("###", originalComment), Template.Replace("###", fixedComment));
         }
@@ -955,18 +959,20 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", originalCode), Template.Replace("###", fixedCode));
         }
 
-        [TestCase("Event args for something", @"Provides data for the <see cref=""TODO""/> event")]
-        [TestCase(@"Event args for <see cref=""IWhatever""/> event", @"Provides data for the <see cref=""IWhatever""/> event")]
+        [TestCase("Event args for something", """Provides data for the <see cref="TODO"/> event""")]
+        [TestCase("""Event args for <see cref="IWhatever"/> event""", """Provides data for the <see cref="IWhatever"/> event""")]
         public void Code_gets_fixed_for_EventArgs_class_(string startingPhrase, string fixedPhrase)
         {
-            const string Template = @"
-/// <summary>
-/// ###.
-/// </summary>
-public class TestMeEventArgs
-{
-}
-";
+            const string Template = """
+
+                                    /// <summary>
+                                    /// ###.
+                                    /// </summary>
+                                    public class TestMeEventArgs
+                                    {
+                                    }
+
+                                    """;
 
             VerifyCSharpFix(Template.Replace("###", startingPhrase), Template.Replace("###", fixedPhrase));
         }
@@ -1010,6 +1016,12 @@ public class TestMe
         [TestCase("The interface shall be implemented by components that want to")]
         [TestCase("This interface shall be implemented by classes that want to")]
         [TestCase("The interface shall be implemented by classes that want to")]
+        [TestCase("Implementations of this class can be used to")]
+        [TestCase("Implementations of this interface can be used to")]
+        [TestCase("Implementers of this class can be used to")]
+        [TestCase("Implementers of this interface can be used to")]
+        [TestCase("Implementer of this class can be used to")]
+        [TestCase("Implementer of this interface can be used to")]
         public void Code_gets_fixed_for_interface_(string startingPhrase)
         {
             const string Template = @"
@@ -1022,6 +1034,38 @@ public interface ITestMe
 ";
 
             VerifyCSharpFix(Template.Replace("###", startingPhrase + " render"), Template.Replace("###", "Renders"));
+        }
+
+        [TestCase("Interface that can be implemented optionally by implementations of")]
+        [TestCase("Interface that can optionally be implemented by")]
+        [TestCase("Interface that can optionally added to classes implementing")]
+        [TestCase("Interface which can be implemented optionally by implementations of")]
+        [TestCase("Interface which can optionally be implemented by")]
+        [TestCase("Interface which can optionally added to classes implementing")]
+        [TestCase("A interface can be implemented optionally by implementations of")]
+        [TestCase("A interface can optionally be implemented by")]
+        [TestCase("A interface can optionally added to classes implementing")]
+        [TestCase("An interface can be implemented optionally by implementations of")]
+        [TestCase("An interface can optionally be implemented by")]
+        [TestCase("An interface can optionally added to classes implementing")]
+        [TestCase("The interface can be implemented optionally by implementations of")]
+        [TestCase("The interface can optionally be implemented by")]
+        [TestCase("The interface can optionally added to classes implementing")]
+        [TestCase("This interface can be implemented optionally by implementations of")]
+        [TestCase("This interface can optionally be implemented by")]
+        [TestCase("This interface can optionally added to classes implementing")]
+        public void Code_gets_fixed_for_extension_interface_(string startingPhrase)
+        {
+            const string Template = @"
+/// <summary>
+/// ### something.
+/// </summary>
+public interface ITestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", startingPhrase), Template.Replace("###", "Enhances"));
         }
 
         [TestCase("Attribute that allows to do something", "Does something")]
@@ -1080,8 +1124,8 @@ public class TestMeAttribute : System.Attribute
         [TestCase("View Model of something", "Represents the view model of something")]
         [TestCase("ViewModel of something", "Represents the view model of something")]
 
-        [TestCase(@"ViewModel for <see cref=""string""/>", "Represents the view model of <see cref=\"string\"/>")]
-        [TestCase(@"ViewModel of <see cref=""string""/>", "Represents the view model of <see cref=\"string\"/>")]
+        [TestCase("""ViewModel for <see cref="string"/>""", """Represents the view model of <see cref="string"/>""")]
+        [TestCase("""ViewModel of <see cref="string"/>""", """Represents the view model of <see cref="string"/>""")]
 
         [TestCase("The view model that is needed to provide", "Provides")]
         [TestCase("The view model which is needed to provide", "Provides")]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -447,78 +447,118 @@ public class TestMe
             VerifyCSharpFix(originalCode, FixedCode);
         }
 
-        [TestCase("Interface that allows to update something", "Updates something")]
-        [TestCase("Interface that can be used to update something", "Updates something")]
-        [TestCase("Interface that could be used to update something", "Updates something")]
-        [TestCase("Interface that may be used to update something", "Updates something")]
-        [TestCase("Interface that shall be used to update something", "Updates something")]
-        [TestCase("Interface that should be used to update something", "Updates something")]
-        [TestCase("Interface that will be used to update something", "Updates something")]
-        [TestCase("Interface that would be used to update something", "Updates something")]
-        [TestCase("Interface which can be used to update something", "Updates something")]
-        [TestCase("Interface which could be used to update something", "Updates something")]
-        [TestCase("Interface which may be used to update something", "Updates something")]
-        [TestCase("Interface which shall be used to update something", "Updates something")]
-        [TestCase("Interface which should be used to update something", "Updates something")]
-        [TestCase("Interface which will be used to update something", "Updates something")]
-        [TestCase("Interface which would be used to update something", "Updates something")]
-        [TestCase("Interface which allows to update something", "Updates something")]
-        [TestCase("A interface that allows to update something", "Updates something")]
-        [TestCase("A interface that can be used to update something", "Updates something")]
-        [TestCase("A interface that could be used to update something", "Updates something")]
-        [TestCase("A interface that may be used to update something", "Updates something")]
-        [TestCase("A interface that shall be used to update something", "Updates something")]
-        [TestCase("A interface that should be used to update something", "Updates something")]
-        [TestCase("A interface that will be used to update something", "Updates something")]
-        [TestCase("A interface that would be used to update something", "Updates something")]
-        [TestCase("A interface which can be used to update something", "Updates something")]
-        [TestCase("A interface which could be used to update something", "Updates something")]
-        [TestCase("A interface which may be used to update something", "Updates something")]
-        [TestCase("A interface which shall be used to update something", "Updates something")]
-        [TestCase("A interface which should be used to update something", "Updates something")]
-        [TestCase("A interface which will be used to update something", "Updates something")]
-        [TestCase("A interface which would be used to update something", "Updates something")]
-        [TestCase("A interface which allows to update something", "Updates something")]
-        [TestCase("An interface that allows to update something", "Updates something")]
-        [TestCase("An interface that can be used to update something", "Updates something")]
-        [TestCase("An interface that could be used to update something", "Updates something")]
-        [TestCase("An interface that may be used to update something", "Updates something")]
-        [TestCase("An interface that shall be used to update something", "Updates something")]
-        [TestCase("An interface that should be used to update something", "Updates something")]
-        [TestCase("An interface that will be used to update something", "Updates something")]
-        [TestCase("An interface that would be used to update something", "Updates something")]
-        [TestCase("An interface which can be used to update something", "Updates something")]
-        [TestCase("An interface which could be used to update something", "Updates something")]
-        [TestCase("An interface which may be used to update something", "Updates something")]
-        [TestCase("An interface which shall be used to update something", "Updates something")]
-        [TestCase("An interface which should be used to update something", "Updates something")]
-        [TestCase("An interface which will be used to update something", "Updates something")]
-        [TestCase("An interface which would be used to update something", "Updates something")]
-        [TestCase("An interface which allows to update something", "Updates something")]
-        [TestCase("The interface that allows to update something", "Updates something")]
-        [TestCase("The interface that can be used to update something", "Updates something")]
-        [TestCase("The interface that could be used to update something", "Updates something")]
-        [TestCase("The interface that may be used to update something", "Updates something")]
-        [TestCase("The interface that shall be used to update something", "Updates something")]
-        [TestCase("The interface that should be used to update something", "Updates something")]
-        [TestCase("The interface that will be used to update something", "Updates something")]
-        [TestCase("The interface that would be used to update something", "Updates something")]
-        [TestCase("The interface which can be used to update something", "Updates something")]
-        [TestCase("The interface which could be used to update something", "Updates something")]
-        [TestCase("The interface which may be used to update something", "Updates something")]
-        [TestCase("The interface which shall be used to update something", "Updates something")]
-        [TestCase("The interface which should be used to update something", "Updates something")]
-        [TestCase("The interface which will be used to update something", "Updates something")]
-        [TestCase("The interface which would be used to update something", "Updates something")]
-        [TestCase("The interface which allows to update something", "Updates something")]
-        [TestCase("This interface allows to update something", "Updates something")]
+        [TestCase("Interface that allows to update", "Updates")]
+        [TestCase("Interface that can be used to update", "Updates")]
+        [TestCase("Interface that could be used to update", "Updates")]
+        [TestCase("Interface that may be used to update", "Updates")]
+        [TestCase("Interface that shall be used to update", "Updates")]
+        [TestCase("Interface that should be used to update", "Updates")]
+        [TestCase("Interface that will be used to update", "Updates")]
+        [TestCase("Interface that would be used to update", "Updates")]
+        [TestCase("Interface which can be used to update", "Updates")]
+        [TestCase("Interface which could be used to update", "Updates")]
+        [TestCase("Interface which may be used to update", "Updates")]
+        [TestCase("Interface which shall be used to update", "Updates")]
+        [TestCase("Interface which should be used to update", "Updates")]
+        [TestCase("Interface which will be used to update", "Updates")]
+        [TestCase("Interface which would be used to update", "Updates")]
+        [TestCase("Interface which allows to update", "Updates")]
+        [TestCase("A interface that allows to update", "Updates")]
+        [TestCase("A interface that can be used to update", "Updates")]
+        [TestCase("A interface that could be used to update", "Updates")]
+        [TestCase("A interface that may be used to update", "Updates")]
+        [TestCase("A interface that shall be used to update", "Updates")]
+        [TestCase("A interface that should be used to update", "Updates")]
+        [TestCase("A interface that will be used to update", "Updates")]
+        [TestCase("A interface that would be used to update", "Updates")]
+        [TestCase("A interface which can be used to update", "Updates")]
+        [TestCase("A interface which could be used to update", "Updates")]
+        [TestCase("A interface which may be used to update", "Updates")]
+        [TestCase("A interface which shall be used to update", "Updates")]
+        [TestCase("A interface which should be used to update", "Updates")]
+        [TestCase("A interface which will be used to update", "Updates")]
+        [TestCase("A interface which would be used to update", "Updates")]
+        [TestCase("A interface which allows to update", "Updates")]
+        [TestCase("An interface that allows to update", "Updates")]
+        [TestCase("An interface that can be used to update", "Updates")]
+        [TestCase("An interface that could be used to update", "Updates")]
+        [TestCase("An interface that may be used to update", "Updates")]
+        [TestCase("An interface that shall be used to update", "Updates")]
+        [TestCase("An interface that should be used to update", "Updates")]
+        [TestCase("An interface that will be used to update", "Updates")]
+        [TestCase("An interface that would be used to update", "Updates")]
+        [TestCase("An interface which can be used to update", "Updates")]
+        [TestCase("An interface which could be used to update", "Updates")]
+        [TestCase("An interface which may be used to update", "Updates")]
+        [TestCase("An interface which shall be used to update", "Updates")]
+        [TestCase("An interface which should be used to update", "Updates")]
+        [TestCase("An interface which will be used to update", "Updates")]
+        [TestCase("An interface which would be used to update", "Updates")]
+        [TestCase("An interface which allows to update", "Updates")]
+        [TestCase("The interface that allows to update", "Updates")]
+        [TestCase("The interface that can be used to update", "Updates")]
+        [TestCase("The interface that could be used to update", "Updates")]
+        [TestCase("The interface that may be used to update", "Updates")]
+        [TestCase("The interface that shall be used to update", "Updates")]
+        [TestCase("The interface that should be used to update", "Updates")]
+        [TestCase("The interface that will be used to update", "Updates")]
+        [TestCase("The interface that would be used to update", "Updates")]
+        [TestCase("The interface which can be used to update", "Updates")]
+        [TestCase("The interface which could be used to update", "Updates")]
+        [TestCase("The interface which may be used to update", "Updates")]
+        [TestCase("The interface which shall be used to update", "Updates")]
+        [TestCase("The interface which should be used to update", "Updates")]
+        [TestCase("The interface which will be used to update", "Updates")]
+        [TestCase("The interface which would be used to update", "Updates")]
+        [TestCase("The interface which allows to update", "Updates")]
+        [TestCase("This interface allows to update", "Updates")]
+        [TestCase("Interface that can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("Interface that can optionally be implemented by", "Enhances")]
+        [TestCase("Interface that can optionally added to classes implementing", "Enhances")]
+        [TestCase("Interface which can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("Interface which can optionally be implemented by", "Enhances")]
+        [TestCase("Interface which can optionally added to classes implementing", "Enhances")]
+        [TestCase("A interface can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("A interface can optionally be implemented by", "Enhances")]
+        [TestCase("A interface can optionally added to classes implementing", "Enhances")]
+        [TestCase("An interface can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("An interface can optionally be implemented by", "Enhances")]
+        [TestCase("An interface can optionally added to classes implementing", "Enhances")]
+        [TestCase("The interface can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("The interface can optionally be implemented by", "Enhances")]
+        [TestCase("The interface can optionally added to classes implementing", "Enhances")]
+        [TestCase("This interface can be implemented optionally by implementations of", "Enhances")]
+        [TestCase("This interface can optionally be implemented by", "Enhances")]
+        [TestCase("This interface can optionally added to classes implementing", "Enhances")]
+        [TestCase("Extension interface for", "Enhances")]
+        [TestCase("Implementations of this class allow to simplify", "Simplifies")]
+        [TestCase("Implementations of this class allows to simplify", "Simplifies")]
+        [TestCase("Implementations of this class can be used to simplify", "Simplifies")]
+        [TestCase("Implementations of this class can influence", "Influences")]
+        [TestCase("Implementations of this interface allows to simplify", "Simplifies")]
+        [TestCase("Implementations of this interface can be used to simplify", "Simplifies")]
+        [TestCase("Implementations of this interface can influence", "Influences")]
+        [TestCase("Implementers of this class allow to simplify", "Simplifies")]
+        [TestCase("Implementers of this class allows to simplify", "Simplifies")]
+        [TestCase("Implementers of this class can be used to simplify", "Simplifies")]
+        [TestCase("Implementers of this class can influence", "Influences")]
+        [TestCase("Implementers of this interface allows to simplify", "Simplifies")]
+        [TestCase("Implementers of this interface can be used to simplify", "Simplifies")]
+        [TestCase("Implementers of this interface can influence", "Influences")]
+        [TestCase("Implementer of this class allow to simplify", "Simplifies")]
+        [TestCase("Implementer of this class allows to simplify", "Simplifies")]
+        [TestCase("Implementer of this class can be used to simplify", "Simplifies")]
+        [TestCase("Implementer of this class can influence", "Influences")]
+        [TestCase("Implementer of this interface allows to simplify", "Simplifies")]
+        [TestCase("Implementer of this interface can be used to simplify", "Simplifies")]
+        [TestCase("Implementer of this interface can influence", "Influences")]
         public void Code_gets_fixed_for_interface_text_(string originalText, string fixedText)
         {
             const string Template = @"
 using System;
 
 /// <summary>
-/// ###
+/// ### something
 /// </summary>
 public interface TestMe
 {
@@ -526,6 +566,57 @@ public interface TestMe
 ";
 
             VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("Helper inferface for")]
+        [TestCase("Helper interface for")]
+        [TestCase("Helper Inferface for")]
+        [TestCase("Helper Interface for")]
+        [TestCase("A helper inferface for")]
+        [TestCase("A helper Inferface for")]
+        [TestCase("A helper Interface for")]
+        [TestCase("A helper interface for")]
+        [TestCase("An helper Inferface for")]
+        [TestCase("An helper inferface for")]
+        [TestCase("An helper Interface for")]
+        [TestCase("An helper interface for")]
+        [TestCase("The helper Inferface for")]
+        [TestCase("The helper inferface for")]
+        [TestCase("The helper Interface for")]
+        [TestCase("The helper interface for")]
+        public void Code_gets_fixed_for_helper_interface_text_(string originalText)
+        {
+            const string Template = @"
+using System;
+
+/// <summary>
+/// ### stuff
+/// </summary>
+public interface TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", "Supports"));
+        }
+
+        [TestCase("Several basic helper functions for")]
+        [TestCase("Basic helper functions for")]
+        [TestCase("Helper functions for")]
+        public void Code_gets_fixed_for_helper_class_text_(string originalText)
+        {
+            const string Template = @"
+using System;
+
+/// <summary>
+/// ### stuff
+/// </summary>
+public static class TestMe
+{
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", """Provides a set of <see langword="static"/> methods for"""));
         }
 
         [TestCase("Simple structure to do stuff", "Represents a simple structure to do stuff")]
@@ -713,6 +804,7 @@ public interface TestMe
         [TestCase("This method will start to do something", "Starts to do something")]
         [TestCase("This starts to do something", "Starts to do something")]
         [TestCase("Trigger something", "Triggers something")]
+        [TestCase("This method should return something", "Returns something")]
         public void Code_gets_fixed_for_method_text_(string originalText, string fixedText)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
@@ -110,8 +110,14 @@ public static class TestMeExtensions
         [TestCase("The extension methods to", "")]
         [TestCase("The extensions for", "")]
         [TestCase("The extensions to", "")]
-        [TestCase(@"Extension methods for <see cref=""String""/>.", @" <see cref=""String""/>.")]
-        [TestCase(@"Extensions for <see cref=""String""/>.", @" <see cref=""String""/>.")]
+        [TestCase("""Extension methods for <see cref="String"/>.""", """ <see cref="String"/>.""")]
+        [TestCase("""Extensions for <see cref="String"/>.""", """ <see cref="String"/>.""")]
+        [TestCase("Contains several basic helper functions for", "")]
+        [TestCase("Provides several basic helper functions for", "")]
+        [TestCase("Has several basic helper functions for", "")]
+        [TestCase("Several basic helper functions for", "")]
+        [TestCase("Basic helper functions for", "")]
+        [TestCase("Helper functions for", "")]
         public void Code_gets_fixed_(string originalCode, string fixedCode)
         {
             const string Template = @"


### PR DESCRIPTION
- Expand MiKo_2012 replacement mappings

- Update MiKo_2019's analyzer logic to treat additional leading words as problematic starts

- Add more recognized "helper functions for …" phrases to MiKo_2039

- Add tests
