### PR TITLE
Bump "Microsoft.VSSDK.BuildTools" from v17.14.2120 to v17.14.2142

### DIFF
--- a/MiKo.Analyzer.Vsix2022/MiKo.Analyzer.Vsix2022.csproj
+++ b/MiKo.Analyzer.Vsix2022/MiKo.Analyzer.Vsix2022.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2120" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2142" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Bump `Microsoft.VSSDK.BuildTools` from version `17.14.2120` to version `17.14.2142`