### PR TITLE
MiKo_3018 is now investigating only methods in source code

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzer.cs
@@ -65,8 +65,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (syntax)
             {
-                case AccessorDeclarationSyntax ads: return ads.Keyword.GetLocation();
-                case ArrowExpressionClauseSyntax aecs: return aecs.ArrowToken.GetLocation();
+                case AccessorDeclarationSyntax a: return a.Keyword.GetLocation();
+                case ArrowExpressionClauseSyntax a: return a.ArrowToken.GetLocation();
                 case IndexerDeclarationSyntax i: return i.ThisKeyword.GetLocation();
                 case MethodDeclarationSyntax m: return m.Identifier.GetLocation();
                 default: return syntax.GetLocation();
@@ -95,7 +95,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         if (methods is null)
                         {
-                            methods = symbol.ContainingType.GetMembersIncludingInherited<IMethodSymbol>().ToLookup(_ => _.Name);
+                            methods = symbol.ContainingType.GetMembersIncludingInherited<IMethodSymbol>()
+                                                           .Where(_ => _.Locations.Any(__ => __.IsInSource))
+                                                           .ToLookup(_ => _.Name);
                         }
 
                         if (methods.Contains(name) && methods[name].Any(DirectlyThrowsObjectDisposedException))
@@ -109,7 +111,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return false;
         }
 
-        private static bool DirectlyThrowsObjectDisposedException(IMethodSymbol symbol) => symbol.GetSyntax().DescendantNodes().Any(ThrowsObjectDisposedException);
+        private static bool DirectlyThrowsObjectDisposedException(IMethodSymbol symbol) => symbol.GetSyntax().DescendantNodes().Any(ThrowsObjectDisposedException) is true;
 
         private static bool AlwaysThrows<T1, T2>(SyntaxNode syntax)
                                                                where T1 : Exception

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzerTests.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                        "protected internal",
                                                                    ];
 
-        private static readonly string[] Visibilities = [.. ProblematicVisibilities, "private "];
+        private static readonly string[] Visibilities = [.. ProblematicVisibilities, "private"];
 
         [Test]
         public void No_issue_is_reported_for_interface() => No_issue_is_reported_for(@"


### PR DESCRIPTION
- Filter candidate symbols to those located in source code before inspecting their syntax

Note:
Currently it is unclear how to reproduce it, although it happens each time for a specific piece of code.
