### PR TITLE
MiKo_6018 no longer reports for "break" on same line as "case"

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6018_BreakStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6018_BreakStatementSurroundedByBlankLinesAnalyzer.cs
@@ -15,5 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         }
 
         protected override SyntaxToken GetKeyword(BreakStatementSyntax node) => node.BreakKeyword;
+
+        protected override bool ShallAnalyzeSwitchSection(SwitchSectionSyntax section, in SyntaxToken keyword) => keyword.IsOnSameLineAs(section.Labels.Last()) is false;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/StatementSurroundedByBlankLinesAnalyzer.cs
@@ -22,6 +22,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected virtual bool ShallAnalyzeOtherStatement(StatementSyntax node) => true;
 
+        protected virtual bool ShallAnalyzeSwitchSection(SwitchSectionSyntax section, in SyntaxToken keyword) => true;
+
         private static bool HasNoBlankLinesAfter(List<StatementSyntax> otherStatements, in FileLinePositionSpan afterPosition)
         {
             for (int index = 0, count = otherStatements.Count; index < count; index++)
@@ -118,30 +120,35 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         private Diagnostic AnalyzeStatement(SwitchSectionSyntax section, T node)
         {
-            var beforePosition = GetLineSpanOfNodeOrLeadingComment(node);
-            var afterPosition = GetLineSpanOfNodeOrTrailingComment(node);
+            var keyword = GetKeyword(node);
 
-            var statements = section.Statements;
-            var otherStatements = statements.Except(node).Where(ShallAnalyzeOtherStatement).ToList();
-
-            var noBlankLinesBefore = HasNoBlankLinesBefore(otherStatements, beforePosition);
-            var noBlankLinesAfter = HasNoBlankLinesAfter(otherStatements, afterPosition);
-
-            if (noBlankLinesAfter is false)
+            if (ShallAnalyzeSwitchSection(section, keyword))
             {
-                // inspect the switch section to see if another switch section directly comes after our node, as in such case we also need some blank lines
-                var nextSection = section.NextSibling();
+                var beforePosition = GetLineSpanOfNodeOrLeadingComment(node);
+                var afterPosition = GetLineSpanOfNodeOrTrailingComment(node);
 
-                if (nextSection != null && statements.Last() == node)
+                var statements = section.Statements;
+                var otherStatements = statements.Except(node).Where(ShallAnalyzeOtherStatement).ToList();
+
+                var noBlankLinesBefore = HasNoBlankLinesBefore(otherStatements, beforePosition);
+                var noBlankLinesAfter = HasNoBlankLinesAfter(otherStatements, afterPosition);
+
+                if (noBlankLinesAfter is false)
                 {
-                    // determine whether the next section has no blank line between itself and our node
-                    noBlankLinesAfter = HasNoBlankLinesAfter(afterPosition, nextSection);
-                }
-            }
+                    // inspect the switch section to see if another switch section directly comes after our node, as in such case we also need some blank lines
+                    var nextSection = section.NextSibling();
 
-            if (noBlankLinesBefore || noBlankLinesAfter)
-            {
-                return Issue(GetKeyword(node), noBlankLinesBefore, noBlankLinesAfter);
+                    if (nextSection != null && statements.Last() == node)
+                    {
+                        // determine whether the next section has no blank line between itself and our node
+                        noBlankLinesAfter = HasNoBlankLinesAfter(afterPosition, nextSection);
+                    }
+                }
+
+                if (noBlankLinesBefore || noBlankLinesAfter)
+                {
+                    return Issue(keyword, noBlankLinesBefore, noBlankLinesAfter);
+                }
             }
 
             return null;

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6018_BreakStatementSurroundedByBlankLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6018_BreakStatementSurroundedByBlankLinesAnalyzerTests.cs
@@ -69,6 +69,28 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_break_statement_as_statement_without_blank_line_after_variable_assignment_in_switch_case_section_when_on_same_line_as_case() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething(GCCollectionMode mode)
+        {
+            int value = 0;
+
+            switch (mode)
+            {
+                case GCCollectionMode.Default:   value = 1; break;
+                case GCCollectionMode.Forced:    value = 2; break;
+                case GCCollectionMode.Optimized: value = 3; break;
+                default:                         value = 4; break;
+            }
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_break_statement_as_statement_without_blank_line_after_variable_assignment_in_method() => An_issue_is_reported_for(@"
 namespace Bla
 {


### PR DESCRIPTION
- Update MiKo_6018 to skip analysis when `break` keyword is on the same line as last switch label

- Add regression test covering single-line `case ...: value = ...; break;`
