### PR TITLE
MiKo_3201 no longer reports 'if' followed up by single block with 4 or more lines

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
@@ -78,7 +78,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             return Array.Empty<Diagnostic>();
                         }
 
-                        if (otherStatements.Any(_ => _ is BlockSyntax other && other.Statements.Count >= MaximumAllowedFollowUpStatements))
+                        if (otherStatements.Any(_ => _ is BlockSyntax other && other.Statements.Count > MaximumAllowedFollowUpStatements))
                         {
                             // inverting the code makes it less readable, so we do not report
                             return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -74,6 +75,12 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         if (node.FirstDescendant<ReturnStatementSyntax>().HasComment())
                         {
                             // the developer documented a reason, in that case we keep the if statement
+                            return Array.Empty<Diagnostic>();
+                        }
+
+                        if (otherStatements.Any(_ => _ is BlockSyntax other && other.Statements.Count >= MaximumAllowedFollowUpStatements))
+                        {
+                            // inverting the code makes it less readable, so we do not report
                             return Array.Empty<Diagnostic>();
                         }
 

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -687,6 +687,12 @@ namespace MiKoSolutions.Analyzers.Rules
                 return null;
             }
 
+            if (block.Statements.Count is 1 && block.Statements[0] is BlockSyntax nested)
+            {
+                // return the nested block instead of the original one
+                block = nested;
+            }
+
             var indentation = spaces + Constants.Indentation;
 
             return block.WithOpenBraceToken(block.OpenBraceToken.WithLeadingSpaces(spaces))

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzerTests.cs
@@ -682,6 +682,31 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_followed_up_by_single_block_with_4_lines() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public void DoSomething(bool flag)
+    {
+        if (flag)
+        {
+            return;
+        }
+
+        {
+            DoSomethingElse(1);
+            DoSomethingElse(2);
+            DoSomethingElse(3);
+            DoSomethingElse(4);
+        }
+    }
+
+    private void DoSomethingElse(int i)
+    {
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_a_single_following_line() => An_issue_is_reported_for(@"
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzerTests.cs
@@ -13,804 +13,902 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     public sealed class MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_non_void_method_without_if_statement() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public int DoSomething()
-    {
-        return 42;
-    }
-}
-");
+        public void No_issue_is_reported_for_non_void_method_without_if_statement() => No_issue_is_reported_for("""
 
-        [Test]
-        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_else_block() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public int DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return -1;
-        }
-        else
-        {
-        }
-
-        return 42;
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_no_else_block_and_1_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public int DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return -1;
-        }
-
-        return x * y + z;
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_no_else_block_and_4_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public int DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return -1;
-        }
-
-        var x = 4;
-        var y = 10;
-        var z = 2;
-
-        return x * y + z;
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_4_following_lines_on_void_method() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
-
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-        DoSomethingElse(4);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_throwing_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag) throw new ArgumentException();
-
-        DoSomethingElse(1);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_block_throwing_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            throw new ArgumentException();
-        }
-
-        DoSomethingElse(1);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_nested_block_returning_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag1, bool flag2)
-    {
-        if (flag1)
-        {
-            if (flag2) return;
-
-            DoSomethingElse(1);
-        }
-
-        DoSomethingElse(2);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_that_has_no_follow_up_code() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_and_no_else_block_and_1_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-
-        DoSomethingElse(4);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_and_no_else_block_and_4_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-
-        DoSomethingElse(4);
-        DoSomethingElse(5);
-        DoSomethingElse(6);
-        DoSomethingElse(7);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_containing_a_method_call_and_a_return_and_no_else_block_and_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            return;
-        }
-
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_while_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        while (true)
-        {
-            if (flag)
+            public class TestMe
             {
-                return;
-            }
-
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_do_while_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        do
-        {
-            if (flag)
-            {
-                return;
-            }
-
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-        while (true);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_for_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        for (var i = 0; i < 10; i++)
-        {
-            if (flag)
-            {
-                return;
-            }
-
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_foreach_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int[] values)
-    {
-        foreach (var value in values)
-        {
-            if (flag)
-            {
-                return;
-            }
-
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_nested_if_statement_inside_a_foreach_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int[] values)
-    {
-        foreach (var value in values)
-        {
-            if (value == 1)
-            {
-                if (flag)
+                public int DoSomething()
                 {
-                    return;
+                    return 42;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_else_block() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public int DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return -1;
+                    }
+                    else
+                    {
+                    }
+
+                    return 42;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_no_else_block_and_1_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public int DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return -1;
+                    }
+
+                    return x * y + z;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_non_void_method_with_if_statement_and_no_else_block_and_4_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public int DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return -1;
+                    }
+
+                    var x = 4;
+                    var y = 10;
+                    var z = 2;
+
+                    return x * y + z;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_4_following_lines_on_void_method() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    DoSomethingElse(1);
+                    DoSomethingElse(2);
+                    DoSomethingElse(3);
+                    DoSomethingElse(4);
                 }
 
-                DoSomethingElse(2);
-                DoSomethingElse(3);
-            }
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_lock_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int[] values)
-    {
-        lock (this)
-        {
-            if (flag)
-            {
-                return;
-            }
-
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-
-        DoSomethingElse(4);
-        DoSomethingElse(5);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
-
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_switch_returns_and_has_2_following_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int value)
-    {
-        switch (value)
-        {
-            case 1:
-            {
-                if (flag)
+                private void DoSomethingElse(int i)
                 {
-                    return;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_throwing_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag) throw new ArgumentException();
+
+                    DoSomethingElse(1);
                 }
 
-                DoSomethingElse(2);
-                DoSomethingElse(3);
+                private void DoSomethingElse(int i)
+                {
+                }
             }
 
-            default:
-                break;
-        }
-
-        DoSomethingElse(4);
-        DoSomethingElse(5);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_do_loop() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_block_throwing_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for("""
 
-        do
-        {
-            DoSomethingElse(1);
-        } while (true);
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        throw new ArgumentException();
+                    }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                    DoSomethingElse(1);
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_while_loop() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-        while (true)
-        {
-            DoSomethingElse(1);
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_for_loop() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_nested_block_returning_if_statement_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for("""
 
-        for (var i = 0; i < 10; i++)
-        {
-            DoSomethingElse(i);
-        }
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag1, bool flag2)
+                {
+                    if (flag1)
+                    {
+                        if (flag2) return;
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                        DoSomethingElse(1);
+                    }
 
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_foreach_loop() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int[] values)
-    {
-        if (flag)
-        {
-            return;
-        }
+                    DoSomethingElse(2);
+                }
 
-        foreach (var value in values)
-        {
-            DoSomethingElse(value);
-        }
-    }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_switch() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int value)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_that_has_no_follow_up_code() => No_issue_is_reported_for("""
 
-        switch (value)
-        {
-            case 0: return;
-            case 1: return;
-        }
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_another_if() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, int value)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_and_no_else_block_and_1_following_lines() => No_issue_is_reported_for("""
 
-        if (value == 0)
-        {
-        }
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                    DoSomethingElse(4);
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_using() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, IDisposable value)
-    {
-        if (flag)
-        {
-            return;
-        }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-        using (value)
-        {
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_try_finally() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, IDisposable value)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_containing_some_lines_and_no_else_block_and_4_following_lines() => No_issue_is_reported_for("""
 
-        try
-        {
-        }
-        finally
-        {
-        }
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                    DoSomethingElse(4);
+                    DoSomethingElse(5);
+                    DoSomethingElse(6);
+                    DoSomethingElse(7);
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_local_function() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag, IDisposable value)
-    {
-        if (flag)
-        {
-            return;
-        }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-        void MyFunction()
-        {
-        }
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_and_comment_above_return_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            // for some reason
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_containing_a_method_call_and_a_return_and_no_else_block_and_2_following_lines() => No_issue_is_reported_for("""
 
-        DoSomethingElse(1);
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        DoSomethingElse(1);
+                        return;
+                    }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                    DoSomethingElse(2);
+                    DoSomethingElse(3);
+                }
 
-        [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_and_comment_behind_return_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return; // for some reason
-        }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-        DoSomethingElse(1);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void No_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_followed_up_by_single_block_with_4_lines() => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_while_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
 
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-            DoSomethingElse(4);
-        }
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    while (true)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                }
 
-        [Test]
-        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_a_single_following_line() => An_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
 
-        DoSomethingElse(1);
-    }
-
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_2_following_lines() => An_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_do_while_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    do
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                    while (true);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
 
         [Test]
-        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_3_following_lines() => An_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_for_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-");
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_foreach_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int[] values)
+                {
+                    foreach (var value in values)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
+
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_nested_if_statement_inside_a_foreach_loop_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int[] values)
+                {
+                    foreach (var value in values)
+                    {
+                        if (value == 1)
+                        {
+                            if (flag)
+                            {
+                                return;
+                            }
+
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_lock_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int[] values)
+                {
+                    lock (this)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
+
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+
+                    DoSomethingElse(4);
+                    DoSomethingElse(5);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_inside_a_switch_returns_and_has_2_following_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int value)
+                {
+                    switch (value)
+                    {
+                        case 1:
+                        {
+                            if (flag)
+                            {
+                                return;
+                            }
+
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+
+                        default:
+                            break;
+                    }
+
+                    DoSomethingElse(4);
+                    DoSomethingElse(5);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_do_loop() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    do
+                    {
+                        DoSomethingElse(1);
+                    } while (true);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_while_loop() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    while (true)
+                    {
+                        DoSomethingElse(1);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_for_loop() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    for (var i = 0; i < 10; i++)
+                    {
+                        DoSomethingElse(i);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_foreach_loop() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int[] values)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    foreach (var value in values)
+                    {
+                        DoSomethingElse(value);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_a_switch() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int value)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    switch (value)
+                    {
+                        case 0: return;
+                        case 1: return;
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_another_if() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, int value)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    if (value == 0)
+                    {
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_using() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, IDisposable value)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    using (value)
+                    {
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_try_finally() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, IDisposable value)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                    }
+                    finally
+                    {
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_is_followed_by_local_function() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag, IDisposable value)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    void MyFunction()
+                    {
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_and_comment_above_return_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        // for some reason
+                        return;
+                    }
+
+                    DoSomethingElse(1);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_and_comment_behind_return_and_no_else_block_and_a_single_following_line() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return; // for some reason
+                    }
+
+                    DoSomethingElse(1);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_followed_up_by_single_block_with_4_lines() => No_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    {
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                        DoSomethingElse(4);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_a_single_following_line() => An_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    DoSomethingElse(1);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_2_following_lines() => An_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    DoSomethingElse(1);
+                    DoSomethingElse(2);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_3_following_lines() => An_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    DoSomethingElse(1);
+                    DoSomethingElse(2);
+                    DoSomethingElse(3);
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_void_method_with_if_statement_and_no_else_block_and_followed_up_by_single_block_with_3_lines() => An_issue_is_reported_for("""
+
+            public class TestMe
+            {
+                public void DoSomething(bool flag)
+                {
+                    if (flag)
+                    {
+                        return;
+                    }
+
+                    {
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
+                }
+
+                private void DoSomethingElse(int i)
+                {
+                }
+            }
+
+            """);
 
         [Test]
         public void Code_gets_fixed_for_void_method_with_normal_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag is false)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag is false)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -818,45 +916,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_inverted_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (!flag)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (!flag)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -864,45 +966,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_is_false_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag is false)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag is false)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag)
-    {
-        if (flag)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -910,45 +1016,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_null_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag != null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag != null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp8);
         }
@@ -956,45 +1066,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_null_if_statement_and_no_else_block_and_3_following_lines_in_CSharp9()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is not null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is not null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp9);
         }
@@ -1002,45 +1116,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_true_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is true)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is true)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (!(flag is true))
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (!(flag is true))
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp8);
         }
@@ -1048,45 +1166,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_true_if_statement_and_no_else_block_and_3_following_lines_in_CSharp9()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is true)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is true)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is not true)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is not true)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp9);
         }
@@ -1094,45 +1216,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_false_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is false)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is false)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (!(flag is false))
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (!(flag is false))
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp8);
         }
@@ -1140,45 +1266,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_nullable_is_false_if_statement_and_no_else_block_and_3_following_lines_in_CSharp9()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is false)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is false)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool? flag)
-    {
-        if (flag is not false)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool? flag)
+                    {
+                        if (flag is not false)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp9);
         }
@@ -1186,45 +1316,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_null_equality_check_as_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o == null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o == null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o != null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o != null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -1232,45 +1366,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_null_inequality_check_as_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o != null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o != null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -1278,45 +1416,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_null_pattern_check_as_if_statement_and_no_else_block_and_3_following_lines()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o != null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o != null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp8);
         }
@@ -1324,45 +1466,49 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_for_void_method_with_null_pattern_check_as_if_statement_and_no_else_block_and_3_following_lines_in_CSharp9()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is null)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is not null)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is not null)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp9);
         }
@@ -1375,45 +1521,53 @@ public class TestMe
         [TestCase("< 42", ">= 42")]
         public void Code_gets_fixed_for_void_method_with_number_check_as_if_statement_and_no_else_block_and_3_following_lines_(string originalCheck, string fixedCheck)
         {
-            var originalCode = @"
-public class TestMe
-{
-    public void DoSomething(int i)
-    {
-        if (i " + originalCheck + @")
-        {
-            return;
-        }
+            var originalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-        DoSomethingElse(3);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(int i)
+                    {
+                        if (i 
+                """ + originalCheck + """
+                )
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                        DoSomethingElse(3);
+                    }
 
-            var fixedCode = @"
-public class TestMe
-{
-    public void DoSomething(int i)
-    {
-        if (i " + fixedCheck + @")
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-            DoSomethingElse(3);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            var fixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(int i)
+                    {
+                        if (i 
+                """ + fixedCheck + """
+                )
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(originalCode, fixedCode);
         }
@@ -1421,49 +1575,53 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_with_comments()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        // some comment
-        DoSomethingElse(1);
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is null)
+                        {
+                            return;
+                        }
 
-        // some other comment
-        DoSomethingElse(2);
-    }
+                        // some comment
+                        DoSomethingElse(1);
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        // some other comment
+                        DoSomethingElse(2);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o != null)
-        {
-            // some comment
-            DoSomethingElse(1);
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-            // some other comment
-            DoSomethingElse(2);
-        }
-    }
+                """;
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o != null)
+                        {
+                            // some comment
+                            DoSomethingElse(1);
+
+                            // some other comment
+                            DoSomethingElse(2);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp8);
         }
@@ -1471,49 +1629,53 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_with_comments_in_CSharp9()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is null)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        // some comment
-        DoSomethingElse(1);
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is null)
+                        {
+                            return;
+                        }
 
-        // some other comment
-        DoSomethingElse(2);
-    }
+                        // some comment
+                        DoSomethingElse(1);
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        // some other comment
+                        DoSomethingElse(2);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(object o)
-    {
-        if (o is not null)
-        {
-            // some comment
-            DoSomethingElse(1);
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-            // some other comment
-            DoSomethingElse(2);
-        }
-    }
+                """;
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(object o)
+                    {
+                        if (o is not null)
+                        {
+                            // some comment
+                            DoSomethingElse(1);
+
+                            // some other comment
+                            DoSomethingElse(2);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode, LanguageVersion.CSharp9);
         }
@@ -1521,43 +1683,47 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_with_complex_logical_AND_condition()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag1, bool flag2)
-    {
-        if (!flag1 && !flag2)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool flag1, bool flag2)
+                    {
+                        if (!flag1 && !flag2)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag1, bool flag2)
-    {
-        if (flag1 || flag2)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag1, bool flag2)
+                    {
+                        if (flag1 || flag2)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -1565,43 +1731,47 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_with_complex_logical_OR_condition()
         {
-            const string OriginalCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag1, bool flag2)
-    {
-        if (!flag1 || !flag2)
-        {
-            return;
-        }
+            const string OriginalCode = """
 
