### PR TITLE
Concurrent dictionaries now use ordinal string comparers

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
@@ -477,7 +477,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                             nameof(EventArgs),
                                                         };
 
-        private static readonly ConcurrentDictionary<string, Pair[]> AlreadyFoundAbbreviations = new ConcurrentDictionary<string, Pair[]>();
+        private static readonly ConcurrentDictionary<string, Pair[]> AlreadyFoundAbbreviations = new ConcurrentDictionary<string, Pair[]>(StringComparer.Ordinal);
 
         /// <summary>
         /// Finds all abbreviations contained in the specified text.

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules
     /// </summary>
     public abstract class Analyzer : DiagnosticAnalyzer
     {
-        private static readonly ConcurrentDictionary<string, DiagnosticDescriptor> KnownRules = new ConcurrentDictionary<string, DiagnosticDescriptor>();
+        private static readonly ConcurrentDictionary<string, DiagnosticDescriptor> KnownRules = new ConcurrentDictionary<string, DiagnosticDescriptor>(StringComparer.Ordinal);
 
         private readonly DiagnosticDescriptor m_rule;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_TestAssertsHaveMessageAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,76 +21,78 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static readonly int[] OneTwo = { 1, 2 };
         private static readonly int[] TwoThree = { 2, 3 };
 
-        private static readonly ConcurrentDictionary<string, int[]> MethodNameToArgumentIndicesMapping = new ConcurrentDictionary<string, int[]>(new[]
-                                                                                                                                                     {
-                                                                                                                                                         // 0 arguments
-                                                                                                                                                         new KeyValuePair<string, int[]>("Fail", Zero),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Ignore", Zero),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Inconclusive", Zero),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Pass", Zero),
+        private static readonly ConcurrentDictionary<string, int[]> MethodNameToArgumentIndicesMapping = new ConcurrentDictionary<string, int[]>(
+                                                                                                                                             new[]
+                                                                                                                                                 {
+                                                                                                                                                     // 0 arguments
+                                                                                                                                                     new KeyValuePair<string, int[]>("Fail", Zero),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Ignore", Zero),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Inconclusive", Zero),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Pass", Zero),
 
-                                                                                                                                                         // 1 argument
-                                                                                                                                                         new KeyValuePair<string, int[]>("AllItemsAreNotNull", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AllItemsAreUnique", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotExist", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotThrow", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotThrowAsync", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Exists", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("False", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsEmpty", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsFalse", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNaN", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNotEmpty", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNotNull", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNull", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsTrue", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Negative", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("NotNull", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("NotZero", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Null", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Positive", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("True", One),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Zero", One),
+                                                                                                                                                     // 1 argument
+                                                                                                                                                     new KeyValuePair<string, int[]>("AllItemsAreNotNull", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AllItemsAreUnique", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotExist", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotThrow", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotThrowAsync", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Exists", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("False", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsEmpty", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsFalse", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNaN", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNotEmpty", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNotNull", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNull", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsTrue", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Negative", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("NotNull", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("NotZero", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Null", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Positive", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("True", One),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Zero", One),
 
-                                                                                                                                                         // 2 arguments
-                                                                                                                                                         new KeyValuePair<string, int[]>("AllItemsAreInstancesOfType", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreEqualIgnoringCase", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreEquivalent", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreNotEqual", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreNotEqualIgnoringCase", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreNotEquivalent", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreNotSame", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreSame", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Contains", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotContain", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotEndWith", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotMatch", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("DoesNotStartsWith", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("EndsWith", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Greater", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("GreaterOrEqual", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsMatch", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNotSubsetOf", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsSubsetOf", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("Less", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("LessOrEqual", Two),
-                                                                                                                                                         new KeyValuePair<string, int[]>("StartsWith", Two),
+                                                                                                                                                     // 2 arguments
+                                                                                                                                                     new KeyValuePair<string, int[]>("AllItemsAreInstancesOfType", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreEqualIgnoringCase", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreEquivalent", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreNotEqual", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreNotEqualIgnoringCase", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreNotEquivalent", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreNotSame", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreSame", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Contains", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotContain", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotEndWith", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotMatch", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("DoesNotStartsWith", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("EndsWith", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Greater", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("GreaterOrEqual", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsMatch", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNotSubsetOf", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsSubsetOf", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("Less", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("LessOrEqual", Two),
+                                                                                                                                                     new KeyValuePair<string, int[]>("StartsWith", Two),
 
-                                                                                                                                                         // 2 or 3 arguments, cannot determine for sure
-                                                                                                                                                         new KeyValuePair<string, int[]>("AreEqual", TwoThree),
+                                                                                                                                                     // 2 or 3 arguments, cannot determine for sure
+                                                                                                                                                     new KeyValuePair<string, int[]>("AreEqual", TwoThree),
 
-                                                                                                                                                         // 1 or 2 arguments, cannot determine for sure
-                                                                                                                                                         new KeyValuePair<string, int[]>("Catch", OneTwo),
-                                                                                                                                                         new KeyValuePair<string, int[]>("CatchAsync", OneTwo),
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsAssignableFrom", OneTwo), // (based on Generics)
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsInstanceOf", OneTwo), // (based on Generics)
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNotAssignableFrom", OneTwo), // (based on Generics)
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsNotInstanceOf", OneTwo), // (based on Generics)
-                                                                                                                                                         new KeyValuePair<string, int[]>("IsOrdered", OneTwo), // (based on comparer as last parameter)
-                                                                                                                                                         new KeyValuePair<string, int[]>("That", OneTwo), // (based on comparer as last parameter)
-                                                                                                                                                         new KeyValuePair<string, int[]>("Throws", OneTwo), // (based on Generics)
-                                                                                                                                                         new KeyValuePair<string, int[]>("ThrowsAsync", OneTwo), // (based on Generics)
-                                                                                                                                                     });
+                                                                                                                                                     // 1 or 2 arguments, cannot determine for sure
+                                                                                                                                                     new KeyValuePair<string, int[]>("Catch", OneTwo),
+                                                                                                                                                     new KeyValuePair<string, int[]>("CatchAsync", OneTwo),
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsAssignableFrom", OneTwo), // (based on Generics)
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsInstanceOf", OneTwo), // (based on Generics)
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNotAssignableFrom", OneTwo), // (based on Generics)
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsNotInstanceOf", OneTwo), // (based on Generics)
+                                                                                                                                                     new KeyValuePair<string, int[]>("IsOrdered", OneTwo), // (based on comparer as last parameter)
+                                                                                                                                                     new KeyValuePair<string, int[]>("That", OneTwo), // (based on comparer as last parameter)
+                                                                                                                                                     new KeyValuePair<string, int[]>("Throws", OneTwo), // (based on Generics)
+                                                                                                                                                     new KeyValuePair<string, int[]>("ThrowsAsync", OneTwo), // (based on Generics)
+                                                                                                                                                 },
+                                                                                                                                             StringComparer.Ordinal);
 
         public MiKo_3109_TestAssertsHaveMessageAnalyzer() : base(Id)
         {


### PR DESCRIPTION
- Add `StringComparer.Ordinal` to `ConcurrentDictionary` constructions.