### PR TITLE
MiKo_3011 is now aware of verbatim identifiers such as '@event'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -3663,7 +3663,7 @@ namespace MiKoSolutions.Analyzers
         /// A <see cref="string"/> that contains the original value with the specified character removed.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Without(this string value, in char character) => value.Without(character.ToString());
+        public static string Without(this string value, in char character) => value?.Without(character.ToString());
 
         /// <summary>
         /// Creates a new <see cref="string"/> with the specified string removed.
@@ -3678,7 +3678,7 @@ namespace MiKoSolutions.Analyzers
         /// A <see cref="string"/> that contains the original value with the specified substring removed.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string Without(this string value, string phrase) => value.Replace(phrase, string.Empty);
+        public static string Without(this string value, string phrase) => value?.Replace(phrase, string.Empty);
 
         /// <summary>
         /// Creates a new <see cref="string"/> with all specified phrases removed.

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -1057,18 +1057,44 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Returns the <see cref="string"/> representation of the specified <see cref="ArgumentSyntax"/> with any verbatim identifier prefixes removed.
+        /// Converts the specified <see cref="ArgumentSyntax"/> to its textual representation with verbatim identifier prefixes removed.
         /// </summary>
-        /// <param name="value">
+        /// <param name="source">
         /// The argument syntax.
         /// </param>
         /// <returns>
-        /// A <see cref="string"/> that contains the string representation of the argument without any '@' verbatim identifier prefixes; or <see langword="null"/> if the argument is <see langword="null"/>.
+        /// A <see cref="string"/> that contains the textual representation of the argument without any '@' verbatim identifier prefixes; or <see langword="null"/> if the argument is <see langword="null"/>.
         /// </returns>
         /// <remarks>
-        /// This method removes the verbatim identifier prefix ('@') from the argument's string representation.
-        /// Verbatim identifiers in C# are used to allow reserved keywords to be used as identifiers by prefixing them with '@'.
+        /// This method removes the verbatim identifier prefix ('@') from the argument's textual representation.
+        /// Verbatim identifiers in C# allow reserved keywords to be used as identifiers by prefixing them with '@'.
         /// </remarks>
-        internal static string ToStringWithoutVerbatimIdentifier(this ArgumentSyntax value) => value?.ToString().Without('@'); // get rid of verbatim identifiers
+        internal static string ToStringWithoutVerbatimIdentifier(this ArgumentSyntax source)
+        {
+            if (source is null)
+            {
+                return null;
+            }
+
+            switch (source.Expression)
+            {
+                case IdentifierNameSyntax identifier:
+                {
+                    return StringWithoutVerbatimIdentifier(identifier);
+                }
+
+                case InvocationExpressionSyntax invocation when invocation.IsNameOf():
+                {
+                    return string.Concat("nameof(", StringWithoutVerbatimIdentifier(invocation.ArgumentList.Arguments[0].Expression), ")");
+                }
+
+                default:
+                    return source.ToString();
+            }
+
+            string StringWithoutVerbatimIdentifier(ExpressionSyntax e) => e is IdentifierNameSyntax i
+                                                                          ? i.Identifier.ValueText.Without('@') // get rid of verbatim identifiers
+                                                                          : e.ToCleanedUpString();
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -414,7 +414,7 @@ namespace MiKoSolutions.Analyzers
 
                         if (arguments.Count > 0)
                         {
-                            return arguments[0].ToString();
+                            return arguments[0].ToStringWithoutVerbatimIdentifier();
                         }
                     }
 
@@ -1055,5 +1055,20 @@ namespace MiKoSolutions.Analyzers
 
             return false;
         }
