### PR TITLE
MiKo_2001 is now aware of events starting with 'occur*'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -38,7 +38,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                                                         new Pair("Occurs invoked ", "Occurs "),
 
-                                                        // special case
+                                                        // special cases
+                                                        new Pair("Occurs occur ", "Occurs "),
+                                                        new Pair("Occurs occurs ", "Occurs "),
+                                                        new Pair("Occurs occured ", "Occurs "),
+                                                        new Pair("Occurs occurred ", "Occurs "),
+                                                        new Pair("Occurs occuring ", "Occurs "),
+                                                        new Pair("Occurs occurring ", "Occurs "),
                                                         new Pair("Occurs that ", "Occurs when "),
                                                         new Pair("Occurs if ", "Occurs when "),
                                                     };

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2001_EventSummaryAnalyzerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -149,6 +150,24 @@ public class TestMe
             VerifyCSharpFix(Template.Replace("###", original), Template.Replace("###", "Occurs when"));
         }
 
+        [Test]
+        public void Code_gets_fixed_for_Occurs_phrase_(
+                                                   [Values("Occur", "occur", "occurs", "Occured", "Occurred", "occured", "occurred", "Occuring", "Occurring", "occuring", "occurring")] string original,
+                                                   [Values("if", "when")] string condition)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary>
+    /// ### something.
+    /// </summary>
+    public event EventHandler MyEvent;
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", original + " " + condition), Template.Replace("###", "Occurs when"));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2001_EventSummaryAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2001_EventSummaryAnalyzer();
@@ -156,6 +175,7 @@ public class TestMe
         protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2001_CodeFixProvider();
 
         // ReSharper disable once ReturnTypeCanBeEnumerable.Local Violates CA1859
+        [ExcludeFromCodeCoverage]
         private static HashSet<string> CreatePhrases()
         {
             string[] starts = ["Event", "This event", "The event", "An event", "A event"];


### PR DESCRIPTION
- Extend cleanup mappings to remove duplicated `occur*` tokens after prefixing with `Occurs `

- Add new test matrix covering `Occur/occur/occurs/occurred/occurring` (including common misspellings) combined with `if/when`

- Mark test helper phrase generator with `[ExcludeFromCodeCoverage]`
