### PR TITLE
MiKo_2245 is now aware of 'filterpriority'

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1128,6 +1128,7 @@ namespace MiKoSolutions.Analyzers
             internal const string Description = "description";
             internal const string Example = "example";
             internal const string Exception = "exception";
+            internal const string FilterPriority = "filterpriority";
             internal const string Include = "include";
             internal const string Inheritdoc = "inheritdoc";
             internal const string Item = "item";

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -967,7 +967,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if the syntax node represents a <c>&lt;c&gt;…&lt;/c&gt;</c> tag; otherwise, <see langword="false"/>.
         /// </returns>
-        internal static bool IsC(this SyntaxNode value) => value is XmlElementSyntax xes && xes.IsC();
+        internal static bool IsC(this SyntaxNode value) => value is XmlElementSyntax e && e.IsC();
 
         /// <summary>
         /// Determines whether a syntax node represents a <c>&lt;c&gt;…&lt;/c&gt;</c> tag.
@@ -1011,7 +1011,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if the syntax node represents a <c>&lt;code&gt;…&lt;/code&gt;</c> tag; otherwise, <see langword="false"/>.
         /// </returns>
-        internal static bool IsCode(this SyntaxNode value) => value is XmlElementSyntax xes && xes.IsCode();
+        internal static bool IsCode(this SyntaxNode value) => value is XmlElementSyntax e && e.IsCode();
 
         /// <summary>
         /// Determines whether an XML element syntax represents a <c>&lt;code&gt;…&lt;/code&gt;</c> tag.
@@ -1096,6 +1096,28 @@ namespace MiKoSolutions.Analyzers
         /// <see langword="true"/> if the XML element syntax represents an exception comment for the specified exception type; otherwise, <see langword="false"/>.
         /// </returns>
         internal static bool IsExceptionCommentFor<T>(this XmlElementSyntax value) where T : Exception => IsExceptionComment(value, typeof(T));
+
+        /// <summary>
+        /// Determines whether a syntax node represents a <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax node to check for the <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the syntax node represents a <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsFilterPriority(this SyntaxNode value) => value is XmlElementSyntax e && e.IsFilterPriority();
+
+        /// <summary>
+        /// Determines whether a syntax node represents a <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax node to check for the <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the syntax node represents a <c>&lt;filterpriority&gt;…&lt;/filterpriority&gt;</c> tag; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsFilterPriority(this XmlElementSyntax value) => value.GetName() is Constants.XmlTag.FilterPriority;
 
         /// <summary>
         /// Determines whether a syntax node represents a <c>&lt;para/&gt;</c> XML tag.
@@ -1356,7 +1378,7 @@ namespace MiKoSolutions.Analyzers
             switch (value)
             {
                 case XmlEmptyElementSyntax xees when xees.GetName() == tagName:
-                case XmlElementSyntax xes when xes.GetName() == tagName:
+                case XmlElementSyntax e when e.GetName() == tagName:
                     return true;
 
                 default:
@@ -1582,12 +1604,12 @@ namespace MiKoSolutions.Analyzers
         {
             switch (value)
             {
-                case XmlElementSyntax xes:
+                case XmlElementSyntax e:
                 {
-                    var newAttributes = xes.StartTag.Attributes.Add(attribute);
-                    var newStartTag = xes.StartTag.WithAttributes(newAttributes);
+                    var newAttributes = e.StartTag.Attributes.Add(attribute);
+                    var newStartTag = e.StartTag.WithAttributes(newAttributes);
 
-                    return xes.ReplaceNode(xes.StartTag, newStartTag) as T;
+                    return e.ReplaceNode(e.StartTag, newStartTag) as T;
                 }
 
                 case XmlEmptyElementSyntax xees:

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
@@ -23,24 +23,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
             {
+                if (xmlText.Parent is XmlElementSyntax parent)
+                {
+                    if (parent.IsCode() || parent.IsC() || parent.IsFilterPriority())
+                    {
+                        continue;
+                    }
+                }
+
                 var textTokens = xmlText.TextTokens;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
                 var textTokensCount = textTokens.Count;
 
                 if (textTokensCount is 0)
-                {
-                    continue;
-                }
-
-                var parent = xmlText.Parent;
-
-                if (parent.IsCode())
-                {
-                    continue;
-                }
-
-                if (parent.IsC())
                 {
                     continue;
                 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzerTests.cs
@@ -28,6 +28,12 @@ public sealed class TestMe { }
 ");
 
         [Test]
+        public void No_issue_is_reported_for_number_in_filterpriority() => No_issue_is_reported_for(@"
+/// <filterpriority>2</filterpriority>
+public sealed class TestMe { }
+");
+
+        [Test]
         public void No_issue_is_reported_for_number_in_c_in_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
 /// <" + tag + @">
 /// This is some text for <c>-1</c>. Just to be sure.


### PR DESCRIPTION
- Introduce `IsFilterPriority` XML tag helpers and added `filterpriority` tag constant

- Update analyzer logic to skip analysis of `XmlText` that belongs to `<filterpriority>`

- Add regression test ensuring no diagnostic is reported for numbers inside `<filterpriority>`

(resolves #1860)