### PR TITLE
Systematically rename of test methods for improved clarity and consistency (following MiKo_1117)

### DIFF
--- a/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringBuilderExtensionsTests.cs
@@ -168,6 +168,6 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "DoEvents", "##Events", ExpectedResult = "CallsDownloadWorkflowForMultipleParameterDownloadDevices")]
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "Download", "My", ExpectedResult = "CallsMyWorkflowForMultipleParameterMyDevices")]
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices", "Workflow", "#", ExpectedResult = "CallsDownload#ForMultipleParameterDownloadDevices")]
-        public static string ReplaceWithProbe_above_threshold_uses_arrays_properly_to_adjust_(string start, string name, string other) => new StringBuilder(start).ReplaceWithProbe(name, other).ToString();
+        public static string ReplaceWithProbe_above_threshold_uses_arrays_to_adjust_(string start, string name, string other) => new StringBuilder(start).ReplaceWithProbe(name, other).ToString();
     }
 }

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("abc42", ExpectedResult = "abc")]
         [TestCase("a1bc", ExpectedResult = "a1bc")]
         [TestCase("a1bc42", ExpectedResult = "a1bc")]
-        public static string WithoutNumberSuffix_works_(string input) => input.WithoutNumberSuffix();
+        public static string WithoutNumberSuffix_returns_text_without_number_suffix_(string input) => input.WithoutNumberSuffix();
 
         [TestCase("ab123", ExpectedResult = true)]
         [TestCase("ab1", ExpectedResult = true)]
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("a8b", ExpectedResult = false)]
         [TestCase("42ab", ExpectedResult = false)]
         [TestCase("1", ExpectedResult = true)]
-        public static bool EndsWithNumber_works_(string input) => input.EndsWithNumber();
+        public static bool EndsWithNumber_detects_number_as_suffix_(string input) => input.EndsWithNumber();
 
         [TestCase("ab123", ExpectedResult = false)]
         [TestCase("ab1", ExpectedResult = false)]
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("42ab", ExpectedResult = true)]
         [TestCase("1ab", ExpectedResult = true)]
         [TestCase("1", ExpectedResult = true)]
-        public static bool StartsWithNumber_works_(string input) => input.StartsWithNumber();
+        public static bool StartsWithNumber_detects_number_as_prefix_(string input) => input.StartsWithNumber();
 
         [TestCase("", ExpectedResult = false)]
         [TestCase("A", ExpectedResult = true)]
@@ -49,7 +49,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("Aa", ExpectedResult = false)]
         [TestCase("aA", ExpectedResult = false)]
         [TestCase("AA", ExpectedResult = true)]
-        public static bool IsAllUpperCase_works_(string input) => input.AsSpan().IsAllUpperCase();
+        public static bool IsAllUpperCase_detects_text_being_all_upper_case_characters_(string input) => input.AsSpan().IsAllUpperCase();
 
         [Test]
         public static void SplitBy_splits_by_single_item_that_is_contained_multiple_times()
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         }
 
         [Test]
-        public static void HumanizedConcatenated_concatenates_correctly()
+        public static void HumanizedConcatenated_concatenates_texts()
         {
             Assert.Multiple(() =>
                                  {

--- a/MiKo.Analyzer.Tests/Linguistics/ArticleProviderTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/ArticleProviderTests.cs
@@ -54,6 +54,6 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("University", ExpectedResult = "A ")]
         [TestCase("user", ExpectedResult = "A ")]
         [TestCase("User", ExpectedResult = "A ")]
-        public static string Provides_correct_indefinite_article_for_(string text) => ArticleProvider.GetArticleFor(text);
+        public static string Provides_matching_indefinite_article_for_(string text) => ArticleProvider.GetArticleFor(text);
     }
 }

--- a/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/PluralizerTests.cs
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("waltz", ExpectedResult = "waltzes")]
         [TestCase("wolf", ExpectedResult = "wolves")]
         [TestCase("woman", ExpectedResult = "women")]
-        public static string Creates_correct_plural_name_(string singularName) => Pluralizer.GetPluralName(singularName);
+        public static string Creates_matching_plural_name_(string singularName) => Pluralizer.GetPluralName(singularName);
 
         [TestCase("access", ExpectedResult = "accesses")]
         [TestCase("accesses", ExpectedResult = "accesses")]
@@ -83,7 +83,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("SyntaxTrivia", ExpectedResult = "SyntaxTrivia")]
         [TestCase("trivia", ExpectedResult = "trivia")]
         [TestCase("Trivia", ExpectedResult = "Trivia")]
-        public static string Makes_correct_plural_name_(string singularName) => Pluralizer.MakePluralName(singularName);
+        public static string Makes_matching_plural_name_(string singularName) => Pluralizer.MakePluralName(singularName);
 
         [TestCase("accesses", ExpectedResult = false)]
         [TestCase("Adoptors", ExpectedResult = true)]

--- a/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/VerbalizerTests.cs
@@ -110,7 +110,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("Stabilization", ExpectedResult = "Stabilize")]
         [TestCase("Subtraction", ExpectedResult = "Subtract")]
         [TestCase("Uninstallation", ExpectedResult = "Uninstall")]
-        public static string TryMakeVerb_finds_proper_verb_(string name)
+        public static string TryMakeVerb_finds_matching_verb_(string name)
         {
             Verbalizer.TryMakeVerb(name, out var result);
 
@@ -184,7 +184,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("export", ExpectedResult = "export")]
         [TestCase("exports", ExpectedResult = "export")]
         [TestCase("exporting", ExpectedResult = "export")]
-        public static string MakeInfiniteVerb_finds_proper_infinite_verb_(string name) => Verbalizer.MakeInfiniteVerb(name);
+        public static string MakeInfiniteVerb_finds_matching_infinite_verb_(string name) => Verbalizer.MakeInfiniteVerb(name);
 
         [TestCase("about", ExpectedResult = "about")]
         [TestCase("absent", ExpectedResult = "absent")]
@@ -234,7 +234,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("that", ExpectedResult = "that")]
         [TestCase("unit", ExpectedResult = "unit")]
         [TestCase("wept", ExpectedResult = "weep")]
-        public static string MakeInfiniteVerb_finds_proper_infinite_verb_if_verb_ends_with_t_(string name) => Verbalizer.MakeInfiniteVerb(name);
+        public static string MakeInfiniteVerb_finds_matching_infinite_verb_if_verb_ends_with_t_(string name) => Verbalizer.MakeInfiniteVerb(name);
 
         [TestCase("", ExpectedResult = "")]
         [TestCase("   ", ExpectedResult = "   ")]
@@ -272,7 +272,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("hid something", ExpectedResult = "hide something")]
         [TestCase("Hidden something", ExpectedResult = "Hide something")]
         [TestCase("hidden something", ExpectedResult = "hide something")]
-        public static string MakeFirstWordInfiniteVerb_finds_proper_infinite_verb_(string name) => Verbalizer.MakeFirstWordInfiniteVerb(name);
+        public static string MakeFirstWordInfiniteVerb_finds_matching_infinite_verb_(string name) => Verbalizer.MakeFirstWordInfiniteVerb(name);
 
         [TestCase("access", ExpectedResult = false)]
         [TestCase("accesses", ExpectedResult = true)]
@@ -394,7 +394,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("monitor", ExpectedResult = "monitors")]
         [TestCase("Monitored", ExpectedResult = "Monitors")]
         [TestCase("monitored", ExpectedResult = "monitors")]
-        public static string MakeThirdPersonSingularVerb_finds_proper_3rd_person_singular_verb_(string name) => Verbalizer.MakeThirdPersonSingularVerb(name);
+        public static string MakeThirdPersonSingularVerb_finds_matching_3rd_person_singular_verb_(string name) => Verbalizer.MakeThirdPersonSingularVerb(name);
 
         [TestCase("false", ExpectedResult = false)]
         [TestCase("true", ExpectedResult = false)]
@@ -478,7 +478,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         [TestCase("Something", ExpectedResult = "Something")]
         [TestCase("Anything", ExpectedResult = "Anything")]
         [TestCase("Everything", ExpectedResult = "Everything")]