-        DoSomethingElse(1);
-        DoSomethingElse(2);
-    }
+                public class TestMe
+                {
+                    public void DoSomething(bool flag1, bool flag2)
+                    {
+                        if (!flag1 || !flag2)
+                        {
+                            return;
+                        }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                        DoSomethingElse(1);
+                        DoSomethingElse(2);
+                    }
 
-            const string FixedCode = @"
-public class TestMe
-{
-    public void DoSomething(bool flag1, bool flag2)
-    {
-        if (flag1 && flag2)
-        {
-            DoSomethingElse(1);
-            DoSomethingElse(2);
-        }
-    }
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
 
-    private void DoSomethingElse(int i)
-    {
-    }
-}
-";
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag1, bool flag2)
+                    {
+                        if (flag1 && flag2)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
@@ -1609,40 +1779,96 @@ public class TestMe
         [Test]
         public void Code_gets_fixed_with_comment_on_follow_up_code()
         {
-            const string OriginalCode = @"
-using System.Collections.Generic;
-using System.Linq;
+            const string OriginalCode = """
 
-public class TestMe
-{
-    public void DoSomething(IEnumerable<int> values)
-    {
-        if (values == null || !values.Any())
-            return;
-        // some comment
-        DoSomething(values.Select(i =>
-            i * 5));
-    }
-}
-";
+                using System.Collections.Generic;
+                using System.Linq;
 
-            const string FixedCode = @"
-using System.Collections.Generic;
-using System.Linq;
+                public class TestMe
+                {
+                    public void DoSomething(IEnumerable<int> values)
+                    {
+                        if (values == null || !values.Any())
+                            return;
+                        // some comment
+                        DoSomething(values.Select(i =>
+                            i * 5));
+                    }
+                }
 
-public class TestMe
-{
-    public void DoSomething(IEnumerable<int> values)
-    {
-        if (values != null && values.Any())
-        {
-            // some comment
-            DoSomething(values.Select(i =>
-                i * 5));
+                """;
+
+            const string FixedCode = """
+
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething(IEnumerable<int> values)
+                    {
+                        if (values != null && values.Any())
+                        {
+                            // some comment
+                            DoSomething(values.Select(i =>
+                                i * 5));
+                        }
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
         }
-    }
-}
-";
+
+        [Test]
+        public void Code_gets_fixed_for_void_method_with_if_statement_and_no_else_block_and_followed_up_by_single_block_with_3_lines()
+        {
+            const string OriginalCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag)
+                        {
+                            return;
+                        }
+
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                public class TestMe
+                {
+                    public void DoSomething(bool flag)
+                    {
+                        if (flag is false)
+                        {
+                            DoSomethingElse(1);
+                            DoSomethingElse(2);
+                            DoSomethingElse(3);
+                        }
+                    }
+
+                    private void DoSomethingElse(int i)
+                    {
+                    }
+                }
+
+                """;
 
             VerifyCSharpFix(OriginalCode, FixedCode);
         }


### PR DESCRIPTION
- Update analyzer logic to ignore `if` statements followed up by a `BlockSyntax` with many contained statements

- Add unit test
