### PR TITLE
Streamlined code to directly release cached StringBuilder

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -1569,12 +1569,10 @@ namespace MiKoSolutions.Analyzers
 
                 if (replaced)
                 {
-                    map[token] = token.WithText(result.ToStringAndRelease());
+                    map[token] = token.WithText(result.ToString());
                 }
-                else
-                {
-                    StringBuilderCache.Release(result);
-                }
+
+                StringBuilderCache.Release(result);
             }
 
             if (map.Count is 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -214,12 +214,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         newText = newText.ReplaceAllWithProbe(TrailingSentenceMarkers, ".");
 
-                        summary = summary.ReplaceToken(token, token.WithText(newText.ToStringAndRelease()));
+                        summary = summary.ReplaceToken(token, token.WithText(newText.ToString()));
                     }
-                    else
-                    {
-                        StringBuilderCache.Release(newText);
-                    }
+
+                    StringBuilderCache.Release(newText);
                 }
             }
 


### PR DESCRIPTION
Refactored to directly use `StringBuilderCache.Release` instead of indirectly using it via  call to `ToStringAndRelease`.