### PR TITLE
Refactored 'NamespaceNamingAnalyzer.AnalyzeNamespaceName' method signature

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,6 +14,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1400_NamespacesInPluralAnalyzer : NamespaceNamingAnalyzer
     {
         public const string Id = "MiKo_1400";
+
+        private static readonly ConcurrentDictionary<string, string> BetterNames = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
 
         private static readonly string[] AllowedSuffixes = new[]
                                                                {
@@ -65,25 +68,29 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         internal static string FindBetterName(string name)
         {
-            if (name is "Model")
-            {
-                return Pluralizer.GetPluralName(Constants.Entity);
-            }
+            return BetterNames.GetOrAdd(name, FindBetterNameLocal);
 
-            // maybe it's a number, so we have to check for that
-            if (name.EndsWithNumber() || name.IsAcronym() || name.EndsWithAny(AllowedSuffixes, StringComparison.OrdinalIgnoreCase))
+            string FindBetterNameLocal(string originalName)
             {
-                // nothing to do here
-                return name;
-            }
+                if (originalName is "Model")
+                {
+                    return Pluralizer.GetPluralName(Constants.Entity);
+                }
 
-            return Pluralizer.GetPluralName(name);
+                // maybe it's a number, so we have to check for that
+                if (originalName.EndsWithNumber() || originalName.IsAcronym() || originalName.EndsWithAny(AllowedSuffixes, StringComparison.OrdinalIgnoreCase))
+                {
+                    // nothing to do here
+                    return originalName;
+                }
+
+                return Pluralizer.GetPluralName(originalName);
+            }
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            var namespaceNames = names.ToList();
-            var namespaceNamesCount = namespaceNames.Count;
+            var namespaceNamesCount = namespaceNames.Length;
 
             if (namespaceNamesCount > 1)
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -16,15 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            foreach (var name in names)
+            List<Diagnostic> issues = null;
+
+            foreach (var name in namespaceNames)
             {
                 if (TechnicalNamespaces.Contains(name.ValueText))
                 {
-                    yield return Issue(name);
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,9 +18,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            foreach (var name in names)
+            List<Diagnostic> issues = null;
+
+            foreach (var name in namespaceNames)
             {
                 var namespaceName = name.ValueText;
 
@@ -30,9 +33,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 if (TechnicalWPFNamespaces.Contains(namespaceName))
                 {
-                    yield return Issue(name);
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1403_RedundantNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1403_RedundantNamespaceAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,17 +15,33 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
+            if (namespaceNames.Length is 1)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            List<Diagnostic> issues = null;
+
             var knownNamespaces = new HashSet<string>();
 
-            foreach (var name in names)
+            foreach (var name in namespaceNames)
             {
-                if (knownNamespaces.Add(name.ValueText) is false)
+                if (knownNamespaces.Add(name.ValueText))
                 {
-                    yield return Issue(name);
+                    continue;
                 }
+
+                if (issues is null)
+                {
+                    issues = new List<Diagnostic>(1);
+                }
+
+                issues.Add(Issue(name));
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -16,15 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            foreach (var name in names)
+            List<Diagnostic> issues = null;
+
+            foreach (var name in namespaceNames)
             {
                 if (NonsenseNamespaces.Contains(name.ValueText))
                 {
-                    yield return Issue(name);
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzer.cs
@@ -17,11 +17,13 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
+            List<Diagnostic> issues = null;
+
             var libraryNamespacesLength = LibraryNamespaces.Length;
 
-            foreach (var name in names)
+            foreach (var name in namespaceNames)
             {
                 var namespaceName = name.ValueText;
 
@@ -31,12 +33,19 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                     if (namespaceName.EndsWith(libraryNamespace, StringComparison.Ordinal))
                     {
-                        yield return Issue(namespaceName, name, libraryNamespace);
+                        if (issues is null)
+                        {
+                            issues = new List<Diagnostic>(1);
+                        }
+
+                        issues.Add(Issue(namespaceName, name, libraryNamespace));
 
                         break;
                     }
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1407_TestNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1407_TestNamespaceAnalyzer.cs
@@ -17,15 +17,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            foreach (var name in names)
+            List<Diagnostic> issues = null;
+
+            foreach (var name in namespaceNames)
             {
                 if (name.ValueText.Contains("Test", StringComparison.OrdinalIgnoreCase))
                 {
-                    yield return Issue(name);
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,24 +12,35 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1409";
 
+        private static readonly ConcurrentDictionary<string, string> BetterNames = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+
         public MiKo_1409_NamespacesDoNotStartOrEndWithUnderscoreAnalyzer() : base(Id)
         {
         }
 
-        protected override IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names)
+        protected override IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames)
         {
-            foreach (var namePart in names)
+            List<Diagnostic> issues = null;
+
+            foreach (var namePart in namespaceNames)
             {
                 var name = namePart.ValueText;
 
-                if (HasIssue(name, Constants.Underscore))
+                if (HasIssue(name.AsSpan(), Constants.Underscore))
                 {
-                    yield return Issue(name, namePart, FindBetterName(name));
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name, namePart, FindBetterName(name)));
                 }
             }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
 
-        private static bool HasIssue(string name, in char character)
+        private static bool HasIssue(in ReadOnlySpan<char> name, in char character)
         {
             if (name.Length is 0)
             {
@@ -37,25 +48,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            if (name.First() == character)
+            if (name[0] == character)
             {
-                var trimmed = name.AsSpan().TrimStart(character);
+                var trimmed = name.TrimStart(character);
 
-                if (trimmed.Length > 0)
-                {
-                    if (trimmed[0].IsNumber())
-                    {
-                        // namespaces starting with numbers need to be "escaped", so this situation is no issue
-                        return false;
-                    }
-                }
-
-                return true;
+                // namespaces starting with numbers need to be "escaped", so this situation is no issue
+                return trimmed.Length <= 0 || trimmed[0].IsNumber() is false;
             }
 
-            return name.Last() == character;
+            return name[name.Length - 1] == character;
         }
 
-        private static string FindBetterName(string name) => name.Trim(Constants.Underscores);
+        private static string FindBetterName(string name) => BetterNames.GetOrAdd(name, _ => _.Trim(Constants.Underscores));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -16,18 +17,18 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected sealed override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNamespaceDeclaration, SyntaxKind.NamespaceDeclaration);
 
-        protected abstract IEnumerable<Diagnostic> AnalyzeNamespaceName(IEnumerable<SyntaxToken> names);
+        protected abstract IReadOnlyList<Diagnostic> AnalyzeNamespaceName(in ReadOnlySpan<SyntaxToken> namespaceNames);
 
         private void AnalyzeNamespaceDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = (NamespaceDeclarationSyntax)context.Node;
 
             // collect all names but start on namespace name to not include any attributes or else in the collection
-            var names = node.Name.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>().Select(_ => _.Identifier);
+            var names = node.Name.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>().Select(_ => _.Identifier).ToArray();
 
             var issues = AnalyzeNamespaceName(names);
 
-            if (issues.IsEmptyArray() is false)
+            if (issues.Count > 0)
             {
                 ReportDiagnostics(context, issues);
             }


### PR DESCRIPTION
- Change `AnalyzeNamespaceName` signature

- Update dependent namespace analyzers accordingly

- Add small performance-related adjustments (such as caching)

