### PR TITLE
Updated test names to match MiKo_1117, Updated MiKo_1117.md about parameters

### DIFF
--- a/Documentation/MiKo_1117.md
+++ b/Documentation/MiKo_1117.md
@@ -53,6 +53,9 @@ Making test names precise and specific provides several important benefits:
 To fix a violation of this rule, rename the test method to be more specific about what scenario is being tested and what the expected outcome is.
 Include details about the exact event being raised or the exception being thrown.
 
+For parameterized tests, ensure the name works correctly with all parameter values.
+Let the parameters express the details instead of putting them into the name.
+
 ## How to suppress violations
 
 ```csharp

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2081_ReadOnlyFieldAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2081_ReadOnlyFieldAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_uncommented_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_readonly_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_readonly_field_with_visibility_([Values("protected", "public", "private", "internal")] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -32,20 +32,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_commented_readonly_field_with_visibility_([Values("private", "internal")] string visibility) => No_issue_is_reported_for(@"
-using System;
-
-public class TestMe
-{
-    /// <summary>
-    /// The field.
-    /// </summary>
-    " + visibility + @" readonly string m_field;
-}
-");
-
-        [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_readonly_field_with_visibility_([Values("protected", "public")] string visibility) => An_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_readonly_field_without_readonly_comment_with_visibility_([Values("private", "internal")] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -58,7 +45,20 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_readonly_field_with_visibility_([Values("protected", "public")] string visibility) => No_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_readonly_field_without_readonly_comment_with_visibility_([Values("protected", "public")] string visibility) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    /// <summary>
+    /// The field.
+    /// </summary>
+    " + visibility + @" readonly string m_field;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_readonly_field_with_readonly_comment_with_visibility_([Values("protected", "public")] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -71,9 +71,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_incorrectly_commented_readonly_TestClass_field_with_visibility_(
-                                                                                                         [Values("protected", "public")] string visibility,
-                                                                                                         [ValueSource(nameof(TestFixtures))] string fixture)
+        public void No_issue_is_reported_for_readonly_field_in_test_class_with_visibility_(
+                                                                                       [Values("protected", "public")] string visibility,
+                                                                                       [ValueSource(nameof(TestFixtures))] string fixture)
             => No_issue_is_reported_for(@"
 using System;
 
@@ -88,7 +88,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_to_add_readonly_comment()
         {
             const string OriginalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2082_EnumMemberAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_enum_member() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_enum_member() => No_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -36,7 +36,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_enum_member() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_member_without_redundant_starting_phrase() => No_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -54,7 +54,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_empty_commented_enum_member() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_member_with_empty_summary() => An_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -72,7 +72,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_enum_member_([Values("Defines", "Indicates", "Represents", "Specifies", "Enum")] string startingPhrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_member_starting_with_redundant_phrase_([Values("Defines", "Indicates", "Represents", "Specifies", "Enum")] string startingPhrase) => An_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -90,7 +90,7 @@ public enum TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_enum_member_that_starts_with_see_cref() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_member_starting_with_see_cref() => An_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -108,9 +108,9 @@ public enum TestMe
 ");
 
         [Test, Combinatorial]
-        public void Code_gets_fixed_for_incorrectly_commented_enum_member_(
-                                                                       [Values("Defines", "Indicates", "Represents", "Specifies", "Enum")] string startingWord,
-                                                                       [Values("", " that", ", that", " whether", ", whether", " for", ", for")] string continuation)
+        public void Code_gets_fixed_for_enum_member_starting_with_redundant_phrase_(
+                                                                                [Values("Defines", "Indicates", "Represents", "Specifies", "Enum")] string startingWord,
+                                                                                [Values("", " that", ", that", " whether", ", whether", " for", ", for")] string continuation)
         {
             const string Template = @"
 using System;
@@ -133,7 +133,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_empty_commented_enum_member()
+        public void Code_gets_fixed_for_enum_member_with_empty_summary()
         {
             const string OriginalCode = @"
 using System;
@@ -156,7 +156,7 @@ public enum TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_special_phrase_of_enum_member()
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern()
         {
             const string OriginalCode = @"
 using System;
@@ -186,7 +186,7 @@ public enum TestMeKind
         }
 
         [Test]
-        public void Code_gets_fixed_for_special_phrase_of_enum_member_suffixed_with_Enum()
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern_when_member_is_suffixed_with_Enum()
         {
             const string OriginalCode = @"
 using System;
@@ -218,7 +218,7 @@ public enum TestMeKind
         [TestCase("TypeEnum")]
         [TestCase("TypesEnum")]
         [TestCase("KindsEnum")]
-        public void Code_gets_fixed_for_special_phrase_of_enum_member_suffixed_with_Enum_and_type_suffixed_with_(string suffix)
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern_when_type_is_suffixed_with_(string suffix)
         {
             var originalCode = @"
 using System;
@@ -256,7 +256,7 @@ public enum TestMe" + suffix + @"
         [TestCase("Completed")]
         [TestCase("Canceled")]
         [TestCase("Failed")]
-        public void Code_gets_fixed_for_special_phrase_of_enum_member_(string phrase1)
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern_for_state_(string phrase1)
         {
             var phrase2 = phrase1.ToLowerCaseAt(0);
 
@@ -287,9 +287,9 @@ public enum MessageType
         [TestCase("Warning", "a warning")]
         [TestCase("Error", "an error")]
         [TestCase("Exception", "an exception")]
-        public void Code_gets_fixed_for_special_phrase_of_enum_member_(string phrase1, string fixedPhrase2)
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern_for_message_(string phrase, string fixedPhrase)
         {
-            var phrase2 = phrase1.ToLowerCaseAt(0);
+            var phrase2 = phrase.ToLowerCaseAt(0);
 
             const string OriginalCode = @"
 public enum MessageType
@@ -311,11 +311,11 @@ public enum MessageType
 
 ";
 
-            VerifyCSharpFix(OriginalCode.Replace("#1#", phrase1).Replace("#2#", phrase2), FixedCode.Replace("#1#", phrase1).Replace("#2#", fixedPhrase2));
+            VerifyCSharpFix(OriginalCode.Replace("#1#", phrase).Replace("#2#", phrase2), FixedCode.Replace("#1#", phrase).Replace("#2#", fixedPhrase));
         }
 
         [Test]
-        public void Code_gets_fixed_for_special_plural_phrase_of_enum_member()
+        public void Code_gets_fixed_for_enum_member_with_Enum_for_pattern_for_plural()
         {
             const string OriginalCode = @"
 public enum ItemsType

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2083_NonReadOnlyFieldAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] Visibilities = ["protected", "public", "private", "internal"];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -24,7 +24,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_non_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_readonly_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_readonly_field_with_readonly_comment_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_field_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_readonly_field_with_readonly_comment_with_visibility_([ValueSource(nameof(Visibilities))] string visibility) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -62,7 +62,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed()
+        public void Code_gets_fixed_to_remove_readonly_comment()
         {
             const string OriginalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2090_EqualityOperatorAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2090_EqualityOperatorAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2090_EqualityOperatorAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_undocumented_normal_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_documented_inequality_operator() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_inequality_operator() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_equality_operator() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_equality_operator_with_standard_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -72,7 +72,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_equality_operator_with_full_qualified_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_equality_operator_with_standard_documentation_using_full_qualified_name() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -88,7 +88,7 @@ namespace Bla
 }");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_equality_operator_summary() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_equality_operator_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -102,7 +102,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_equality_operator_returnValue() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_equality_operator_with_non_standard_returns_documentation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -117,7 +117,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_equality_operator_parameter() => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_equality_operator_with_non_standard_parameter_documentation() => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2091_InequalityOperatorAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2091_InequalityOperatorAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2091_InequalityOperatorAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_undocumented_normal_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_documented_equality_operator() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_equality_operator() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_inequality_operator() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_inequality_operator_with_standard_documentation() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -72,7 +72,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_inequality_operator_with_full_qualified_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_inequality_operator_with_standard_documentation_using_full_qualified_name() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -89,7 +89,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_inequality_operator_summary() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_inequality_operator_with_non_standard_summary() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -103,7 +103,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_inequality_operator_returnValue() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_inequality_operator_with_non_standard_returns_documentation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -118,7 +118,7 @@ public class TestMe
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_inequality_operator_parameter() => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_inequality_operator_with_non_standard_parameter_documentation() => An_issue_is_reported_for(2, @"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2101_ExampleUsesCodeTagAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2101_ExampleUsesCodeTagAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_items_without_example_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_items_without_example() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -52,7 +52,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_items_with_correct_example_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_example_with_code_tag() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -102,7 +102,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_example_docu_on_type() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_example_without_code_tag_on_type() => An_issue_is_reported_for(@"
 using System;
 
 /// <summary>
@@ -117,7 +117,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_example_docu_on_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_example_without_code_tag_on_method() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -133,7 +133,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_example_docu_on_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_example_without_code_tag_on_property() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -149,7 +149,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_documented_example_docu_on_event() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_example_without_code_tag_on_event() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -165,7 +165,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_single_line_example_code_on_method()
+        public void Code_gets_fixed_for_single_line_example_on_method()
         {
             const string OriginalCode = @"
 using System;
@@ -203,7 +203,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_double_line_example_code_on_method()
+        public void Code_gets_fixed_for_multi_line_example_on_method()
         {
             const string OriginalCode = @"
 using System;
@@ -243,7 +243,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_starting_text_and_double_line_example_code_on_method()
+        public void Code_gets_fixed_for_example_with_preceding_text_on_method()
         {
             const string OriginalCode = @"
 using System;
@@ -285,7 +285,7 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_surrounding_text_and_double_line_example_code_on_method()
+        public void Code_gets_fixed_for_example_with_surrounding_text_on_method()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2202_DocumentationUsesIdentifierInsteadOfIdAnalyzerTests.cs
@@ -25,12 +25,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                     ];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
 public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_term_in_commented_class_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_using_identifier_term_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier something.
 /// </" + xmlTag + @">
@@ -48,7 +48,7 @@ public sealed class TestMe { }
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongIds))] string id) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documentation_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongIds))] string id) => An_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The " + id.Trim() + @" something.
 /// </" + xmlTag + @">
@@ -56,7 +56,7 @@ public sealed class TestMe { }
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_ending_comment_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongIds))] string id) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documentation_ending_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongIds))] string id) => An_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The " + id.Trim() + @"
 /// </" + xmlTag + @">
@@ -64,7 +64,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void Code_gets_fixed_for_type_comment_with_([ValueSource(nameof(WrongIds))] string wrongId)
+        public void Code_gets_fixed_for_type_documentation_([ValueSource(nameof(WrongIds))] string wrongId)
         {
             const string Template = @"
 /// <summary>
@@ -80,7 +80,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_for_type_comment_ending_with_([ValueSource(nameof(WrongIds))] string wrongId)
+        public void Code_gets_fixed_for_type_documentation_ending_([ValueSource(nameof(WrongIds))] string wrongId)
         {
             const string Template = @"
 /// <summary>
@@ -96,7 +96,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_for_type_special_start_with_A_([ValueSource(nameof(WrongIds))] string wrongId)
+        public void Code_gets_fixed_when_preceded_by_article_([ValueSource(nameof(WrongIds))] string wrongId)
         {
             const string OriginalTemplate = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2203_DocumentationUsesUniqueIdentifierInsteadOfGuidAnalyzerTests.cs
@@ -25,12 +25,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                       ];
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
 public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_term_in_commented_class_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_using_unique_identifier_term_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The unique identifier something.
 /// </" + xmlTag + @">
@@ -38,7 +38,7 @@ public sealed class TestMe { }
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_Guid_in_code_tag_([Values("c", "code")] string xmlTag, [ValueSource(nameof(WrongGuids))] string wrongValue) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_code_tag_([Values("c", "code")] string xmlTag, [ValueSource(nameof(WrongGuids))] string wrongValue) => No_issue_is_reported_for(@"
 /// <summary>
 /// <" + xmlTag + @">
 /// The " + wrongValue.Trim() + @" something.
@@ -48,7 +48,7 @@ public sealed class TestMe { }
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_Guid_in_Xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongGuids))] string wrongValue) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documentation_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [ValueSource(nameof(WrongGuids))] string wrongValue) => An_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The " + wrongValue.Trim() + @" something.
 /// </" + xmlTag + @">
@@ -56,7 +56,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void Code_gets_fixed_for_type_comment_with_([ValueSource(nameof(WrongGuids))] string wrongGuid)
+        public void Code_gets_fixed_for_type_documentation_with_([ValueSource(nameof(WrongGuids))] string wrongGuid)
         {
             const string Template = @"
 /// <summary>
@@ -72,7 +72,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_for_type_comment_ending_with_([ValueSource(nameof(WrongGuids))] string wrongGuid)
+        public void Code_gets_fixed_for_type_documentation_ending_with_([ValueSource(nameof(WrongGuids))] string wrongGuid)
         {
             const string Template = @"
 /// <summary>
@@ -88,7 +88,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_for_type_special_start_with_A_([ValueSource(nameof(WrongGuids))] string wrongGuid)
+        public void Code_gets_fixed_when_preceded_by_article_([ValueSource(nameof(WrongGuids))] string wrongGuid)
         {
             const string OriginalTemplate = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzerTests.cs
@@ -33,9 +33,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_Enumeration_in_Xml_tag_(
-                                                                 [ValueSource(nameof(XmlTags))] string xmlTag,
-                                                                 [ValueSource(nameof(EnumerationMarkers))] string marker)
+        public void An_issue_is_reported_for_enumeration_markers_in_xml_tag_(
+                                                                         [ValueSource(nameof(XmlTags))] string xmlTag,
+                                                                         [ValueSource(nameof(EnumerationMarkers))] string marker)
             => An_issue_is_reported_for(2, @"
 /// <" + xmlTag + @">
 /// " + marker + @" something.
@@ -46,7 +46,7 @@ public sealed class TestMe { }
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_dot_enumeration_in_comment_([ValueSource(nameof(MarkerBeginnings))] string markerBegin) => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_asterisk_markers_in_documentation_([ValueSource(nameof(MarkerBeginnings))] string markerBegin) => An_issue_is_reported_for(2, @"
 /// <summary>
 /// The reason" + markerBegin + @"
 /// * It is something.
@@ -57,7 +57,7 @@ public sealed class TestMe { }
 
         [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
         [Test]
-        public void An_issue_is_reported_for_slash_enumeration_in_comment_([ValueSource(nameof(MarkerBeginnings))] string markerBegin) => An_issue_is_reported_for(2, @"
+        public void An_issue_is_reported_for_dash_markers_in_documentation_([ValueSource(nameof(MarkerBeginnings))] string markerBegin) => An_issue_is_reported_for(2, @"
 /// <summary>
 /// The reason" + markerBegin + @"
 /// - It is something.
@@ -67,12 +67,12 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_uncommented_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
 public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_normal_comment_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_enumeration_markers_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier for something.
 /// </" + xmlTag + @">
@@ -80,7 +80,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_comment_with_double_slash_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_with_double_dash_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier -- if available.
 /// </" + xmlTag + @">
@@ -88,7 +88,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_comment_with_slash_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_with_single_dash_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier - if available - for something.
 /// </" + xmlTag + @">
@@ -96,7 +96,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_comment_with_slash_and_see_langword_Null_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_with_single_dash_and_see_langword_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier - if not <see langword=""null""/> - for something.
 /// </" + xmlTag + @">
@@ -104,7 +104,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_comment_with_double_slash_and_see_langword_Null_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_with_double_dash_and_see_langword_in_xml_tag_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identifier -- if not <see langword=""null""/>.
 /// </" + xmlTag + @">
@@ -112,7 +112,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_comment_containing_similar_words_([Values("heuristic", "et cetera", "superb")] string word) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_containing_similar_words_([Values("heuristic", "et cetera", "superb")] string word) => No_issue_is_reported_for(@"
 /// <summary>
 /// The identifier " + word + @". Seems to be no problem.
 /// </summary>
@@ -120,7 +120,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void Code_gets_fixed_with_multi_line_text_at_beginning_for_([ValueSource(nameof(Markers))] string marker)
+        public void Code_gets_fixed_with_preceding_multi_line_text_([ValueSource(nameof(Markers))] string marker)
         {
             var originalCode = @"
 /// <summary>
@@ -148,7 +148,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_with_single_line_text_at_beginning_for_([ValueSource(nameof(Markers))] string marker)
+        public void Code_gets_fixed_with_preceding_single_line_text_([ValueSource(nameof(Markers))] string marker)
         {
             var originalCode = @"
 /// <summary>
@@ -174,7 +174,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_with_multi_line_text_at_end_for_([ValueSource(nameof(Markers))] string marker)
+        public void Code_gets_fixed_with_following_multi_line_text_([ValueSource(nameof(Markers))] string marker)
         {
             var originalCode = @"
 /// <summary>
@@ -202,7 +202,7 @@ public sealed class TestMe { }
         }
 
         [Test]
-        public void Code_gets_fixed_with_single_line_text_at_end_for_([ValueSource(nameof(Markers))] string marker)
+        public void Code_gets_fixed_with_following_single_line_text_([ValueSource(nameof(Markers))] string marker)
         {
             var originalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2300_MeaninglessCommentAnalyzerTests.cs
@@ -99,7 +99,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         [Test]
         public void No_issue_is_reported_for_uncommented_method() => No_issue_is_reported_for(@"
-
 public class TestMe
 {
     public void DoSomething()
@@ -110,7 +109,6 @@ public class TestMe
 
         [Test, Combinatorial]
         public void No_issue_is_reported_for_separator_comment_([Values("", " ")] string gap, [Values("----", "****", "====", "####")] string comment) => No_issue_is_reported_for(@"
-
 public class TestMe
 {
     public void DoSomething()
@@ -121,8 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_method() => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_meaningful_comment() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -133,8 +130,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_method_with_line_break_where_second_comment_is_short_enough_to_trigger_an_issue() => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_meaningful_multi_line_comment() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -146,8 +142,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_website_link_in_comment_([Values("http://", "https://")] string link) => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_comment_with_website_link_([Values("http://", "https://")] string link) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -158,8 +153,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_incorrectly_commented_method_with_small_comment_but_escaped_Comments_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_escaped_meaningless_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -171,7 +165,6 @@ public class TestMe
 
         [Test]
         public void No_issue_is_reported_for_empty_comment_([Values("", " ")] string gap) => No_issue_is_reported_for(@"
-
 public class TestMe
 {
     public void DoSomething()
@@ -182,8 +175,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_hex_number_in_comment_([Values("", " ")] string gap) => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_comment_with_hex_number_([Values("", " ")] string gap) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -194,8 +186,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_allowed_text_in_comment_([Values("", " ")] string gap, [ValueSource(nameof(AllowedComments))] string comment) => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_comment_with_special_text_([Values("", " ")] string gap, [ValueSource(nameof(AllowedComments))] string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -206,21 +197,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_ReSharper_formatter_advice_comment_([Values("", " ")] string gap, [Values("@formatter:off", "@formatter:on")] string comment) => No_issue_is_reported_for(@"
-
-public class TestMe
-{
-    public void DoSomething()
-    {
-        //" + gap + comment + @"
-        int i = 0;
-    }
-}
-");
-
-        [Test, Combinatorial]
-        public void No_issue_is_reported_for_ReSharper_disabling_rule_comment_([Values("", " ")] string gap, [Values("ReSharper disable Something", "ReSharper restore Something")] string comment) => No_issue_is_reported_for(@"
-
+        public void No_issue_is_reported_for_comment_with_ReSharper_formatter_directive_([Values("", " ")] string gap, [Values("@formatter:off", "@formatter:on")] string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -232,8 +209,19 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_commented_method_with_reason_in_comment_([ValueSource(nameof(Comments))] string comment, [Values("because", "reason")] string reason) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_with_([Values("", " ")] string gap, [Values("ReSharper disable Something", "ReSharper restore Something")] string comment) => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething()
+    {
+        //" + gap + comment + @"
+        int i = 0;
+    }
+}
+");
 
+        [Test, Combinatorial]
+        public void No_issue_is_reported_for_comment_with_reason_([ValueSource(nameof(Comments))] string comment, [Values("because", "reason")] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -244,8 +232,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_commented_method_with_small_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_too_short_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -256,8 +243,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_commented_method_with_long_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_comment_without_context_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -268,8 +254,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_method_with_arrow_inside_comment_([Values("", " ")] string gap) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_comment_with_arrow_([Values("", " ")] string gap) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -280,8 +265,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_small_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_too_short_comment_in_documented_method_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -295,8 +279,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_long_comment_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_comment_without_context_in_documented_method_([Values("", " ")] string gap, [ValueSource(nameof(Comments))] string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -310,8 +293,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_and_documented_method_with_arrow_inside_comment_([Values("", " ")] string gap) => An_issue_is_reported_for(@"
-
+        public void An_issue_is_reported_for_comment_with_arrow_in_documented_method_([Values("", " ")] string gap) => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -326,7 +308,6 @@ public class TestMe
 
         [Test]
         public void No_issue_is_reported_for_uncommented_field_within_region() => No_issue_is_reported_for(@"
-
 public class TestMe
 {
     #region Some region

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentException.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentException.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         [TestCase("\"some message\", \"X\", null")]
         [TestCase("\"some message\", nameof(TestMe), null")]
         [TestCase("\"some message\", new Exception()")]
-        public void No_issue_is_reported_for_incorrectly_thrown_ArgumentException_on_parameterless_method_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentException_on_parameterless_method_(string parameters) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -31,7 +31,7 @@ public class TestMe
         [TestCase("\"some message\", nameof(x)")]
         [TestCase("\"some message\", \"x\", null")]
         [TestCase("\"some message\", nameof(x), null")]
-        public void No_issue_is_reported_for_correctly_thrown_ArgumentException_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentException_with_valid_parameter_name_(string parameters) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -53,7 +53,7 @@ public class TestMe
         [TestCase("\"some message\", \"X\", null")]
         [TestCase("\"some message\", nameof(TestMe), null")]
         [TestCase("\"some message\", new Exception()")]
-        public void An_issue_is_reported_for_incorrectly_thrown_ArgumentException_(string parameters) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_with_missing_or_wrong_parameter_name_(string parameters) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -66,7 +66,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_thrown_ArgumentException_with_string_literal() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentException_with_string_interpolation_as_message() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -79,514 +79,530 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_no_parameters_on_property()
+        public void Code_gets_fixed_for_ArgumentException_without_parameters_on_property()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public int Something
-    {
-        get => 42;
-        set
-        {
-            if (value == 42) throw new ArgumentException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public int Something
+                                            {
+                                                get => 42;
+                                                set
+                                                {
+                                                    if (value == 42) throw new ArgumentException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public int Something
-    {
-        get => 42;
-        set
-        {
-            if (value == 42) throw new ArgumentException(""TODO"", nameof(value));
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public int Something
+                                         {
+                                             get => 42;
+                                             set
+                                             {
+                                                 if (value == 42) throw new ArgumentException("TODO", nameof(value));
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_no_parameters_on_indexer_key()
+        public void Code_gets_fixed_for_ArgumentException_without_parameters_on_indexer_key()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public int this[int key]
-    {
-        get => 42;
-        set
-        {
-            if (key == 42) throw new ArgumentException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public int this[int key]
+                                            {
+                                                get => 42;
+                                                set
+                                                {
+                                                    if (key == 42) throw new ArgumentException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public int this[int key]
-    {
-        get => 42;
-        set
-        {
-            if (key == 42) throw new ArgumentException(""TODO"", nameof(key));
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public int this[int key]
+                                         {
+                                             get => 42;
+                                             set
+                                             {
+                                                 if (key == 42) throw new ArgumentException("TODO", nameof(key));
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_no_parameters_on_indexer_value()
+        public void Code_gets_fixed_for_ArgumentException_without_parameters_on_indexer_value()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public int this[int key]
-    {
-        get => 42;
-        set
-        {
-            if (value == 42) throw new ArgumentException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public int this[int key]
+                                            {
+                                                get => 42;
+                                                set
+                                                {
+                                                    if (value == 42) throw new ArgumentException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public int this[int key]
-    {
-        get => 42;
-        set
-        {
-            if (value == 42) throw new ArgumentException(""TODO"", nameof(value));
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public int this[int key]
+                                         {
+                                             get => 42;
+                                             set
+                                             {
+                                                 if (value == 42) throw new ArgumentException("TODO", nameof(value));
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_no_parameters_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentException_without_parameters_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42) throw new ArgumentException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""TODO"", nameof(x));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42) throw new ArgumentException("TODO", nameof(x));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_no_parameters_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentException_without_parameters_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y)
-    {
-        if (y == 42) throw new ArgumentException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y)
+                                            {
+                                                if (y == 42) throw new ArgumentException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y)
-    {
-        if (y == 42) throw new ArgumentException(""TODO"", nameof(y));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y)
+                                         {
+                                             if (y == 42) throw new ArgumentException("TODO", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_message_only_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentException_with_message_only_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42) throw new ArgumentException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""some message"", nameof(x));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42) throw new ArgumentException("some message", nameof(x));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_message_only_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentException_with_message_only_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42) throw new ArgumentException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y, int z)
+                                            {
+                                                if (y == 42) throw new ArgumentException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42) throw new ArgumentException(""some message"", nameof(y));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y, int z)
+                                         {
+                                             if (y == 42) throw new ArgumentException("some message", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_parameter_name_only_instead_of_message_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentException_with_parameter_name_as_message_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""x"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42) throw new ArgumentException("x");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""TODO"", nameof(x));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42) throw new ArgumentException("TODO", nameof(x));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_parameter_name_only_instead_of_message_on_method_with_multiple_parameter()
+        public void Code_gets_fixed_for_ArgumentException_with_parameter_name_as_message_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y)
-    {
-        if (y == 42) throw new ArgumentException(""y"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y)
+                                            {
+                                                if (y == 42) throw new ArgumentException("y");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y)
-    {
-        if (y == 42) throw new ArgumentException(""TODO"", nameof(y));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y)
+                                         {
+                                             if (y == 42) throw new ArgumentException("TODO", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_message_only_and_some_comment()
+        public void Code_gets_fixed_for_ArgumentException_with_message_only_and_comment()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42)
-        {
-            // some comment
-            throw new ArgumentException(""some message""); // some more comment
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42)
+                                                {
+                                                    // some comment
+                                                    throw new ArgumentException("some message"); // some more comment
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42)
-        {
-            // some comment
-            throw new ArgumentException(""some message"", nameof(x)); // some more comment
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42)
+                                             {
+                                                 // some comment
+                                                 throw new ArgumentException("some message", nameof(x)); // some more comment
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_reversed_message_and_parameter_as_string()
+        public void Code_gets_fixed_for_ArgumentException_with_swapped_message_and_parameter_name_as_string()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""x"", ""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42) throw new ArgumentException("x", "some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""some message"", nameof(x));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42) throw new ArgumentException("some message", nameof(x));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_reversed_message_and_parameter_as_nameof()
+        public void Code_gets_fixed_for_ArgumentException_with_swapped_message_and_parameter_name_as_nameof()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(nameof(x), ""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x)
+                                            {
+                                                if (x == 42) throw new ArgumentException(nameof(x), "some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x)
-    {
-        if (x == 42) throw new ArgumentException(""some message"", nameof(x));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x)
+                                         {
+                                             if (x == 42) throw new ArgumentException("some message", nameof(x));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_multiple_parameters_on_method_and_return_in_if_statement()
+        public void Code_gets_fixed_for_ArgumentException_with_multiple_parameters_on_method_and_return_in_if_statement()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            return;
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y, int z)
+                                            {
+                                                if (y == 42)
+                                                    return;
 
-        throw new ArgumentException();
-    }
-}
-";
+                                                throw new ArgumentException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            return;
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y, int z)
+                                         {
+                                             if (y == 42)
+                                                 return;
 
-        throw new ArgumentException(""TODO"", nameof(y));
-    }
-}
-";
+                                             throw new ArgumentException("TODO", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_multiple_parameters_on_method_and_in_else_statement()
+        public void Code_gets_fixed_for_ArgumentException_with_multiple_parameters_on_method_and_in_else_statement()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            return;
-        else
-            throw new ArgumentException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y, int z)
+                                            {
+                                                if (y == 42)
+                                                    return;
+                                                else
+                                                    throw new ArgumentException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            return;
-        else
-            throw new ArgumentException(""TODO"", nameof(y));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y, int z)
+                                         {
+                                             if (y == 42)
+                                                 return;
+                                             else
+                                                 throw new ArgumentException("TODO", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_multiple_parameters_on_method_and_string_interpolation()
+        public void Code_gets_fixed_for_ArgumentException_with_multiple_parameters_on_method_and_string_interpolation()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            throw new ArgumentException($""'y' should be 42 but was {y}"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y, int z)
+                                            {
+                                                if (y == 42)
+                                                    throw new ArgumentException($"'y' should be 42 but was {y}");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, int z)
-    {
-        if (y == 42)
-            throw new ArgumentException($""'y' should be 42 but was {y}"", nameof(y));
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y, int z)
+                                         {
+                                             if (y == 42)
+                                                 throw new ArgumentException($"'y' should be 42 but was {y}", nameof(y));
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentException_with_multiple_parameters_on_method_and_exception()
+        public void Code_gets_fixed_for_ArgumentException_with_multiple_parameters_on_method_and_inner_exception()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, Exception ex)
-    {
-        if (y == 42)
-            throw new ArgumentException(""y"", ""some message"", ex);
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(int x, int y, Exception ex)
+                                            {
+                                                if (y == 42)
+                                                    throw new ArgumentException("y", "some message", ex);
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(int x, int y, Exception ex)
-    {
-        if (y == 42)
-            throw new ArgumentException(""some message"", nameof(y), ex);
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(int x, int y, Exception ex)
+                                         {
+                                             if (y == 42)
+                                                 throw new ArgumentException("some message", nameof(y), ex);
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
     }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentNullException.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentNullException.cs
@@ -9,7 +9,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         [TestCase("nameof(x)")]
         [TestCase("\"x\", \"some message\"")]
         [TestCase("nameof(x), \"some message\"")]
-        public void No_issue_is_reported_for_correctly_thrown_ArgumentNullException_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentNullException_with_valid_parameter_name_(string parameters) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -30,7 +30,7 @@ public class TestMe
         [TestCase("\"some message\", \"x\"")]
         [TestCase("\"some message\", nameof(x)")]
         [TestCase("\"some message\", new Exception()")]
-        public void An_issue_is_reported_for_incorrectly_thrown_ArgumentNullException_(string parameters) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentNullException_with_missing_or_wrong_parameter_name_(string parameters) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -43,355 +43,366 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_no_parameters_on_property()
+        public void Code_gets_fixed_for_ArgumentNullException_without_parameters_on_property()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object Something
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentNullException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object Something
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (value is null) throw new ArgumentNullException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object Something
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentNullException(nameof(value), ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object Something
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (value is null) throw new ArgumentNullException(nameof(value), "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_no_parameters_on_indexer_key()
+        public void Code_gets_fixed_for_ArgumentNullException_without_parameters_on_indexer_key()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (key is null) throw new ArgumentNullException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object this[object key]
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (key is null) throw new ArgumentNullException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (key is null) throw new ArgumentNullException(nameof(key), ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object this[object key]
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (key is null) throw new ArgumentNullException(nameof(key), "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_no_parameters_on_indexer_value()
+        public void Code_gets_fixed_for_ArgumentNullException_without_parameters_on_indexer_value()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentNullException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object this[object key]
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (value is null) throw new ArgumentNullException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentNullException(nameof(value), ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object this[object key]
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (value is null) throw new ArgumentNullException(nameof(value), "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_no_parameters_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentNullException_without_parameters_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentNullException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(nameof(x), ""TODO"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentNullException(nameof(x), "TODO");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_no_parameters_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentNullException_without_parameters_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y)
-    {
-        if (y is null) throw new ArgumentNullException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x, object y)
+                                            {
+                                                if (y is null) throw new ArgumentNullException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y)
-    {
-        if (y is null) throw new ArgumentNullException(nameof(y), ""TODO"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x, object y)
+                                         {
+                                             if (y is null) throw new ArgumentNullException(nameof(y), "TODO");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_message_only_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentNullException_with_message_only_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentNullException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(nameof(x), ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentNullException(nameof(x), "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_message_only_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentNullException_with_message_only_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null) throw new ArgumentNullException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x, object y, object z)
+                                            {
+                                                if (y is null) throw new ArgumentNullException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null) throw new ArgumentNullException(nameof(y), ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x, object y, object z)
+                                         {
+                                             if (y is null) throw new ArgumentNullException(nameof(y), "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_message_only_and_some_comment()
+        public void Code_gets_fixed_for_ArgumentNullException_with_message_only_and_comment()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null)
-        {
-            // some comment
-            throw new ArgumentNullException(""some message""); // some more comment
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null)
+                                                {
+                                                    // some comment
+                                                    throw new ArgumentNullException("some message"); // some more comment
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null)
-        {
-            // some comment
-            throw new ArgumentNullException(nameof(x), ""some message""); // some more comment
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null)
+                                             {
+                                                 // some comment
+                                                 throw new ArgumentNullException(nameof(x), "some message"); // some more comment
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_reversed_message_and_parameter_as_string()
+        public void Code_gets_fixed_for_ArgumentNullException_with_swapped_message_and_parameter_name_as_string()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(""some message"", ""x"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentNullException("some message", "x");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(nameof(x), ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentNullException(nameof(x), "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_reversed_message_and_parameter_as_nameof()
+        public void Code_gets_fixed_for_ArgumentNullException_with_swapped_message_and_parameter_name_as_nameof()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(""some message"", nameof(x));
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentNullException("some message", nameof(x));
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentNullException(nameof(x), ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentNullException(nameof(x), "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentNullException_with_multiple_parameters_on_method_and_string_interpolation()
+        public void Code_gets_fixed_for_ArgumentNullException_with_multiple_parameters_on_method_and_string_interpolation()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null)
-            throw new ArgumentNullException($""'y' should be null but was {y}"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x, object y, object z)
+                                            {
+                                                if (y is null)
+                                                    throw new ArgumentNullException($"'y' should be null but was {y}");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null)
-            throw new ArgumentNullException(nameof(y), $""'y' should be null but was {y}"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x, object y, object z)
+                                         {
+                                             if (y is null)
+                                                 throw new ArgumentNullException(nameof(y), $"'y' should be null but was {y}");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
     }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentOutOfRangeException.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentOutOfRangeException.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         [TestCase("nameof(x), \"some message\"")]
         [TestCase("\"x\", 42, \"some message\"")]
         [TestCase("nameof(x), 42, \"some message\"")]
-        public void No_issue_is_reported_for_correctly_thrown_ArgumentOutOfRangeException_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ArgumentOutOfRangeException_with_valid_parameter_name_(string parameters) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -35,7 +35,7 @@ public class TestMe
         [TestCase("\"some message\", new Exception()")]
         [TestCase("\"some message\", 42, \"x\"")]
         [TestCase("\"some message\", 42, nameof(x)")]
-        public void An_issue_is_reported_for_incorrectly_thrown_ArgumentOutOfRangeException_(string parameters) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_ArgumentOutOfRangeException_with_missing_or_wrong_parameter_name_(string parameters) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -48,287 +48,296 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_no_parameters_on_property()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_without_parameters_on_property()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object Something
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentOutOfRangeException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object Something
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (value is null) throw new ArgumentOutOfRangeException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object Something
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentOutOfRangeException(nameof(value), value, ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object Something
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (value is null) throw new ArgumentOutOfRangeException(nameof(value), value, "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_no_parameters_on_indexer_key()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_without_parameters_on_indexer_key()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (key is null) throw new ArgumentOutOfRangeException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object this[object key]
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (key is null) throw new ArgumentOutOfRangeException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (key is null) throw new ArgumentOutOfRangeException(nameof(key), key, ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object this[object key]
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (key is null) throw new ArgumentOutOfRangeException(nameof(key), key, "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_no_parameters_on_indexer_value()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_without_parameters_on_indexer_value()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentOutOfRangeException();
-        }
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public object this[object key]
+                                            {
+                                                get => null;
+                                                set
+                                                {
+                                                    if (value is null) throw new ArgumentOutOfRangeException();
+                                                }
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public object this[object key]
-    {
-        get => null;
-        set
-        {
-            if (value is null) throw new ArgumentOutOfRangeException(nameof(value), value, ""TODO"");
-        }
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public object this[object key]
+                                         {
+                                             get => null;
+                                             set
+                                             {
+                                                 if (value is null) throw new ArgumentOutOfRangeException(nameof(value), value, "TODO");
+                                             }
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_no_parameters_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_without_parameters_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentOutOfRangeException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, ""TODO"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, "TODO");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_no_parameters_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_without_parameters_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y)
-    {
-        if (y is null) throw new ArgumentOutOfRangeException();
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x, object y)
+                                            {
+                                                if (y is null) throw new ArgumentOutOfRangeException();
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y)
-    {
-        if (y is null) throw new ArgumentOutOfRangeException(nameof(y), y, ""TODO"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x, object y)
+                                         {
+                                             if (y is null) throw new ArgumentOutOfRangeException(nameof(y), y, "TODO");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_message_only_on_method_with_single_parameter()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_with_message_only_on_method_with_single_parameter()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentOutOfRangeException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_message_only_on_method_with_multiple_parameters()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_with_message_only_on_method_with_multiple_parameters()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null) throw new ArgumentOutOfRangeException(""some message"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x, object y, object z)
+                                            {
+                                                if (y is null) throw new ArgumentOutOfRangeException("some message");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x, object y, object z)
-    {
-        if (y is null) throw new ArgumentOutOfRangeException(nameof(y), y, ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x, object y, object z)
+                                         {
+                                             if (y is null) throw new ArgumentOutOfRangeException(nameof(y), y, "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_reversed_message_and_parameter_as_string()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_with_swapped_message_and_parameter_name_as_string()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(""some message"", ""x"");
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentOutOfRangeException("some message", "x");
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_thrown_ArgumentOutOfRangeException_with_reversed_message_and_parameter_as_nameof()
+        public void Code_gets_fixed_for_ArgumentOutOfRangeException_with_swapped_message_and_parameter_name_as_nameof()
         {
-            const string OriginalCode = @"
-using System;
+            const string OriginalCode = """
+                                        using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(""some message"", nameof(x));
-    }
-}
-";
+                                        public class TestMe
+                                        {
+                                            public void DoSomething(object x)
+                                            {
+                                                if (x is null) throw new ArgumentOutOfRangeException("some message", nameof(x));
+                                            }
+                                        }
+                                        """;
 
-            const string FixedCode = @"
-using System;
+            const string FixedCode = """
+                                     using System;
 
-public class TestMe
-{
-    public void DoSomething(object x)
-    {
-        if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, ""some message"");
-    }
-}
-";
+                                     public class TestMe
+                                     {
+                                         public void DoSomething(object x)
+                                         {
+                                             if (x is null) throw new ArgumentOutOfRangeException(nameof(x), x, "some message");
+                                         }
+                                     }
+                                     """;
+
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
     }


### PR DESCRIPTION
- Refactor test method names for clearer, more specific descriptions of scenarios and expected outcomes

- Improve parameterized test naming so that parameter values convey details instead of being embedded in method names

- Update MiKo_1117 documentation with guidance on naming parameterized tests

- Modernize test code by using raw string literals for better readability