### PR TITLE
MiKo_1100 is now prepared if a test type starts with 'Testable'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzer.cs
@@ -87,6 +87,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 typeName = typeName.Slice(TestablePrefix.Length);
             }
 
+            if (typeName.Length is 0)
+            {
+                return false;
+            }
+
             return testClass.Name.AsSpan().StartsWith(typeName, StringComparison.Ordinal);
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzerTests.cs
@@ -192,6 +192,24 @@ namespace Bla
 ");
 
         [Test]
+        public void An_issue_is_reported_for_type_named_Testable_and_test_class_with_starting_with_wrong_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class Testable
+    {
+    }
+
+    [" + fixture + @"]
+    public class TestMeTests
+    {
+        private Testable ObjectUnderTest { get; set; }
+
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_type_starting_with_Testable_and_test_class_with_starting_with_wrong_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => An_issue_is_reported_for(@"
 namespace Bla
 {


### PR DESCRIPTION
- Adjust MiKo_1100 to strip a leading "Testable" from the type-under-test name when checking test-class prefixes

- Add unit tests covering the "Testable" scenarios