-        public static string MakeGerundVerb_finds_proper_gerund_verb_(string name) => Verbalizer.MakeGerundVerb(name);
+        public static string MakeGerundVerb_finds_matching_gerund_verb_(string name) => Verbalizer.MakeGerundVerb(name);
 
         [TestCase("Canceled", ExpectedResult = true)]
         [TestCase("Cancel", ExpectedResult = false)]

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2000_MalformedDocumentationAnalyzerTests.cs
@@ -45,7 +45,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_class() => No_issue_is_reported_for(@"
 /// <summary>
 /// Something valid.
 /// </summary>
@@ -55,7 +55,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_class_with_escaped_XML_entity_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_class_with_escaped_XML_entity_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
 /// <summary>
 /// Something " + entity + @" valid.
 /// </summary>
@@ -65,7 +65,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_class_with_escaped_XML_entity_without_spaces_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_class_with_escaped_XML_entity_without_spaces_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
 /// <summary>
 /// Something" + entity + @"valid.
 /// </summary>
@@ -75,7 +75,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_class_inside_c_tag_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_class_inside_c_tag_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
 /// <summary>
 /// Something valid.
 /// <c>
@@ -88,7 +88,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_class_inside_code_tag_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_class_inside_code_tag_([Values("&amp;", "&lt;")] string entity) => No_issue_is_reported_for(@"
 /// <summary>
 /// Something valid.
 /// <code>
@@ -101,7 +101,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_method() => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -112,7 +112,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_property() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_property() => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -123,7 +123,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_event() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_event() => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -134,7 +134,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_on_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_on_field() => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
@@ -33,7 +33,7 @@ public interface TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_event_on_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_with_summary_starting_with_Occurs() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_event_on_class_with_para_tags() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_with_summary_starting_with_Occurs_inside_para_tag() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2002_EventArgsSummaryAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2002_EventArgsSummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_EventArgs_class_without_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs
@@ -21,7 +21,7 @@ public class MyEventArgs : EventArgs
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_EventArgs_name_suffix_not_inheriting_from_EventArgs() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -33,7 +33,7 @@ public class MyEventArgs // simply has event args indicator but does not inherit
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_unsealed_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unsealed_EventArgs_class_with_summary_providing_data_for_specific_event() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -45,7 +45,7 @@ public class MyEventArgs : EventArgs
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_sealed_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_sealed_EventArgs_class_with_summary_providing_data_for_specific_event_and_inheritance_restriction() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -58,7 +58,7 @@ public sealed class MyEventArgs : EventArgs
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_multi_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_EventArgs_class_with_summary_providing_data_for_multiple_events() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -72,7 +72,7 @@ public class MyEventArgs : EventArgs
         [TestCase("Does something.")]
         [TestCase("Provides some stuff for the event.")]
         [TestCase("Provides data for the event.")]
-        public void An_issue_is_reported_for_incorrectly_commented_EventArgs_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventArgs_class_with_summary_not_following_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -84,7 +84,7 @@ public class MyEventArgs : EventArgs
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_to_replace_summary_with_standard_provides_data_phrase_and_TODO_event_reference()
         {
             const string OriginalCode = @"
 using System;
@@ -112,7 +112,7 @@ public class MyEventArgs : EventArgs
         }
 
         [Test]
-        public void Code_gets_fixed_but_keeps_Remarks()
+        public void Code_gets_fixed_to_replace_summary_while_preserving_remarks_section()
         {
             const string OriginalCode = @"
 using System;
@@ -146,7 +146,7 @@ public class MyEventArgs : EventArgs
         }
 
         [Test]
-        public void Code_gets_fixed_for_comment_with_link_to_event()
+        public void Code_gets_fixed_to_replace_summary_phrase_while_extracting_and_preserving_event_reference()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2003_EventHandlerSummaryAnalyzerTests.cs
@@ -38,7 +38,7 @@ public class TestMe
 
         [TestCase("Handles the <see cref='MyEvent' /> event.")]
         [TestCase("<para>Handles the <see cref='MyEvent' /> event.</para>")]
-        public void No_issue_is_reported_for_correctly_documented_event_handling_method_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_summary_starting_with_(string comment) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -81,7 +81,7 @@ namespace Bla
         [TestCase("When the <see cref='MyEvent' /> event.")]
         [TestCase("when the <see cref='MyEvent' /> event.")]
         [TestCase("Raised when the <see cref='MyEvent' /> event.")]
-        public void An_issue_is_reported_for_incorrectly_documented_event_handling_method_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_handling_method_with_summary_starting_with_(string comment) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2004_EventHandlerParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2004_EventHandlerParametersAnalyzerTests.cs
@@ -40,7 +40,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_interitdoc_documented_event_handling_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_inheritdoc_documented_event_handling_method() => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class MyEventArgs : System.EventArgs { }
@@ -68,7 +68,7 @@ namespace Bla
         [TestCase("The source of the event", "Unused")]
         [TestCase("<para>The source of the event.</para>", "<para>Unused.</para>")]
         [TestCase("<para>The source of the event</para>", "<para>Unused</para>")]
-        public void No_issue_is_reported_for_correctly_documented_event_handling_method_(string sender, string e) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_standard_parameter_documentation_(string sender, string e) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -90,7 +90,7 @@ namespace Bla
         [TestCase("The source of the event.", "An <see cref=\"EventArgs\" /> that contains the event data.")]
         [TestCase("The source of the event.", "An <see cref='System.EventArgs' /> that contains the event data.")]
         [TestCase("The source of the event.", "An <see cref=\"System.EventArgs\" /> that contains the event data.")]
-        public void No_issue_is_reported_for_correctly_documented_event_handling_method_with_vocal_at_begin_(string sender, string e) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_EventArgs_starting_with_vowel_(string sender, string e) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -108,7 +108,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_partly_documented_event_handling_method_with_missing_documentation_for_sender() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_missing_sender_documentation() => No_issue_is_reported_for(@"
 public class MyEventArgs : System.EventArgs { }
 
 public class TestMe
@@ -122,7 +122,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_partly_documented_event_handling_method_with_missing_documentation_for_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_missing_EventArgs_documentation() => No_issue_is_reported_for(@"
 public class MyEventArgs : System.EventArgs { }
 
 public class TestMe
@@ -136,7 +136,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_partly_documented_event_handling_method_with_missing_documentation_for_sender_and_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_handling_method_with_missing_parameter_documentation() => No_issue_is_reported_for(@"
 public class MyEventArgs : System.EventArgs { }
 
 public class TestMe
@@ -149,7 +149,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_if_sender_and_EventArgs_are_commented()
+        public void Code_gets_fixed_by_replacing_with_standard_parameter_documentation_for_both_parameters()
         {
             const string OriginalCode = @"
 using System;
@@ -185,7 +185,7 @@ class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_if_sender_and_EventArgs_are_commented_on_different_lines()
+        public void Code_gets_fixed_by_replacing_with_standard_parameter_documentation_for_both_parameters_on_separate_lines()
         {
             const string OriginalCode = @"
 using System;
@@ -225,7 +225,7 @@ class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_if_sender_is_not_commented_and_EventArgs_is_commented_incorrectly()
+        public void Code_gets_fixed_by_replacing_with_standard_EventArgs_documentation()
         {
             const string OriginalCode = @"
 using System;
@@ -259,7 +259,7 @@ class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_if_EventArgs_is_not_commented_and_sender_is_commented_incorrectly()
+        public void Code_gets_fixed_by_replacing_with_standard_sender_documentation()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2005_EventArgsInDocumentationAnalyzerTests.cs
@@ -10,14 +10,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [TestFixture]
     public sealed class MiKo_2005_EventArgsInDocumentationAnalyzerTests : CodeFixVerifier
     {
-        private static readonly string[] IncorrectPhrases =
-                                                            [
-                                                                "This is an event arg comment.",
-                                                                "This is an event args comment.",
-                                                            ];
+        private static readonly string[] ProblematicPhrases =
+                                                              [
+                                                                  "This is an event arg comment.",
+                                                                  "This is an event args comment.",
+                                                              ];
 
         [Test]
-        public void No_issue_is_reported_for_non_commented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_members() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public event EventHandler MyEvent;
@@ -31,7 +31,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_problematic_phrases() => No_issue_is_reported_for(@"
 /// <summary>
 /// This is a comment.
 /// </summary>
@@ -60,7 +60,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_class_commented_with_event_argument() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_full_spelling_event_argument() => No_issue_is_reported_for(@"
 /// <summary>
 /// This is an event argument comment.
 /// </summary>
@@ -70,7 +70,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_class_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_abbreviated_phrase_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"
 /// <summary>
 /// " + phrase + @"
 /// </summary>
@@ -80,14 +80,14 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_class_without_leading_spaces_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"///<summary>" + phrase + @"</summary>
+        public void An_issue_is_reported_for_class_with_abbreviated_phrase_in_compact_format_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"///<summary>" + phrase + @"</summary>
 public class TestMe
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_event_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_with_abbreviated_phrase_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -98,7 +98,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_property_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_abbreviated_phrase_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -109,7 +109,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_method_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_abbreviated_phrase_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -120,7 +120,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_([ValueSource(nameof(IncorrectPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_with_abbreviated_phrase_([ValueSource(nameof(ProblematicPhrases))] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2006_RoutedEventFieldDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_RoutedEvent_field() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_RoutedEvent_field_with_standard_summary_and_value_documentation() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -40,7 +40,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_summary() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_RoutedEvent_field_with_standard_summary_documentation() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_summary_with_readonly_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_RoutedEvent_field_with_standard_summary_including_readonly_note() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -70,7 +70,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_value() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_RoutedEvent_field_with_standard_value_documentation() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_summary() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_RoutedEvent_field_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -100,7 +100,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_value() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_RoutedEvent_field_with_non_standard_value() => An_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -115,7 +115,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_to_replace_custom_documentation_with_standard_phrases()
         {
             const string OriginalCode = @"
 using System.Windows;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2010_SealedClassSummaryAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2010_SealedClassSummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void Struct_is_not_reported() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_struct() => No_issue_is_reported_for(@"
 /// <summary>
 /// Something.
 /// </summary>
@@ -22,7 +22,7 @@ public struct TestMe
 ");
 
         [Test]
-        public void Unsealed_class_is_not_reported() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unsealed_class() => No_issue_is_reported_for(@"
 /// <summary>
 /// Something.
 /// </summary>
@@ -32,7 +32,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Sealed_non_public_class_is_not_reported() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_public_sealed_class() => No_issue_is_reported_for(@"
 /// <summary>
 /// Something.
 /// </summary>
@@ -42,14 +42,14 @@ private sealed class TestMe
 ");
 
         [Test]
-        public void No_documentation_is_not_reported() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_sealed_class() => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
 }
 ");
 
         [Test]
-        public void Correct_documentation_is_not_reported() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_sealed_class_with_inheritance_statement() => No_issue_is_reported_for(@"
 /// <summary>
 /// This class cannot be inherited.
 /// </summary>
@@ -59,7 +59,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void Missing_documentation_is_reported() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_sealed_class_without_inheritance_statement() => An_issue_is_reported_for(@"
 /// <summary>
 /// Some documentation
 /// </summary>
@@ -69,7 +69,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void Missing_documentation_is_not_reported_for_TestClass_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_sealed_test_class_without_inheritance_statement_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
 /// <summary>
 /// Some documentation
 /// </summary>
@@ -80,7 +80,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void Wrong_placed_documentation_is_reported() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_sealed_class_with_misplaced_inheritance_statement() => An_issue_is_reported_for(@"
 /// <summary>
 /// This class cannot be inherited.
 /// Some documentation
@@ -91,7 +91,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_class()
+        public void Code_gets_fixed_by_adding_inheritance_statement_at_end_of_summary()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -115,7 +115,7 @@ public sealed class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_record()
+        public void Code_gets_fixed_by_adding_inheritance_statement_at_end_of_summary_for_record()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -139,7 +139,7 @@ public sealed record TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text()
+        public void Code_gets_fixed_by_moving_inheritance_statement_to_end_of_summary()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -164,7 +164,7 @@ public sealed class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text_on_single_line()
+        public void Code_gets_fixed_by_moving_inheritance_statement_from_middle_of_line_to_end()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -190,7 +190,7 @@ public sealed class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text_all_on_single_line()
+        public void Code_gets_fixed_by_extracting_and_moving_inheritance_statement_to_end()
         {
             const string OriginalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2011_UnsealedClassSummaryAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2011_UnsealedClassSummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void Struct_is_not_reported() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_struct() => No_issue_is_reported_for("""
 
                                                                          /// <summary>
                                                                          /// Something.
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                          """);
 
         [Test]
-        public void Sealed_public_class_is_not_reported() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_sealed_public_class() => No_issue_is_reported_for("""
 
                                                                                       /// <summary>
                                                                                       /// This class cannot be inherited.
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                       """);
 
         [Test]
-        public void Sealed_non_public_class_is_not_reported() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_sealed_non_public_class() => No_issue_is_reported_for("""
 
                                                                                           /// <summary>
                                                                                           /// Something.
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                           """);
 
         [Test]
-        public void No_documentation_is_not_reported() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for("""
 
                                                                                    public sealed class TestMe
                                                                                    {
@@ -57,7 +57,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                    """);
 
         [Test]
-        public void Correct_documentation_is_not_reported() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_unsealed_class_without_inheritance_statement() => No_issue_is_reported_for("""
 
                                                                                         /// <summary>
                                                                                         /// Something.
@@ -69,7 +69,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                         """);
 
         [Test]
-        public void Wrong_start_placed_documentation_is_reported() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_unsealed_class_with_inheritance_statement_at_start() => An_issue_is_reported_for("""
 
                                                                                                /// <summary>
                                                                                                /// This class cannot be inherited.
@@ -82,7 +82,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                                """);
 
         [Test]
-        public void Wrong_end_placed_documentation_is_reported() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_unsealed_class_with_inheritance_statement_at_end() => An_issue_is_reported_for("""
 
                                                                                              /// <summary>
                                                                                              /// Something.
@@ -95,7 +95,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                              """);
 
         [Test]
-        public void Wrong_documentation_is_not_reported_for_TestClass_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unsealed_test_class_with_inheritance_statement_([ValueSource(nameof(TestFixtures))] string fixture) => No_issue_is_reported_for(@"
 /// <summary>
 /// Some documentation
 /// This class cannot be inherited.
@@ -107,7 +107,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Malformed_documentation_is_reported() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_unsealed_class_with_inheritance_statement_after_incomplete_sentence() => An_issue_is_reported_for("""
 
                                                                                       /// <summary>
                                                                                       /// Saves & Loads the relevant layout inforamtion of the ribbon within <see cref="XmlRibbonLayout"/>
@@ -120,7 +120,7 @@ public class TestMe
                                                                                       """);
 
         [Test]
-        public void Code_gets_fixed_for_class()
+        public void Code_gets_fixed_by_removing_inheritance_statement_from_end_of_summary()
         {
             const string OriginalCode = """
 
@@ -148,7 +148,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_record()
+        public void Code_gets_fixed_by_removing_inheritance_statement_from_end_of_summary_for_record()
         {
             const string OriginalCode = """
 
@@ -176,7 +176,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text()
+        public void Code_gets_fixed_by_removing_inheritance_statement_from_start_of_summary()
         {
             const string OriginalCode = """
 
@@ -204,7 +204,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text_on_single_line()
+        public void Code_gets_fixed_by_removing_inheritance_statement_from_middle_of_line()
         {
             const string OriginalCode = """
 
@@ -233,7 +233,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_wrong_placed_sealed_text_all_on_single_line()
+        public void Code_gets_fixed_by_extracting_and_removing_inheritance_statement_from_single_line()
         {
             const string OriginalCode = """
 
@@ -260,7 +260,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_malformed_documentation()
+        public void Code_gets_fixed_by_removing_inheritance_statement_after_incomplete_sentence()
         {
             const string OriginalCode = """
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2013_EnumSummaryAnalyzerTests.cs
@@ -12,14 +12,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2013_EnumSummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_class_without_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
 public class TestMe
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_class_with_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_class() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some documentation.
 /// </summary>
@@ -29,14 +29,14 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_enum_without_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_enum() => No_issue_is_reported_for(@"
 public enum TestMe
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_enum_with_correct_phrase() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_with_standard_phrase() => No_issue_is_reported_for(@"
 /// <summary>
 /// Defines values that specify something.
 /// </summary>
@@ -46,7 +46,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_enum_with_correct_phrase_in_para_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_with_standard_phrase_in_para_tag() => No_issue_is_reported_for(@"
 /// <summary>
 /// <para>
 /// Defines values that specify something.
@@ -58,7 +58,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_enum_with_empty_phrase() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_with_empty_summary() => An_issue_is_reported_for(@"
 /// <summary>
 ///
 /// </summary>
@@ -68,7 +68,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_enum_with_wrong_phrase() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_with_non_standard_phrase() => An_issue_is_reported_for(@"
 /// <summary>
 /// Some documentation.
 /// </summary>
@@ -78,7 +78,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_enum_with_wrong_phrase_in_para_tag() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_with_non_standard_phrase_in_para_tag() => An_issue_is_reported_for(@"
 /// <summary>
 /// <para>
 /// Defines something.
@@ -90,7 +90,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_comment_with_see_cref_only() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_with_only_see_cref_in_summary() => An_issue_is_reported_for(@"
 /// <summary>
 /// <see cref=""TestMe""/>
 /// </summary>
@@ -100,7 +100,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -123,7 +123,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_single_line()
+        public void Code_gets_fixed_by_replacing_summary_on_single_line_with_standard_phrase()
         {
             const string OriginalCode = @"
 /// <summary>Something to do.</summary>
@@ -144,7 +144,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_multiline()
+        public void Code_gets_fixed_by_replacing_multiline_summary_with_standard_phrase()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -169,7 +169,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_no_spaces_after_slashes()
+        public void Code_gets_fixed_when_comment_has_no_spaces_after_slashes()
         {
             const string OriginalCode = @"
 ///<summary>
@@ -192,7 +192,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed__when_on_same_line_with_no_spaces_after_slashes()
+        public void Code_gets_fixed_when_summary_on_single_line_has_no_spaces_after_slashes()
         {
             const string OriginalCode = @"
 ///<summary>Something to do.</summary>
@@ -213,7 +213,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_multiline_but_no_spaces_after_slashes()
+        public void Code_gets_fixed_when_multiline_summary_has_no_spaces_after_slashes()
         {
             const string OriginalCode = @"
 ///<summary>
@@ -238,7 +238,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_seecref_multiline()
+        public void Code_gets_fixed_by_prepending_standard_phrase_to_multiline_summary_with_see_cref()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -265,7 +265,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_with_seecref_on_single_line()
+        public void Code_gets_fixed_by_prepending_standard_phrase_to_single_line_summary_with_see_cref()
         {
             const string OriginalCode = @"
 /// <summary><see cref=""TestMe""/> Something to do.</summary>
@@ -307,7 +307,7 @@ public enum TestMe
         [TestCase("Specify")]
         [TestCase("Specified")]
         [TestCase("Specifies")]
-        public void Code_gets_fixed_for_almost_correct_documentation_(string firstWord)
+        public void Code_gets_fixed_by_normalizing_to_standard_phrase_(string firstWord)
         {
             var originalCode = @"
 /// <summary>
@@ -385,7 +385,7 @@ public enum TestMe
         [TestCase("Sets", "")]
         [TestCase("Gets or sets", "")]
         [TestCase("Gets or Sets", "")]
-        public void Code_gets_fixed_for_documentation_(string start, string fixedStart)
+        public void Code_gets_fixed_by_replacing_common_starting_phrases_(string start, string fixedStart)
         {
             var originalCode = @"
 /// <summary>
@@ -419,7 +419,7 @@ public enum TestMe
         [TestCase("Direction", "directions")]
         [TestCase("DirectionKind", "directions")]
         [TestCase("ReferenceTypes", "references")]
-        public void Code_gets_fixed_for_special_documentation_(string typeName, string fixedEnding)
+        public void Code_gets_fixed_by_generating_type_specific_phrase_for_enum_(string typeName, string fixedEnding)
         {
             var originalCode = @"
 /// <summary>
@@ -453,7 +453,7 @@ public enum " + typeName + @"
         [TestCase("Direction", "directions")]
         [TestCase("DirectionKind", "directions")]
         [TestCase("ReferenceTypes", "references")]
-        public void Code_gets_fixed_for_sentenced_with_special_documentation_(string typeName, string fixedEnding)
+        public void Code_gets_fixed_by_generating_type_specific_phrase_for_enum_with_sentence_(string typeName, string fixedEnding)
         {
             var originalCode = @"
 /// <summary>
@@ -479,7 +479,7 @@ public enum " + typeName + @"
         [TestCase("MessageKind", "messages")]
         [TestCase("MessageType", "messages")]
         [TestCase("MessageDef", "message definitions")]
-        public void Code_gets_fixed_for_sentenced_with_special_documentation_suffixed_with_Enum_(string typeName, string fixedEnding)
+        public void Code_gets_fixed_by_generating_type_specific_phrase_for_enum_with_Enum_suffix_(string typeName, string fixedEnding)
         {
             var originalCode = @"
 /// <summary>
@@ -504,7 +504,7 @@ public enum " + typeName + @"Enum
         [TestCase("StateOfText", "states of texts")]
         [TestCase("KindOfText", "kinds of texts")]
         [TestCase("TypeOfText", "kinds of texts")]
-        public void Code_gets_fixed_for_sentenced_with_special_documentation_prefixed_with_(string prefix, string fixedText)
+        public void Code_gets_fixed_by_generating_phrase_based_on_enum_name_pattern_(string prefix, string fixedText)
         {
             var originalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2014_DisposeDefaultPhraseAnalyzerTests.cs
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Dispose_method_with_standard_summary() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_with_para_tags() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Dispose_method_with_standard_summary_in_para_tags() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_with_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Dispose_method_with_standard_summary_and_parameter_documentation() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -61,7 +61,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_with_parameter_and_para_tags() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Dispose_method_with_standard_documentation_in_para_tags() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -80,7 +80,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_summary_documentation_without_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameterless_Dispose_method_with_non_standard_summary() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -92,7 +92,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_summary_documentation_with_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Dispose_method_with_non_standard_summary() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -109,7 +109,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_parameter_documentation() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Dispose_method_with_non_standard_parameter_documentation() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -122,7 +122,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_empty_parameter_documentation() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Dispose_method_with_empty_parameter_documentation() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -135,7 +135,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_missing_parameter_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Dispose_method_with_missing_parameter_documentation() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -147,7 +147,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method_without_parameter()
+        public void Code_gets_fixed_by_replacing_with_standard_summary_for_parameterless_Dispose_method()
         {
             const string OriginalCode = @"
 using System;
@@ -177,7 +177,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_method_with_parameter()
+        public void Code_gets_fixed_by_replacing_with_standard_documentation_for_Dispose_method_with_parameter()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2015_FireMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2015_FireMethodsAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2015_FireMethodsAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_undocumented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_method_property_event_and_field_without_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -28,7 +28,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_method_property_event_and_field_with_documentation_not_containing_fire_terms() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>Does something.</summary>
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_documentation_containing_fire_term_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">Does fire.</" + tag + @">
@@ -64,7 +64,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_documentation_containing_fire_term_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -75,7 +75,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_documentation_containing_fire_term_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -86,7 +86,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_event_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_documentation_containing_fire_term_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -97,7 +97,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_field_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_documentation_containing_fire_term_in_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -108,7 +108,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_exception()
+        public void Code_gets_fixed_to_replace_fire_terms_with_throw_for_exception_documentation_on_single_line()
         {
             const string OriginalCode = @"
 using System;
@@ -132,7 +132,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_exception_when_on_different_lines()
+        public void Code_gets_fixed_to_replace_fire_terms_with_throw_for_exception_documentation_on_multiple_lines()
         {
             const string OriginalCode = @"
 using System;
@@ -162,7 +162,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_event()
+        public void Code_gets_fixed_to_replace_fire_terms_with_raise_for_event_documentation_on_single_line()
         {
             const string OriginalCode = @"
 using System;
@@ -186,7 +186,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_event_when_on_different_lines()
+        public void Code_gets_fixed_to_replace_fire_terms_with_raise_for_event_documentation_on_multiple_lines()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
@@ -31,7 +31,7 @@ public class TestMe
         [TestCase("void")]
         [TestCase("Task")]
         [TestCase("Task<int>")]
-        public void No_issue_is_reported_for_correctly_documented_async_method_(string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_method_with_Asynchronously_in_summary_(string returnType) => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -43,7 +43,7 @@ public class TestMe
 
         [TestCase("Task")]
         [TestCase("Task<int>")]
-        public void No_issue_is_reported_for_correctly_documented_non_async_Task_method_(string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_returning_method_with_Asynchronously_in_summary_(string returnType) => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -56,7 +56,7 @@ public class TestMe
         [TestCase("void")]
         [TestCase("Task")]
         [TestCase("Task<int>")]
-        public void An_issue_is_reported_for_incorrectly_documented_async_method_(string returnType) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_method_without_Asynchronously_in_summary_(string returnType) => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -68,7 +68,7 @@ public class TestMe
 
         [TestCase("Task")]
         [TestCase("Task<int>")]
-        public void An_issue_is_reported_for_incorrectly_documented_Task_method_(string returnType) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Task_returning_method_without_Asynchronously_in_summary_(string returnType) => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -80,7 +80,7 @@ public class TestMe
 
         [TestCase("Task")]
         [TestCase("Task<int>")]
-        public void An_issue_is_reported_for_comment_with_see_cref_only_(string returnType) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Task_returning_method_with_only_see_cref_in_summary_(string returnType) => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -94,7 +94,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_and_upper_case_text_adjusted()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_summary_on_single_line()
         {
             const string OriginalCode = """
 
@@ -120,7 +120,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_intended_upper_case_text_adjusted()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_summary_with_extra_spaces()
         {
             const string OriginalCode = """
 
@@ -146,7 +146,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_lower_case_text_kept()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_lowercase_summary()
         {
             const string OriginalCode = """
 
@@ -172,7 +172,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_seeCref_element_moved()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_summary_with_see_cref()
         {
             const string OriginalCode = """
 
@@ -198,7 +198,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_upper_case_text_adjusted_when_on_different_lines()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_multiline_summary()
         {
             const string OriginalCode = """
 
@@ -226,7 +226,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_seeCref_element_moved_when_on_different_lines()
+        public void Code_gets_fixed_by_prepending_Asynchronously_to_multiline_summary_with_see_cref()
         {
             const string OriginalCode = """
 
@@ -254,7 +254,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_upper_case_text_adjusted_when_infinite_and_on_different_lines()
+        public void Code_gets_fixed_by_prepending_Asynchronously_and_adjusting_verb_to_third_person()
         {
             const string OriginalCode = """
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2017_DependencyPropertyDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_DependencyProperty_field() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_standard_summary_and_value() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -40,7 +40,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_summary() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_standard_summary() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_summary_with_readonly_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_standard_summary_including_readonly_statement() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -70,7 +70,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field_value() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_standard_value() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_summary() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyProperty_field_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -100,7 +100,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_value() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyProperty_field_with_non_standard_value() => An_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -115,7 +115,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_by_replacing_with_standard_documentation()
         {
             const string OriginalCode = @"
 using System.Windows;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2019_3rdPersonSingularVerbSummaryAnalyzerTests.cs
@@ -76,7 +76,7 @@ public class TestMeException : System.Exception
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_3rd_person_singular_verb_documentation() => No_issue_is_reported_for(@"
 using System;
 
 using Bla
@@ -196,7 +196,7 @@ using Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([Values("Provide", "This are")] string start) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_non_3rd_person_singular_verb_documentation_([Values("Provide", "This are")] string start) => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -208,7 +208,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class_in_para_tag_([Values("Provide", "This are")] string start) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_non_3rd_person_singular_verb_in_para_tag_([Values("Provide", "This are")] string start) => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -222,7 +222,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([Values("Perform", "Miss", "Mixs", "Buzzs", "Enrichs", "This are")] string verb) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_non_3rd_person_singular_verb_documentation_([Values("Perform", "Miss", "Mixs", "Buzzs", "Enrichs", "This are")] string verb) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -235,7 +235,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_async_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_method_with_non_3rd_person_singular_verb_documentation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -248,7 +248,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_non_3rd_person_singular_verb_documentation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -261,7 +261,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_starting_with_term_([Values("Recursively")] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_3rd_person_verb_after_adverb_([Values("Recursively")] string term) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -274,7 +274,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_private_class_with_see_cref_as_second_word() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_private_class_with_see_cref_as_second_word_and_3rd_person_verb() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -288,7 +288,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_private_class_with_see_cref_as_second_word() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_private_class_with_see_cref_as_second_word_and_non_3rd_person_verb() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2021_ParamDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething(object o) { }
@@ -26,7 +26,7 @@ public class TestMe
         [TestCase("System.StringComparison")]
         [TestCase(nameof(Boolean))]
         [TestCase(nameof(StringComparison))]
-        public void No_issue_is_reported_for_method_with_(string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_parameter_of_type_(string type) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -56,7 +56,7 @@ public class TestMe
         [TestCase("unused")]
         [TestCase("Unused")]
         [TestCase("Unused.")]
-        public void No_issue_is_reported_for_method_with_correct_comment_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_starting_with_article_or_unused_(string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -66,7 +66,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_comment_and_line_break_after_first_word_([Values("A", "An", "The")] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_with_article_followed_by_line_break_and_see_tag_([Values("A", "An", "The")] string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -84,7 +84,7 @@ public class TestMe
         [TestCase("<summary />")]
         [TestCase("<inheritdoc />")]
         [TestCase("<exclude />")]
-        public void No_issue_is_reported_for_method_with_missing_documentation_(string xmlElement) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_missing_parameter_documentation_(string xmlElement) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// " + xmlElement + @"
@@ -94,7 +94,7 @@ public class TestMe
 
         [TestCase("whatever.")]
         [TestCase("Whatever.")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_not_starting_with_article_(string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -138,7 +138,7 @@ public class TestMe
         [TestCase("Reference to the", "The")]
         [TestCase("Reference to a", "The")]
         [TestCase("Reference to an", "The")]
-        public void Code_gets_fixed_for_parameter_with_(string originalStart, string fixedStart)
+        public void Code_gets_fixed_by_replacing_common_parameter_documentation_phrases_(string originalStart, string fixedStart)
         {
             const string Template = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2022_OutParamDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething(out object o) { }
@@ -20,7 +20,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_out_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_out_parameter() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -30,7 +30,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_comment_phrase() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_out_parameter_with_standard_phrase_for_contains() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -40,7 +40,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_comment_phrase_for_bool() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_bool_out_parameter_with_standard_phrase_for_indicates() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -57,7 +57,7 @@ public class TestMe
         [TestCase("On return, indicates something.")]
         [TestCase("On successful return, indicates something.")]
         [TestCase("")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_out_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -70,7 +70,7 @@ public class TestMe
         [TestCase("On false, returns something.")]
         [TestCase("On successful return, contains something.")]
         [TestCase("")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_on_bool_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_bool_out_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary />
@@ -82,7 +82,7 @@ public class TestMe
         [TestCase("<summary />")]
         [TestCase("<inheritdoc />")]
         [TestCase("<exclude />")]
-        public void No_issue_is_reported_for_method_with_missing_documentation_(string xmlElement) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_missing_out_parameter_documentation_(string xmlElement) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// " + xmlElement + @"
@@ -273,7 +273,7 @@ public class TestMe
         [TestCase("Value that indicates the something.")]
         [TestCase("value which indicates the something.")]
         [TestCase("Value which indicates the something.")]
-        public void Code_gets_fixed_for_boolean_out_parameter_(string text)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_bool_out_parameter_(string text)
         {
             var originalCode = @"
 using System.Windows;
@@ -497,7 +497,7 @@ public class TestMe
         [TestCase("Will receive the object.")]
         [TestCase("will return the object.")]
         [TestCase("Will return the object.")]
-        public void Code_gets_fixed_for_out_parameter_(string text)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_out_parameter_(string text)
         {
             var originalCode = @"
 using System.Windows;
@@ -525,7 +525,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_out_parameter_on_single_line()
+        public void Code_gets_fixed_by_adding_standard_phrase_with_TODO_for_empty_out_parameter_on_single_line()
         {
             const string OriginalCode = @"
 using System.Windows;
@@ -553,7 +553,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_out_parameter_on_separate_lines()
+        public void Code_gets_fixed_by_adding_standard_phrase_with_TODO_for_empty_out_parameter_on_separate_lines()
         {
             const string OriginalCode = @"
 using System.Windows;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzerTests.cs
@@ -89,7 +89,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_boolean_parameter() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_boolean_parameter_with_standard_phrase() => No_issue_is_reported_for("""
 
             using System;
 
@@ -106,7 +106,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_boolean_parameter_with_additional_info() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_boolean_parameter_with_standard_phrase_and_additional_info() => No_issue_is_reported_for("""
 
             using System;
 
@@ -124,7 +124,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_boolean_parameter_of_Dispose_method() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_boolean_disposing_parameter_of_Dispose_method() => No_issue_is_reported_for("""
 
             using System;
 
@@ -153,7 +153,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [TestCase("true to some condition, <c>false</c> otherwise.")]
         [TestCase("<value>true</value> to some condition")]
         [TestCase("true to some condition, <value>false</value> otherwise.")]
-        public void An_issue_is_reported_for_incorrectly_documented_boolean_parameter_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -167,7 +167,7 @@ public class TestMe
 
         [TestCase("Some", "some")]
         [TestCase("Tests the", "test the")]
-        public void Code_gets_fixed_on_same_line_(string textToFix, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_on_single_line_(string textToFix, string fixedText)
         {
             const string OriginalCode = """
 
@@ -203,7 +203,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_comment_with_ending_dot()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_removing_ending_dot()
         {
             const string OriginalCode = """
 
@@ -239,7 +239,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_different_line()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_on_separate_line()
         {
             const string OriginalCode = """
 
@@ -277,7 +277,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_text_with_ending_seeCref()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_preserving_ending_see_cref()
         {
             const string OriginalCode = """
 
@@ -315,7 +315,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_special_phrase_([ValueSource(nameof(IndicatePhrases))] string phrase)
+        public void Code_gets_fixed_by_converting_indicate_phrase_to_standard_phrase_([ValueSource(nameof(IndicatePhrases))] string phrase)
         {
             var originalCode = @"
 using System;
@@ -349,7 +349,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_Or_not_special_phrase()
+        public void Code_gets_fixed_by_converting_or_not_phrase_to_standard_phrase()
         {
             const string OriginalCode = """
 
@@ -385,7 +385,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_special_phrase_with_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
+        public void Code_gets_fixed_by_converting_indicate_phrase_to_standard_phrase_preserving_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
         {
             var originalCode = @"
 using System;
@@ -417,7 +417,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_phrase_with_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
+        public void Code_gets_fixed_by_converting_true_false_phrase_to_standard_phrase_preserving_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
         {
             var originalCode = @"
 using System;
@@ -449,7 +449,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_phrase_with_separate_line_for_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
+        public void Code_gets_fixed_by_converting_multiline_true_false_phrase_to_standard_phrase_preserving_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
         {
             var originalCode = @"
 using System;
@@ -482,7 +482,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_without_links_for_phrase_with_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
+        public void Code_gets_fixed_by_converting_unformatted_true_false_phrase_to_standard_phrase_preserving_default_case_([ValueSource(nameof(DefaultCases))] string defaultCase)
         {
             var originalCode = @"
 using System;
@@ -514,7 +514,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_optional_parameter_phrase_([ValueSource(nameof(OptionalPhrases))] string phrase)
+        public void Code_gets_fixed_by_converting_optional_phrase_to_standard_phrase_([ValueSource(nameof(OptionalPhrases))] string phrase)
         {
             var originalCode = @"
 using System;
@@ -548,7 +548,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_true_phrase_([ValueSource(nameof(TruePhrases))] string phrase)
+        public void Code_gets_fixed_by_converting_true_phrase_to_standard_phrase_on_single_line_([ValueSource(nameof(TruePhrases))] string phrase)
         {
             var originalCode = @"
 using System;
@@ -582,7 +582,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_different_line_for_true_phrase_([ValueSource(nameof(TruePhrases))] string phrase)
+        public void Code_gets_fixed_by_converting_true_phrase_to_standard_phrase_on_separate_line_([ValueSource(nameof(TruePhrases))] string phrase)
         {
             var originalCode = @"
 using System;
@@ -618,7 +618,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_If_phrase_([ValueSource(nameof(ConditionalPhrases))] string phrase)
+        public void Code_gets_fixed_by_converting_conditional_phrase_to_standard_phrase_([ValueSource(nameof(ConditionalPhrases))] string phrase)
         {
             var originalCode = @"
 using System;
@@ -652,7 +652,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_If_Else_phrase_([ValueSource(nameof(ConditionalPhrases))] string phraseStart)
+        public void Code_gets_fixed_by_converting_conditional_phrase_with_else_to_standard_phrase_([ValueSource(nameof(ConditionalPhrases))] string phraseStart)
         {
             var originalCode = @"
 using System;
@@ -686,7 +686,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_If_Otherwise_phrase_([ValueSource(nameof(ConditionalPhrases))] string phraseStart)
+        public void Code_gets_fixed_by_converting_conditional_phrase_with_otherwise_to_standard_phrase_([ValueSource(nameof(ConditionalPhrases))] string phraseStart)
         {
             var originalCode = @"
 using System;
@@ -763,7 +763,7 @@ public class TestMe
         [TestCase("true to indicate whether the operation succeeded; otherwise false.", """<see langword="true"/> to indicate that the operation succeeded; otherwise, <see langword="false"/>.""")]
         [TestCase("true to indicate that the operation succeeded; otherwise, false.", """<see langword="true"/> to indicate that the operation succeeded; otherwise, <see langword="false"/>.""")]
         [TestCase("true to indicate whether the operation succeeded; otherwise, false.", """<see langword="true"/> to indicate that the operation succeeded; otherwise, <see langword="false"/>.""")]
-        public void Code_gets_fixed_on_same_line_for_phrase_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_normalizing_various_phrases_(string originalPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -795,7 +795,7 @@ public class TestMe
 
         [Ignore("TODO: RKN Fix when you know how to fix it.")]
         [Test]
-        public void Code_gets_fixed_on_multi_line_for_phrase()
+        public void Code_gets_fixed_by_converting_multiline_true_false_descriptions()
         {
             const string OriginalCode = """
 
@@ -835,7 +835,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_mixed_multi_line_for_phrase()
+        public void Code_gets_fixed_by_converting_mixed_multiline_phrase()
         {
             const string OriginalCode = """
 
@@ -874,7 +874,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_same_line_for_empty_comment()
+        public void Code_gets_fixed_by_adding_standard_phrase_with_TODO_for_empty_parameter_on_single_line()
         {
             const string OriginalCode = """
 
@@ -908,7 +908,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_different_line_for_empty_comment()
+        public void Code_gets_fixed_by_adding_standard_phrase_with_TODO_for_empty_parameter_on_separate_lines()
         {
             const string OriginalCode = """
 
@@ -945,7 +945,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_primary_class_constructor()
+        public void Code_gets_fixed_for_primary_class_constructor()
         {
             const string OriginalCode = """
 
@@ -977,7 +977,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_primary_struct_constructor()
+        public void Code_gets_fixed_for_primary_struct_constructor()
         {
             const string OriginalCode = """
 
@@ -1009,7 +1009,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_on_primary_record_constructor()
+        public void Code_gets_fixed_for_primary_record_constructor()
         {
             const string OriginalCode = """
 
@@ -1087,7 +1087,7 @@ public class TestMe
         [TestCase("Whether or not something should be updated during anything.", """<see langword="true"/> to update something during anything; otherwise, <see langword="false"/>.""")]
         [TestCase("whether something should be updated during anything.", """<see langword="true"/> to update something during anything; otherwise, <see langword="false"/>.""")]
         [TestCase("Whether something should be updated during anything.", """<see langword="true"/> to update something during anything; otherwise, <see langword="false"/>.""")]
-        public void Code_gets_fixed_for_should_be_phrase(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_normalizing_should_phrases_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                        ];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething(object o) { }
@@ -43,7 +43,7 @@ public class TestMe
         [TestCase("System.Boolean")]
         [TestCase(nameof(Boolean))]
         [TestCase(nameof(Object))]
-        public void No_issue_is_reported_for_method_with_(string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_non_enum_parameter_of_type_(string type) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_out_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_out_enum_parameter() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -67,9 +67,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_comment_(
-                                                                      [ValueSource(nameof(CorrectStartingPhrases))] string comment,
-                                                                      [Values("something", "something.")] string continuation)
+        public void No_issue_is_reported_for_enum_parameter_with_standard_phrase_(
+                                                                              [ValueSource(nameof(CorrectStartingPhrases))] string comment,
+                                                                              [Values("something", "something.")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 
@@ -82,7 +82,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_bitmask_comment_([ValueSource(nameof(CorrectFlagsStartingPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_flags_enum_parameter_with_standard_phrase_([ValueSource(nameof(CorrectFlagsStartingPhrases))] string comment) => No_issue_is_reported_for(@"
 using System;
 using System.Globalization;
 
@@ -95,9 +95,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_with_correct_comment_(
-                                                                    [ValueSource(nameof(CorrectStartingPhrases))] string comment,
-                                                                    [Values("something", "something.")] string continuation)
+        public void No_issue_is_reported_for_enum_parameter_in_ctor_with_standard_phrase_(
+                                                                                      [ValueSource(nameof(CorrectStartingPhrases))] string comment,
+                                                                                      [Values("something", "something.")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 
@@ -111,7 +111,7 @@ public class TestMe
 
         [TestCase("Unused")]
         [TestCase("Unused.")]
-        public void No_issue_is_reported_for_method_with_correct_unused_comment_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_parameter_documented_as_unused_(string comment) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -123,29 +123,29 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_type_comment_(
-                                                                           [Values(
-                                                                               """A <see cref="StringComparison" /> value""",
-                                                                               """A <see cref="StringComparison"/> value""",
-                                                                               """A <see cref="System.StringComparison" /> value""",
-                                                                               """A <see cref="System.StringComparison"/> value""",
-                                                                               """An <see cref="StringComparison" /> value""",
-                                                                               """An <see cref="StringComparison"/> value""",
-                                                                               """An <see cref="System.StringComparison" /> value""",
-                                                                               """An <see cref="System.StringComparison"/> value""",
-                                                                               """One of the <see cref="StringComparison" /> enumeration members""",
-                                                                               """One of the <see cref="StringComparison" /> enumeration values""",
-                                                                               """One of the <see cref="StringComparison" /> members""",
-                                                                               """One of the <see cref="StringComparison" /> values""",
-                                                                               """One of the <see cref="StringComparison"/> enumeration members""",
-                                                                               """One of the <see cref="StringComparison"/> enumeration values""",
-                                                                               """One of the <see cref="StringComparison"/> members""",
-                                                                               """One of the <see cref="StringComparison"/> values""",
-                                                                               """The <see cref="StringComparison" /> value""",
-                                                                               """The <see cref="StringComparison"/> value""",
-                                                                               """The <see cref="System.StringComparison" /> value""",
-                                                                               """The <see cref="System.StringComparison"/> value""")] string comment,
-                                                                           [Values("that specifies", "specifying", "that defines", "defining")] string continuation)
+        public void No_issue_is_reported_for_enum_parameter_with_see_cref_and_continuation_(
+                                                                                        [Values(
+                                                                                            """A <see cref="StringComparison" /> value""",
+                                                                                            """A <see cref="StringComparison"/> value""",
+                                                                                            """A <see cref="System.StringComparison" /> value""",
+                                                                                            """A <see cref="System.StringComparison"/> value""",
+                                                                                            """An <see cref="StringComparison" /> value""",
+                                                                                            """An <see cref="StringComparison"/> value""",
+                                                                                            """An <see cref="System.StringComparison" /> value""",
+                                                                                            """An <see cref="System.StringComparison"/> value""",
+                                                                                            """One of the <see cref="StringComparison" /> enumeration members""",
+                                                                                            """One of the <see cref="StringComparison" /> enumeration values""",
+                                                                                            """One of the <see cref="StringComparison" /> members""",
+                                                                                            """One of the <see cref="StringComparison" /> values""",
+                                                                                            """One of the <see cref="StringComparison"/> enumeration members""",
+                                                                                            """One of the <see cref="StringComparison"/> enumeration values""",
+                                                                                            """One of the <see cref="StringComparison"/> members""",
+                                                                                            """One of the <see cref="StringComparison"/> values""",
+                                                                                            """The <see cref="StringComparison" /> value""",
+                                                                                            """The <see cref="StringComparison"/> value""",
+                                                                                            """The <see cref="System.StringComparison" /> value""",
+                                                                                            """The <see cref="System.StringComparison"/> value""")] string comment,
+                                                                                        [Values("that specifies", "specifying", "that defines", "defining")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 
@@ -161,7 +161,7 @@ public class TestMe
         [TestCase("Whatever.")]
         [TestCase("A bitwise combination of enumeration values that does something")]
         [TestCase("A bitwise combination of the enumeration values that does something")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -174,7 +174,7 @@ public class TestMe
 
         [TestCase("whatever.")]
         [TestCase("Whatever.")]
-        public void An_issue_is_reported_for_ctor_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_parameter_in_ctor_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -188,7 +188,7 @@ public class TestMe
         [TestCase("<summary />")]
         [TestCase("<inheritdoc />")]
         [TestCase("<exclude />")]
-        public void No_issue_is_reported_for_method_with_missing_documentation_(string xmlElement) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_missing_enum_parameter_documentation_(string xmlElement) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -199,7 +199,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method()
+        public void Code_gets_fixed_by_prepending_standard_phrase_for_enum_parameter_in_method()
         {
             const string OriginalCode = @"
 using System;
@@ -228,7 +228,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ctor()
+        public void Code_gets_fixed_by_prepending_standard_phrase_for_enum_parameter_in_ctor()
         {
             const string OriginalCode = @"
 using System;
@@ -257,7 +257,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_primary_class_ctor()
+        public void Code_gets_fixed_by_prepending_standard_phrase_for_enum_parameter_in_primary_class_ctor()
         {
             const string OriginalCode = @"
 using System;
@@ -284,7 +284,7 @@ public class TestMe(StringComparison o)
         }
 
         [Test]
-        public void Code_gets_fixed_for_primary_struct_ctor()
+        public void Code_gets_fixed_by_prepending_standard_phrase_for_enum_parameter_in_primary_struct_ctor()
         {
             const string OriginalCode = @"
 using System;
@@ -311,7 +311,7 @@ public struct TestMe(StringComparison o)
         }
 
         [Test]
-        public void Code_gets_fixed_for_primary_record_ctor()
+        public void Code_gets_fixed_by_prepending_standard_phrase_for_enum_parameter_in_primary_record_ctor()
         {
             const string OriginalCode = @"
 using System;
@@ -338,7 +338,7 @@ public record TestMe(StringComparison o)
         }
 
         [Test]
-        public void Code_gets_fixed_when_on_different_lines()
+        public void Code_gets_fixed_by_prepending_standard_phrase_on_separate_lines()
         {
             const string OriginalCode = @"
 using System;
@@ -369,7 +369,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_when_inside_para_tag()
+        public void Code_gets_fixed_by_prepending_standard_phrase_inside_para_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -439,7 +439,7 @@ public class TestMe
         [TestCase("Enum that indicates")]
         [TestCase("enum which indicates")]
         [TestCase("Enum which indicates")]
-        public void Code_gets_fixed_for_phrase_(string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_common_enum_phrases_(string originalPhrase)
         {
             var originalCode = @"
 using System;
@@ -470,7 +470,7 @@ public class TestMe
         }
 
         [TestCase("The minimum expected C# language version.", "the minimum expected C# language version.")]
-        public void Code_gets_fixed_for_phrase_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_normalizing_and_lowercasing_continuation_(string originalPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -553,7 +553,7 @@ public class TestMe
         [TestCase("A", "specifies a")]
         [TestCase("An", "specifies an")]
         [TestCase("The", "specifies the")]
-        public void Code_gets_fixed_for_flags_phrase_(string originalPhrase, string fixedContinuation)
+        public void Code_gets_fixed_by_normalizing_flags_enum_phrases_(string originalPhrase, string fixedContinuation)
         {
             var originalCode = @"
 using System;
@@ -593,7 +593,7 @@ public class TestMe
         [TestCase("The flag to investigate for", "specifies the value to investigate for")]
         [TestCase("The value to investigate", "specifies the value to investigate")]
         [TestCase("The value to investigate for", "specifies the value to investigate for")]
-        public void Code_gets_fixed_for_complete_flags_phrase_(string originalPhrase, string fixedContinuation)
+        public void Code_gets_fixed_by_normalizing_complete_flags_enum_phrases_(string originalPhrase, string fixedContinuation)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething(object o) { }
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [TestCase(nameof(Object))]
-        public void No_issue_is_reported_for_method_with_(string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_non_CancellationToken_parameter_(string type) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_out_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_out_CancellationToken_parameter() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [TestCase("The token to monitor for cancellation requests.")]
-        public void No_issue_is_reported_for_method_with_correct_comment_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_CancellationToken_parameter_with_standard_phrase_(string comment) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -61,7 +61,7 @@ public class TestMe
 
         [TestCase("whatever.")]
         [TestCase("Whatever.")]
-        public void An_issue_is_reported_for_method_with_wrong_comment_phrase_(string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_CancellationToken_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -76,7 +76,7 @@ public class TestMe
         [TestCase("<summary />")]
         [TestCase("<inheritdoc />")]
         [TestCase("<exclude />")]
-        public void No_issue_is_reported_for_method_with_missing_documentation_(string xmlElement) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_missing_CancellationToken_parameter_documentation_(string xmlElement) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -87,7 +87,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase()
         {
             const string OriginalCode = @"
 using System;
@@ -118,7 +118,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_when_on_different_lines()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_on_separate_lines()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzerTests.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                          ];
 
         [Test]
-        public void No_issue_is_reported_for_method_that_has_no_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_parameters() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -72,7 +72,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_no_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constructor_without_parameters() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -88,7 +88,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_that_has_no_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method_with_parameter() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -105,7 +105,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_no_documentation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_constructor_with_parameter() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -120,7 +120,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_that_has_correctly_documented_unused_parameter_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_unused_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -139,7 +139,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_correctly_documented_unused_parameter_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constructor_with_unused_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -156,7 +156,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_that_has_correctly_documented_used_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_used_parameter_documented_with_description() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -175,7 +175,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_correctly_documented_used_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constructor_with_used_parameter_documented_with_description() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -195,7 +195,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_that_has_unused_variable_but_correctly_documented_used_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_used_parameter_and_unused_variable() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -214,7 +214,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_unused_variable_but_correctly_documented_used_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constructor_with_used_parameter_and_unused_variable() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -235,7 +235,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_that_has_used_parameter_documented_as_unused_([ValueSource(nameof(UnusedPhrases))] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_used_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -254,7 +254,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_ctor_that_has_used_parameter_documented_as_unused_([ValueSource(nameof(UnusedPhrases))] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_constructor_with_used_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -274,7 +274,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_yet_unfinished_method_that_has_parameter_documented_as_unused_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_incomplete_method_with_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -289,7 +289,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_yet_unfinished_ctor_that_has_parameter_documented_as_unused_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_incomplete_constructor_with_parameter_documented_as_([ValueSource(nameof(UnusedPhrases))] string comment) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2027_SerializationCtorParamDefaultPhraseAnalyzerTests.cs
@@ -67,7 +67,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_ctor_that_has_correctly_documented_serialization_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_serialization_ctor_with_standard_parameter_phrases() => No_issue_is_reported_for(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -86,7 +86,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_ctor_that_has_incorrectly_documented_SerializationInfo_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_serialization_ctor_with_non_standard_SerializationInfo_parameter_phrase() => An_issue_is_reported_for(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -105,7 +105,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_ctor_that_has_incorrectly_documented_StreamingContext_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_serialization_ctor_with_non_standard_StreamingContext_parameter_phrase() => An_issue_is_reported_for(@"
 using System;
 using System.Runtime.Serialization;
 
@@ -124,7 +124,7 @@ namespace Bla
 ");
 
         [Test]
-        public void Code_gets_fixed_for_SerializationInfo()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_SerializationInfo()
         {
             const string OriginalCode = @"
 using System;
@@ -162,7 +162,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_StreamingContext()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_StreamingContext()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2028_ParamPhraseContainsNameOnlyAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correctly_commented_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_with_descriptive_documentation() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -40,17 +40,17 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_incorrectly_commented_parameter_([Values(
-                                                                                                 "A result.",
-                                                                                                 "a result",
-                                                                                                 "The result.",
-                                                                                                 "the result",
-                                                                                                 "An result.",
-                                                                                                 "   a result   ",
-                                                                                                 "Result.",
-                                                                                                 "result",
-                                                                                                 "  result  ")]
-                                                                                         string documentation)
+        public void An_issue_is_reported_for_parameter_documentation_containing_only_parameter_name_([Values(
+                                                                                                         "A result.",
+                                                                                                         "a result",
+                                                                                                         "The result.",
+                                                                                                         "the result",
+                                                                                                         "An result.",
+                                                                                                         "   a result   ",
+                                                                                                         "Result.",
+                                                                                                         "result",
+                                                                                                         "  result  ")]
+                                                                                                     string documentation)
             => An_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public object DoSomething(object o) => null;
@@ -21,7 +21,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public object DoSomething { get; set; }
@@ -58,10 +58,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("A whatever", "An whatever", "The whatever")] string comment,
-                                                                [Values("string", "bool", "Task", "Task<string>", "Task<bool>", nameof(String), nameof(Boolean))] string returnType)
+        public void No_issue_is_reported_for_method_returning_specific_types_with_standard_phrase_(
+                                                                                               [Values("returns", "value")] string xmlTag,
+                                                                                               [Values("A whatever", "An whatever", "The whatever")] string comment,
+                                                                                               [Values("string", "bool", "Task", "Task<string>", "Task<bool>", nameof(String), nameof(Boolean))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -79,9 +79,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_method_(
-                                                                     [Values("returns", "value")] string xmlTag,
-                                                                     [Values("A whatever", "An whatever", "The whatever")] string comment)
+        public void No_issue_is_reported_for_return_value_starting_with_article_(
+                                                                             [Values("returns", "value")] string xmlTag,
+                                                                             [Values("A whatever", "An whatever", "The whatever")] string comment)
             => No_issue_is_reported_for(@"
 using System;
 
@@ -98,9 +98,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_method_(
-                                                                 [Values("returns", "value")] string xmlTag,
-                                                                 [Values("Whatever")] string comment)
+        public void An_issue_is_reported_for_return_value_not_starting_with_article_(
+                                                                                 [Values("returns", "value")] string xmlTag,
+                                                                                 [Values("Whatever")] string comment)
             => An_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2031_TaskReturnTypeDefaultPhraseAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public Task DoSomething(object o) => null;
@@ -20,7 +20,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public Task DoSomething { get; set; }
@@ -39,9 +39,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("Task<bool>", "Task<string>")] string returnType)
+        public void No_issue_is_reported_for_generic_Task_method_with_non_Task_documentation_(
+                                                                                          [Values("returns", "value")] string xmlTag,
+                                                                                          [Values("Task<bool>", "Task<string>")] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -72,7 +72,7 @@ public class TestMe
         [TestCase("WhenAny", "A <see cref=\"System.Threading.Tasks.Task{TResult}\" /> that represents the completion of one of the supplied tasks. Its <see cref=\"System.Threading.Tasks.Task{TResult}.Result\"/> is the task that completed first.")]
         [TestCase("WhenAny", "A <see cref=\"System.Threading.Tasks.Task{TResult}\"/> that represents the completion of one of the supplied tasks. Its <see cref=\"System.Threading.Tasks.Task{TResult}.Result\" /> is the task that completed first.")]
         [TestCase("WhenAny", "A <see cref=\"System.Threading.Tasks.Task{TResult}\"/> that represents the completion of one of the supplied tasks. Its <see cref=\"System.Threading.Tasks.Task{TResult}.Result\"/> is the task that completed first.")]
-        public void No_issue_is_reported_for_special_method_(string methodName, string comment)
+        public void No_issue_is_reported_for_special_Task_method_with_standard_phrase_(string methodName, string comment)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -90,9 +90,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Task_only_method_(
-                                                                               [Values("returns", "value")] string xmlTag,
-                                                                               [Values("task", "<see cref=\"Task\" />", "<see cref=\"Task\"/>")] string comment)
+        public void No_issue_is_reported_for_non_generic_Task_method_with_standard_phrase_(
+                                                                                       [Values("returns", "value")] string xmlTag,
+                                                                                       [Values("task", "<see cref=\"Task\" />", "<see cref=\"Task\"/>")] string comment)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_Task_only_method_([Values("returns", "value")] string xmlTag, [Values("A whatever", "An whatever", "The whatever")] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_generic_Task_method_with_non_standard_phrase_([Values("returns", "value")] string xmlTag, [Values("A whatever", "An whatever", "The whatever")] string comment) => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -127,10 +127,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_generic_Task_method_(
-                                                                                  [Values("returns", "value")] string xmlTag,
-                                                                                  [Values("task", "<see cref=\"Task{TResult}\" />", "<see cref=\"Task{TResult}\"/>", "<see cref=\"System.Threading.Tasks.Task{TResult}\" />", "<see cref=\"System.Threading.Tasks.Task{TResult}\"/>")] string task,
-                                                                                  [Values("<see cref=\"System.Threading.Tasks.Task{TResult}.Result\" />", "<see cref=\"System.Threading.Tasks.Task{TResult}.Result\"/>")] string result)
+        public void No_issue_is_reported_for_generic_Task_method_with_standard_phrase_(
+                                                                                   [Values("returns", "value")] string xmlTag,
+                                                                                   [Values("task", "<see cref=\"Task{TResult}\" />", "<see cref=\"Task{TResult}\"/>", "<see cref=\"System.Threading.Tasks.Task{TResult}\" />", "<see cref=\"System.Threading.Tasks.Task{TResult}\"/>")] string task,
+                                                                                   [Values("<see cref=\"System.Threading.Tasks.Task{TResult}.Result\" />", "<see cref=\"System.Threading.Tasks.Task{TResult}.Result\"/>")] string result)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -148,7 +148,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_generic_Task_method_([Values("returns", "value")] string xmlTag, [Values("A whatever", "An whatever", "The whatever")] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_generic_Task_method_with_non_standard_phrase_([Values("returns", "value")] string xmlTag, [Values("A whatever", "An whatever", "The whatever")] string comment) => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -173,7 +173,7 @@ public class TestMe
         [TestCase("An awaitable Task.")]
         [TestCase("An awaitable task")]
         [TestCase("An awaitable Task")]
-        public void Code_gets_fixed_for_non_generic_method_(string originalText)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_non_generic_Task_(string originalText)
         {
             var originalCode = @"
 using System;
@@ -289,7 +289,7 @@ public class TestMe
         [TestCase(@"A task that represents the asynchronous operation; the task's Result contains the project.", @"the project.")]
         [TestCase(@"A task that represents the asynchronous operation; the Task's result contains the project.", @"the project.")]
         [TestCase(@"A task that represents the asynchronous operation; the Task's Result contains the project.", @"the project.")]
-        public void Code_gets_fixed_for_generic_method_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_generic_Task_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -328,7 +328,7 @@ public class TestMe
         [TestCase("Task WhenAll()", "A task that represents the completion of all of the supplied tasks.")]
         [TestCase("Task WhenAny()", "A task that represents the completion of one of the supplied tasks. Its <see cref=\"Task{TResult}.Result\"/> is the task that completed first.")]
         [TestCase("Task<int> WhenAny()", "A task that represents the completion of one of the supplied tasks. Its <see cref=\"Task{TResult}.Result\"/> is the task that completed first.")]
-        public void Code_gets_fixed_for_special_method_(string specialMethod, string comment)
+        public void Code_gets_fixed_by_replacing_with_method_specific_standard_phrase_(string specialMethod, string comment)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] BooleanReturnValues = [.. BooleanOnlyReturnValues, .. BooleanTaskReturnValues];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_method_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething(object o) => null;
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething { get; set; }
@@ -49,9 +49,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("void", "int", "Task", "Task<int>", "Task<string>")] string returnType)
+        public void No_issue_is_reported_for_method_with_non_Boolean_return_type_(
+                                                                              [Values("returns", "value")] string xmlTag,
+                                                                              [Values("void", "int", "Task", "Task<int>", "Task<string>")] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -69,11 +69,11 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_only_method_(
-                                                                                  [Values("returns", "value")] string xmlTag,
-                                                                                  [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                  [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                  [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_Boolean_method_with_standard_phrase_(
+                                                                              [Values("returns", "value")] string xmlTag,
+                                                                              [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                              [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                              [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -91,12 +91,12 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_only_method_with_default_phrase_(
-                                                                                                      [Values("returns", "value")] string xmlTag,
-                                                                                                      [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                                      [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                                      [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
-                                                                                                      [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_Boolean_method_with_standard_phrase_including_default_(
+                                                                                                [Values("returns", "value")] string xmlTag,
+                                                                                                [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                                [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                                [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
+                                                                                                [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -114,11 +114,11 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_only_method_with_line_break_(
-                                                                                                  [Values("returns", "value")] string xmlTag,
-                                                                                                  [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                                  [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                                  [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_Boolean_method_with_standard_phrase_on_multiple_lines_(
+                                                                                                [Values("returns", "value")] string xmlTag,
+                                                                                                [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                                [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                                [ValueSource(nameof(BooleanOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -137,11 +137,11 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_Task_method_(
-                                                                                  [Values("returns", "value")] string xmlTag,
-                                                                                  [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                  [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                  [ValueSource(nameof(BooleanTaskReturnValues))] string returnType)
+        public void No_issue_is_reported_for_Boolean_Task_method_with_standard_phrase_(
+                                                                                   [Values("returns", "value")] string xmlTag,
+                                                                                   [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                   [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                   [ValueSource(nameof(BooleanTaskReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -159,7 +159,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_only_property_with_To_and_setter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Boolean_property_with_setter_using_to_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -175,10 +175,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_method_(
-                                                                 [Values("returns", "value")] string xmlTag,
-                                                                 [Values("A whatever", "An whatever", "The whatever")] string comment,
-                                                                 [ValueSource(nameof(BooleanReturnValues))] string returnType)
+        public void An_issue_is_reported_for_Boolean_method_with_non_standard_phrase_(
+                                                                                  [Values("returns", "value")] string xmlTag,
+                                                                                  [Values("A whatever", "An whatever", "The whatever")] string comment,
+                                                                                  [ValueSource(nameof(BooleanReturnValues))] string returnType)
             => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -196,7 +196,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_commented_method_with_starting_phrase_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
+        public void An_issue_is_reported_for_Boolean_method_with_simple_starting_phrase_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
             => An_issue_is_reported_for(@"
 using System;
 
@@ -213,7 +213,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_returns_tag_inside_summary_tag_and_wrong_commented_method_with_starting_phrase_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
+        public void An_issue_is_reported_for_Boolean_method_with_returns_tag_inside_summary_tag_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
             => An_issue_is_reported_for(@"
 using System;
 
@@ -238,7 +238,7 @@ public class TestMe
         [TestCase("In case that the stuff is done, True; else False.", "the stuff is done")]
         [TestCase("If <see langword=\"true\"/> calling method should return, otherwise not", "calling method should return")]
         [TestCase("<see langword=\"true\"/> in case that the stuff is done, in all other cases returns <see langword=\"false\"/>.", "the stuff is done")]
-        public void Code_gets_fixed_for_non_generic_method_(string comment, string fixedPhrase)
+        public void Code_gets_fixed_for_Boolean_method_(string comment, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -271,7 +271,7 @@ public class TestMe
         [TestCase(" Something . ", "something")]
         [TestCase("Something.", "something")]
         [TestCase("If the stuff is done, True; False else.", "the stuff is done")]
-        public void Code_gets_fixed_for_generic_method_(string comment, string fixedPhrase)
+        public void Code_gets_fixed_for_Boolean_Task_method_(string comment, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -343,7 +343,7 @@ public class TestMe
         [TestCase("true, if something, false else.")]
         [TestCase("true when something else false")]
         [TestCase("true when something else false.")]
-        public void Code_gets_fixed_for_almost_correct_comment_on_non_generic_method_(string comment)
+        public void Code_gets_fixed_for_Boolean_method_with_almost_standard_phrase_(string comment)
         {
             var originalCode = @"
 using System;
@@ -400,7 +400,7 @@ public class TestMe
         [TestCase("false in the other case.")]
         [TestCase("false in other cases.")]
         [TestCase("false in other case.")]
-        public void Code_gets_fixed_for_almost_correct_comment_with_trailing_other_cases_(string comment)
+        public void Code_gets_fixed_for_Boolean_method_with_trailing_other_cases_phrase_(string comment)
         {
             var originalCode = @"
 using System;
@@ -432,7 +432,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_multiline_comment_on_non_generic_method_variant_1()
+        public void Code_gets_fixed_for_Boolean_method_with_multiline_comment_split_at_comma()
         {
             const string OriginalCode = @"
 using System;
@@ -465,7 +465,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_multiline_comment_on_non_generic_method_variant_2()
+        public void Code_gets_fixed_for_Boolean_method_with_multiline_comment_starting_with_Will_return()
         {
             const string OriginalCode = @"
 using System;
@@ -499,7 +499,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_multiline_comment_on_non_generic_method_variant_3()
+        public void Code_gets_fixed_for_Boolean_method_with_multiline_comment_having_listed_conditions()
         {
             const string OriginalCode = @"
 using System;
@@ -539,7 +539,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_multiple_references_in_comment_on_non_generic_method()
+        public void Code_gets_fixed_for_Boolean_method_with_multiple_references()
         {
             const string OriginalCode = @"
 using System;
@@ -589,7 +589,7 @@ public class TestMe
         [TestCase(@"Returns a task that completes with a result of <see langword=""true""/> if something, returns <see langword=""false""/> otherwise.")]
         [TestCase(@"Returns a task that will complete with a result of <see langword=""true""/> if something, <see langword=""false""/> otherwise.")]
         [TestCase(@"Returns a task that will complete with a result of <see langword=""true""/> if something, returns <see langword=""false""/> otherwise.")]
-        public void Code_gets_fixed_for_almost_correct_comment_on_generic_method_(string comment)
+        public void Code_gets_fixed_for_Boolean_Task_method_with_almost_standard_phrase_(string comment)
         {
             var originalCode = @"
 using System;
@@ -639,7 +639,7 @@ public class TestMe
         [TestCase(@"Returns <see langref=""false""/> if something.")]
         [TestCase(@"Returns <see langword=""false""/> if something.")]
         [TestCase("false: if something, true: otherwise.")]
-        public void Code_gets_not_fixed_for_almost_correct_comment_on_non_generic_method_if_starting_with_false_(string comment)
+        public void Code_gets_not_fixed_for_Boolean_method_starting_with_false_(string comment)
         {
             var originalCode = @"
 using System;
@@ -662,7 +662,7 @@ public class TestMe
         [TestCase(@"A task that will complete with a result of <see langword=""false""/> if something, <see langword=""true""/> otherwise.")]
         [TestCase(@"Returns a task that will complete with a result of <see langword=""false""/> if something, <see langword=""true""/> otherwise.")]
         [TestCase(@"Returns a task that will complete with a result of <see langword=""false""/> if something, returns <see langword=""true""/> otherwise.")]
-        public void Code_gets_not_fixed_for_almost_correct_comment_on_generic_method_if_starting_with_false_(string comment)
+        public void Code_gets_not_fixed_for_Boolean_Task_method_starting_with_false_(string comment)
         {
             var originalCode = @"
 using System;
@@ -716,7 +716,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_fix_places_fix_after_starting_para_tag()
+        public void Code_fix_places_langword_after_starting_para_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -754,7 +754,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_simple_starting_phrase_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
+        public void Code_gets_fixed_for_Boolean_method_with_simple_starting_phrase_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
         {
             var originalCode = @"
 using System;
@@ -784,7 +784,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_returns_tag_inside_summary_tag_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
+        public void Code_gets_fixed_for_Boolean_method_with_returns_tag_inside_summary_tag_([ValueSource(nameof(SimpleStartingPhrases))] string comment)
         {
             var originalCode = @"
 using System;
@@ -825,7 +825,7 @@ public class TestMe
         [TestCase("True means")]
         [TestCase("True means that")]
         [TestCase("True of")] // typo
-        public void Code_gets_fixed_for_specific_starting_phrase_(string comment)
+        public void Code_gets_fixed_for_Boolean_method_with_specific_starting_phrase_(string comment)
         {
             var originalCode = @"
 using System;
@@ -855,7 +855,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_fix_recognizes_Otherwise_at_end_of_first_line_in_multi_line_comment_([Values("Otherwise ", "Otherwise")] string lastWordOnFirstLine)
+        public void Code_fix_recognizes_Otherwise_at_end_of_first_line_in_multiline_comment_([Values("Otherwise ", "Otherwise")] string lastWordOnFirstLine)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2033_StringReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] StringReturnValues = [.. StringOnlyReturnValues, .. StringTaskReturnValues];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_method_([ValueSource(nameof(StringReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method_([ValueSource(nameof(StringReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething(object o) => null;
@@ -39,7 +39,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property_([ValueSource(nameof(StringReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property_([ValueSource(nameof(StringReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething { get; set; }
@@ -47,9 +47,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("void", "int", "Task", "Task<int>", "Task<bool>")] string returnType)
+        public void No_issue_is_reported_for_method_with_return_type_(
+                                                                  [Values("returns", "value")] string xmlTag,
+                                                                  [Values("void", "int", "Task", "Task<int>", "Task<bool>")] string returnType)
             => No_issue_is_reported_for($$"""
 
                                           using System;
@@ -69,10 +69,10 @@ public class TestMe
                                           """);
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_String_only_method_(
-                                                                                 [Values("returns", "value")] string xmlTag,
-                                                                                 [Values("", " ")] string space,
-                                                                                 [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_String_method_with_standard_phrase_(
+                                                                             [Values("returns", "value")] string xmlTag,
+                                                                             [Values("", " ")] string space,
+                                                                             [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for($$"""
 
                                           using System;
@@ -92,10 +92,10 @@ public class TestMe
                                           """);
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_consist_String_only_method_(
-                                                                                         [Values("returns", "value")] string xmlTag,
-                                                                                         [Values("", " ")] string space,
-                                                                                         [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_String_method_with_standard_phrase_using_consists_(
+                                                                                            [Values("returns", "value")] string xmlTag,
+                                                                                            [Values("", " ")] string space,
+                                                                                            [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for($$"""
 
                                           using System;
@@ -115,10 +115,10 @@ public class TestMe
                                           """);
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_ToString_method_(
-                                                                              [Values("returns")] string xmlTag,
-                                                                              [Values("", " ")] string space,
-                                                                              [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_ToString_method_with_standard_phrase_(
+                                                                               [Values("returns")] string xmlTag,
+                                                                               [Values("", " ")] string space,
+                                                                               [ValueSource(nameof(StringOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for($$"""
 
                                           using System;
@@ -138,10 +138,10 @@ public class TestMe
                                           """);
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_String_Task_method_(
-                                                                                 [Values("returns", "value")] string xmlTag,
-                                                                                 [Values("", " ")] string space,
-                                                                                 [ValueSource(nameof(StringTaskReturnValues))] string returnType)
+        public void No_issue_is_reported_for_String_Task_method_with_standard_phrase_(
+                                                                                  [Values("returns", "value")] string xmlTag,
+                                                                                  [Values("", " ")] string space,
+                                                                                  [ValueSource(nameof(StringTaskReturnValues))] string returnType)
             => No_issue_is_reported_for($$"""
 
                                           using System;
@@ -161,7 +161,7 @@ public class TestMe
                                           """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_String_interned_method() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_String_method_with_interned_phrase() => No_issue_is_reported_for("""
 
                                                                                                                       using System;
                                                                                                                       using System.Threading.Tasks;
@@ -180,10 +180,10 @@ public class TestMe
                                                                                                                       """);
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_method_(
-                                                                 [Values("returns", "value")] string xmlTag,
-                                                                 [Values("A whatever", "An whatever", "The whatever")] string comment,
-                                                                 [ValueSource(nameof(StringReturnValues))] string returnType)
+        public void An_issue_is_reported_for_String_method_with_non_standard_phrase_(
+                                                                                 [Values("returns", "value")] string xmlTag,
+                                                                                 [Values("A whatever", "An whatever", "The whatever")] string comment,
+                                                                                 [ValueSource(nameof(StringReturnValues))] string returnType)
             => An_issue_is_reported_for($$"""
 
                                           using System;
@@ -203,7 +203,7 @@ public class TestMe
                                           """);
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_method()
+        public void Code_gets_fixed_for_String_method()
         {
             const string OriginalCode = """
 
@@ -241,7 +241,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_method_with_line_break()
+        public void Code_gets_fixed_for_String_method_with_multiline_comment()
         {
             const string OriginalCode = """
 
@@ -348,7 +348,7 @@ public class TestMe
         [TestCase("The single string which represents")]
         [TestCase("The single string with")]
         [TestCase("The string value with")]
-        public void Code_gets_fixed_for_non_generic_method_starting_with_(string phrase)
+        public void Code_gets_fixed_for_String_method_with_non_standard_starting_phrase_(string phrase)
         {
             var originalCode = @"
 using System;
@@ -400,7 +400,7 @@ public class TestMe
         [TestCase("A humanized concatenation of the strings", "the humanized concatenation of the strings")]
         [TestCase("value of something", "the value of something")]
         [TestCase("Value of something", "the value of something")]
-        public void Code_gets_fixed_for_non_generic_method_starting_and_continuing_with_(string phrase, string continuation)
+        public void Code_gets_fixed_for_String_method_with_special_phrase_(string phrase, string continuation)
         {
             var originalCode = @"
 using System;
@@ -434,7 +434,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_method()
+        public void Code_gets_fixed_for_String_Task_method()
         {
             const string OriginalCode = """
 
@@ -474,7 +474,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_almost_correct_generic_method()
+        public void Code_gets_fixed_for_String_Task_method_with_almost_standard_phrase()
         {
             const string OriginalCode = """
 
@@ -516,7 +516,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_almost_correct_phrase()
+        public void Code_gets_fixed_for_String_Task_method_with_property_reference()
         {
             const string OriginalCode = """
 
@@ -616,7 +616,7 @@ public class TestMe
         }
 
         [Test(Description = "Reverse-ordered Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/366")]
-        public void Code_gets_fixed_for_issue_366_order_reversed()
+        public void Code_gets_fixed_for_issue_366_with_reversed_member_order()
         {
             const string OriginalCode = """
 
@@ -675,7 +675,7 @@ public class TestMe
 
         [TestCase("", Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/401")]
         [TestCase("some ", Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/401")]
-        public void Code_gets_fixed_for_non_generic_method_and_issue_401_when_phrase_is_almost_correct_(string phrase)
+        public void Code_gets_fixed_for_String_property_with_almost_standard_phrase_and_issue_401_(string phrase)
         {
             const string OriginalCode = """
 
@@ -717,7 +717,7 @@ public class TestMe
         }
 
         [Test(Description = "Bugfix for https://github.com/RalfKoban/MiKo-Analyzers/issues/401")]
-        public void Code_gets_fixed_for_non_generic_method_and_issue_401_when_complete_phrase_gets_added()
+        public void Code_gets_fixed_for_String_property_with_missing_phrase_and_issue_401()
         {
             const string OriginalCode = """
 
@@ -759,7 +759,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_method_and_issue_401_when_phrase_is_almost_correct_variant_1()
+        public void Code_gets_fixed_for_String_Task_method_with_single_line_almost_standard_phrase_and_issue_401()
         {
             const string OriginalCode = """
 
@@ -799,7 +799,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_method_and_issue_401_when_phrase_is_almost_correct_variant_2()
+        public void Code_gets_fixed_for_String_Task_method_with_multiline_almost_standard_phrase_and_issue_401()
         {
             const string OriginalCode = """
 
@@ -841,7 +841,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_method_and_almost_correct_phrase_([Values("that returns", "which returns", "returning", "which contains")] string text)
+        public void Code_gets_fixed_for_String_property_with_almost_standard_phrase_([Values("that returns", "which returns", "returning", "which contains")] string text)
         {
             var originalCode = @"
 using System;
@@ -879,7 +879,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_method_and_almost_correct_phrase_without_see_Cref_([Values("that returns", "which returns", "returning", "which contains", "that contains", "containing")] string text)
+        public void Code_gets_fixed_for_String_property_with_almost_standard_phrase_without_see_cref_([Values("that returns", "which returns", "returning", "which contains", "that contains", "containing")] string text)
         {
             var originalCode = @"
 using System;
@@ -917,7 +917,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_method_and_almost_correct_phrase_with_see_Cref_([Values("that returns", "which returns", "returning", "which contains", "that contains", "containing")] string text)
+        public void Code_gets_fixed_for_String_property_with_almost_standard_phrase_and_multiple_see_cref_([Values("that returns", "which returns", "returning", "which contains", "that contains", "containing")] string text)
         {
             var originalCode = @"
 using System;
@@ -993,7 +993,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_phrase_The_string_result()
+        public void Code_gets_fixed_for_String_property_with_phrase_The_string_result()
         {
             const string OriginalCode = """
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2034_EnumReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2034_EnumReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] EnumReturnValues = [.. EnumOnlyReturnValues, .. EnumTaskReturnValues];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_method_([ValueSource(nameof(EnumReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method_([ValueSource(nameof(EnumReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething(object o) => null;
@@ -36,7 +36,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property_([ValueSource(nameof(EnumReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property_([ValueSource(nameof(EnumReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething { get; set; }
@@ -44,9 +44,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("void", "int", "Task", "Task<int>", "Task<bool>")] string returnType)
+        public void No_issue_is_reported_for_method_returning_non_enum_type_(
+                                                                         [Values("returns", "value")] string xmlTag,
+                                                                         [Values("void", "int", "Task", "Task<int>", "Task<bool>")] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -64,9 +64,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Enum_only_method_(
-                                                                               [Values("returns", "value")] string xmlTag,
-                                                                               [ValueSource(nameof(EnumOnlyReturnValues))] string returnType)
+        public void No_issue_is_reported_for_non_generic_enum_return_with_standard_phrase_(
+                                                                                       [Values("returns", "value")] string xmlTag,
+                                                                                       [ValueSource(nameof(EnumOnlyReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -84,10 +84,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Enum_Task_method_(
-                                                                               [Values("returns", "value")] string xmlTag,
-                                                                               [Values("", " ")] string space,
-                                                                               [ValueSource(nameof(EnumTaskReturnValues))] string returnType)
+        public void No_issue_is_reported_for_Task_enum_return_with_standard_phrase_(
+                                                                                [Values("returns", "value")] string xmlTag,
+                                                                                [Values("", " ")] string space,
+                                                                                [ValueSource(nameof(EnumTaskReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -105,10 +105,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_method_(
-                                                                 [Values("returns", "value")] string xmlTag,
-                                                                 [Values("A whatever", "An whatever", "The whatever")] string comment,
-                                                                 [ValueSource(nameof(EnumReturnValues))] string returnType)
+        public void An_issue_is_reported_for_enum_return_with_non_standard_phrase_(
+                                                                               [Values("returns", "value")] string xmlTag,
+                                                                               [Values("A whatever", "An whatever", "The whatever")] string comment,
+                                                                               [ValueSource(nameof(EnumReturnValues))] string returnType)
             => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -135,7 +135,7 @@ public class TestMe
         [TestCase("""Something, such as <see cref="string.Empty"/>.""", """the something, such as <see cref="string.Empty"/>.""")]
         [TestCase("""If something, the result is <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
         [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
-        public void Code_gets_fixed_for_non_generic_method_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_enum_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -180,7 +180,7 @@ public class TestMe
         [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>.""", """<see cref="StringComparison.Ordinal"/> if something.""")]
         [TestCase("""If something, the result is <see cref="StringComparison.Ordinal"/>""", """<see cref="StringComparison.Ordinal"/> if something""")]
         [TestCase("""If something, the result will be <see cref="StringComparison.Ordinal"/>""", """<see cref="StringComparison.Ordinal"/> if something""")]
-        public void Code_gets_fixed_for_generic_method_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_Task_enum_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2035_EnumerableReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -43,7 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         public static void PrepareTestEnvironment() => MiKo_2035_CodeFixProvider.LoadData();
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_method_([ValueSource(nameof(ReturnTypes))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method_([ValueSource(nameof(ReturnTypes))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething(object o) => null;
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property_([ValueSource(nameof(ReturnTypes))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property_([ValueSource(nameof(ReturnTypes))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething { get; set; }
@@ -59,7 +59,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_commented_method_returning_a_([Values("XmlNode", "XmlElement", "XmlDocument")] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_commented_method_returning_XmlNode_type_([Values("XmlNode", "XmlElement", "XmlDocument")] string returnType) => No_issue_is_reported_for(@"
 using System.Xml;
 
 public class TestMe
@@ -72,9 +72,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("void", "int", "string", "Task", "Task<int>", "Task<bool>, Task<string>")] string returnType)
+        public void No_issue_is_reported_for_method_returning_non_enumerable_type_(
+                                                                               [Values("returns", "value")] string xmlTag,
+                                                                               [Values("void", "int", "string", "Task", "Task<int>", "Task<bool>, Task<string>")] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -94,10 +94,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Array_only_method_(
-                                                                                [Values("returns", "value")] string xmlTag,
-                                                                                [Values("int", "string")] string returnType,
-                                                                                [Values("An array of", "The array of")] string startingPhrase)
+        public void No_issue_is_reported_for_array_return_with_standard_phrase_(
+                                                                            [Values("returns", "value")] string xmlTag,
+                                                                            [Values("int", "string")] string returnType,
+                                                                            [Values("An array of", "The array of")] string startingPhrase)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -117,7 +117,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Byte_array_only_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_byte_array_return_with_standard_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -133,9 +133,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_sequence_commented_Enumerable_only_method_(
-                                                                                              [Values("returns", "value")] string xmlTag,
-                                                                                              [Values("A sequence that contains", "A sequence of")] string startPhrase)
+        public void No_issue_is_reported_for_IEnumerable_return_with_sequence_phrase_(
+                                                                                  [Values("returns", "value")] string xmlTag,
+                                                                                  [Values("A sequence that contains", "A sequence of")] string startPhrase)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -154,10 +154,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_List_method_(
-                                                                          [Values("returns", "value")] string xmlTag,
-                                                                          [Values("A", "An")] string startingWord,
-                                                                          [Values("that contains", "containing")] string continuation)
+        public void No_issue_is_reported_for_List_return_with_see_cref_and_standard_phrase_(
+                                                                                        [Values("returns", "value")] string xmlTag,
+                                                                                        [Values("A", "An")] string startingWord,
+                                                                                        [Values("that contains", "containing")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -176,10 +176,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_List_of_method_(
-                                                                             [Values("returns", "value")] string xmlTag,
-                                                                             [Values("A", "An")] string startingWord,
-                                                                             [Values("that contains", "containing")] string continuation)
+        public void No_issue_is_reported_for_List_of_return_with_see_cref_and_standard_phrase_(
+                                                                                           [Values("returns", "value")] string xmlTag,
+                                                                                           [Values("A", "An")] string startingWord,
+                                                                                           [Values("that contains", "containing")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -198,7 +198,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Enumerable_only_method_([Values("returns", "value")] string xmlTag)
+        public void No_issue_is_reported_for_IEnumerable_return_with_sequence_of_phrase_([Values("returns", "value")] string xmlTag)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -217,10 +217,10 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Enumerable_method_(
-                                                                                [Values("returns", "value")] string xmlTag,
-                                                                                [Values("A", "An")] string startingWord,
-                                                                                [Values("that contains", "containing")] string continuation)
+        public void No_issue_is_reported_for_IEnumerable_return_with_see_cref_and_standard_phrase_(
+                                                                                               [Values("returns", "value")] string xmlTag,
+                                                                                               [Values("A", "An")] string startingWord,
+                                                                                               [Values("that contains", "containing")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -239,10 +239,10 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Enumerable_of_method_(
-                                                                                   [Values("returns", "value")] string xmlTag,
-                                                                                   [Values("A", "An")] string startingWord,
-                                                                                   [Values("that contains", "containing")] string continuation)
+        public void No_issue_is_reported_for_IEnumerable_of_return_with_see_cref_and_standard_phrase_(
+                                                                                                  [Values("returns", "value")] string xmlTag,
+                                                                                                  [Values("A", "An")] string startingWord,
+                                                                                                  [Values("that contains", "containing")] string continuation)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -261,10 +261,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Enumerable_Task_method_(
-                                                                                     [Values("returns", "value")] string xmlTag,
-                                                                                     [Values("", " ")] string space,
-                                                                                     [ValueSource(nameof(TaskReturnTypes))] string returnType)
+        public void No_issue_is_reported_for_Task_enumerable_return_with_standard_phrase_(
+                                                                                      [Values("returns", "value")] string xmlTag,
+                                                                                      [Values("", " ")] string space,
+                                                                                      [ValueSource(nameof(TaskReturnTypes))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -284,7 +284,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Enumerable_Select_like_method_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Select_like_method_with_standard_phrase_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -302,10 +302,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_wrong_commented_method_(
-                                                                 [Values("returns", "value")] string xmlTag,
-                                                                 [Values("A whatever", "An whatever", "The whatever")] string comment,
-                                                                 [ValueSource(nameof(ReturnTypes))] string returnType)
+        public void An_issue_is_reported_for_enumerable_return_with_non_standard_phrase_(
+                                                                                     [Values("returns", "value")] string xmlTag,
+                                                                                     [Values("A whatever", "An whatever", "The whatever")] string comment,
+                                                                                     [ValueSource(nameof(ReturnTypes))] string returnType)
             => An_issue_is_reported_for(@"
 using System;
 using System.Collections;
@@ -325,7 +325,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_array_type()
+        public void Code_gets_fixed_by_replacing_with_array_phrase_for_array_type()
         {
             const string OriginalCode = """
 
@@ -361,7 +361,7 @@ public class TestMe
         }
 
         [TestCase("The adjusted trivia array with proper whitespace indentation for comments", "An array of the adjusted trivia with proper whitespace indentation for comments")]
-        public void Code_gets_fixed_for_array_type_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_normalizing_array_phrases_(string originalText, string fixedText)
         {
             const string Template = """
 
@@ -384,7 +384,7 @@ public class TestMe
         }
 
         [TestCase("The modified set after something", "A collection of elements from the original set after something")]
-        public void Code_gets_fixed_for_hashset_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_hashset_(string originalText, string fixedText)
         {
             const string Template = """
 
@@ -445,7 +445,7 @@ public class TestMe
         [TestCase(@"The array of <see cref=""byte""/>s which contains")]
         [TestCase(@"The array of")]
         [TestCase(@"The array with")]
-        public void Code_gets_fixed_for_byte_array_type_(string text)
+        public void Code_gets_fixed_by_replacing_with_byte_array_phrase_(string text)
         {
             var originalCode = @"
 public class TestMe
@@ -477,7 +477,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_collection_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_collection_phrases_for_non_generic_collection_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
         {
             const string Template = """
 
@@ -502,7 +502,7 @@ public class TestMe
 
         [TestCase("Some integers.", "A collection of some integers.")]
         [TestCase("The mapping information.", "A collection of the mapping information.")]
-        public void Code_gets_fixed_for_non_generic_collection_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_non_generic_collection_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -526,7 +526,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_readonly_([Values("readonly", "read only", "read-only")] string modification, [Values("list", "collection")] string collection)
+        public void Code_gets_fixed_by_normalizing_readonly_phrases_for_generic_readonly_collection_([Values("readonly", "read only", "read-only")] string modification, [Values("list", "collection")] string collection)
         {
             const string Template = """
 
@@ -551,7 +551,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_collection_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_collection_phrases_for_generic_collection_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
         {
             const string Template = """
 
@@ -581,7 +581,7 @@ public class TestMe
         [TestCase("Get the integers.", "A collection of the integers.")]
         [TestCase("The List with the integers.", "A collection of the integers.")]
         [TestCase("A List with the integers.", "A collection of the integers.")]
-        public void Code_gets_fixed_for_generic_collection_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_generic_collection_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -607,7 +607,7 @@ public class TestMe
 
         [TestCase("Some integers.", "A collection of some integers.")]
         [TestCase("The mapping information.", "A collection of the mapping information.")]
-        public void Code_gets_fixed_for_generic_collection_on_same_line_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_generic_collection_on_same_line_(string originalPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -647,7 +647,7 @@ public class TestMe
         [TestCase("Some data", "A collection of my items that contains some data")]
         [TestCase("Gets the information.", "A collection of my items that contains the information.")]
         [TestCase("Get the information.", "A collection of my items that contains the information.")]
-        public void Code_gets_fixed_for_generic_collection_with_non_primitive_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_generic_collection_with_non_primitive_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -675,7 +675,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_enumerable_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_sequence_phrases_for_non_generic_enumerable_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
         {
             const string Template = """
 
@@ -705,7 +705,7 @@ public class TestMe
         [TestCase("A read-only list of attributes of the specified type.", "A sequence that contains attributes of the specified type.")]
         [TestCase("A separated syntax list of parameters accessible from the given context.", "A sequence that contains parameters accessible from the given context.")]
         [TestCase("An enumerable of strings that represents the text content without trivia.", "A sequence that contains the text content without trivia.")]
-        public void Code_gets_fixed_for_non_generic_enumerable_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_non_generic_enumerable_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -729,7 +729,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_generic_enumerable_on_same_line_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_sequence_phrases_for_non_generic_enumerable_on_same_line_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
         {
             var originalCode = @"
 using System;
@@ -771,7 +771,7 @@ public class TestMe
         [TestCase("A read-only list of attributes of the specified type.", "A sequence that contains attributes of the specified type.")]
         [TestCase("A separated syntax list of parameters accessible from the given context.", "A sequence that contains parameters accessible from the given context.")]
         [TestCase("An enumerable of strings that represents the text content without trivia.", "A sequence that contains the text content without trivia.")]
-        public void Code_gets_fixed_for_non_generic_enumerable_on_same_line_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_non_generic_enumerable_on_same_line_(string originalPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -807,7 +807,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_enumerable_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
+        public void Code_gets_fixed_by_normalizing_sequence_phrases_for_generic_enumerable_([ValueSource(nameof(StartingPhrases))] string originalPhrase)
         {
             const string Template = """
 
@@ -833,7 +833,7 @@ public class TestMe
 
         [TestCase("Some integers.", "A sequence that contains some integers.")]
         [TestCase("The mapping information.", "A sequence that contains the mapping information.")]
-        public void Code_gets_fixed_for_generic_enumerable_with_primitive_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_generic_enumerable_with_primitive_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -859,7 +859,7 @@ public class TestMe
 
         [TestCase("Some integers.", "A sequence that contains some integers.")]
         [TestCase("The mapping information.", "A sequence that contains the mapping information.")]
-        public void Code_gets_fixed_for_generic_enumerable_with_primitive_type_on_same_line_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_generic_enumerable_with_primitive_type_on_same_line_(string originalPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -898,7 +898,7 @@ public class TestMe
 
         [TestCase("Some data", "A sequence that contains some data")]
         [TestCase("All ancestors of the specified type", "A sequence that contains all ancestors of the specified type")]
-        public void Code_gets_fixed_for_generic_enumerable_with_non_primitive_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_generic_enumerable_with_non_primitive_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -927,7 +927,7 @@ public class TestMe
 
         [TestCase("Some data", "A sequence that contains some data")]
         [TestCase("All ancestors of the specified type", "A sequence that contains all ancestors of the specified type")]
-        public void Code_gets_fixed_for_generic_enumerable_with_generic_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_sequence_phrase_for_generic_enumerable_with_generic_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -956,7 +956,7 @@ public class TestMe
 
         [TestCase("Some data", "A collection of my nodes that contains some data")]
         [TestCase("All ancestors of the specified type", "A collection of my nodes that contains all ancestors of the specified type")]
-        public void Code_gets_fixed_for_generic_collection_with_generic_closed_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_generic_collection_with_generic_closed_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -985,7 +985,7 @@ public class TestMe
 
         [TestCase("Some data", "A collection of some data")]
         [TestCase("All ancestors of the specified type", "A collection of all ancestors of the specified type")]
-        public void Code_gets_fixed_for_generic_collection_with_generic_open_type_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_replacing_with_collection_phrase_for_generic_collection_with_generic_open_type_(string originalPhrase, string fixedPhrase)
         {
             const string Template = """
 
@@ -1016,7 +1016,7 @@ public class TestMe
         [TestCase("An awaitable task.", "")]
         [TestCase("An awaitable task", "")]
         [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
-        public void Code_gets_fixed_for_Task_with_generic_collection_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_Task_collection_phrase_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -1065,7 +1065,7 @@ public class TestMe
         [TestCase("An awaitable task.", "")]
         [TestCase("An awaitable task", "")]
         [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
-        public void Code_gets_fixed_for_Task_with_generic_collection_on_same_line_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_Task_collection_phrase_on_same_line_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -1106,7 +1106,7 @@ public class TestMe
 
         [TestCase("Some integers.", "some integers.")]
         [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
-        public void Code_gets_fixed_for_Task_with_array_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_Task_array_phrase_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -1149,7 +1149,7 @@ public class TestMe
 
         [TestCase("Some data.", "some data.")]
         [TestCase("A task that represents the asynchronous operation. The Result is something", "something")]
-        public void Code_gets_fixed_for_Task_with_byte_array_(string originalText, string fixedText)
+        public void Code_gets_fixed_by_replacing_with_Task_byte_array_phrase_(string originalText, string fixedText)
         {
             var originalCode = @"
 using System;
@@ -1191,7 +1191,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_return_value_with_almost_correct_start_and_see_cref_XML_tag_([ValueSource(nameof(OfStartingPhrases))] string start)
+        public void Code_gets_fixed_by_normalizing_collection_of_phrases_with_see_cref_([ValueSource(nameof(OfStartingPhrases))] string start)
         {
             var originalCode = @"
 using System;
@@ -1231,7 +1231,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_generic_return_value_with_almost_correct_start_and_see_cref_XML_tag_on_same_line_([ValueSource(nameof(OfStartingPhrases))] string start)
+        public void Code_gets_fixed_by_normalizing_collection_of_phrases_with_see_cref_on_same_line_([ValueSource(nameof(OfStartingPhrases))] string start)
         {
             var originalCode = @"
 using System;
@@ -1269,7 +1269,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_collection_phrase_on_array()
+        public void Code_gets_fixed_by_replacing_collection_phrase_with_array_phrase_for_array()
         {
             const string OriginalCode = """
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2036_PropertyDefaultValuePhraseAnalyzerTests.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private CodeFixProvider CurrentCodeFixProvider { get; set; }
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_commented_method_([ValueSource(nameof(BooleanReturnValues))] string returnType, [Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_boolean_return_type_([ValueSource(nameof(BooleanReturnValues))] string returnType, [Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_property_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_property_([ValueSource(nameof(BooleanReturnValues))] string returnType) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public " + returnType + @" DoSomething { get; set; }
@@ -43,9 +43,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_method_that_returns_a_(
-                                                                [Values("returns", "value")] string xmlTag,
-                                                                [Values("void", "int", "Task", "Task<int>", "Task<string>")] string returnType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_returning_non_boolean_or_enum_type_(
+                                                                                    [Values("returns", "value")] string xmlTag,
+                                                                                    [Values("void", "int", "Task", "Task<int>", "Task<string>")] string returnType) => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -62,11 +62,11 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_commented_Boolean_property_with_missing_default_value_(
-                                                                                                [Values("returns", "value")] string xmlTag,
-                                                                                                [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                                [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                                [ValueSource(nameof(BooleanReturnValues))] string returnType)
+        public void An_issue_is_reported_for_boolean_property_missing_default_value_phrase_(
+                                                                                        [Values("returns", "value")] string xmlTag,
+                                                                                        [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                        [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                        [ValueSource(nameof(BooleanReturnValues))] string returnType)
             => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -84,12 +84,12 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_property_with_default_phrase_(
-                                                                                                   [Values("returns", "value")] string xmlTag,
-                                                                                                   [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                                   [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                                   [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
-                                                                                                   [ValueSource(nameof(BooleanReturnValues))] string returnType)
+        public void No_issue_is_reported_for_boolean_property_with_default_value_phrase_(
+                                                                                     [Values("returns", "value")] string xmlTag,
+                                                                                     [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                     [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                     [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
+                                                                                     [ValueSource(nameof(BooleanReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -107,12 +107,12 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_commented_Boolean_property_with_default_phrase_and_line_break_(
-                                                                                                                  [Values("returns", "value")] string xmlTag,
-                                                                                                                  [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
-                                                                                                                  [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
-                                                                                                                  [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
-                                                                                                                  [ValueSource(nameof(BooleanReturnValues))] string returnType)
+        public void No_issue_is_reported_for_boolean_property_with_default_value_phrase_on_separate_line_(
+                                                                                                      [Values("returns", "value")] string xmlTag,
+                                                                                                      [Values("<see langword=\"true\" />", "<see langword=\"true\"/>")] string trueValue,
+                                                                                                      [Values("<see langword=\"false\" />", "<see langword=\"false\"/>")] string falseValue,
+                                                                                                      [Values("<see langword=\"true\"/>", "<see langword=\"false\"/>")] string defaultValue,
+                                                                                                      [ValueSource(nameof(BooleanReturnValues))] string returnType)
             => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
@@ -131,7 +131,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_commented_Enum_property_with_missing_default_value_([Values("returns", "value")] string xmlTag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_property_missing_default_value_phrase_([Values("returns", "value")] string xmlTag) => An_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -154,7 +154,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_commented_Enum_property_with_default_value_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_property_with_default_value_phrase_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -177,7 +177,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_commented_Enum_property_with_default_value_and_line_break_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_property_with_default_value_phrase_on_separate_line_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -201,7 +201,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_commented_Enum_property_with_explicitly_commented_no_default_value_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_property_with_explicit_no_default_value_phrase_([Values("returns", "value")] string xmlTag) => No_issue_is_reported_for(@"
 using System;
 using System.Threading.Tasks;
 
@@ -225,7 +225,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_boolean_having_no_default_value()
+        public void Code_gets_fixed_by_adding_no_default_value_phrase_for_boolean()
         {
             CurrentCodeFixProvider = new MiKo_2036_NoDefault_CodeFixProvider();
 
@@ -264,7 +264,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_boolean_having_false_as_default_value()
+        public void Code_gets_fixed_by_adding_false_default_value_phrase_for_boolean()
         {
             CurrentCodeFixProvider = new MiKo_2036_DefaultFalse_CodeFixProvider();
 
@@ -303,7 +303,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_boolean_having_true_as_default_value()
+        public void Code_gets_fixed_by_adding_true_default_value_phrase_for_boolean()
         {
             CurrentCodeFixProvider = new MiKo_2036_DefaultTrue_CodeFixProvider();
 
@@ -342,7 +342,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_Enum_as_default_value()
+        public void Code_gets_fixed_by_adding_enum_default_value_phrase()
         {
             CurrentCodeFixProvider = new MiKo_2036_Enum_CodeFixProvider();
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2037_CommandPropertySummaryAnalyzerTests.cs
@@ -40,7 +40,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_readwrite_property_([ValueSource(nameof(ValidPhrasesForReadWrite))] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_readwrite_Command_property_with_standard_summary_([ValueSource(nameof(ValidPhrasesForReadWrite))] string phrase) => No_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -53,7 +53,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_readonly_property_([ValueSource(nameof(ValidPhrasesForReadOnly))] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_readonly_Command_property_with_standard_summary_([ValueSource(nameof(ValidPhrasesForReadOnly))] string phrase) => No_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -66,7 +66,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_writeonly_property_([ValueSource(nameof(ValidPhrasesForWriteOnly))] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_writeonly_Command_property_with_standard_summary_([ValueSource(nameof(ValidPhrasesForWriteOnly))] string phrase) => No_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -79,7 +79,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_readwrite_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_readwrite_Command_property_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -92,7 +92,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_readonly_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_readonly_Command_property_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -105,7 +105,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_writeonly_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_writeonly_Command_property_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System.Windows.Input;
 
 public class TestMe
@@ -118,7 +118,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_readonly_arrow_Command_property()
+        public void Code_gets_fixed_by_replacing_with_standard_summary_for_readonly_arrow_Command_property()
         {
             const string OriginalCode = @"
 using System.Windows.Input;
@@ -148,7 +148,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_readonly_Command_property()
+        public void Code_gets_fixed_by_replacing_with_standard_summary_for_readonly_Command_property()
         {
             const string OriginalCode = @"
 using System.Windows.Input;
@@ -178,7 +178,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_writeonly_Command_property()
+        public void Code_gets_fixed_by_replacing_with_standard_summary_for_writeonly_Command_property()
         {
             const string OriginalCode = @"
 using System.Windows.Input;
@@ -208,7 +208,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_readwrite_Command_property()
+        public void Code_gets_fixed_by_replacing_with_standard_summary_for_readwrite_Command_property()
         {
             const string OriginalCode = @"
 using System.Windows.Input;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2038_CommandTypeSummaryAnalyzerTests.cs
@@ -37,7 +37,7 @@ public interface ITestMe : ICommand
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_command_class_with_standard_summary() => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -55,7 +55,7 @@ public class TestMe : ICommand
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ICommand_interface_with_standard_summary() => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -68,7 +68,7 @@ public interface ITestMe : ICommand
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_class_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -100,7 +100,7 @@ public class TestMe : ICommand
         [TestCase("Interface for a command in")]
         [TestCase("Interface for a command that can do")]
         [TestCase("Interface for a command which can do")]
-        public void An_issue_is_reported_for_incorrectly_documented_interface_(string text) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ICommand_interface_with_non_standard_summary_(string text) => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -113,7 +113,7 @@ public interface ITestMe : ICommand
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class_with_see_cref() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_class_with_only_see_cref_in_summary() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -223,7 +223,7 @@ public class TestMe : ICommand
         [TestCase("This command is used to execute", "execute")]
         [TestCase("Tries to execute", "execute")]
         [TestCase("Wrapper for", "wrap")]
-        public void Code_gets_fixed_(string originalComment, string fixedComment)
+        public void Code_gets_fixed_by_normalizing_to_standard_command_summary_(string originalComment, string fixedComment)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2039_ExtensionMethodsClassSummaryAnalyzerTests.cs
@@ -42,7 +42,7 @@ public static class TestMeExtensions
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_extension_class_([ValueSource(nameof(ValidPhrases))] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_class_with_standard_summary_phrase_([ValueSource(nameof(ValidPhrases))] string phrase) => No_issue_is_reported_for(@"
 /// <summary>
 /// " + phrase + @" something.
 /// </summary>
@@ -53,7 +53,7 @@ public static class TestMeExtensions
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_extension_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_class_with_non_standard_summary_phrase() => An_issue_is_reported_for(@"
 /// <summary>
 /// Does something.
 /// </summary>
@@ -118,7 +118,7 @@ public static class TestMeExtensions
         [TestCase("Several basic helper functions for", "")]
         [TestCase("Basic helper functions for", "")]
         [TestCase("Helper functions for", "")]
-        public void Code_gets_fixed_(string originalCode, string fixedCode)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_(string originalCode, string fixedCode)
         {
             const string Template = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2040_LangwordAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2040_LangwordAnalyzerTests.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData().Take(TestLimit)];
 
         [Test]
-        public void No_issue_is_reported_for_undocumented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_members() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -53,7 +53,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_on_class_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_summary_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something. " + term + @"
 /// </summary>
@@ -63,7 +63,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_on_method_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_summary_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -74,7 +74,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_on_property_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_summary_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -85,7 +85,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_on_event_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_summary_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -96,7 +96,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_on_field_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_summary_([ValueSource(nameof(CorrectItems))] string term) => No_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -107,7 +107,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_valid_code_example_on_class_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_example_section_containing_code_tag_with_keywords_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something.
 /// </summary>
@@ -125,7 +125,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_valid_code_inside_remarks_section_on_class_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_remarks_section_containing_code_tag_with_keywords_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something.
 /// </summary>
@@ -145,7 +145,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_valid_text_inside_c_in_summary_on_class_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_summary_containing_c_tag_with_keywords_in_larger_text_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something with <c>some special text with " + term + @" here</c>.
 /// </summary>
@@ -155,7 +155,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_valid_but_special_text_inside_c_in_summary_on_class_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_summary_containing_nested_c_tags_with_keywords_and_XML_entities_([ValueSource(nameof(Terms))] string term) => No_issue_is_reported_for(@"
 /// <summary>
 /// Does something with <c><c>&lt;value&gt;" + term + @"&lt;/value&gt;</c></c>.
 /// </summary>
@@ -165,7 +165,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_class_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_summary_containing_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 /// <summary>
 /// Does something. " + term + @"
 /// </summary>
@@ -175,7 +175,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_method_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_summary_containing_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -186,7 +186,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_method_returnValue_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_returns_section_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -200,7 +200,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_property_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_summary_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -211,7 +211,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_property_value_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_value_section_containing_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -225,7 +225,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_event_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_summary_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -236,7 +236,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_field_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_summary_([ValueSource(nameof(WrongItemsWithCode))] string term) => An_issue_is_reported_for(@"
 public sealed class TestMe
 {
     /// <summary>
@@ -248,7 +248,7 @@ public sealed class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrect_documentation_on_parameter() => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_parameter_documentation_with_True_and_False_as_plain_text() => An_issue_is_reported_for(2, @"
 public sealed class TestMe
 {
     /// <summary>
@@ -260,7 +260,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_example_on_class_([ValueSource(nameof(WrongItemsWithoutCode))] string term) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_example_section_containing_([ValueSource(nameof(WrongItemsWithoutCode))] string term) => An_issue_is_reported_for(@"
 /// <summary>
 /// Does something.
 /// </summary>
@@ -273,7 +273,7 @@ public sealed class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_in_summary_([ValueSource(nameof(CodeFixData))] TestCaseData data)
+        public void Code_gets_fixed_for_summary_by_wrapping_keywords_in_see_langword_tags_([ValueSource(nameof(CodeFixData))] TestCaseData data)
         {
             const string Template = @"
 /// <summary>
@@ -288,7 +288,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_in_combined_summary()
+        public void Code_gets_fixed_for_summary_containing_multiple_keywords_by_wrapping_each_in_see_langword_tags()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -312,7 +312,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_wrong_documentation_on_parameter_([Values(":", ",", "")] string delimiter)
+        public void Code_gets_fixed_for_parameter_documentation_by_wrapping_True_and_False_in_see_langword_tags_([Values(":", ",", "")] string delimiter)
         {
             var originalCode = @"
 public sealed class TestMe
@@ -340,7 +340,7 @@ public sealed class TestMe
         }
 
         [Test]
-        public void CodeFix_keeps_space_after_see_comment()
+        public void Code_gets_fixed_by_preserving_space_after_existing_see_langword_tag()
         {
             const string OriginalCode = @"
 /// <returns><see langword=""true""/> if something, false else.</returns>
@@ -360,7 +360,7 @@ public class TestMe
         }
 
         [Test]
-        public void CodeFix_keeps_source_code_comment_untouched()
+        public void Code_gets_fixed_by_wrapping_keywords_outside_code_tag_while_preserving_code_content()
         {
             const string OriginalCode = @"
 /// <example>
@@ -394,7 +394,7 @@ public class TestMe
         }
 
         [Test]
-        public void CodeFix_keeps_other_text_inside_c_([ValueSource(nameof(Terms))] string term)
+        public void Code_gets_fixed_by_wrapping_keywords_outside_c_tag_while_preserving_c_tag_content_([ValueSource(nameof(Terms))] string term)
         {
             var originalCode = @"
 public sealed class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2043_DelegateSummaryAnalyzerTests.cs
@@ -41,7 +41,7 @@ public delegate void TestMe();
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_delegate() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_delegate_with_standard_summary_phrase() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -52,7 +52,7 @@ public delegate void TestMe();
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_delegate() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_delegate_with_non_standard_summary_phrase() => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -63,7 +63,7 @@ public delegate void TestMe();
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_delegate_with_see_cref() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_delegate_starting_with_see_cref() => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2044_InvalidSeeParameterInXmlAnalyzerTests.cs
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_without_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_without_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_see_cref_parameter_references() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([Values("see", "seealso")] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_see_cref_referencing_parameter_([Values("see", "seealso")] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -61,7 +61,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_tag_([Values("see", "seealso")] string tag)
+        public void Code_gets_fixed_by_replacing_see_cref_with_paramref_([Values("see", "seealso")] string tag)
         {
             var originalCode = @"
 public class TestMe
@@ -87,7 +87,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_multiple_tags_([Values("see", "seealso")] string tag)
+        public void Code_gets_fixed_by_replacing_multiple_see_cref_with_paramref_([Values("see", "seealso")] string tag)
         {
             var originalCode = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2045_InvalidParameterReferenceInSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2045_InvalidParameterReferenceInSummaryAnalyzerTests.cs
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_without_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_without_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_parameter_references_in_summary() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -49,7 +49,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([Values("param", "paramref")] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_tag_in_summary_([Values("param", "paramref")] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -62,7 +62,7 @@ public class TestMe
 ");
 
         [Test]
-        public void A_single_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
+        public void A_single_issue_is_reported_for_param_tag_in_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -75,7 +75,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_empty_([Values("param", "paramref")] string tag)
+        public void Code_gets_fixed_by_replacing_self_closing_tag_with_parameter_name_([Values("param", "paramref")] string tag)
         {
             const string Template = @"
 using System;
@@ -93,7 +93,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_([Values("param", "paramref")] string tag)
+        public void Code_gets_fixed_by_replacing_tag_pair_with_parameter_name_([Values("param", "paramref")] string tag)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2046_InvalidTypeParameterReferenceInXmlAnalyzerTests.cs
@@ -42,7 +42,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_summary_on_method_without_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_summary_on_non_generic_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -56,7 +56,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_summary_on_generic_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_summary_on_generic_method_without_type_parameter_reference() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -70,7 +70,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_summary_on_generic_method_with_see_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_generic_method_with_see_langword_tag() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -87,7 +87,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_summary_on_non_generic_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_summary_on_method_in_generic_type_without_type_parameter_reference() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe<T> where T : class
@@ -101,7 +101,7 @@ public class TestMe<T> where T : class
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_summary_on_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_generic_type_with_typeparamref_tag() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -115,7 +115,7 @@ public class TestMe<T> where T: class
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_on_generic_method_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_generic_method_referencing_type_parameter_using_tag_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -129,7 +129,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_on_non_generic_method_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_in_generic_type_referencing_type_parameter_in_summary_using_tag_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe<T> where T : class
@@ -143,7 +143,7 @@ public class TestMe<T> where T : class
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_returnValue_on_non_generic_method_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_in_generic_type_referencing_type_parameter_in_returns_using_tag_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe<T> where T : class
@@ -156,7 +156,7 @@ public class TestMe<T> where T : class
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_exception_on_non_generic_method_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_in_generic_type_referencing_type_parameter_in_exception_using_tag_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe<T> where T : class
@@ -169,7 +169,7 @@ public class TestMe<T> where T : class
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_on_generic_type_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_generic_type_referencing_type_parameter_using_tag_([ValueSource(nameof(WrongTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -183,7 +183,7 @@ public class TestMe<T> where T: class
 ");
 
         [Test]
-        public void Code_gets_fixed_for_([ValueSource(nameof(WrongTags))] string tag)
+        public void Code_gets_fixed_by_replacing_tag_with_typeparamref_([ValueSource(nameof(WrongTags))] string tag)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzerTests.cs
@@ -43,7 +43,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_will_phrases() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>Does something.</summary>
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [TestCase("Something not willing to do anything.")]
-        public void No_issue_is_reported_for_specific_comment_(string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_willing_word_not_used_as_future_tense_(string phrase) => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>" + phrase + @"</summary>
@@ -79,7 +79,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">" + phrase + "</" + tag + @">
@@ -89,7 +89,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -100,7 +100,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -111,7 +111,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_event_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -122,7 +122,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_field_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -133,7 +133,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_interface_property_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_property_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public interface ITestMe
@@ -144,7 +144,7 @@ public interface ITestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_interface_indexer_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_indexer_containing_will_phrase_in_tag_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public interface ITestMe
@@ -156,7 +156,7 @@ public interface ITestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_gets_reported() => An_issue_is_reported_for(3, @"
+        public void An_issue_gets_reported_for_multiple_will_phrases_in_documentation() => An_issue_is_reported_for(3, @"
 using System;
 
 public interface ITestMe
@@ -216,7 +216,7 @@ public interface ITestMe
         [TestCase("The manager will not create any issues.", "The manager does not create any issues.")]
         [TestCase("The managers will not create any issues.", "The managers do not create any issues.")]
         [TestCase("The managers will be successful.", "The managers are successful.")]
-        public void Code_gets_fixed_(string originalPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_converting_future_tense_to_present_tense_(string originalPhrase, string fixedPhrase)
         {
             const string Template = @"
 using System;
@@ -232,7 +232,7 @@ public interface ITestMe
         }
 
         [TestCase("This will start", "This starts", @"The return value will be <see langword=""false""/>.", @"The return value is <see langword=""false""/>.")]
-        public void Code_gets_fixed_when_on_separate_lines_(string originalPhrase, string fixedPhrase, string originalReturn, string fixedReturn)
+        public void Code_gets_fixed_by_converting_multiple_will_phrases_to_present_tense_(string originalPhrase, string fixedPhrase, string originalReturn, string fixedReturn)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2050_ExceptionSummaryAnalyzerTests.cs
@@ -84,7 +84,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_exception_with_standard_documentation() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -153,7 +153,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_type() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_exception_type_with_standard_summary() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -168,7 +168,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_type() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_exception_type() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -180,7 +180,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_without_params() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_parameterless_exception_constructor_with_standard_documentation() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -203,7 +203,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_without_params() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_parameterless_exception_constructor() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -218,7 +218,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_but_missing_overloads_exception_ctor_without_params() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_parameterless_exception_constructor_without_overloads() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -236,7 +236,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_message_only_exception_constructor_with_standard_documentation() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -258,7 +258,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_only_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_message_only_exception_constructor() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -274,7 +274,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_message_and_inner_exception_constructor_with_standard_documentation() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -300,7 +300,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_message_and_exception_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_message_and_inner_exception_constructor() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -315,7 +315,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_serialization_constructor_with_standard_documentation() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -343,7 +343,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_non_documented_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_undocumented_serialization_constructor() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -359,7 +359,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_but_missing_remarks_exception_ctor_with_serialization_param() => No_issue_is_reported_for("""
+        public void No_issue_is_reported_for_serialization_constructor_without_remarks() => No_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -384,7 +384,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_exception_type() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_exception_type_with_non_standard_summary() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -399,7 +399,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_overloads_on_exception_ctor_without_params() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_parameterless_exception_constructor_with_non_standard_overloads() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -422,7 +422,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_message_only_exception_constructor_with_non_standard_summary() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -444,7 +444,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_only_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_message_only_exception_constructor_with_non_standard_message_param_documentation() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -466,7 +466,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_message_and_inner_exception_constructor_with_non_standard_summary() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -492,7 +492,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_message_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_message_and_inner_exception_constructor_with_non_standard_message_param_documentation() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -518,7 +518,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_exception_param_of_exception_ctor_with_message_and_exception_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_message_and_inner_exception_constructor_with_non_standard_inner_exception_param_documentation() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -544,7 +544,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_summary_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_serialization_constructor_with_non_standard_summary() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -575,7 +575,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_SerializationInfo_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_serialization_constructor_with_non_standard_info_param_documentation() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -603,7 +603,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_StreamingContext_param_of_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_serialization_constructor_with_non_standard_context_param_documentation() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;
@@ -631,7 +631,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             """);
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_remarks_on_exception_ctor_with_serialization_param() => An_issue_is_reported_for("""
+        public void An_issue_is_reported_for_serialization_constructor_with_non_standard_remarks() => An_issue_is_reported_for("""
 
             using System;
             using System.Runtime.Serialization;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2051_ExceptionTagDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2051_ExceptionTagDefaultPhraseAnalyzerTests.cs
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_([ValueSource(nameof(ExceptionTypes))] string exceptionType) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_exception_starting_with_paramref_([ValueSource(nameof(ExceptionTypes))] string exceptionType) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -66,9 +66,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_(
-                                                                                    [ValueSource(nameof(ExceptionTypes))] string exceptionType,
-                                                                                    [ValueSource(nameof(ForbiddenExceptionStartingPhrases))] string startingPhrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_exception_starting_with_forbidden_phrase_(
+                                                                                   [ValueSource(nameof(ExceptionTypes))] string exceptionType,
+                                                                                   [ValueSource(nameof(ForbiddenExceptionStartingPhrases))] string startingPhrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -84,7 +84,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_para_tag_throwing_an_ObjectDisposedException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ObjectDisposedException_with_forbidden_phrase_inside_para_tag() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -102,134 +102,134 @@ public class TestMe
 ");
 
         [TestCase(nameof(Exception), "If it's ", "It's ")]
-        [TestCase(nameof(Exception), @"Gets thrown when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"gets thrown when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"in case <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"In case <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"In case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Is thrown when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Thrown if <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
+        [TestCase(nameof(Exception), """Gets thrown when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """gets thrown when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """in case <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """In case <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """In case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Is thrown when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Thrown if <paramref name="o"/> """, """<paramref name="o"/> """)]
         [TestCase(nameof(Exception), "Thrown if any error ", "Any error ")]
-        [TestCase(nameof(Exception), @"Thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Thrown when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Throws if <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Throws if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Throws when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Throws when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"thrown if <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
+        [TestCase(nameof(Exception), """Thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Thrown when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Throws if <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Throws if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Throws when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Throws when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """thrown if <paramref name="o"/> """, """<paramref name="o"/> """)]
         [TestCase(nameof(Exception), "thrown if any error ", "Any error ")]
-        [TestCase(nameof(Exception), @"thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"thrown when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"throws if <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"throws if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"throws when <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception that will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception which will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"The exception will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"This exception will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that is thrown in case that the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that is thrown in case which the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception that will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"A exception which will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception that will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"An exception which will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that gets thrown in case that the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that gets thrown in case which the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception that will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which gets thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which gets thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which gets thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which is thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which is thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which is thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which will be thrown if the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which will be thrown in case the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which will be thrown in case that the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which will be thrown in case which the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
-        [TestCase(nameof(Exception), @"Exception which will be thrown when the <paramref name=""o""/> ", @"<paramref name=""o""/> ")]
+        [TestCase(nameof(Exception), """thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """thrown when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """throws if <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """throws if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """throws when <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception that will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception which will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """The exception will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """This exception will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that is thrown in case that the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that is thrown in case which the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception that will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """A exception which will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception that will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """An exception which will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that gets thrown in case that the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that gets thrown in case which the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception that will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which gets thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which gets thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which gets thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which is thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which is thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which is thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which will be thrown if the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which will be thrown in case the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which will be thrown in case that the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which will be thrown in case which the <paramref name="o"/> """, """<paramref name="o"/> """)]
+        [TestCase(nameof(Exception), """Exception which will be thrown when the <paramref name="o"/> """, """<paramref name="o"/> """)]
         [TestCase(nameof(InvalidOperationException), "Throw in case that the file cannot be converted to the ", "The file cannot be converted to the ")]
         [TestCase(nameof(InvalidOperationException), "Throw in case that a module cannot be loaded into ", "A module cannot be loaded into ")]
         [TestCase(nameof(InvalidOperationException), "Thrown in case that the file cannot be converted to the ", "The file cannot be converted to the ")]
         [TestCase(nameof(InvalidOperationException), "Thrown in case that a module cannot be loaded into ", "A module cannot be loaded into ")]
-        public void Code_gets_fixed_for_(string exceptionType, string startingPhrase, string fixedPhrase)
+        public void Code_gets_fixed_by_removing_forbidden_starting_phrase_(string exceptionType, string startingPhrase, string fixedPhrase)
         {
             var originalCode = @"
 using System;
@@ -272,7 +272,7 @@ public class TestMe
         [TestCase("Thrown when the")]
         [TestCase("Throws if the")]
         [TestCase("Throws when the")]
-        public void Code_gets_fixed_for_ObjectDisposedException_(string startingPhrase)
+        public void Code_gets_fixed_by_replacing_with_standard_ObjectDisposedException_phrase_(string startingPhrase)
         {
             var originalCode = @"
 using System;
@@ -308,7 +308,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ObjectDisposedException_with_para_tag()
+        public void Code_gets_fixed_by_replacing_with_standard_ObjectDisposedException_phrase_removing_para_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -353,7 +353,7 @@ public class TestMe
         [TestCase("System." + nameof(ArgumentNullException), @"If <paramref name=""o""/> is null")]
         [TestCase("System." + nameof(ArgumentNullException), @"If <paramref name=""o""/> is <see langword=""null""/>")]
         [TestCase("System." + nameof(ArgumentNullException), @"If the <paramref name=""o""/> is <see langword=""null""/>.")]
-        public void Code_gets_fixed_for_ArgumentNullException_and_single_parameter_(string exceptionType, string text)
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentNullException_phrase_for_single_parameter_(string exceptionType, string text)
         {
             var originalCode = @"
 using System;
@@ -389,7 +389,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentNullException_and_2_referenced_parameters()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentNullException_phrase_for_multiple_parameters()
         {
             const string OriginalCode = @"
 using System;
@@ -427,7 +427,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentNullException_and_2_parameters_but_only_1_referenced_one()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentNullException_phrase_for_single_referenced_parameter()
         {
             const string OriginalCode = @"
 using System;
@@ -469,7 +469,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentNullException_and_3_parameters_but_only_2_referenced_ones_variant_1()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentNullException_phrase_for_referenced_parameters_variant_1()
         {
             const string OriginalCode = @"
 using System;
@@ -507,7 +507,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentNullException_and_3_parameters_but_only_2_referenced_ones_variant_2()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentNullException_phrase_for_referenced_parameters_variant_2()
         {
             const string OriginalCode = @"
 using System;
@@ -545,7 +545,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentOutOfRangeException_and_method_with_1_parameter()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentOutOfRangeException_phrase_for_single_parameter()
         {
             const string OriginalCode = @"
 using System;
@@ -581,7 +581,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentOutOfRangeException_and_method_with_3_parameters_but_only_1_mentioned()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentOutOfRangeException_phrase_for_single_mentioned_parameter()
         {
             const string OriginalCode = @"
 using System;
@@ -617,7 +617,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentOutOfRangeException_and_method_with_3_parameters_but_only_2_mentioned()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentOutOfRangeException_phrase_for_two_mentioned_parameters()
         {
             const string OriginalCode = @"
 using System;
@@ -653,7 +653,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentOutOfRangeException_and_method_with_3_parameters_and_all_3_mentioned()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentOutOfRangeException_phrase_for_three_mentioned_parameters()
         {
             const string OriginalCode = @"
 using System;
@@ -689,7 +689,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentException_on_property_indexer()
+        public void Code_gets_fixed_by_replacing_with_standard_ArgumentException_phrase_for_indexer()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2052_ArgumentNullExceptionPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2052_ArgumentNullExceptionPhraseAnalyzerTests.cs
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_with_standard_phrase_for_single_parameter() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -53,7 +53,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException_for_Nullable_struct() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_with_standard_phrase_for_Nullable_struct() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException_for_multiple_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_with_standard_phrase_for_multiple_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -87,7 +87,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentNullException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_with_non_standard_phrase() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -103,7 +103,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentNullException_for_Nullable_struct() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_with_non_standard_phrase_for_Nullable_struct() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -119,7 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentNullException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -135,7 +135,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_1st_parameter_throwing_an_ArgumentNullException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_with_non_standard_phrase_for_first_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -153,7 +153,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_2nd_parameter_throwing_an_ArgumentNullException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_with_non_standard_phrase_for_second_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -210,7 +210,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_property_throwing_an_ArgumentNullException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_ArgumentNullException_with_standard_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -226,7 +226,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentNullException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentNullException_with_non_standard_phrase() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -242,7 +242,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentNullException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentNullException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -258,7 +258,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_generic_type_that_is_a_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_generic_class_constrained_method_with_ArgumentNullException_with_standard_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -289,7 +289,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_generic_type_that_is_a_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_generic_class_constrained_method_with_ArgumentNullException_with_non_standard_phrase() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -329,7 +329,7 @@ public class TestMe
         [TestCase("System." + nameof(ArgumentNullException), @"If <paramref name=""o""/> is <see langword=""null""/>")]
         [TestCase("System." + nameof(ArgumentNullException), @"If the <paramref name=""o""/> is <see langword=""null""/>.")]
         [TestCase("System." + nameof(ArgumentNullException), @"The <paramref name=""o""/> is <see langword=""null""/>.")]
-        public void Code_gets_fixed_for_single_parameter_(string exceptionType, string text)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_single_parameter_(string exceptionType, string text)
         {
             var originalCode = @"
 using System;
@@ -365,7 +365,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_2_referenced_parameters()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_multiple_parameters()
         {
             const string OriginalCode = @"
 using System;
@@ -403,7 +403,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_ArgumentNullException_only_and_2_available_parameters_but_only_1_referenced_one()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_only_referenced_parameter_when_multiple_exceptions()
         {
             const string OriginalCode = @"
 using System;
@@ -445,7 +445,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_3_parameters_but_only_2_referenced_ones_variant_1()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_only_referenced_parameters_variant_1()
         {
             const string OriginalCode = @"
 using System;
@@ -483,7 +483,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_3_parameters_but_only_2_referenced_ones_variant_2()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_only_referenced_parameters_variant_2()
         {
             const string OriginalCode = @"
 using System;
@@ -521,7 +521,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_property()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_property_setter()
         {
             const string OriginalCode = @"
 using System;
@@ -557,7 +557,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_property_indexer()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_indexer()
         {
             const string OriginalCode = @"
 using System;
@@ -593,7 +593,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_exception()
+        public void Code_gets_fixed_by_adding_standard_phrase_for_empty_ArgumentNullException()
         {
             const string OriginalCode = @"
 using System;
@@ -621,7 +621,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_exception_on_for_method_with_multiple_parameters_and_additional_struct_parameter_set_to_default()
+        public void Code_gets_fixed_by_adding_standard_phrase_for_empty_ArgumentNullException_ignoring_struct_parameters()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2053_ArgumentNullExceptionWrongParameterInPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2053_ArgumentNullExceptionWrongParameterInPhraseAnalyzerTests.cs
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException_for_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_documenting_class_parameter() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_para_tags_throwing_an_ArgumentNullException_for_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_documenting_class_parameter_inside_para_tags() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -68,7 +68,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException_for_Nullable_struct() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_documenting_Nullable_struct_parameter() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -84,7 +84,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentNullException_for_multiple_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_documenting_multiple_nullable_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -102,7 +102,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentNullException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_documenting_non_nullable_struct_parameter() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -118,7 +118,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_para_tags_throwing_an_ArgumentNullException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_documenting_non_nullable_struct_parameter_inside_para_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -136,7 +136,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_1st_parameter_throwing_an_ArgumentNullException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_documenting_non_nullable_struct_as_first_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -154,7 +154,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_2nd_parameter_throwing_an_ArgumentNullException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_documenting_non_nullable_struct_as_second_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -211,7 +211,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_property_throwing_an_ArgumentNullException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_ArgumentNullException_for_class_type() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -227,7 +227,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentNullException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentNullException_for_non_nullable_struct_type() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -243,7 +243,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_generic_type_that_is_a_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_generic_class_constrained_parameter() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -274,7 +274,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_generic_type_that_is_a_struct() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_generic_struct_constrained_parameter() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2054_ArgumentExceptionPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2054_ArgumentExceptionPhraseAnalyzerTests.cs
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentException_([Values("is", "does", "has", "contains")] string phrase) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentException_starting_with_paramref_and_verb_([Values("is", "does", "has", "contains")] string phrase) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentException_for_multiple_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentException_starting_with_paramref_and_verb_for_multiple_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_not_starting_with_paramref() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_1st_parameter_throwing_an_ArgumentException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_not_starting_with_paramref_for_first_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -119,7 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_2nd_parameter_throwing_an_ArgumentException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_not_starting_with_paramref_for_second_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -176,7 +176,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_property_throwing_an_ArgumentException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_ArgumentException_starting_with_paramref_and_verb() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -192,7 +192,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentException_not_starting_with_paramref() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -208,7 +208,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -224,7 +224,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_if_an_ArgumentException_is_thrown_only_for_one_of_muliple_referenced_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentException_comparing_multiple_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -240,7 +240,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method()
+        public void Code_gets_fixed_by_replacing_with_paramref_starting_phrase_for_method()
         {
             const string OriginalCode = @"
 using System;
@@ -276,7 +276,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_property_indexer()
+        public void Code_gets_fixed_by_replacing_with_paramref_starting_phrase_for_indexer()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2055_ArgumentOutOfRangeExceptionPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2055_ArgumentOutOfRangeExceptionPhraseAnalyzerTests.cs
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentOutOfRangeException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentOutOfRangeException_starting_with_paramref() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_throwing_an_ArgumentOutOfRangeException_for_multiple_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentOutOfRangeException_starting_with_paramref_for_multiple_parameters() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentOutOfRangeException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentOutOfRangeException_not_starting_with_paramref() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_throwing_an_ArgumentOutOfRangeException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentOutOfRangeException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_1st_parameter_throwing_an_ArgumentOutOfRangeException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentOutOfRangeException_not_starting_with_paramref_for_first_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -119,7 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_2nd_parameter_throwing_an_ArgumentOutOfRangeException_for_multiple_parameters() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentOutOfRangeException_not_starting_with_paramref_for_second_of_multiple_parameters() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -176,7 +176,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_property_throwing_an_ArgumentOutOfRangeException() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_ArgumentOutOfRangeException_starting_with_paramref() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -192,7 +192,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentOutOfRangeException() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentOutOfRangeException_not_starting_with_paramref() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -208,7 +208,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_throwing_an_ArgumentOutOfRangeException_without_paramref_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_ArgumentOutOfRangeException_without_paramref_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -224,7 +224,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method_with_1_parameter()
+        public void Code_gets_fixed_by_replacing_with_paramref_starting_phrase()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2056_ObjectDisposedExceptionPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2056_ObjectDisposedExceptionPhraseAnalyzerTests.cs
@@ -24,7 +24,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_method_without_exception_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_without_exception_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -39,7 +39,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_method_with_exception_docu_for_other_exception() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_with_other_exception_type() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_with_standard_disposed_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -71,7 +71,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_para_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_with_standard_disposed_phrase_inside_para_tag() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -91,7 +91,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ObjectDisposedException_with_non_standard_phrase() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -107,7 +107,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_para_tags() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ObjectDisposedException_with_non_standard_phrase_inside_para_tags() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -123,7 +123,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_Close_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_with_standard_closed_phrase_when_Close_method_exists() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -143,7 +143,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_Close_method_in_base_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_with_standard_closed_phrase_when_Close_method_exists_in_base_class() => No_issue_is_reported_for(@"
 using System;
 
 public class Base
@@ -166,7 +166,7 @@ public class TestMe : Base
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_Close_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ObjectDisposedException_with_non_standard_phrase_when_Close_method_exists() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -186,7 +186,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_fully_qualified_exception()
+        public void Code_gets_fixed_by_replacing_with_standard_disposed_phrase_for_fully_qualified_exception()
         {
             const string OriginalCode = @"
 using System;
@@ -221,7 +221,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_named_exception()
+        public void Code_gets_fixed_by_replacing_with_standard_disposed_phrase()
         {
             const string OriginalCode = @"
 using System;
@@ -256,7 +256,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_exception_with_Close_method()
+        public void Code_gets_fixed_by_replacing_with_standard_closed_phrase_when_Close_method_exists()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2057_ObjectDisposedExceptionWrongPlacedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2057_ObjectDisposedExceptionWrongPlacedAnalyzerTests.cs
@@ -24,7 +24,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_method_without_exception_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_without_exception_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -39,7 +39,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_method_with_exception_docu_for_other_exception() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_exception_documentation_for_other_exception() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_in_IDisposable_type() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe : IDisposable
@@ -73,7 +73,7 @@ public class TestMe : IDisposable
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ObjectDisposedException_in_non_IDisposable_type() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -89,7 +89,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_Dispose_in_base_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ObjectDisposedException_when_base_class_implements_IDisposable() => No_issue_is_reported_for(@"
 using System;
 
 public class Base : IDisposable
@@ -114,7 +114,7 @@ public class TestMe : Base
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_by_removing_ObjectDisposedException_documentation()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -53,7 +53,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_class_with_standard_summary_phrase() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -99,7 +99,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_method_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_standard_summary_phrase_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
 using System;
 
 public class Whatever : IWhatever
@@ -120,7 +120,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_method_on_generic_type_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_standard_summary_phrase_for_generic_type_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
 using System;
 
 public class Whatever<T> : IWhatever<T>
@@ -141,7 +141,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_method_on_generic_collection_type_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_standard_summary_phrase_for_generic_collection_type_([Values(" ", "")] string gap) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -163,7 +163,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_method_on_string() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_standard_summary_phrase_for_string() => No_issue_is_reported_for(@"
 public class TestMeFactory
 {
     /// <summary>
@@ -174,7 +174,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_factory_method_on_generic_string_collection() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_standard_summary_phrase_for_string_collection() => No_issue_is_reported_for(@"
 using System.Collections.Generic;
 
 public class TestMeFactory
@@ -187,7 +187,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_factory_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_class_with_non_standard_summary_phrase() => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -199,7 +199,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_factory_method_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_method_with_non_standard_summary_phrase_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
 using System;
 
 public class Whatever : IWhatever
@@ -220,7 +220,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_factory_method_on_generic_type_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_method_with_non_standard_summary_phrase_for_generic_type_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
 using System;
 
 public class Whatever<T> : IWhatever<T>
@@ -241,7 +241,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_factory_method_on_generic_collection_type_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_method_with_non_standard_summary_phrase_for_generic_collection_type_([Values(" ", "")] string gap) => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -263,7 +263,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void Code_gets_fixed_for_class_summary_([ValueSource(nameof(ClassSummaryStartingPhrases))] string summary)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_factory_class_summary_([ValueSource(nameof(ClassSummaryStartingPhrases))] string summary)
         {
             var originalCode = @"
 /// <summary>
@@ -289,7 +289,7 @@ public class TestMeFactory
         }
 
         [Test]
-        public void Code_gets_fixed_for_interface_summary_([ValueSource(nameof(InterfaceSummaryStartingPhrases))] string summary)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_factory_interface_summary_([ValueSource(nameof(InterfaceSummaryStartingPhrases))] string summary)
         {
             var originalCode = @"
 /// <summary>
@@ -327,7 +327,7 @@ public interface ITestMeFactory
         [TestCase("Used for creating a")]
         [TestCase("Used to create a")]
         [TestCase(@"Creates an <see cref=""string""/> with a")]
-        public void Code_gets_fixed_for_method_summary_(string summary)
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_factory_method_summary_(string summary)
         {
             var originalCode = @"
 public class TestMeFactory
@@ -353,7 +353,7 @@ public class TestMeFactory
         }
 
         [Test]
-        public void Code_gets_fixed_for_specific_method_summary_that_continues_with_based_on()
+        public void Code_gets_fixed_by_replacing_based_on_with_default_values_for()
         {
             const string OriginalCode = @"
 public class TestMeFactory
@@ -382,7 +382,7 @@ public class TestMeFactory
         [TestCase("Create a factory")]
         [TestCase("Creates an instance of <see cref=\"string\"/>")]
         [TestCase("Create an instance of <see cref=\"string\"/>")]
-        public void Code_gets_fixed_for_specific_method_summary_that_continues_with_that_(string phrase)
+        public void Code_gets_fixed_by_replacing_continuation_that_with_default_values_that_(string phrase)
         {
             var originalCode = @"
 public class TestMeFactory
@@ -408,7 +408,7 @@ public class TestMeFactory
         }
 
         [Test]
-        public void Code_gets_fixed_for_collection_method_summary()
+        public void Code_gets_fixed_by_replacing_with_standard_phrase_for_collection_factory_method()
         {
             const string OriginalCode = @"
 using System;
@@ -468,7 +468,7 @@ internal interface IFactory
         }
 
         [Test]
-        public void Code_gets_fixed_for_almost_correct_method_summary_starting_phrase_([ValueSource(nameof(MethodStartingPhrases))] string summary, [Values("class", "type")] string type)
+        public void Code_gets_fixed_by_normalizing_almost_standard_factory_method_summary_([ValueSource(nameof(MethodStartingPhrases))] string summary, [Values("class", "type")] string type)
         {
             var originalCode = @"
 internal interface IFactory
@@ -494,7 +494,7 @@ internal interface IFactory
         }
 
         [Test]
-        public void Code_gets_fixed_for_almost_correct_interface_summary_starting_phrase_([ValueSource(nameof(MethodStartingPhrases))] string summary, [Values("class", "type")] string type)
+        public void Code_gets_fixed_by_normalizing_almost_standard_factory_interface_summary_([ValueSource(nameof(MethodStartingPhrases))] string summary, [Values("class", "type")] string type)
         {
             var originalCode = @"
 /// <summary>
@@ -597,13 +597,13 @@ internal interface IFactory
                                    "Represents methods",
                                    "Represents",
                                    //// "The class containing factory methods", // we do not test them to limit number of tests
-                                   //// "The class containing methods", // we do not test them to limit number of tests
+   //// "The class containing methods", // we do not test them to limit number of tests
                                    "The class contains factory methods",
                                    "The class contains methods",
                                    "The class provides factory methods",
                                    "The class provides methods",
                                    //// "The class providing factory methods", // we do not test them to limit number of tests
-                                   //// "The class providing methods", // we do not test them to limit number of tests
+   //// "The class providing methods", // we do not test them to limit number of tests
                                    "The class that contains factory methods",
                                    "The class that contains methods",
                                    "The class that provides factory methods",

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2070_ReturnsSummaryAnalyzerTests.cs
@@ -54,7 +54,7 @@ public class TestMe : IEnumerable
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_summary_of_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_summary() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary></summary>
@@ -65,7 +65,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_summary_not_starting_with_Returns() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -104,7 +104,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_method_that_starts_with_see_cref() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_starting_with_see_cref() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -117,7 +117,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_property_that_starts_with_see_cref() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_starting_with_see_cref() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -128,7 +128,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([Values("Return", "Returns", "return", "returns")] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_summary_starting_with_Returns_([Values("Return", "Returns", "return", "returns")] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -141,7 +141,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([Values("Return", "Returns", "return", "returns")] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_summary_starting_with_Returns_([Values("Return", "Returns", "return", "returns")] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -152,7 +152,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_non_boolean_property_summary()
+        public void Code_gets_fixed_by_replacing_Returns_with_Gets_for_non_boolean_property()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -184,7 +184,7 @@ public class TestMe
         [TestCase(@"Returns <see langword=""true""/> whether")]
         [TestCase(@"Returns <see langref=""true""/> if")]
         [TestCase(@"Returns <see langref=""true""/> whether")]
-        public void Code_gets_fixed_for_boolean_property_summary_(string startPhrase)
+        public void Code_gets_fixed_by_replacing_Returns_with_Gets_a_value_indicating_whether_for_boolean_property_(string startPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -220,7 +220,7 @@ public class TestMe
         [TestCase(@"Returns <see langword=""true""/> whether")]
         [TestCase(@"Returns <see langref=""true""/> if")]
         [TestCase(@"Returns <see langref=""true""/> whether")]
-        public void Code_gets_fixed_for_boolean_method_summary_(string startPhrase)
+        public void Code_gets_fixed_by_replacing_Returns_with_Determines_whether_for_boolean_method_(string startPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -251,7 +251,7 @@ public class TestMe
         [TestCase(@"Returns <see langword=""false""/> whether")]
         [TestCase(@"Returns <see langref=""false""/> if")]
         [TestCase(@"Returns <see langref=""false""/> whether")]
-        public void Code_gets_not_fixed_for_boolean_method_summary_starting_with_false_(string startPhrase)
+        public void Code_does_not_get_fixed_for_boolean_method_starting_with_Returns_false_(string startPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -283,7 +283,7 @@ public class TestMe
         [TestCase(@"Returns <see langword=""true""/> whether")]
         [TestCase(@"Returns <see langref=""true""/> if")]
         [TestCase(@"Returns <see langref=""true""/> whether")]
-        public void Code_gets_fixed_for_boolean_async_method_summary_(string startPhrase)
+        public void Code_gets_fixed_by_replacing_Returns_with_Asynchronously_determines_whether_for_boolean_async_method_(string startPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -309,7 +309,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_boolean_Task_method_summary()
+        public void Code_gets_fixed_by_replacing_Returns_with_Asynchronously_determines_whether_for_boolean_Task_method()
         {
             const string OriginalCode = @"
 using System.Threading.Tasks;
@@ -339,7 +339,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_boolean_method_summary()
+        public void Code_gets_fixed_by_replacing_Returns_with_Gets_for_non_boolean_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -365,7 +365,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_boolean_async_method_summary()
+        public void Code_gets_fixed_by_replacing_Asynchronously_returns_with_Asynchronously_gets_for_non_boolean_async_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -391,7 +391,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_boolean_Task_method_summary()
+        public void Code_gets_fixed_by_replacing_Returns_with_Asynchronously_gets_for_non_boolean_Task_method()
         {
             const string OriginalCode = @"
 using System.Threading.Tasks;
@@ -421,7 +421,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_and_space_before_link_is_kept()
+        public void Code_gets_fixed_and_preserves_spacing_before_see_cref()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -468,7 +468,7 @@ public class TestMe
         [TestCase(@", otherwise; <see langref=""false""/>")]
         [TestCase(@", otherwise, <see langref=""false""/>")]
         [TestCase(@", otherwise <see langref=""false""/>")]
-        public void Code_gets_fixed_for_ending_phrase_(string phrase)
+        public void Code_gets_fixed_by_removing_ending_phrase_(string phrase)
         {
             var originalCode = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2071_EnumMethodSummaryAnalyzerTests.cs
@@ -33,7 +33,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_members_without_boolean_phrases() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(BooleanPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_method_with_boolean_indicating_phrase_([ValueSource(nameof(BooleanPhrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -78,7 +78,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([ValueSource(nameof(BooleanPhrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_property_with_boolean_indicating_phrase_([ValueSource(nameof(BooleanPhrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2072_TrySummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2072_TrySummaryAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2072_TrySummaryAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_Try_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool TryDoSomething()
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_summary_of_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_method_with_empty_summary() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary></summary>
@@ -33,7 +33,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Try_method_with_summary_that_does_not_start_with_Try_or_Tries() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -46,7 +46,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_that_starts_documentation_with_see_cref() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Try_method_with_summary_starting_with_see_cref() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -59,7 +59,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_Try_method_([Values("Try", "Tries")] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Try_method_with_summary_starting_with_phrase_([Values("Try", "Tries")] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -72,7 +72,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_async_Try_method_([Values("try", "tries")] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_Try_method_with_summary_containing_asynchronously_and_phrase_([Values("try", "tries")] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_non_Try_method_([Values("Try", "Tries")] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_Try_method_with_summary_starting_with_phrase_([Values("Try", "Tries")] string phrase) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -98,7 +98,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_([Values("Try to", "Tries to")] string startPhrase)
+        public void Code_gets_fixed_to_phrase_Attempts_to_instead_of_phrase_([Values("Try to", "Tries to")] string startPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -124,7 +124,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_Async()
+        public void Code_gets_fixed_to_replace_Asynchronously_tries_with_Asynchronously_attempts()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -150,7 +150,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_in_middle()
+        public void Code_gets_fixed_to_replace_multiple_occurrences_of_tries_with_attempts()
         {
             const string OriginalCode = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2073_ContainsMethodSummaryDefaultPhraseAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] MethodNames = ["Contains", "ContainsKey", "ContainsValue"];
 
         [Test]
-        public void No_issue_is_reported_for_undocumented_method_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_Contains_method_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool " + methodName + @"()
@@ -24,7 +24,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Contains_method_with_summary_not_starting_with_Determines_whether_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_see_cref_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Contains_method_with_see_cref_not_followed_by_Determines_whether_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_async_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_Contains_method_with_summary_not_containing_Determines_whether_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_documented_non_Contains_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_Contains_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -76,7 +76,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Contains_method_with_summary_starting_with_Determines_whether_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -89,7 +89,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_documented_async_method_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_Contains_method_with_summary_containing_Determines_whether_([ValueSource(nameof(MethodNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -102,7 +102,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_to_start_summary_with_Determines_whether()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -128,7 +128,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_async_phrase()
+        public void Code_gets_fixed_to_replace_Asynchronously_does_with_Asynchronously_determines_whether()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -154,7 +154,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_Determines_if_phrase()
+        public void Code_gets_fixed_to_replace_Determines_if_with_Determines_whether()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -180,7 +180,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_Checks_if_phrase_with_dot_directly_after_XML_tag()
+        public void Code_gets_fixed_to_replace_Checks_if_with_Determines_whether_when_dot_directly_after_XML_tag()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -206,7 +206,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_phrase_with_spaces_on_same_line()
+        public void Code_gets_fixed_for_empty_summary_with_spaces_on_same_line()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -230,7 +230,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_phrase_without_contents_on_same_line()
+        public void Code_gets_fixed_for_empty_summary_without_contents_on_same_line()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -254,7 +254,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_phrase_without_contents_on_different_lines()
+        public void Code_gets_fixed_for_empty_summary_without_contents_on_different_lines()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -279,7 +279,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_phrase_without_leading_space()
+        public void Code_gets_fixed_for_empty_summary_without_leading_space()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -305,7 +305,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_phrase_with_leading_space()
+        public void Code_gets_fixed_for_empty_summary_with_leading_space()
         {
             const string OriginalCode = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2074_ContainsParameterDefaultPhraseAnalyzerTests.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                            ];
 
         [Test]
-        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_Contains_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool Contains()
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_documented_method_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
+        public void No_issue_is_reported_for_documented_parameter_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
             => No_issue_is_reported_for(@"
 public class TestMe
 {
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_documented_method_with_multiple_parameters_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
+        public void No_issue_is_reported_for_documented_parameter_on_method_with_multiple_parameters_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
             => No_issue_is_reported_for(@"
 public class TestMe
 {
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correctly_documented_extension_method_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
+        public void No_issue_is_reported_for_documented_parameter_on_extension_method_([ValueSource(nameof(MethodNames))] string methodName, [ValueSource(nameof(CorrectComments))] string comment)
             => No_issue_is_reported_for(@"
 public static class TestMe
 {
@@ -94,7 +94,7 @@ public static class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_documented_non_Contains_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_Contains_method() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_wrong_phrase_in_parameter_documentation_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -126,7 +126,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_first_parameter_of_incorrectly_documented_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_wrong_phrase_in_parameter_documentation_on_method_with_multiple_parameters_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -145,7 +145,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_second_parameter_of_incorrectly_documented_extension_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_wrong_phrase_in_parameter_documentation_on_extension_method_([ValueSource(nameof(MethodNames))] string methodName) => An_issue_is_reported_for(@"
 public static class TestMe
 {
     /// <summary>
@@ -164,9 +164,9 @@ public static class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_empty_parameter_on_method_(
-                                                                    [ValueSource(nameof(MethodNames))] string methodName,
-                                                                    [Values(@"<param name=""i""></param>", @"<param name=""i"">     </param>")] string parameter)
+        public void An_issue_is_reported_for_empty_parameter_documentation_(
+                                                                        [ValueSource(nameof(MethodNames))] string methodName,
+                                                                        [Values(@"<param name=""i""></param>", @"<param name=""i"">     </param>")] string parameter)
             => An_issue_is_reported_for(@"
 public class TestMe
 {
@@ -188,7 +188,7 @@ public class TestMe
         [TestCase("The value to check", "The value")]
         [TestCase("The value to check for", "The value")]
         [TestCase("The value to check if contained", "The value")]
-        public void Code_gets_fixed_for_simple_text(string originalStartingPhrase, string fixedStartingPhrase)
+        public void Code_gets_fixed_to_use_seek_(string originalStartingPhrase, string fixedStartingPhrase)
         {
             var originalCode = @"
 public class TestMe
@@ -224,7 +224,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_text_with_seeCref_and_ending_dot()
+        public void Code_gets_fixed_to_append_to_seek_when_ending_with_dot()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -260,7 +260,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_text_with_seeCref_without_ending_dot()
+        public void Code_gets_fixed_to_append_to_seek_when_not_ending_with_dot()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -296,7 +296,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_text_with_seeCref_on_same_line_without_ending_dot()
+        public void Code_gets_fixed_to_append_to_seek_when_on_same_line()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -328,7 +328,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_text()
+        public void Code_gets_fixed_for_empty_parameter_documentation()
         {
             const string OriginalCode = @"
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2077_SummaryShouldNotUseCodeTagAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2077_SummaryShouldNotUseCodeTagAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_items_without_code() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_summary_without_code_tag() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_items_with_correct_example_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_code_tag_in_example_section() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_summary_on_type() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_code_tag_in_type_summary() => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -116,7 +116,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_summary_on_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_code_tag_in_method_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -132,7 +132,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_summary_on_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_code_tag_in_property_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -148,7 +148,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_summary_on_event() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_code_tag_in_event_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2080_FieldSummaryDefaultPhraseAnalyzerTests.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         public static void PrepareTestEnvironment() => MiKo_2080_CodeFixProvider.LoadData();
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_field() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -31,7 +31,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_starting_with_The() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_enumerable_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_collection_field_starting_with_Contains() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_boolean_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_field_starting_with_Indicates_whether() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -71,7 +71,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_Guid_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Guid_field_starting_with_unique_identifier_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -84,7 +84,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_const_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_const_field_starting_with_The() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -110,7 +110,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_([Values("Bla bla.", "Contains something.", "Indicates whether something.")] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_with_wrong_starting_phrase_([Values("Bla bla.", "Contains something.", "Indicates whether something.")] string comment) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -123,7 +123,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_enumerable_field_([Values("Bla bla", "Indicates whether something.")] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_collection_field_with_wrong_starting_phrase_([Values("Bla bla", "Indicates whether something.")] string comment) => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -137,7 +137,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_boolean_field_([Values("Bla bla", "The field", "Contains something.")] string comment) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_field_with_wrong_starting_phrase_([Values("Bla bla", "The field", "Contains something.")] string comment) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -150,7 +150,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_DependencyProperty_field_summary_with_readonly_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_readonly_comment() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
@@ -165,20 +165,20 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_RoutedEvent_field_summary_with_readonly_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_RoutedEvent_field_with_readonly_comment() => No_issue_is_reported_for(@"
 using System.Windows;
 
 public class TestMe
 {
     /// <summary>
-    /// Identifies the <see cref=""TouchUp""/> routed event.
+    /// Identifies the <see cref=""TouchUp""/> routed event. This field is read-only.
     /// </summary>
     public static readonly System.Windows.RoutedEvent TouchUpEvent;
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_constant_boolean_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constant_boolean_field_starting_with_The() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -192,7 +192,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_field_that_starts_with_see_cref() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_starting_with_see_cref() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -206,9 +206,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_commented_constant_boolean_field_(
-                                                                                       [Values("Bla bla", "Indicates whether the field", "Contains something.")] string comment,
-                                                                                       [Values("bool")] string fieldType)
+        public void An_issue_is_reported_for_constant_boolean_field_with_wrong_starting_phrase_(
+                                                                                            [Values("Bla bla", "Indicates whether the field", "Contains something.")] string comment,
+                                                                                            [Values("bool")] string fieldType)
             => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
@@ -278,7 +278,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_non_constant_boolean_field_([ValueSource(nameof(WrongBooleanPhrases))] string originalComment)
+        public void Code_gets_fixed_for_non_constant_boolean_field_with_various_phrases_([ValueSource(nameof(WrongBooleanPhrases))] string originalComment)
         {
             const string Template = @"
 using System;
@@ -297,7 +297,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_nullable_non_constant_boolean_field_([ValueSource(nameof(WrongBooleanPhrases))] string originalComment)
+        public void Code_gets_fixed_for_nullable_boolean_field_with_various_phrases_([ValueSource(nameof(WrongBooleanPhrases))] string originalComment)
         {
             const string Template = @"
 using System;
@@ -482,7 +482,7 @@ public class TestMe
         [TestCase("This is a list for")]
         [TestCase("This is a list of")]
         [TestCase("This list holds")]
-        public void Code_gets_fixed_for_collection_field_(string originalComment)
+        public void Code_gets_fixed_for_collection_field_with_various_phrases_(string originalComment)
         {
             const string Template = @"
 using System;
@@ -508,7 +508,7 @@ public class TestMe
         [TestCase("List of all supersets", "Contains the supersets")]
         [TestCase("List of all sub-sets", "Contains the sub-sets")]
         [TestCase("List of all super-sets", "Contains the super-sets")]
-        public void Code_gets_fixed_for_collection_field_(string originalComment, string fixedComment)
+        public void Code_gets_fixed_for_collection_field_with_subset_superset_phrases_(string originalComment, string fixedComment)
         {
             const string Template = @"
 using System;
@@ -576,7 +576,7 @@ public class TestMe
         [TestCase("Holds an something", "The something")]
         [TestCase("Defines a something", "The something")]
         [TestCase("Use this something", "The something")]
-        public void Code_gets_fixed_for_normal_field_(string originalComment, string fixedComment)
+        public void Code_gets_fixed_for_field_(string originalComment, string fixedComment)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2223_DocumentationDoesNotUsePlainTextReferencesAnalyzerTests.cs
@@ -89,7 +89,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_plain_text_references() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -104,7 +104,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_para() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_plain_text_references_inside_para_tag() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -121,7 +121,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_see_cref() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_see_cref_tag() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -136,7 +136,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_upper_case_only_abbreviation() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_uppercase_abbreviation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -151,7 +151,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_upper_case_only_abbreviation_in_plural_form() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_uppercase_abbreviation_in_plural_form() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -166,7 +166,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_upper_case_only_abbreviation_in_genitive_case() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_uppercase_abbreviation_in_genitive_case() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -181,7 +181,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_upper_case_only_abbreviation_in_past_tense_case() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_uppercase_abbreviation_in_past_tense() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -196,7 +196,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_upper_case_only_abbreviation_and_additional_information() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_uppercase_abbreviation_and_hyphenated_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -213,7 +213,7 @@ public class TestMe
         [TestCase("{B19F1C23-57F6-4a4E-aa69-5EE303F5184B}")]
         [TestCase("B19F1C23-57F6-4a4E-aa69-5EE303F5184B")]
         [TestCase("B19F1C2357F64a4Eaa695EE303F5184B")]
-        public void No_issue_is_reported_for_correctly_documented_method_with_Guid_(string value) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_Guid_(string value) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -228,7 +228,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_hyperlink_([Values("http", "https", "ftp", "ftps")] string preamble) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_URL_([Values("http", "https", "ftp", "ftps")] string preamble) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -243,7 +243,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_hyperlink_anchor_and_descriptive_text_([Values(@"<a href=""http://www.nunit.org/"">NUnit</a>")] string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_HTML_anchor_tag_([Values(@"<a href=""http://www.nunit.org/"">NUnit</a>")] string text) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -258,7 +258,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_fully_qualified_path() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_file_path() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -273,7 +273,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_keyboard_shortcut() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_keyboard_shortcut() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -288,7 +288,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_known_text_([ValueSource(nameof(WellknownWords))] string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_wellknown_product_name_([ValueSource(nameof(WellknownWords))] string text) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -303,7 +303,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_combined_text_([Values("Undo/Redo", "XYZ1234:Method", "PublicKeyToken=1234")] string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_special_combined_syntax_([Values("Undo/Redo", "XYZ1234:Method", "PublicKeyToken=1234")] string text) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -318,7 +318,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_compiler_warning_([Values("CS0012", "CS0067")] string warning) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_compiler_diagnostic_code_([Values("CS0012", "CS0067")] string warning) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -333,7 +333,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_file_extension_in_quotes() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_wildcard_file_pattern_in_quotes() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -348,7 +348,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_file_extension_not_in_quotes() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_wildcard_file_pattern() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -363,7 +363,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_hash() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_hash_delimited_text() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -378,7 +378,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_starting_number() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_identifier_starting_with_number() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -393,7 +393,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_starting_number_as_pseudo_namespace_or_type_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_qualified_name_starting_with_number() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -423,7 +423,7 @@ public class TestMe
         [TestCase("( such as nothing etc.)")]
         [TestCase("(such as anything, nothing, etc.)")]
         [TestCase("(such as anything, nothing, etc.). So")]
-        public void No_issue_is_reported_for_correctly_documented_method_with_(string example) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_abbreviation_(string example) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -438,7 +438,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_exclamation_mark() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_exclamation_mark_in_text() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -527,7 +527,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_method_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -542,7 +542,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_para() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_method_name_inside_para_tag() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -559,7 +559,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_at_end_of_sentence() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_method_name_at_end_of_sentence() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -576,7 +576,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_embraced_method_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_parenthesized_method_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -593,7 +593,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_single_quoted_method_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_single_quoted_method_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -610,7 +610,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_quoted_method_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_double_quoted_method_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -627,7 +627,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_embraced_and_quoted_method_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_quoted_and_parenthesized_method_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -644,7 +644,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_reference_to_default_typeparam() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_default_expression() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -661,7 +661,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_starting_underscore_number() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_identifier_starting_with_underscore() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -676,7 +676,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_braces() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_method_invocation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -691,7 +691,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_on_interface() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_method_with_plain_text_method_invocation() => An_issue_is_reported_for(@"
 using System;
 
 public interface TestMe
@@ -704,7 +704,7 @@ public interface TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_on_interface_with_array_return_type() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_method_with_array_return_type_and_plain_text_reference() => An_issue_is_reported_for(@"
 using System;
 
 public interface TestMe
@@ -717,7 +717,7 @@ public interface TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_on_interface_with_generic_return_value_that_contains_an_array() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_method_with_generic_array_return_type_and_plain_text_reference() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -731,7 +731,7 @@ public interface TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_on_interface_with_generic_array_return_type() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_interface_method_with_array_of_generic_return_type_and_plain_text_reference() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -745,7 +745,7 @@ public interface TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_parameter_member_access() => An_issue_is_reported_for(@"
 using System;
 using System.IO;
 
@@ -761,7 +761,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_([ValueSource(nameof(NonCompoundWords))] string type) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_plain_text_type_name_([ValueSource(nameof(NonCompoundWords))] string type) => An_issue_is_reported_for(@"
 using System;
 using System.IO;
 
@@ -777,7 +777,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_(
+        public void An_issue_is_reported_for_method_with_plain_text_member_name_(
                                                                              [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
                                                                              [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
             => An_issue_is_reported_for(@"
@@ -796,7 +796,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_([ValueSource(nameof(NonCompoundWords))] string type)
+        public void Code_gets_fixed_for_plain_text_type_name_([ValueSource(nameof(NonCompoundWords))] string type)
         {
             const string Template = """
 
@@ -819,9 +819,9 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_(
-                                                                        [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
-                                                                        [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        public void Code_gets_fixed_for_plain_text_member_name_(
+                                                            [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                            [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
         {
             const string Template = """
 
@@ -844,7 +844,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_ending_with_([ValueSource(nameof(NonCompoundWords))] string type)
+        public void Code_gets_fixed_for_plain_text_type_name_at_end_of_sentence_([ValueSource(nameof(NonCompoundWords))] string type)
         {
             const string Template = """
 
@@ -867,9 +867,9 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_ending_with_(
-                                                                               [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
-                                                                               [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        public void Code_gets_fixed_for_plain_text_member_at_end_of_sentence_(
+                                                                          [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                          [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
         {
             const string Template = """
 
@@ -892,7 +892,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_ending_with_dot_on_method_with_([ValueSource(nameof(NonCompoundWords))] string type)
+        public void Code_gets_fixed_for_plain_text_type_name_before_period_([ValueSource(nameof(NonCompoundWords))] string type)
         {
             const string Template = """
 
@@ -915,9 +915,9 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_on_single_line_with_(
-                                                                                       [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
-                                                                                       [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        public void Code_gets_fixed_for_plain_text_member_on_single_line_comment_(
+                                                                              [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                              [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
         {
             const string Template = """
 
@@ -938,9 +938,9 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_on_single_line_ending_with_(
-                                                                                              [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
-                                                                                              [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
+        public void Code_gets_fixed_for_plain_text_member_at_end_of_single_line_comment_(
+                                                                                     [Values("string", "String", "Sring", "sring", "Sting", "sting")] string type,
+                                                                                     [Values("Empty", "empty", "Empy", "empy", "Emtpy", "emtpy")] string property)
         {
             const string Template = """
 
@@ -961,7 +961,7 @@ public class TestMe
         }
 
         [TestCase("TestMe", "TestMe")]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_type_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_plain_text_class_name_(string originalName, string fixedName)
         {
             const string Template = """
 
@@ -1008,7 +1008,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_comment_with_empty_string()
+        public void Code_gets_fixed_for_plain_text_string_in_empty_string_comment()
         {
             const string OriginalCode = """
                                         using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2224_DocumentationPlacesContentsOnSeparateLineAnalyzerTests.cs
@@ -43,7 +43,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_documented_method_when_start_and_end_tag_are_on_separate_lines_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_XML_tag_with_start_and_end_on_separate_lines_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -57,7 +57,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_empty_documented_method_when_start_and_end_tag_are_on_separate_lines_and_there_is_an_empty_line_in_between_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_empty_XML_tag_with_start_and_end_on_separate_lines_and_empty_line_in_between_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -72,7 +72,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_tag_with_content_on_separate_line_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -91,7 +91,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_para_or_para() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_para_or_para() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -109,7 +109,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_method_with_empty_para_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_empty_para_tag_on_separate_line() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -126,7 +126,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_empty_documented_method_when_start_and_end_tag_are_on_same_lines_([ValueSource(nameof(Tags))] string tag, [Values("", " ", "  ")] string gap) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_XML_tag_with_start_and_end_on_same_line_([ValueSource(nameof(Tags))] string tag, [Values("", " ", "  ")] string gap) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -140,7 +140,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_text_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_XML_tag_with_text_on_same_line_as_start_and_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe
@@ -154,7 +154,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_with_see_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_XML_tag_with_see_cref_on_same_line_as_start_and_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe
@@ -167,7 +167,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_see_is_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_with_see_cref_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -181,7 +181,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_see_is_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_with_see_cref_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -195,7 +195,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_text_is_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_with_text_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -209,7 +209,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_text_is_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_with_text_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -224,7 +224,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_some_inner_XML_elements_are_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_XML_tag_with_inner_XML_element_on_same_line_as_start_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe
@@ -240,7 +240,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_some_inner_XML_elements_are_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_with_inner_XML_element_on_same_line_as_end_tag_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -256,7 +256,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_some_XML_elements_are_on_same_line_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_XML_tag_end_on_same_line_as_next_XML_tag_start_([ValueSource(nameof(Tags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -274,7 +274,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_text_after_it() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_para_tag_on_same_line_with_text_after_it() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -291,7 +291,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_XML_element_after_it() => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_empty_para_tag_on_same_line_with_XML_element_after_it() => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe
@@ -306,7 +306,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_text_before_it() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_para_tag_on_same_line_with_text_before_it() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -323,7 +323,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_element_before_it() => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_empty_para_tag_on_same_line_with_XML_element_before_it() => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe
@@ -338,7 +338,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_another_empty_element() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_empty_para_tag_on_same_line_with_another_empty_para_tag() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -355,7 +355,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_text()
+        public void Code_gets_fixed_to_place_text_on_separate_line_between_start_and_end_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -387,7 +387,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_text_is_on_same_line_as_start_tag()
+        public void Code_gets_fixed_to_place_text_on_separate_line_after_start_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -420,7 +420,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_text_is_on_same_line_as_end_tag()
+        public void Code_gets_fixed_to_place_text_on_separate_line_before_end_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -453,7 +453,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_with_see()
+        public void Code_gets_fixed_to_place_see_cref_on_separate_line_between_start_and_end_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -485,7 +485,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_see_is_on_same_line_as_start_tag()
+        public void Code_gets_fixed_to_place_see_cref_on_separate_line_after_start_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -518,7 +518,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_see_is_on_same_line_as_end_tag()
+        public void Code_gets_fixed_to_place_see_cref_on_separate_line_before_end_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -551,7 +551,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_same_line_with_text_after()
+        public void Code_gets_fixed_to_place_empty_para_tag_on_separate_line_from_text_after()
         {
             const string OriginalCode = @"
 using System;
@@ -588,7 +588,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_line_with_text_before()
+        public void Code_gets_fixed_to_place_empty_para_tag_on_separate_line_from_text_before()
         {
             const string OriginalCode = @"
 using System;
@@ -625,7 +625,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_line_with_text_before_and_after()
+        public void Code_gets_fixed_to_place_empty_para_tag_on_separate_line_from_text_before_and_after()
         {
             const string OriginalCode = @"
 using System;
@@ -661,7 +661,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_line_as_start_tag()
+        public void Code_gets_fixed_to_place_empty_para_tag_on_separate_line_after_start_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -696,7 +696,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_line_as_end_tag()
+        public void Code_gets_fixed_to_place_empty_para_tag_on_separate_line_before_end_tag()
         {
             const string OriginalCode = @"
 using System;
@@ -731,7 +731,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_method_if_empty_para_tag_is_on_line_as_another_empty_tag()
+        public void Code_gets_fixed_to_place_empty_para_tags_on_separate_lines()
         {
             const string OriginalCode = @"
 using System;
@@ -770,7 +770,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_documented_response()
+        public void Code_gets_fixed_to_place_response_content_on_separate_line()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1008_DependencyPropertyEventHandlingMethodParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1008_DependencyPropertyEventHandlingMethodParametersAnalyzerTests.cs
@@ -38,7 +38,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_d_and_e_parameters() => No_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -59,7 +59,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_d_and_e_parameters() => No_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -83,7 +83,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_local_function_if_surrounding_method_is_event_handling_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_inside_event_handling_method() => No_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -107,7 +107,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyObject_on_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_DependencyObject_parameter_named_s() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -128,7 +128,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyObject_on_overridden_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_overridden_method_with_DependencyObject_parameter_named_s() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -149,7 +149,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyObject_on_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_DependencyObject_parameter_named_s() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -173,7 +173,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyChangedEventArgs_on_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_DependencyPropertyChangedEventArgs_parameter_named_args() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -194,7 +194,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyChangedEventArgs_on_overridden_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_overridden_method_with_DependencyPropertyChangedEventArgs_parameter_named_args() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs
@@ -214,7 +214,7 @@ namespace Bla
 }");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyChangedEventArgs_on_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_DependencyPropertyChangedEventArgs_parameter_named_args() => An_issue_is_reported_for(@"
 namespace System.Windows
 {
     public struct DependencyPropertyChangedEventArgs

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1009_EventHandlerLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1009_EventHandlerLocalVariableAnalyzerTests.cs
@@ -24,7 +24,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_non_EventHandler_variable() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_EventHandler_variable() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_EventHandler_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_EventHandler_variable_named_handler() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_generic_EventHandler_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_generic_EventHandler_variable_named_handler() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_var_EventHandler_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_var_EventHandler_variable_named_handler() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -80,7 +80,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_EventHandler_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventHandler_variable() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -93,7 +93,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_EventHandler_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_var_EventHandler_variable() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_PropertyChangingEventHandler_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_var_PropertyChangingEventHandler_variable() => An_issue_is_reported_for(@"
 using System;
 using System.ComponentModel;
 
@@ -128,7 +128,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_PropertyChangedEventHandler_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_var_PropertyChangedEventHandler_variable() => An_issue_is_reported_for(@"
 using System;
 using System.ComponentModel;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -318,7 +318,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] WrongWords = [.. BadPrefixes.Except(AllowedWords)];
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_code() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_code_without_abbreviations() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -346,7 +346,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_prefix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_well_known_abbreviation_as_prefix_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -358,7 +358,7 @@ namespace Bla
 }");
 
         [Test]
-        public void No_issue_is_reported_for_postfix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_well_known_abbreviation_as_suffix_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -370,7 +370,7 @@ namespace Bla
 }");
 
         [Test]
-        public void No_issue_is_reported_for_underscore_separated_prefix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_well_known_abbreviation_as_prefix_with_underscore_separator_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -382,7 +382,7 @@ namespace Bla
 }");
 
         [Test]
-        public void No_issue_is_reported_for_underscore_separated_postfix_well_known_abbreviation_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_well_known_abbreviation_as_suffix_with_underscore_separator_([Values("MEF", "ALT")] string abbreviation) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -394,7 +394,7 @@ namespace Bla
 }");
 
         [Test] // verifies that 'wParam' and 'lParam' which are used by Windows C++ API are not reported as abbreviations even though they actually are
-        public void No_issue_is_reported_for_special_parameters_wParam_and_lParam() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Windows_API_parameters_wParam_and_lParam() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -406,7 +406,7 @@ namespace Bla
 }");
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_method_([ValueSource(nameof(AllowedWords))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_([ValueSource(nameof(AllowedWords))] string methodName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -422,7 +422,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_method_with_upper_case_suffix_([ValueSource(nameof(AllowedTerms))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_upper_case_suffix_([ValueSource(nameof(AllowedTerms))] string methodName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -438,7 +438,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_method_with_lower_case_suffix_([ValueSource(nameof(AllowedTerms))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_lower_case_suffix_([ValueSource(nameof(AllowedTerms))] string methodName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -454,7 +454,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_property_([ValueSource(nameof(AllowedWords))] string propertyName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_([ValueSource(nameof(AllowedWords))] string propertyName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -467,7 +467,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_properly_named_variable_([ValueSource(nameof(AllowedWords))] string variableName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_([ValueSource(nameof(AllowedWords))] string variableName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -484,7 +484,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_variable_([ValueSource(nameof(WrongWords))] string variableName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_([ValueSource(nameof(WrongWords))] string variableName) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -501,7 +501,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_foreach_variable_([ValueSource(nameof(WrongWords))] string variableName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_foreach_variable_([ValueSource(nameof(WrongWords))] string variableName) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -523,7 +523,7 @@ namespace Bla
         [TestCase("MaxVer", "MaximumVersion")]
         [TestCase("Cur", "Current")]
         [TestCase("Prev", "Previous")]
-        public void Code_gets_fixed_for_incorrectly_named_property_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_property_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -545,7 +545,7 @@ namespace Bla
         [TestCase("appVar", "applicationVariable")]
         [TestCase("cur", "current")]
         [TestCase("prev", "previous")]
-        public void Code_gets_fixed_for_incorrectly_named_foreach_variable_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_foreach_variable_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -570,7 +570,7 @@ namespace Bla
         [TestCase("config", "configuration")]
         [TestCase("cur", "current")]
         [TestCase("prev", "previous")]
-        public void Code_gets_fixed_for_incorrectly_named_field_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_field_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -590,7 +590,7 @@ namespace Bla
         [TestCase("lang", "language")]
         [TestCase("decl", "declaration")]
         [TestCase("impl", "implementation")]
-        public void Code_gets_fixed_for_incorrectly_named_tuple_element_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_tuple_element_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -612,7 +612,7 @@ namespace Bla
         [TestCase("lang", "language")]
         [TestCase("decl", "declaration")]
         [TestCase("impl", "implementation")]
-        public void Code_gets_fixed_for_incorrectly_named_deconstructed_simplified_variable_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_deconstructed_simplified_variable_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -636,7 +636,7 @@ namespace Bla
         [TestCase("lang", "language")]
         [TestCase("decl", "declaration")]
         [TestCase("impl", "implementation")]
-        public void Code_gets_fixed_for_incorrectly_named_deconstructed_variable_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_deconstructed_variable_by_expanding_abbreviation_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1068_WorkflowMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1068_WorkflowMethodsAnalyzerTests.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1068_WorkflowMethodsAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_methods_of_non_WorkFlow_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_Workflow_class() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething() { }
@@ -21,7 +21,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_methods_of_Workflow_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Workflow_class_with_Run_and_CanRun_methods() => No_issue_is_reported_for(@"
 public class Workflow
 {
     public void Run() { }
@@ -32,7 +32,7 @@ public class Workflow
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_methods_of_Workflow_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Workflow_interface_with_Run_and_CanRun_methods() => No_issue_is_reported_for(@"
 public interface IWorkflow
 {
     void Run();
@@ -43,7 +43,7 @@ public interface IWorkflow
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_Run_method_of_Workflow_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Workflow_class_with_void_method_not_named_Run() => An_issue_is_reported_for(@"
 public class Workflow
 {
     public void DoSomething() { }
@@ -51,7 +51,7 @@ public class Workflow
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_CanRun_method_of_Workflow_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Workflow_class_with_boolean_method_not_named_CanRun() => An_issue_is_reported_for(@"
 public class Workflow
 {
     public bool Whatever() { }
@@ -59,7 +59,7 @@ public class Workflow
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_RunAsync_method_of_Workflow_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Workflow_class_with_Task_method_not_named_RunAsync() => An_issue_is_reported_for(@"
 public class Workflow
 {
     public async Task BlaAsync() { }
@@ -67,7 +67,7 @@ public class Workflow
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_CanRunAsync_method_of_Workflow_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Workflow_class_with_Task_bool_method_not_named_CanRunAsync() => An_issue_is_reported_for(@"
 public class Workflow
 {
     public async Task<bool> BlaAgain() { }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1070_CollectionLocalVariableAnalyzerTests.cs
@@ -105,7 +105,7 @@ public class TestMe
         [TestCase("XmlNode node")]
         [TestCase("XNode myNode")]
         [TestCase("XNode node")]
-        public void No_issue_is_reported_for_method_with_variable_(string variable) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_(string variable) => No_issue_is_reported_for(@"
 using System;
 using System.Xml;
 using System.Xml.Linq;
@@ -120,7 +120,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_non_Collection_variable() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_collection_variable() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -133,7 +133,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_Collection_variable_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_collection_variable_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -147,7 +147,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_Collection_variable_with_correct_name_and_additional_suffix_([ValueSource(nameof(CorrectNamesWithSuffixes))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_collection_variable_with_suffix_([ValueSource(nameof(CorrectNamesWithSuffixes))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -161,7 +161,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_var_Collection_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_var_collection_variable_with_plural_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -175,7 +175,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_byte_array_for_hash() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_byte_array_named_hash() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -193,7 +193,7 @@ public class TestMe
         [TestCase("IQueryable<int> query")]
         [TestCase("IOrderedQueryable query")]
         [TestCase("IOrderedQueryable<int> query")]
-        public void No_issue_is_reported_for_method_with_(string variable) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Linq_variable_(string variable) => No_issue_is_reported_for(@"
 using System.Linq;
 
 public class TestMe
@@ -206,7 +206,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_variable_of_specific_type_with_number_at_the_end() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_of_enumerable_type_with_number_suffix_matching_type_name() => No_issue_is_reported_for(@"
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -225,7 +225,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_Collection_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_collection_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -239,7 +239,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_Collection_variable_with_incorrect_name_with_suffix_([ValueSource(nameof(WrongNamesWithSuffixes))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_collection_variable_with_suffix_([ValueSource(nameof(WrongNamesWithSuffixes))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -253,7 +253,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_Collection_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_var_collection_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -267,7 +267,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_Collection_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_pattern_with_plural_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -285,7 +285,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_Collection_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_pattern_with_singular_name() => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -318,7 +318,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_strange_ref_usage() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ref_var_with_conditional_reference() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -331,7 +331,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_XML_node() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XmlNode_variable() => No_issue_is_reported_for(@"
 using System;
 using System.Xml;
 
@@ -347,7 +347,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_XML_Linq_node() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XNode_variable() => No_issue_is_reported_for(@"
 using System;
 using System.Xml;
 using System.Xml.Linq;
@@ -365,7 +365,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_document_node() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_of_enumerable_type_named_after_type() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -383,7 +383,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_document_variable_in_foreach() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_foreach_variable_of_enumerable_type_named_after_type() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -403,7 +403,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_IGrouping_node() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_IGrouping_variable() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -434,7 +434,7 @@ public class TestMe
         [TestCase("allElementReferenceNodeList", "allElements")]
         [TestCase("elementNodeList", "elements")]
         [TestCase("elementReferenceNodeList", "elements")]
-        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        public void Code_gets_fixed_by_pluralizing_variable_name_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -452,7 +452,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_variable_declaration_pattern()
+        public void Code_gets_fixed_by_pluralizing_variable_declaration_pattern_name()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzerTests.cs
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_non_Boolean_variable() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_boolean_variable() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_Boolean_variable_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_variable_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -68,7 +68,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_var_Boolean_variable_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_var_boolean_variable_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -82,7 +82,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_Boolean_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -96,7 +96,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_Boolean_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_var_boolean_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_Boolean_variable_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_pattern_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -128,7 +128,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_Boolean_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_pattern_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1072_BooleanMethodPropertyNamedAsQuestionAnalyzerTests.cs
@@ -95,7 +95,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_non_Boolean_return_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_boolean_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -108,7 +108,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_non_Boolean_return_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_boolean_property() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -118,7 +118,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_Boolean_return_type_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_test_method_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -134,7 +134,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_Boolean_return_type_and_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_method_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -148,7 +148,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_property_with_Boolean_return_type_and_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_property_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -159,7 +159,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_Boolean_return_type_and_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_method_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -173,7 +173,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_with_Boolean_return_type_and_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_property_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1073_BooleanFieldNamedAsQuestionAnalyzerTests.cs
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_non_Boolean_field_([ValueSource(nameof(Prefixes))] string prefix) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_boolean_field_([ValueSource(nameof(Prefixes))] string prefix) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_Boolean_field_with_correct_name_([ValueSource(nameof(CorrectNames))] string name, [ValueSource(nameof(Prefixes))] string prefix) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_boolean_field_([ValueSource(nameof(CorrectNames))] string name, [ValueSource(nameof(Prefixes))] string prefix) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_Boolean_field_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name, [ValueSource(nameof(Prefixes))] string prefix) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_boolean_field_([ValueSource(nameof(WrongNames))] string name, [ValueSource(nameof(Prefixes))] string prefix) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1080_UseNumbersInsteadOfWordingAnalyzerTests.cs
@@ -107,7 +107,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                       ];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_namespace_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla" + name + @"
@@ -122,7 +122,7 @@ namespace Bla" + name + @"
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe" + name + @"
@@ -134,7 +134,7 @@ public class TestMe" + name + @"
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -162,7 +162,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method_parameter_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_parameter_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -174,7 +174,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_property_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -184,7 +184,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -194,7 +194,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_event_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -204,7 +204,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -217,7 +217,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_declaration_pattern_with_correct_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_pattern_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -235,7 +235,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_in_foreach_loop_with_incorrect_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_foreach_variable_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -250,7 +250,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_correctly_named_namespace_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 namespace Some" + name + @"
@@ -265,7 +265,7 @@ namespace Some" + name + @"
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_type_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe" + name + @"
@@ -277,7 +277,7 @@ public class TestMe" + name + @"
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -289,7 +289,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_correctly_named_method_parameter_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_parameter_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -301,7 +301,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_property_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -311,7 +311,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_field_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -321,7 +321,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_event_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -331,7 +331,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -344,7 +344,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_declaration_pattern_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_pattern_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -361,7 +361,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_in_foreach_loop_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_foreach_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -376,7 +376,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_constant_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_constant_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -387,7 +387,7 @@ public class TestMe
 
         [TestCase("CalculateLevenshteinDistanceOnly")]
         [TestCase("CalculateLevensteinDistanceOnly")]
-        public void No_issue_is_reported_for_method_(string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_special_method_(string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1088_SingletonInstancesShouldBeNamedInstanceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1088_SingletonInstancesShouldBeNamedInstanceAnalyzerTests.cs
@@ -32,7 +32,7 @@ public struct TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_enum_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum() => No_issue_is_reported_for(@"
 
 public enum TestMe
 {
@@ -59,7 +59,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_without_properties_or_fields() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_properties_or_fields() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -69,7 +69,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_only_non_static_properties_and_fields() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_with_only_non_static_members() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool SomeProperty { get; set; }
@@ -79,7 +79,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_static_property_that_returns_some_other_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_static_property_returning_different_type() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool SomeProperty { get; set; }
@@ -87,7 +87,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_static_field_that_is_of_some_other_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_static_field_of_different_type() => No_issue_is_reported_for(@"
 public class TestMe
 {
     private static int _someField;
@@ -95,7 +95,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_correctly_named_static_singleton_property_([Values("Instance", "Empty", "Default", "Zero")] string propertyName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_static_singleton_property_([Values("Instance", "Empty", "Default", "Zero")] string propertyName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static TestMe " + propertyName + @" { get; set; }
@@ -103,9 +103,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_correctly_named_static_singleton_field_(
-                                                                                           [ValueSource(nameof(FieldPrefixes))] string prefix,
-                                                                                           [Values("instance", "empty", "default", "zero", "Instance", "Empty", "Default", "Zero")] string fieldName)
+        public void No_issue_is_reported_for_static_singleton_field_(
+                                                                 [ValueSource(nameof(FieldPrefixes))] string prefix,
+                                                                 [Values("instance", "empty", "default", "zero", "Instance", "Empty", "Default", "Zero")] string fieldName)
             => No_issue_is_reported_for(@"
 public class TestMe
 {
@@ -114,7 +114,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_incorrectly_named_static_singleton_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_static_singleton_property_named_Singleton() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public static TestMe Singleton { get; set; }
@@ -122,7 +122,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_incorrectly_named_static_singleton_field_([ValueSource(nameof(FieldPrefixes))] string prefix) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_static_singleton_field_named_singleton_([ValueSource(nameof(FieldPrefixes))] string prefix) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public static TestMe " + prefix + @"singleton;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzerTests.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1098_TypeNameFollowsInterfaceNameSchemeAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_without_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_without_interface() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -38,7 +38,7 @@ public class TestMe
         [TestCase(nameof(IDeserializationCallback))]
         [TestCase("IDragSource")]
         [TestCase("IDropTarget")]
-        public void No_issue_is_reported_for_correctly_named_type_with_(string interfaceName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_implementing_interface_(string interfaceName) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -52,7 +52,7 @@ public abstract class TestMe : " + interfaceName + @"
 
         [TestCase("IValueConverter")]
         [TestCase("IMultiValueConverter")]
-        public void No_issue_is_reported_for_correctly_named_converter_type_with_(string interfaceName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_with_Converter_suffix_implementing_converter_interface_(string interfaceName) => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Data;
 
@@ -62,7 +62,7 @@ public abstract class TestMeConverter : " + interfaceName + @"
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_name_matching_interface_name() => No_issue_is_reported_for(@"
 using System;
 
 public interface ITestCandidate
@@ -75,7 +75,7 @@ public abstract class TestCandidate : ITestCandidate
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_with_number_suffix() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_name_matching_interface_name_without_number_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public interface ITestCandidate42
@@ -88,7 +88,7 @@ public abstract class TestCandidate : ITestCandidate42
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_with_Has_ability_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_implementing_Has_ability_interface() => No_issue_is_reported_for(@"
 using System;
 
 public interface IHasSomeName
@@ -101,7 +101,7 @@ public abstract class TestMe : IHasSomeName
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_with_Provider_suffix() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_implementing_Provider_interface() => No_issue_is_reported_for(@"
 using System;
 
 public interface ISomeProvider
@@ -114,7 +114,7 @@ public abstract class TestMe : ISomeProvider
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_type_with_Extended_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_name_matching_Extended_interface_without_Extended_prefix() => No_issue_is_reported_for(@"
 using System;
 
 public interface IExtendedTestMe
@@ -127,7 +127,7 @@ public abstract class TestMe : IExtendedTestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_command_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_with_Command_suffix_implementing_Command_interface() => No_issue_is_reported_for(@"
 using System;
 
 public interface ISomeCommand
@@ -140,7 +140,7 @@ public abstract class TestMeCommand : ISomeCommand
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_type() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_name_not_matching_interface_name() => An_issue_is_reported_for(@"
 using System;
 
 public interface ITestCandidate
@@ -153,7 +153,7 @@ public abstract class TestMe : ITestCandidate
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_type_for_HashTable() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_name_not_matching_HashTable_interface_name() => An_issue_is_reported_for(@"
 using System;
 
 public interface IHashTable
@@ -166,7 +166,7 @@ public abstract class TestMe : IHashTable
 ");
 
         [Test]
-        public void An_issue_is_reported_for_correctly_named_type_with_Extended_interface() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_name_not_matching_Extended_interface_without_matching_base_name() => An_issue_is_reported_for(@"
 using System;
 
 public interface IExtendedSomething

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1108_MockNamingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1108_MockNamingAnalyzerTests.cs
@@ -45,7 +45,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_field_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
 public class TestMe
 {
     private int _" + name + @";
@@ -62,7 +62,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_field_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -71,7 +71,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_variable() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -83,7 +83,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_variable_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -94,7 +94,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_variable_in_foreach_loop() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_foreach_variable_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -108,7 +108,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -120,7 +120,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_variable_in_foreach_loop_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_foreach_variable_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -134,7 +134,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_variable_declaration() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -150,7 +150,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_variable_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -166,7 +166,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_variable_on_multi_variable_declaration_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_multi_variable_declaration_in_non_test_class_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -177,7 +177,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_variable_on_multi_variable_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_multi_variable_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -189,7 +189,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -200,7 +200,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameter_in_ctor() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_constructor_parameter_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -211,7 +211,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_parameter_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -222,7 +222,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_parameter_in_ctor_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_constructor_parameter_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -233,7 +233,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_parameter_in_lambda_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_lambda_parameter_([ValueSource(nameof(WrongNames))] string name) => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -245,7 +245,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field_declaration() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_declaration_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -254,7 +254,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_field_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -263,7 +263,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_multi_field_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_multi_field_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -272,7 +272,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_property_declaration() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_declaration_without_test_double_terminology() => No_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -281,7 +281,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_property_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_declaration_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 [TestFixture]
 public class TestMe
 {
@@ -297,13 +297,13 @@ public class TestMe
         [TestCase("[TestFixture] class TestMe { void Do(int mock1) { } }", "[TestFixture] class TestMe { void Do(int mock1) { } }")]
         [TestCase("[TestFixture] class TestMe { void Do(int mockValue1) { } }", "[TestFixture] class TestMe { void Do(int value1) { } }")]
         [TestCase("[TestFixture] class TestMe { public TestMe(int childFake) { } }", "[TestFixture] class TestMe { public TestMe(int child) { } }")]
-        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+        public void Code_gets_fixed_by_removing_test_double_terminology_from_name_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         [TestCase("mockValue", "value")]
         [TestCase("mockedValue", "value")]
         [TestCase("fakeValue", "value")]
         [TestCase("fakedValue", "value")]
-        public void Code_gets_fixed_for_local_variable_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_local_variable_by_removing_test_double_prefix_(string originalName, string fixedName)
         {
             var originalCode = @"
 [TestFixture]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1118_TestMethodsButAsyncSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1118_TestMethodsButAsyncSuffixAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1118_TestMethodsButAsyncSuffixAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_non_async_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_async_method_without_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_non_async_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_async_local_function_without_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -57,7 +57,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_returning_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -67,7 +67,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_returning_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -80,7 +80,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_non_async_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_async_method_with_Async_suffix_outside_test_class() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -90,9 +90,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_without_Async_suffix_(
+                                                                           [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                           [ValueSource(nameof(Tests))] string test)
         => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -103,10 +103,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_incorrect_name_(
-                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                          [ValueSource(nameof(Tests))] string test,
-                                                                          [Values("DoSomethingAsync", "Do_something_async", "DoSomethingAsync_", "Do_something_async_")] string methodName)
+        public void An_issue_is_reported_for_test_method_with_Async_suffix_(
+                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                        [ValueSource(nameof(Tests))] string test,
+                                                                        [Values("DoSomethingAsync", "Do_something_async", "DoSomethingAsync_", "Do_something_async_")] string methodName)
         => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -120,7 +120,7 @@ public class TestMe
         [TestCase("DoSomethingAsync_", "DoSomething_")]
         [TestCase("Do_something_async", "Do_something")]
         [TestCase("Do_something_async_", "Do_something_")]
-        public void Code_gets_fixed_for_method_(string originalName, string fixedName)
+        public void Code_gets_fixed_by_removing_Async_suffix_from_method_name_(string originalName, string fixedName)
         {
             const string Template = @"
 
@@ -138,9 +138,9 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_lower_case_method_(
-                                                       [ValueSource(nameof(TestFixtures))] string fixture,
-                                                       [ValueSource(nameof(Tests))] string test)
+        public void Code_gets_fixed_by_removing_async_suffix_from_snake_case_method_name_(
+                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                      [ValueSource(nameof(Tests))] string test)
         {
             var template = @"
 [" + fixture + @"]

--- a/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Ordering/MiKo_4105_ObjectUnderTestFieldOrderingAnalyzerTests.cs
@@ -119,8 +119,8 @@ public class TestMeTests
 
         [Test]
         public void No_issue_is_reported_for_a_test_class_with_the_field_coming_after_only_constant_fields_(
-                                                                                                   [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                                   [ValueSource(nameof(Tests))] string test)
+                                                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                                        [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 using NUnit.Framework;
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6058_TypeParameterConstraintClauseIndentedBelowParameterListAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_on_same_lines() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_on_same_line() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T1, T2>() where T1 : class where T2 : class
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_type_parameter_constraint_clause_properly_indented_on_different_line() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_type_parameter_constraint_clause_aligned_with_closing_parenthesis() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T>()
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_properly_indented_on_different_lines() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_aligned_with_closing_parenthesis() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T1, T2>()
@@ -86,7 +86,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_on_same_lines() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_on_same_line() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -98,7 +98,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_properly_indented_on_different_line() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_aligned_with_closing_parenthesis() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -111,7 +111,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_properly_indented_on_different_lines() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_aligned_with_closing_parenthesis() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -139,14 +139,14 @@ public " + type + @" TestMe<T> where T : class
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_aligned_horizontally_([ValueSource(nameof(Types))] string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_on_same_line_([ValueSource(nameof(Types))] string type) => No_issue_is_reported_for(@"
 public " + type + @" TestMe<T1, T2, T3> where T1 : class where T2 : class where T3 : class
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clause_indented_too_far_left() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T>()
@@ -156,7 +156,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_type_parameter_constraint_clause_indented_too_far_right() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T>()
@@ -166,7 +166,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_indented_too_far_left() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T1, T2>()
@@ -177,7 +177,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_multiple_type_parameter_constraint_clauses_indented_too_far_right() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething<T1, T2>()
@@ -188,7 +188,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_indented_too_far_left() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -201,7 +201,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_type_parameter_constraint_clause_indented_too_far_right() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -214,7 +214,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_indented_too_far_left() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -228,7 +228,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_multiple_type_parameter_constraint_clauses_indented_too_far_right() => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -242,7 +242,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_with_type_parameter_constraint_clause_indented_too_far_left_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
 public " + type + @" TestMe<T>
     where T : class
 {
@@ -250,7 +250,7 @@ public " + type + @" TestMe<T>
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_with_type_parameter_constraint_clause_indented_too_far_right_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
 public " + type + @" TestMe<T>
                                     where T : class
 {
@@ -258,7 +258,7 @@ public " + type + @" TestMe<T>
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_indented_too_far_left_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
 public " + type + @" TestMe<T1, T2>
     where T1 : class
     where T2 : class
@@ -267,7 +267,7 @@ public " + type + @" TestMe<T1, T2>
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_with_multiple_type_parameter_constraint_clauses_indented_too_far_right_([ValueSource(nameof(Types))] string type) => An_issue_is_reported_for(@"
 public " + type + @" TestMe<T1, T2>
                                           where T1 : class
                                           where T2 : class
@@ -276,7 +276,7 @@ public " + type + @" TestMe<T1, T2>
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_parenthesis_when_indented_too_far_left_for_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -300,7 +300,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_method_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_parenthesis_when_indented_too_far_right_for_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -324,7 +324,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_parenthesis_when_indented_too_far_left_for_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -350,7 +350,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_method_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_parenthesis_when_indented_too_far_right_for_method()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -376,7 +376,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_local_function_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_parenthesis_when_indented_too_far_left_for_local_function()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -406,7 +406,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_local_function_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_parenthesis_when_indented_too_far_right_for_local_function()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -436,7 +436,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_local_function_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_parenthesis_when_indented_too_far_left_for_local_function()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -468,7 +468,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_local_function_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_parenthesis_when_indented_too_far_right_for_local_function()
         {
             const string OriginalCode = @"
 public class TestMe
@@ -500,7 +500,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_class_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_class()
         {
             const string OriginalCode = @"
 public class TestMe<T>
@@ -519,7 +519,7 @@ public class TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_class_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_class()
         {
             const string OriginalCode = @"
 public class TestMe<T>
@@ -539,7 +539,7 @@ public class TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_class_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_class()
         {
             const string OriginalCode = @"
 public class TestMe<T1, T2>
@@ -560,7 +560,7 @@ public class TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_class_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_class()
         {
             const string OriginalCode = @"
 public class TestMe<T1, T2>
@@ -582,7 +582,7 @@ public class TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_interface_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_interface()
         {
             const string OriginalCode = @"
 public interface TestMe<T>
@@ -601,7 +601,7 @@ public interface TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_interface_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_interface()
         {
             const string OriginalCode = @"
 public interface TestMe<T>
@@ -621,7 +621,7 @@ public interface TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_interface_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_interface()
         {
             const string OriginalCode = @"
 public interface TestMe<T1, T2>
@@ -642,7 +642,7 @@ public interface TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_interface_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_interface()
         {
             const string OriginalCode = @"
 public interface TestMe<T1, T2>
@@ -664,7 +664,7 @@ public interface TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_record_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_record()
         {
             const string OriginalCode = @"
 public record TestMe<T>
@@ -683,7 +683,7 @@ public record TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_record_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_record()
         {
             const string OriginalCode = @"
 public record TestMe<T>
@@ -703,7 +703,7 @@ public record TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_record_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_record()
         {
             const string OriginalCode = @"
 public record TestMe<T1, T2>
@@ -724,7 +724,7 @@ public record TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_record_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_record()
         {
             const string OriginalCode = @"
 public record TestMe<T1, T2>
@@ -746,7 +746,7 @@ public record TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_struct_with_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_struct()
         {
             const string OriginalCode = @"
 public struct TestMe<T>
@@ -765,7 +765,7 @@ public struct TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_struct_with_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_line()
+        public void Code_gets_fixed_to_align_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_struct()
         {
             const string OriginalCode = @"
 public struct TestMe<T>
@@ -785,7 +785,7 @@ public struct TestMe<T>
         }
 
         [Test]
-        public void Code_gets_fixed_for_struct_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_left_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_left_for_struct()
         {
             const string OriginalCode = @"
 public struct TestMe<T1, T2>
@@ -806,7 +806,7 @@ public struct TestMe<T1, T2>
         }
 
         [Test]
-        public void Code_gets_fixed_for_struct_with_multiple_type_parameter_constraint_clause_incorrectly_indented_to_right_on_different_lines()
+        public void Code_gets_fixed_to_align_first_constraint_clause_with_closing_angle_bracket_when_indented_too_far_right_for_struct()
         {
             const string OriginalCode = @"
 public struct TestMe<T1, T2>

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6059_BooleanOperatorsAreIndentedToLeftAnalyzerTests.cs
@@ -27,7 +27,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_if_statement_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_if_statement_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -45,7 +45,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_if_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_if_statement_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -61,7 +61,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_if_statement_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_if_statement_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -77,7 +77,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_if_statement_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_if_statement_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -93,7 +93,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_if_statement_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_if_statement_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -109,7 +109,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_if_statement_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_if_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -145,7 +145,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_if_statement_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_if_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -181,7 +181,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_if_statement_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_if_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -230,7 +230,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_return_statement_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_return_statement_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -246,7 +246,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_return_statement_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_return_statement_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -260,7 +260,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_return_statement_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_return_statement_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -274,7 +274,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_return_statement_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_return_statement_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -288,7 +288,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_return_statement_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_return_statement_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -302,7 +302,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_return_statement_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_return_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -334,7 +334,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_return_statement_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_return_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -366,7 +366,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_return_statement_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_return_statement()
         {
             const string OriginalCode = @"
 using System;
@@ -418,7 +418,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_when_clause_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_when_clause_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -441,7 +441,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_when_clause_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_when_clause_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -462,7 +462,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_when_clause_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_when_clause_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -483,7 +483,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_when_clause_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_when_clause_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -504,7 +504,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_when_clause_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_when_clause_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -525,7 +525,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_when_clause_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_when_clause()
         {
             const string OriginalCode = @"
 using System;
@@ -571,7 +571,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_when_clause_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_when_clause()
         {
             const string OriginalCode = @"
 using System;
@@ -617,7 +617,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_when_clause_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_when_clause()
         {
             const string OriginalCode = @"
 using System;
@@ -676,7 +676,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_declaration_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -692,7 +692,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_variable_declaration_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_variable_declaration_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -706,7 +706,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -720,7 +720,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -734,7 +734,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_declaration_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_declaration_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -748,7 +748,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_variable_declaration()
         {
             const string OriginalCode = @"
 using System;
@@ -780,7 +780,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_variable_declaration()
         {
             const string OriginalCode = @"
 using System;
@@ -812,7 +812,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_variable_declaration_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_variable_declaration()
         {
             const string OriginalCode = @"
 using System;
@@ -857,7 +857,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_assignment_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_assignment_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -873,7 +873,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_assignment_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_assignment_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -887,7 +887,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_assignment_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_assignment_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -901,7 +901,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_assignment_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_assignment_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -915,7 +915,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_assignment_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_assignment_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -929,7 +929,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_assignment_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_assignment()
         {
             const string OriginalCode = @"
 using System;
@@ -961,7 +961,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_assignment_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_assignment()
         {
             const string OriginalCode = @"
 using System;
@@ -993,7 +993,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_assignment_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_assignment()
         {
             const string OriginalCode = @"
 using System;
@@ -1042,7 +1042,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_argument_in_case_operator_is_behind_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_argument_with_operator_after_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1062,7 +1062,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_argument_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_argument_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1080,7 +1080,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_argument_in_case_operator_is_indented_to_right_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_argument_with_operator_aligned_with_right_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1098,7 +1098,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_argument_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_argument_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1116,7 +1116,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_argument_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_argument_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1134,7 +1134,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_argument_in_case_operator_is_indented_to_right_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_right_operand_for_argument()
         {
             const string OriginalCode = @"
 using System;
@@ -1174,7 +1174,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_argument_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_argument()
         {
             const string OriginalCode = @"
 using System;
@@ -1214,7 +1214,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_argument_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_argument()
         {
             const string OriginalCode = @"
 using System;
@@ -1271,7 +1271,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_lambda_argument_in_case_operator_is_correctly_outdented_to_left_operand() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_lambda_argument_with_operator_outdented_one_space_from_left_operand() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1289,7 +1289,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_lambda_argument_in_case_operator_is_indented_below_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_lambda_argument_with_operator_aligned_with_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1307,7 +1307,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_lambda_argument_in_case_operator_is_outdented_to_left_operand() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_lambda_argument_with_operator_outdented_2_spaces_from_left_operand() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -1325,7 +1325,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_lambda_argument_in_case_operator_is_indented_below_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_aligned_with_left_operand_for_lambda_argument()
         {
             const string OriginalCode = @"
 using System;
@@ -1365,7 +1365,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_lambda_argument_in_case_operator_is_outdented_to_left_operand()
+        public void Code_gets_fixed_to_outdent_operator_one_space_from_left_operand_when_outdented_2_spaces_for_lambda_argument()
         {
             const string OriginalCode = @"
 using System;


### PR DESCRIPTION
- Systematically rename of test methods for improved clarity and consistency

- Apply a descriptive, scenario‑focused naming pattern, including:
  - `No_issue_is_reported_for_...`
  - `An_issue_is_reported_for_...`
  - `Code_gets_fixed_by_...`

- Method names now explicitly reflect:
  - the member type under test
  - the documentation or code scenario
  - the expected analyzer outcome

- Enhance overall test readability, navigability, and maintainability

- No functional changes - test logic and content are unchanged