+
+        /// <summary>
+        /// Returns the <see cref="string"/> representation of the specified <see cref="ArgumentSyntax"/> with any verbatim identifier prefixes removed.
+        /// </summary>
+        /// <param name="value">
+        /// The argument syntax.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the string representation of the argument without any '@' verbatim identifier prefixes; or <see langword="null"/> if the argument is <see langword="null"/>.
+        /// </returns>
+        /// <remarks>
+        /// This method removes the verbatim identifier prefix ('@') from the argument's string representation.
+        /// Verbatim identifiers in C# are used to allow reserved keywords to be used as identifiers by prefixing them with '@'.
+        /// </remarks>
+        internal static string ToStringWithoutVerbatimIdentifier(this ArgumentSyntax value) => value?.ToString().Without('@'); // get rid of verbatim identifiers
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -1055,46 +1055,5 @@ namespace MiKoSolutions.Analyzers
 
             return false;
         }
-
-        /// <summary>
-        /// Converts the specified <see cref="ArgumentSyntax"/> to its textual representation with verbatim identifier prefixes removed.
-        /// </summary>
-        /// <param name="source">
-        /// The argument syntax.
-        /// </param>
-        /// <returns>
-        /// A <see cref="string"/> that contains the textual representation of the argument without any '@' verbatim identifier prefixes; or <see langword="null"/> if the argument is <see langword="null"/>.
-        /// </returns>
-        /// <remarks>
-        /// This method removes the verbatim identifier prefix ('@') from the argument's textual representation.
-        /// Verbatim identifiers in C# allow reserved keywords to be used as identifiers by prefixing them with '@'.
-        /// </remarks>
-        internal static string ToStringWithoutVerbatimIdentifier(this ArgumentSyntax source)
-        {
-            if (source is null)
-            {
-                return null;
-            }
-
-            switch (source.Expression)
-            {
-                case IdentifierNameSyntax identifier:
-                {
-                    return StringWithoutVerbatimIdentifier(identifier);
-                }
-
-                case InvocationExpressionSyntax invocation when invocation.IsNameOf():
-                {
-                    return string.Concat("nameof(", StringWithoutVerbatimIdentifier(invocation.ArgumentList.Arguments[0].Expression), ")");
-                }
-
-                default:
-                    return source.ToString();
-            }
-
-            string StringWithoutVerbatimIdentifier(ExpressionSyntax e) => e is IdentifierNameSyntax i
-                                                                          ? i.Identifier.ValueText.Without('@') // get rid of verbatim identifiers
-                                                                          : e.ToCleanedUpString();
-        }
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2717,18 +2717,14 @@ namespace MiKoSolutions.Analyzers
             switch (source.Expression)
             {
                 case IdentifierNameSyntax identifier:
-                    return StringWithoutVerbatimIdentifier(identifier);
+                    return identifier.Identifier.ValueText;
 
                 case InvocationExpressionSyntax invocation when invocation.IsNameOf() && invocation.ArgumentList.Arguments.FirstOrDefault() is ArgumentSyntax argument:
-                    return string.Concat("nameof(", StringWithoutVerbatimIdentifier(argument.Expression), ")");
+                    return string.Concat("nameof(", argument.ToString().Without('@'), ")"); // get rid of verbatim identifiers
 
                 default:
                     return source.ToString();
             }
-
-            string StringWithoutVerbatimIdentifier(ExpressionSyntax e) => e is IdentifierNameSyntax i
-                                                                          ? i.Identifier.ValueText.Without('@') // get rid of verbatim identifiers
-                                                                          : e.ToCleanedUpString();
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -2679,7 +2679,57 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A cleaned-up <see cref="string"/> representation of the expression.
         /// </returns>
