### PR TITLE
Refactored code to exit early

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -1124,7 +1124,7 @@ namespace MiKoSolutions.Analyzers
         /// <see langword="true"/> if the sequence is found; otherwise, <see langword="false"/>.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Contains(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> finding, in StringComparison comparison) => value.IndexOf(finding, comparison) >= 0;
+        public static bool Contains(this in ReadOnlySpan<char> value, in ReadOnlySpan<char> finding, in StringComparison comparison) => value.IndexOf(finding, comparison) >= 0; // Perf: when compared other than with Ordinal comparison, a string gets created internally
 
         /// <summary>
         /// Determines whether the span of characters contains the specified substring using the given <see cref="string"/> comparison.
@@ -1149,7 +1149,7 @@ namespace MiKoSolutions.Analyzers
                 return false;
             }
 
-            return value.Contains(finding.AsSpan(), comparison);
+            return value.Contains(finding.AsSpan(), comparison); // Perf: when compared other than with Ordinal comparison, a string gets created internally
         }
 
         /// <summary>
@@ -4038,6 +4038,7 @@ namespace MiKoSolutions.Analyzers
 
             for (int index = 0, findingLength = finding.Length; ; index += findingLength)
             {
+                // do not use 'IndexOf' from 'Span' as in case of 'StringComparison.OrdinalIgnoreCase' it would create multiple strings (see 'IndexOf' method inside 'MemoryExtensions')
                 index = value.IndexOf(finding, index, StringComparison.OrdinalIgnoreCase);
 
                 if (index is -1)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzer.cs
@@ -49,17 +49,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var locations = GetAllLocations(token, Phrase);
                 var locationsCount = locations.Count;
 
-                if (locationsCount > 0)
+                if (locationsCount is 0)
                 {
-                    if (results is null)
-                    {
-                        results = new List<Diagnostic>(locationsCount);
-                    }
+                    continue;
+                }
 
-                    for (var index = 0; index < locationsCount; index++)
-                    {
-                        results.Add(Issue(locations[index]));
-                    }
+                if (results is null)
+                {
+                    results = new List<Diagnostic>(locationsCount);
+                }
+
+                for (var index = 0; index < locationsCount; index++)
+                {
+                    results.Add(Issue(locations[index]));
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzer.cs
@@ -34,20 +34,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var token = textTokens[index];
 
-                var allLocations = GetAllLocations(token, Phrase, StringComparison.OrdinalIgnoreCase);
-                var allLocationsCount = allLocations.Count;
+                var locations = GetAllLocations(token, Phrase, StringComparison.OrdinalIgnoreCase);
+                var locationsCount = locations.Count;
 
-                if (allLocationsCount > 0)
+                if (locationsCount is 0)
                 {
-                    if (issues is null)
-                    {
-                        issues = new List<Diagnostic>(allLocationsCount);
-                    }
+                    continue;
+                }
 
-                    for (var locationIndex = 0; locationIndex < allLocationsCount; locationIndex++)
-                    {
-                        issues.Add(Issue(allLocations[locationIndex]));
-                    }
+                if (issues is null)
+                {
+                    issues = new List<Diagnostic>(locationsCount);
+                }
+
+                foreach (var location in locations)
+                {
+                    issues.Add(Issue(location));
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
@@ -52,10 +52,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
 
                     var locations = GetAllLocations(token, Phrase);
+                    var locationsCount = locations.Count;
+
+                    if (locationsCount is 0)
+                    {
+                        continue;
+                    }
 
                     if (issues is null)
                     {
-                        issues = new List<Diagnostic>(locations.Count);
+                        issues = new List<Diagnostic>(locationsCount);
                     }
 
                     foreach (var location in locations)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
@@ -52,10 +52,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
 
                     var locations = GetAllLocations(token, Phrase, StringComparison.OrdinalIgnoreCase);
+                    var locationsCount = locations.Count;
+
+                    if (locationsCount is 0)
+                    {
+                        continue;
+                    }
 
                     if (issues is null)
                     {
-                        issues = new List<Diagnostic>(locations.Count);
+                        issues = new List<Diagnostic>(locationsCount);
                     }
 
                     foreach (var location in locations)


### PR DESCRIPTION
- Refactor multiple `AnalyzeComment` implementations to `continue` early when `locations.Count is 0`

- Simplify issue-collection loops

- Add inline performance comments in `StringExtensions` around span-based `Contains` and `AllIndicesNonOrdinal`
