### PR TITLE
Local variable naming analyzer (such as MiKo_1063) now also investigate variable declarations of using statements

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/LocalVariableNamingAnalyzer.cs
@@ -21,6 +21,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             context.RegisterSyntaxNodeAction(AnalyzeTupleExpression, SyntaxKind.TupleExpression);
             context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.SingleVariableDesignation);
             context.RegisterSyntaxNodeAction(AnalyzeVariableDesignation, SyntaxKind.ParenthesizedVariableDesignation);
+
+            context.RegisterSyntaxNodeAction(AnalyzeUsingStatement, SyntaxKind.UsingStatement);
         }
 
         protected override bool ShallAnalyze(ITypeSymbol symbol) => base.ShallAnalyze(symbol) || symbol?.TypeKind is TypeKind.Array; // accept analysis of arrays

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -825,7 +825,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         /// <summary>
-        /// Analyzes a foreach statement.
+        /// Analyzes a <see langword="foreach"/> statement.
         /// </summary>
         /// <param name="context">
         /// The syntax node analysis context.
@@ -846,7 +846,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         }
 
         /// <summary>
-        /// Analyzes a for statement.
+        /// Analyzes a <see langword="for"/> statement.
         /// </summary>
         /// <param name="context">
         /// The syntax node analysis context.
@@ -854,23 +854,21 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         protected virtual void AnalyzeForStatement(SyntaxNodeAnalysisContext context)
         {
             var node = (ForStatementSyntax)context.Node;
-            var variableDeclaration = node.Declaration;
 
-            if (variableDeclaration is null)
-            {
-                // ignore variables that are not set
-                return;
-            }
+            AnalyzeVariableDeclaration(node.Declaration, context);
+        }
 
-            var semanticModel = context.SemanticModel;
-            var type = variableDeclaration.GetTypeSymbol(semanticModel);
+        /// <summary>
+        /// Analyzes a <see langword="using"/> statement.
+        /// </summary>
+        /// <param name="context">
+        /// The syntax node analysis context.
+        /// </param>
+        protected virtual void AnalyzeUsingStatement(SyntaxNodeAnalysisContext context)
+        {
+            var node = (UsingStatementSyntax)context.Node;
 
-            if (ShallAnalyze(type))
-            {
-                var issues = AnalyzeIdentifiers(semanticModel, type, variableDeclaration.Variables.ToArray(_ => _.Identifier));
-
-                ReportDiagnostics(context, issues);
-            }
+            AnalyzeVariableDeclaration(node.Declaration, context);
         }
 
         /// <summary>
@@ -987,6 +985,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 default:
                     return Array.Empty<Diagnostic>();
+            }
+        }
+
+        private void AnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, in SyntaxNodeAnalysisContext context)
+        {
+            if (variableDeclaration is null)
+            {
+                // ignore variables that are not set
+                return;
+            }
+
+            var semanticModel = context.SemanticModel;
+            var type = variableDeclaration.GetTypeSymbol(semanticModel);
+
+            if (ShallAnalyze(type))
+            {
+                var issues = AnalyzeIdentifiers(semanticModel, type, variableDeclaration.Variables.ToArray(_ => _.Identifier));
+
+                ReportDiagnostics(context, issues);
             }
         }
     }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzerTests.cs
@@ -1060,6 +1060,37 @@ namespace Bla
             VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
         }
 
+        [TestCase("lang", "language")]
+        [TestCase("decl", "declaration")]
+        [TestCase("impl", "implementation")]
+        public void Code_gets_fixed_for_using_variable_by_expanding_abbreviation_(string originalName, string fixedName)
+        {
+            const string Template = @"
+using System;
+
+namespace Bla
+{
+    public class Disposable : IDisposable
+    {
+        public static IDisposable Create() => new Disposable();
+
+        public void Dispose() { }
+    }
+
+    public class TestMe
+    {
+        public void DoSomething()
+        {
+            using (var ### = Disposable.Create())
+            {
+            }
+        }
+    }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
         protected override string GetDiagnosticId() => MiKo_1063_AbbreviationsInNameAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1063_AbbreviationsInNameAnalyzer();


### PR DESCRIPTION
- Register analysis for `SyntaxKind.UsingStatement` in `LocalVariableNamingAnalyzer`

- Refactor `for` statement variable-declaration analysis into a shared helper and reuse it for `using` statements

- Add MiKo_1063 test coverage verifying abbreviations are expanded for variables declared in `using (...)`