-        internal static string ToCleanedUpString(this ExpressionSyntax source) => source?.ToString().Without(Constants.WhiteSpaces);
+        internal static string ToCleanedUpString(this ExpressionSyntax source)
+        {
+            switch (source)
+            {
+                case null:
+                    return null;
+
+                case IdentifierNameSyntax i:
+                    return i.Identifier.ValueText;
+
+                default:
+                    return source.ToString().Without(Constants.WhiteSpaces);
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="ArgumentSyntax"/> to its textual representation with verbatim identifier prefixes removed.
+        /// </summary>
+        /// <param name="source">
+        /// The argument syntax.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the textual representation of the argument without any '@' verbatim identifier prefixes; or <see langword="null"/> if the argument is <see langword="null"/>.
+        /// </returns>
+        /// <remarks>
+        /// This method removes the verbatim identifier prefix ('@') from the argument's textual representation.
+        /// Verbatim identifiers in C# allow reserved keywords to be used as identifiers by prefixing them with '@'.
+        /// </remarks>
+        internal static string ToStringWithoutVerbatimIdentifier(this ArgumentSyntax source)
+        {
+            if (source is null)
+            {
+                return null;
+            }
+
+            switch (source.Expression)
+            {
+                case IdentifierNameSyntax identifier:
+                    return StringWithoutVerbatimIdentifier(identifier);
+
+                case InvocationExpressionSyntax invocation when invocation.IsNameOf() && invocation.ArgumentList.Arguments.FirstOrDefault() is ArgumentSyntax argument:
+                    return string.Concat("nameof(", StringWithoutVerbatimIdentifier(argument.Expression), ")");
+
+                default:
+                    return source.ToString();
+            }
+
+            string StringWithoutVerbatimIdentifier(ExpressionSyntax e) => e is IdentifierNameSyntax i
+                                                                          ? i.Identifier.ValueText.Without('@') // get rid of verbatim identifiers
+                                                                          : e.ToCleanedUpString();
+        }
 
         /// <summary>
         /// Attempts to get Moq types from a member access expression.

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
@@ -113,7 +113,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         var nameB = partB.ToString();
 
                         var argument = arguments[0];
-                        var argumentName = argument.ToStringWithoutVerbatimIdentifier();
+                        var argumentName = argument.ToString();
 
                         if (nameB == argumentName || nameA == argumentName)
                         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/LogicalConditionsComparisonCanBeSimplifiedMaintainabilityAnalyzer.cs
@@ -113,7 +113,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         var nameB = partB.ToString();
 
                         var argument = arguments[0];
-                        var argumentName = argument.ToString();
+                        var argumentName = argument.ToStringWithoutVerbatimIdentifier();
 
                         if (nameB == argumentName || nameA == argumentName)
                         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzer.cs
@@ -166,7 +166,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool ParameterIsReferenced(ArgumentSyntax argument, IMethodSymbol method)
         {
-            var argumentName = argument.ToString();
+            var argumentName = argument.ToStringWithoutVerbatimIdentifier();
 
             return method.Parameters.Select(_ => _.Name).Any(_ => argumentName == _.SurroundedWithDoubleQuote() || argumentName == AsNameof(_));
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3011_CodeFixProvider.cs
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     var argument = arguments[0];
 
-                    if (argument.ToString() == parameter.GetName().SurroundedWithDoubleQuote())
+                    if (argument.ToStringWithoutVerbatimIdentifier() == parameter.GetName().SurroundedWithDoubleQuote())
                     {
                         // seems like the 'message' parameter has been misused for the parameter name
                         return ArgumentList(ToDo(), ParamName(parameter));

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     // this is a new-found line, so inspect start position
                     if (argumentPosition.Character != characterPosition)
                     {
-                        yield return Issue(argument.ToString().AsSpan().HumanizedTakeFirst(50), argument, CreateProposalForSpaces(characterPosition));
+                        yield return Issue(argument.ToStringWithoutVerbatimIdentifier().AsSpan().HumanizedTakeFirst(50), argument, CreateProposalForSpaces(characterPosition));
                     }
                 }
                 else

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentNullException.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3011_ArgumentExceptionsParamNameAnalyzerTests.ArgumentNullException.cs
@@ -21,6 +21,19 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void No_issue_is_reported_for_ArgumentNullException_with_valid_verbatim_parameter_name() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void DoSomething(int @event)
+    {
+        if (@event == 42) throw new ArgumentNullException(nameof(@event));
+    }
+}
+");
+
         [TestCase("")]
         [TestCase("\"X\"")]
         [TestCase("nameof(TestMe)")]


### PR DESCRIPTION
- Introduce `ToStringWithoutVerbatimIdentifier()`

- Add test ensuring MiKo_3011 accepts `nameof(@event)` for an `ArgumentNullException`

- Update diagnostic message text generation to strip verbatim identifier prefixes
