### PR TITLE
MiKo_3046 is now aware of the empty string

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3046_CodeFixProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
@@ -19,11 +20,20 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {
-            SyntaxNode updatedSyntax = GetUpdatedSyntax((LiteralExpressionSyntax)syntax);
+            var updatedSyntax = GetUpdatedSyntax((LiteralExpressionSyntax)syntax);
 
             return Task.FromResult(updatedSyntax);
         }
 
-        private static InvocationExpressionSyntax GetUpdatedSyntax(LiteralExpressionSyntax syntax) => NameOf(syntax);
+        private static SyntaxNode GetUpdatedSyntax(LiteralExpressionSyntax syntax)
+        {
+            if (syntax.Token.ValueText.Length is 0)
+            {
+                // seems like the empty string, so we will not convert it to 'nameof'
+                return Member(PredefinedType(SyntaxKind.StringKeyword), nameof(string.Empty));
+            }
+
+            return NameOf(syntax);
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzerTests.cs
@@ -72,47 +72,101 @@ namespace Bla
         [Test]
         public void Code_gets_fixed_for_([ValueSource(nameof(MethodNames))] string methodName)
         {
-            var originalCode = @"
-using System;
+            const string OriginalCode = """
 
-namespace Bla
-{
-    public class TestMe
-    {
-        public string MyProperty { get; set; }
+                                        using System;
 
-        private void DoSomething()
-        {
-            " + methodName + @"(""MyProperty"");
+                                        namespace Bla
+                                        {
+                                            public class TestMe
+                                            {
+                                                public string MyProperty { get; set; }
+
+                                                private void DoSomething()
+                                                {
+                                                    ###("MyProperty");
+                                                }
+
+                                                private void ###(string name)
+                                                { }
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     namespace Bla
+                                     {
+                                         public class TestMe
+                                         {
+                                             public string MyProperty { get; set; }
+
+                                             private void DoSomething()
+                                             {
+                                                 ###(nameof(MyProperty));
+                                             }
+
+                                             private void ###(string name)
+                                             { }
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode.Replace("###", methodName), FixedCode.Replace("###", methodName));
         }
 
-        private void " + methodName + @"(string name)
-        { }
-    }
-}
-";
-
-            var fixedCode = @"
-using System;
-
-namespace Bla
-{
-    public class TestMe
-    {
-        public string MyProperty { get; set; }
-
-        private void DoSomething()
+        [Test]
+        public void Code_gets_fixed_for_empty_string_at_([ValueSource(nameof(MethodNames))] string methodName)
         {
-            " + methodName + @"(nameof(MyProperty));
-        }
+            const string OriginalCode = """
 
-        private void " + methodName + @"(string name)
-        { }
-    }
-}
-";
+                                        using System;
 
-            VerifyCSharpFix(originalCode, fixedCode);
+                                        namespace Bla
+                                        {
+                                            public class TestMe
+                                            {
+                                                public string MyProperty { get; set; }
+
+                                                private void DoSomething()
+                                                {
+                                                    ###("");
+                                                }
+
+                                                private void ###(string name)
+                                                { }
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+
+                                     namespace Bla
+                                     {
+                                         public class TestMe
+                                         {
+                                             public string MyProperty { get; set; }
+
+                                             private void DoSomething()
+                                             {
+                                                 ###(string.Empty);
+                                             }
+
+                                             private void ###(string name)
+                                             { }
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode.Replace("###", methodName), FixedCode.Replace("###", methodName));
         }
 
         protected override string GetDiagnosticId() => MiKo_3046_OnPropertyChangedMethodUsesNameofAnalyzer.Id;


### PR DESCRIPTION
- Update `MiKo_3046_CodeFixProvider` to replace `""` with `string.Empty` rather than `nameof()`

- Add unit tests