### PR TITLE
MiKo_6037 is now aware of an invocation's argument having an invocation itself

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +14,27 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
     {
         public override string FixableDiagnosticId => "MiKo_6037";
 
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<InvocationExpressionSyntax>().FirstOrDefault();
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            var foundArgument = false;
+
+            // we have an argument that is part of an invocation, but the invocation itself could also be part of another argument,
+            // so we need to find the argument first and then get the invocation from it (as otherwise we would report the wrong, nested invocation)
+            foreach (var node in syntaxNodes)
+            {
+                switch (node)
+                {
+                    case ArgumentSyntax _:
+                        foundArgument = true;
+                        break;
+
+                    case InvocationExpressionSyntax i when foundArgument:
+                        return i;
+                }
+            }
+
+            return null;
+        }
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzerTests.cs
@@ -261,6 +261,45 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_if_complete_AddRange_call_spanning_multiple_lines_with_single_argument_on_separate_line()
+        {
+            const string OriginalCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething(IEnumerable<int> values)
+    {
+        var items = new List<string>();
+
+        items.AddRange(
+            values.Select(_ => _.ToString()));
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestMe
+{
+    public void DoSomething(IEnumerable<int> values)
+    {
+        var items = new List<string>();
+
+        items.AddRange(values.Select(_ => _.ToString()));
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6037_SingleArgumentsAreOnSameLineAsInvocationAnalyzer();


### PR DESCRIPTION
- Update analyzer to select the invocation *containing* the reported argument rather than a nested invocation found at the same span

- Add test covering scenario with single argument that is an invocation spanning multiple lines
