### PR TITLE
MiKo_2001 is now aware of events starting with 'fire'/'raise'/'trigger'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -18,18 +17,33 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private const string SpecialTerm = "Occurs that ";
-
-        private static readonly string[] SpecialTerms = { SpecialTerm };
-
-        private static readonly Pair[] SpecialTermReplacementMap = { new Pair(SpecialTerm, "Occurs when ") };
-
-        private static readonly Pair[] ReplacementMap = CreatePhrases().Select(_ => new Pair(_))
-                                                                       .Append(new Pair("Invoked if ", "when "))
-                                                                       .Append(new Pair("Invoked when ", "when "))
-                                                                       .OrderDescendingByLengthAndText(_ => _.Key);
+        private static readonly Pair[] ReplacementMap = CreatePhrases().Select(_ => new Pair(_)).OrderDescendingByLengthAndText(_ => _.Key);
 
         private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+
+        private static readonly Pair[] CleanUpMap =
+                                                    {
+                                                        new Pair("Occurs fire ", "Occurs "),
+                                                        new Pair("Occurs fired ", "Occurs "),
+                                                        new Pair("Occurs fires ", "Occurs "),
+                                                        new Pair("Occurs firing ", "Occurs "),
+                                                        new Pair("Occurs raise ", "Occurs "),
+                                                        new Pair("Occurs raised ", "Occurs "),
+                                                        new Pair("Occurs raises ", "Occurs "),
+                                                        new Pair("Occurs raising ", "Occurs "),
+                                                        new Pair("Occurs trigger ", "Occurs "),
+                                                        new Pair("Occurs triggered ", "Occurs "),
+                                                        new Pair("Occurs triggers ", "Occurs "),
+                                                        new Pair("Occurs triggering ", "Occurs "),
+
+                                                        new Pair("Occurs invoked ", "Occurs "),
+
+                                                        // special case
+                                                        new Pair("Occurs that ", "Occurs when "),
+                                                        new Pair("Occurs if ", "Occurs when "),
+                                                    };
+
+        private static readonly string[] CleanUpPhrases = CleanUpMap.ToArray(_ => _.Key);
 
 //// ncrunch: rdi default
 
@@ -44,23 +58,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax GetUpdatedSyntax(XmlElementSyntax syntax)
         {
-            var preparedComment = PrepareComment(syntax);
-
+            var preparedComment = Comment(syntax, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
             var fixedComment = CommentStartingWith(preparedComment, Constants.Comments.EventSummaryStartingPhrase);
+            var cleanedComment = Comment(fixedComment, CleanUpPhrases, CleanUpMap);
 
-            var text = fixedComment.Content[0].WithoutXmlCommentExterior();
-
-            if (text.StartsWith(SpecialTerm, StringComparison.Ordinal))
-            {
-                return Comment(fixedComment, SpecialTerms, SpecialTermReplacementMap);
-            }
-
-            return fixedComment;
+            return cleanedComment;
         }
 
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
-
-//// ncrunch: rdi off
+        //// ncrunch: rdi off
 
         private static HashSet<string> CreatePhrases()
         {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
@@ -102,7 +102,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_event_phrase_([ValueSource(nameof(StartingPhrases))] string originalComment, [Values("after", "before", "when", "for")] string condition)
+        public void Code_gets_fixed_for_event_phrase_([ValueSource(nameof(StartingPhrases))] string originalComment, [Values("after", "before", "for")] string condition)
         {
             const string Template = @"
 public class TestMe
@@ -118,7 +118,23 @@ public class TestMe
         }
 
         [Test]
-        public void Code_gets_fixed_for_([Values("When", "Indicates that", "Invoked if", "Invoked when")] string original)
+        public void Code_gets_fixed_for_event_phrase_condition_([ValueSource(nameof(StartingPhrases))] string originalComment, [Values("if", "when")] string condition)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public event EventHandler MyEvent;
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalComment + " " + condition), Template.Replace("###", "Occurs when"));
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_([Values("When", "Indicates that")] string original)
         {
             const string Template = @"
 public class TestMe
@@ -207,6 +223,36 @@ public class TestMe
                     results.Add(string.Concat(start, " ", verb));
                 }
             }
+
+            results.Add("Fire");
+            results.Add("Fired");
+            results.Add("Fires");
+            results.Add("Firing");
+            results.Add("fire");
+            results.Add("fired");
+            results.Add("fires");
+            results.Add("firing");
+
+            results.Add("Raise");
+            results.Add("Raised");
+            results.Add("Raises");
+            results.Add("Raising");
+            results.Add("raise");
+            results.Add("raised");
+            results.Add("raises");
+            results.Add("raising");
+
+            results.Add("Trigger");
+            results.Add("Triggered");
+            results.Add("Triggers");
+            results.Add("Triggering");
+            results.Add("trigger");
+            results.Add("triggered");
+            results.Add("triggers");
+            results.Add("triggering");
+
+            results.Add("Invoked");
+            results.Add("invoked");
 
             return results;
         }


### PR DESCRIPTION
- Extend event-summary test phrase set to include `fire`, `raise`, `trigger` and `invoked` (incl. variants)

- Refactor code-fix logic to add a cleanup pass that
  - removes verb-leading `Occurs <verb> …` artifacts
  - normalizes `Occurs if/that …` to `Occurs when …`

- Add dedicated test for `if`/`when` conditions