### PR TITLE
MiKo_1404 is now aware of 'AsyncHelpers'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
@@ -10,7 +10,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1404";
 
-        private static readonly HashSet<string> NonsenseNamespaces = new HashSet<string> { "Helper", "Helpers", "Util", "Utils", "Utility", "Utilities", "Misc", "Miscellaneous" };
+        private static readonly HashSet<string> NonsenseNamespaces = new HashSet<string> { "AsyncHelper", "AsyncHelpers", "Helper", "Helpers", "Util", "Utils", "Utility", "Utilities", "Misc", "Miscellaneous" };
 
         public MiKo_1404_NonsenseNamespacesAnalyzer() : base(Id)
         {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzerTests.cs
@@ -12,6 +12,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         private static readonly string[] ForbiddenNamespaceNames =
                                                                    [
+                                                                       "AsyncHelper",
+                                                                       "AsyncHelpers",
                                                                        "Helper",
                                                                        "Helpers",
                                                                        "Misc",


### PR DESCRIPTION
- Add `AsyncHelper` and `AsyncHelpers` to list of 'forbidden' namespaces

- Update test cases
