### PR TITLE
MiKo_1408 no longer reports for types within global namespaces

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -22,11 +21,18 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         private Diagnostic[] AnalyzeNamespaceNames(INamedTypeSymbol symbol, string qualifiedNamespaceOfExtensionMethod)
         {
-            // get namespace (qualified) of class and of extension method parameter (first one) and compare those
-
             // ReSharper disable once LoopCanBePartlyConvertedToQuery
-            foreach (var namespaceSymbol in symbol.GetExtensionMethods().Select(_ => _.Parameters[0].Type.ContainingNamespace).WhereNotNull())
+            foreach (var extensionMethod in symbol.GetExtensionMethods())
             {
+                // get namespace (qualified) of class and of extension method parameter (first one) and compare those
+                var namespaceSymbol = extensionMethod.Parameters[0].Type.ContainingNamespace;
+
+                if (namespaceSymbol is null || namespaceSymbol.IsGlobalNamespace)
+                {
+                    // we cannot move it into no namespace or the global one, so we keep the name
+                    continue;
+                }
+
                 var ns = namespaceSymbol.ToString();
 
                 if (ns != qualifiedNamespaceOfExtensionMethod)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
@@ -14,10 +14,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         public void No_issue_is_reported_for_non_extension_method_class() => No_issue_is_reported_for(@"
 namespace Bla
 {
-  public class TestMe
-  {
-      public void DoSomething(int i) { }
-  }
+    public class TestMe
+    {
+        public void DoSomething(int i) { }
+    }
 }
 ");
 
@@ -25,40 +25,29 @@ namespace Bla
         public void No_issue_is_reported_for_extension_method_class_with_correct_namespace() => No_issue_is_reported_for(@"
 namespace System
 {
-  public static class TestMe
-  {
-      public static void DoSomething(this int i) { }
-  }
+    public static class TestMe
+    {
+        public static void DoSomething(this int i) { }
+    }
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace() => An_issue_is_reported_for(@"
-namespace Bla
-{
-  public static class TestMe
-  {
-      public static void DoSomething(this int i) { }
-  }
-}
-");
-
-        [Test]
-        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace_2() => An_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_method_class_with_global_namespace() => No_issue_is_reported_for(@"
 namespace Bla.Blubb
 {
-  public class TestMe
-  {
-      public void DoSomething(int i) { }
-  }
+    public class TestMe
+    {
+        public void DoSomething(int i) { }
+    }
 }
 
 namespace Blubber.Bla.Blubb
 {
-  public static class TestMeExtensions
-  {
-      public static void DoSomething(this TestMe t) { }
-  }
+    public static class TestMeExtensions
+    {
+        public static void DoSomething(this TestMe t) { }
+    }
 }
 ");
 
@@ -71,6 +60,38 @@ namespace Bla
         public static void DoSomething<T>(this T value) where T : class
         {
         } 
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace() => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public static class TestMe
+    {
+        public static void DoSomething(this int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace_2() => An_issue_is_reported_for(@"
+namespace Blah.Blubb
+{
+    public class TestMe
+    {
+        public void DoSomething(int i) { }
+    }
+}
+
+namespace Blubber.Bla.Blubbdiblubb
+{
+    using Blah.Blubb;
+
+    public static class TestMeExtensions
+    {
+        public static void DoSomething(this TestMe t) { }
     }
 }
 ");

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
@@ -22,6 +22,28 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_incomplete_extension_method() => No_issue_is_reported_for(@"
+namespace System
+{
+    public static class TestMe
+    {
+        public static void DoSomething(this 
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_incomplete_extension_method_with_type() => No_issue_is_reported_for(@"
+namespace System
+{
+    public static class TestMe
+    {
+        public static void DoSomething(this int 
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_extension_method_class_with_correct_namespace() => No_issue_is_reported_for(@"
 namespace System
 {
@@ -33,7 +55,7 @@ namespace System
 ");
 
         [Test]
-        public void No_issue_is_reported_for_extension_method_class_with_global_namespace() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_methods_extending_type_in_global_namespace() => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
@@ -34,6 +34,23 @@ namespace System
 
         [Test]
         public void No_issue_is_reported_for_extension_method_class_with_global_namespace() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public void DoSomething(int i) { }
+}
+
+namespace Blubber.Bla.Blubb
+{
+    public static class TestMeExtensions
+    {
+        public static void DoSomething(this TestMe t) { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_extension_method_class_with_same_sub_namespace_as_extended_type() => No_issue_is_reported_for(@"
 namespace Bla.Blubb
 {
     public class TestMe


### PR DESCRIPTION
- Skip namespace comparison for the global namespace

- Update unit tests to cover the global-namespace scenario
