### PR TITLE
Added new rule MiKo_6073 about vertical alignment of LINQ queries

### DIFF
--- a/Documentation/MiKo_6073.md
+++ b/Documentation/MiKo_6073.md
@@ -1,0 +1,46 @@
+﻿# MiKo_6073: Align LINQ query clauses vertically
+
+## Cause
+
+A LINQ query expression contains clauses that are not vertically aligned with the opening `from` clause.
+
+## Rule description
+
+Code readability improves when LINQ query clauses are aligned vertically.
+This makes the query clearer and easier to follow.
+
+### Rationale behind
+
+Consistent vertical alignment of LINQ query clauses makes the overall structure of a query immediately visible.
+A reader can scan the clauses top to bottom without having to search for where each one begins.
+
+Keeping LINQ query clauses vertically aligned provides several important benefits:
+
+- **Improved Readability**:
+  When all clauses start at the same column, the query reads like a structured block rather than a scattered sequence of tokens.
+  This makes it easier to understand what the query does without carefully parsing each line.
+
+- **Easier Scanning**:
+  Aligned clauses allow a reader to quickly identify the individual parts of a query, such as filtering, ordering, and projection, without extra effort.
+
+- **Reduced Cognitive Load**:
+  When the visual structure of a query is consistent, less mental effort is needed to parse it.
+  This is especially helpful for developers who are less familiar with LINQ syntax.
+
+- **Better Maintainability**:
+  A consistently formatted query is easier to modify.
+  Adding, removing, or reordering clauses is straightforward when each clause follows the same indentation pattern.
+
+- **Consistent Code Style**:
+  Uniform formatting across all LINQ queries in a codebase creates a predictable style that every team member can rely on.
+
+## How to fix violations
+
+To fix a violation of this rule, adjust the indentation of the misaligned LINQ query clauses so that they all start at the same horizontal position as the opening `from` clause.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_6073
+#pragma warning restore MiKo_6073
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -467,6 +467,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6072_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6073_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StringBuilderCache.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -633,6 +633,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6072_BaseExpressionSurroundedByBlankLinesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\StatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15223,7 +15223,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TODO.
+        ///   Looks up a localized string similar to Avoid writing long chains of method or property calls, because they tightly couple your code to the internal structure of multiple objects. This makes the code fragile and harder to read or test. Instead, expose clear operations on your objects to keep the code simple and maintainable..
         /// </summary>
         internal static string MiKo_3504_Description {
             get {
@@ -18529,6 +18529,42 @@ namespace MiKoSolutions.Analyzers {
         internal static string MiKo_6072_Title {
             get {
                 return ResourceManager.GetString("MiKo_6072_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align LINQ query clause vertically along with others.
+        /// </summary>
+        internal static string MiKo_6073_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6073_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code readability improves when LINQ query clauses are aligned vertically. This makes the query clearer and easier to follow..
+        /// </summary>
+        internal static string MiKo_6073_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6073_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align LINQ query clause vertically along with others.
+        /// </summary>
+        internal static string MiKo_6073_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6073_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align LINQ query clauses vertically.
+        /// </summary>
+        internal static string MiKo_6073_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6073_Title", resourceCulture);
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -6427,4 +6427,16 @@ This style avoids dangling operators, aligns with common C# style guides and too
   <data name="MiKo_6072_Title" xml:space="preserve">
     <value>Surround base class calls with blank lines</value>
   </data>
+  <data name="MiKo_6073_CodeFixTitle" xml:space="preserve">
+    <value>Align LINQ query clause vertically along with others</value>
+  </data>
+  <data name="MiKo_6073_Description" xml:space="preserve">
+    <value>Code readability improves when LINQ query clauses are aligned vertically. This makes the query clearer and easier to follow.</value>
+  </data>
+  <data name="MiKo_6073_MessageFormat" xml:space="preserve">
+    <value>Align LINQ query clause vertically along with others</value>
+  </data>
+  <data name="MiKo_6073_Title" xml:space="preserve">
+    <value>Align LINQ query clauses vertically</value>
+  </data>
 </root>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     var typePosition = GetStartPosition(initializer);
                     var openBracePosition = openBraceToken.GetStartPosition();
 
-                    if (typePosition.Line != openBracePosition.Line && typePosition.Character != openBracePosition.Character)
+                    if (NotVerticallyAligned(typePosition, openBracePosition))
                     {
                         return Issue(openBraceToken, CreateProposalForSpaces(typePosition.Character));
                     }
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     var keywordPosition = anonymous.NewKeyword.GetPositionAfterEnd();
                     var openBracePosition = openBraceToken.GetStartPosition();
 
-                    if (keywordPosition.Line != openBracePosition.Line && openBracePosition.Character != keywordPosition.Character)
+                    if (NotVerticallyAligned(keywordPosition, openBracePosition))
                     {
                         return Issue(openBraceToken, CreateProposalForSpaces(keywordPosition.Character));
                     }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6030_InitializerBracesAreOnSamePositionLikeTypeAnalyzer.cs
@@ -64,14 +64,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     var openBraceToken = initializer.OpenBraceToken;
 
                     var typePosition = GetStartPosition(initializer);
-                    var openBracePosition = openBraceToken.GetStartPosition();
 
-                    if (NotVerticallyAligned(typePosition, openBracePosition))
-                    {
-                        return Issue(openBraceToken, CreateProposalForSpaces(typePosition.Character));
-                    }
-
-                    return null;
+                    return NotVerticallyAligned(openBraceToken, typePosition)
+                           ? Issue(openBraceToken, CreateProposalForSpaces(typePosition.Character))
+                           : null;
                 }
 
                 case AnonymousObjectCreationExpressionSyntax anonymous:
@@ -79,14 +75,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     var openBraceToken = anonymous.OpenBraceToken;
 
                     var keywordPosition = anonymous.NewKeyword.GetPositionAfterEnd();
-                    var openBracePosition = openBraceToken.GetStartPosition();
 
-                    if (NotVerticallyAligned(keywordPosition, openBracePosition))
-                    {
-                        return Issue(openBraceToken, CreateProposalForSpaces(keywordPosition.Character));
-                    }
-
-                    return null;
+                    return NotVerticallyAligned(openBraceToken, keywordPosition)
+                           ? Issue(openBraceToken, CreateProposalForSpaces(keywordPosition.Character))
+                           : null;
                 }
 
                 default:

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
@@ -26,9 +27,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var openBraceToken = block.OpenBraceToken;
 
                 var casePosition = caseToken.GetStartPosition();
-                var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (NotVerticallyAligned(casePosition, openBracePosition))
+                if (NotVerticallyAligned(openBraceToken, casePosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(casePosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var casePosition = caseToken.GetStartPosition();
                 var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (casePosition.Line != openBracePosition.Line && casePosition.Character != openBracePosition.Character)
+                if (NotVerticallyAligned(casePosition, openBracePosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(casePosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6036_OpenBracesAreOnSamePositionLikeArrowOfLambdaAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6036_OpenBracesAreOnSamePositionLikeArrowOfLambdaAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var openBraceToken = block.OpenBraceToken;
                 var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (operatorPosition.Line != openBracePosition.Line && operatorPosition.Character != openBracePosition.Character)
+                if (NotVerticallyAligned(operatorPosition, openBracePosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(operatorPosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6036_OpenBracesAreOnSamePositionLikeArrowOfLambdaAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6036_OpenBracesAreOnSamePositionLikeArrowOfLambdaAnalyzer.cs
@@ -36,9 +36,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var operatorPosition = GetStartPosition(lambda);
 
                 var openBraceToken = block.OpenBraceToken;
-                var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (NotVerticallyAligned(operatorPosition, openBracePosition))
+                if (NotVerticallyAligned(openBraceToken, operatorPosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(operatorPosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
@@ -25,9 +26,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var switchPosition = syntax.SwitchKeyword.GetPositionAfterEnd();
 
                 var openBraceToken = syntax.OpenBraceToken;
-                var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (NotVerticallyAligned(switchPosition, openBracePosition))
+                if (NotVerticallyAligned(openBraceToken, switchPosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(switchPosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var openBraceToken = syntax.OpenBraceToken;
                 var openBracePosition = openBraceToken.GetStartPosition();
 
-                if (switchPosition.Line != openBracePosition.Line && switchPosition.Character != openBracePosition.Character)
+                if (NotVerticallyAligned(switchPosition, openBracePosition))
                 {
                     ReportDiagnostics(context, Issue(openBraceToken, CreateProposalForSpaces(switchPosition.Character)));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs
@@ -53,18 +53,16 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var openBracketToken = syntax.OpenBracketToken;
                 var openBracketPosition = openBracketToken.GetStartPosition();
-
                 var startPosition = GetStartPosition(syntax);
 
-                if (NotVerticallyAligned(openBracketPosition, startPosition))
+                if (NotVerticallyAligned(startPosition, openBracketPosition))
                 {
                     return Issue(openBracketToken, CreateProposalForSpaces(startPosition.Character));
                 }
 
                 var closeBracketToken = syntax.CloseBracketToken;
-                var closeBracketPosition = closeBracketToken.GetStartPosition();
 
-                if (NotVerticallyAligned(openBracketPosition, closeBracketPosition))
+                if (NotVerticallyAligned(closeBracketToken, openBracketPosition))
                 {
                     return Issue(closeBracketToken, CreateProposalForSpaces(openBracketPosition.Character));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6056_CollectionExpressionBracesAreOnSamePositionAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                 var startPosition = GetStartPosition(syntax);
 
-                if (openBracketPosition.Line != startPosition.Line && openBracketPosition.Character != startPosition.Character)
+                if (NotVerticallyAligned(openBracketPosition, startPosition))
                 {
                     return Issue(openBracketToken, CreateProposalForSpaces(startPosition.Character));
                 }
@@ -64,7 +64,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 var closeBracketToken = syntax.CloseBracketToken;
                 var closeBracketPosition = closeBracketToken.GetStartPosition();
 
-                if (openBracketPosition.Line != closeBracketPosition.Line && openBracketPosition.Character != closeBracketPosition.Character)
+                if (NotVerticallyAligned(openBracketPosition, closeBracketPosition))
                 {
                     return Issue(closeBracketToken, CreateProposalForSpaces(openBracketPosition.Character));
                 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_CodeFixProvider.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6073_CodeFixProvider)), Shared]
+    public sealed class MiKo_6073_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6073";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.First();
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
+        {
+            SyntaxNode updatedSyntax = GetUpdatedSyntax(syntax, issue);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        private static SyntaxNode GetUpdatedSyntax(SyntaxNode node, Diagnostic issue)
+        {
+            var spaces = GetProposedSpaces(issue);
+
+            return node.WithLeadingSpaces(spaces);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6073";
+
+        public MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer() : base(Id, SymbolKind.NamedType)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeQueryExpression, SyntaxKind.QueryExpression);
+
+        private void AnalyzeQueryExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is QueryExpressionSyntax node)
+            {
+                var issues = AnalyzeQuery(node);
+
+                ReportDiagnostics(context, issues);
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeQuery(QueryExpressionSyntax node)
+        {
+            var startPosition = node.FromClause.GetStartPosition();
+            var startPositionCharacter = startPosition.Character;
+
+            foreach (var clause in node.Body.Clauses)
+            {
+                var clausePosition = clause.GetStartPosition();
+
+                if (NotVerticallyAligned(startPosition, clausePosition))
+                {
+                    yield return Issue(clause, CreateProposalForSpaces(startPositionCharacter));
+                }
+            }
+
+            var selectPart = node.Body.SelectOrGroup;
+            var selectPartPosition = selectPart.GetStartPosition();
+
+            if (NotVerticallyAligned(startPosition, selectPartPosition))
+            {
+                yield return Issue(selectPart, CreateProposalForSpaces(startPositionCharacter));
+            }
+
+            var continuationPart = node.Body.Continuation;
+
+            if (continuationPart != null)
+            {
+                var continuationPartPosition = continuationPart.GetStartPosition();
+
+                if (selectPartPosition.Line != continuationPartPosition.Line && NotVerticallyAligned(startPosition, continuationPartPosition))
+                {
+                    yield return Issue(continuationPart, CreateProposalForSpaces(startPositionCharacter));
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {
@@ -18,48 +19,59 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeQueryExpression, SyntaxKind.QueryExpression);
 
-        private void AnalyzeQueryExpression(SyntaxNodeAnalysisContext context)
+        private static IEnumerable<SyntaxNode> GetProblematicNodes(QueryBodySyntax body, LinePosition startPosition)
         {
-            if (context.Node is QueryExpressionSyntax node)
+            var currentBody = body;
+
+            while (true)
             {
-                var issues = AnalyzeQuery(node);
-
-                ReportDiagnostics(context, issues);
-            }
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeQuery(QueryExpressionSyntax node)
-        {
-            var startPosition = node.FromClause.GetStartPosition();
-            var startPositionCharacter = startPosition.Character;
-
-            foreach (var clause in node.Body.Clauses)
-            {
-                var clausePosition = clause.GetStartPosition();
-
-                if (NotVerticallyAligned(startPosition, clausePosition))
+                foreach (var clause in currentBody.Clauses)
                 {
-                    yield return Issue(clause, CreateProposalForSpaces(startPositionCharacter));
+                    var clausePosition = clause.GetStartPosition();
+
+                    if (NotVerticallyAligned(startPosition, clausePosition))
+                    {
+                        yield return clause;
+                    }
                 }
-            }
 
-            var selectPart = node.Body.SelectOrGroup;
-            var selectPartPosition = selectPart.GetStartPosition();
+                var selectPart = currentBody.SelectOrGroup;
+                var selectPartPosition = selectPart.GetStartPosition();
 
-            if (NotVerticallyAligned(startPosition, selectPartPosition))
-            {
-                yield return Issue(selectPart, CreateProposalForSpaces(startPositionCharacter));
-            }
+                if (NotVerticallyAligned(startPosition, selectPartPosition))
+                {
+                    yield return selectPart;
+                }
 
-            var continuationPart = node.Body.Continuation;
+                var continuationPart = currentBody.Continuation;
 
-            if (continuationPart != null)
-            {
+                if (continuationPart is null)
+                {
+                    // nothing more to report
+                    yield break;
+                }
+
+                currentBody = continuationPart.Body;
+
                 var continuationPartPosition = continuationPart.GetStartPosition();
 
                 if (selectPartPosition.Line != continuationPartPosition.Line && NotVerticallyAligned(startPosition, continuationPartPosition))
                 {
-                    yield return Issue(continuationPart, CreateProposalForSpaces(startPositionCharacter));
+                    yield return continuationPart;
+                }
+            }
+        }
+
+        private void AnalyzeQueryExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is QueryExpressionSyntax node)
+            {
+                var startPosition = node.FromClause.GetStartPosition();
+                var problematicNodes = GetProblematicNodes(node.Body, startPosition);
+
+                foreach (var problematicNode in problematicNodes)
+                {
+                    ReportDiagnostics(context, Issue(problematicNode, CreateProposalForSpaces(startPosition.Character)));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
@@ -70,5 +70,20 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         /// otherwise, <see langword="false"/>.
         /// </returns>
         protected static bool NotVerticallyAligned(in LinePosition left, in LinePosition right) => left.Line != right.Line && left.Character != right.Character;
+
+        /// <summary>
+        /// Determines whether a given <see cref="SyntaxToken"/> is not vertically aligned based on a given <see cref="LinePosition"/>.
+        /// </summary>
+        /// <param name="token">
+        /// The <see cref="SyntaxToken"/> to compare.
+        /// </param>
+        /// <param name="position">
+        /// The <see cref="LinePosition"/> to compare with.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the <see cref="LinePosition"/> of <paramref name="token"/> and <paramref name="position"/> differ in both line number and character position;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        protected static bool NotVerticallyAligned(in SyntaxToken token, in LinePosition position) => NotVerticallyAligned(position, token.GetStartPosition());
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/SpacingAnalyzer.cs
@@ -55,5 +55,20 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                                                                                                                new Pair(Constants.AnalyzerCodeFixSharedData.Spaces, spaces.ToString("D")),
                                                                                                                new Pair(Constants.AnalyzerCodeFixSharedData.AdditionalSpaces, additionalSpaces.ToString("D")),
                                                                                                            };
+
+        /// <summary>
+        /// Determines whether two <see cref="LinePosition"/> values are not vertically aligned.
+        /// </summary>
+        /// <param name="left">
+        /// The first <see cref="LinePosition"/> to compare.
+        /// </param>
+        /// <param name="right">
+        /// The second <see cref="LinePosition"/> to compare with.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="left"/> and <paramref name="right"/> differ in both line number and character position;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        protected static bool NotVerticallyAligned(in LinePosition left, in LinePosition right) => left.Line != right.Line && left.Character != right.Character;
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzerTests.cs
@@ -1,0 +1,956 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_vertically_aligned_Linq_query() => No_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                 where item.Length > 0
+                                 select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void No_issue_is_reported_for_vertically_aligned_Linq_query_with_query_continuation_on_same_line_as_group() => No_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                {
+                    var result = from word in words
+                                 group word by word.ToLower() into g   // <-- QueryContinuationSyntax starts here
+                                 where g.Count() > 1                   //     QueryBodySyntax inside the continuation
+                                 select (Key: g.Key, Count: g.Count());
+
+                    return result;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_select_clause_is_indented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                 where item.Length > 0
+                                  select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_select_clause_is_outdented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                 where item.Length > 0
+                                select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_indented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                  where item.Length > 0
+                                 select item;
+                }
+            }
+
+            """);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_indented_and_select_clause_is_outdented() => An_issue_is_reported_for(2, """
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                  where item.Length > 0
+                                select item;
+                }
+            }
+
+            """);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_indented_and_select_clause_is_indented() => An_issue_is_reported_for(2, """
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                  where item.Length > 0
+                                  select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_outdented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                where item.Length > 0
+                                 select item;
+                }
+            }
+
+            """);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_outdented_and_select_clause_is_outdented() => An_issue_is_reported_for(2, """
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                where item.Length > 0
+                                select item;
+                }
+            }
+
+            """);
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_where_clause_is_outdented_and_select_clause_is_indented() => An_issue_is_reported_for(2, """
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                where item.Length > 0
+                                  select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_from_clause_is_indented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from x in new List<string>()
+                                  from y in new List<string>()
+                                 where x.Length != y.Length
+                                 select x;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_from_clause_is_outdented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from x in new List<string>()
+                                from y in new List<string>()
+                                 where x.Length != y.Length
+                                 select x;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_let_clause_is_indented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                  let count = item.Length
+                                 where count > 0
+                                 select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_let_clause_is_outdented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public void DoSomething()
+                {
+                    var result = from item in new List<string>()
+                                let count = item.Length
+                                 where count > 0
+                                 select item;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_continuation_clause_is_indented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                {
+                    var result = from word in words
+                                 group word by word.ToLower()
+                                  into g   // <-- QueryContinuationSyntax starts here
+                                 where g.Count() > 1
+                                 select (Key: g.Key, Count: g.Count());
+
+                    return result;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void An_issue_is_reported_for_vertically_aligned_Linq_query_if_continuation_clause_is_outdented() => An_issue_is_reported_for("""
+
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class TestMe
+            {
+                public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                {
+                    var result = from word in words
+                                 group word by word.ToLower()
+                                into g   // <-- QueryContinuationSyntax starts here
+                                 where g.Count() > 1
+                                 select (Key: g.Key, Count: g.Count());
+
+                    return result;
+                }
+            }
+
+            """);
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_select_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public void DoSomething()
+                                            {
+                                                var result = from item in new List<string>()
+                                                             where item.Length > 0
+                                                              select item;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething()
+                                         {
+                                             var result = from item in new List<string>()
+                                                          where item.Length > 0
+                                                          select item;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_select_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public void DoSomething()
+                                            {
+                                                var result = from item in new List<string>()
+                                                             where item.Length > 0
+                                                            select item;
+                                            }
+                                        }
+
+                                        """;
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething()
+                                         {
+                                             var result = from item in new List<string>()
+                                                          where item.Length > 0
+                                                          select item;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                      where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_indented_and_select_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                      where item.Length > 0
+                                    select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_indented_and_select_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                      where item.Length > 0
+                                      select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                    where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_outdented_and_select_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                    where item.Length > 0
+                                    select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_is_outdented_and_select_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                    where item.Length > 0
+                                      select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                     where item.Length > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_from_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from x in new List<string>()
+                                      from y in new List<string>()
+                                     where x.Length != y.Length
+                                     select x;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething()
+                                         {
+                                             var result = from x in new List<string>()
+                                                          from y in new List<string>()
+                                                          where x.Length != y.Length
+                                                          select x;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_from_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from x in new List<string>()
+                                    from y in new List<string>()
+                                     where x.Length != y.Length
+                                     select x;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from x in new List<string>()
+                                     from y in new List<string>()
+                                     where x.Length != y.Length
+                                     select x;
+                    }
+                }
+
+                """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_let_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                      let count = item.Length
+                                     where count > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething()
+                                         {
+                                             var result = from item in new List<string>()
+                                                          let count = item.Length
+                                                          where count > 0
+                                                          select item;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_let_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class TestMe
+                {
+                    public void DoSomething()
+                    {
+                        var result = from item in new List<string>()
+                                    let count = item.Length
+                                     where count > 0
+                                     select item;
+                    }
+                }
+
+                """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public void DoSomething()
+                                         {
+                                             var result = from item in new List<string>()
+                                                          let count = item.Length
+                                                          where count > 0
+                                                          select item;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_continuation_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                              into g   // <-- QueryContinuationSyntax starts here
+                                                             where g.Count() > 1
+                                                             select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_continuation_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                            into g   // <-- QueryContinuationSyntax starts here
+                                                             where g.Count() > 1
+                                                             select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6073_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzerTests.cs
@@ -947,6 +947,206 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_after_continuation_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                             into g   // <-- QueryContinuationSyntax starts here
+                                                              where g.Count() > 1
+                                                             select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_where_clause_after_continuation_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                             into g   // <-- QueryContinuationSyntax starts here
+                                                            where g.Count() > 1
+                                                             select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_select_clause_after_continuation_clause_is_indented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                             into g   // <-- QueryContinuationSyntax starts here
+                                                             where g.Count() > 1
+                                                              select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_vertically_aligned_Linq_query_if_select_clause_after_continuation_clause_is_outdented()
+        {
+            const string OriginalCode = """
+
+                                        using System;
+                                        using System.Collections.Generic;
+                                        using System.Linq;
+
+                                        public class TestMe
+                                        {
+                                            public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                            {
+                                                var result = from word in words
+                                                             group word by word.ToLower()
+                                                             into g   // <-- QueryContinuationSyntax starts here
+                                                             where g.Count() > 1
+                                                            select (Key: g.Key, Count: g.Count());
+
+                                                return result;
+                                            }
+                                        }
+
+                                        """;
+
+            const string FixedCode = """
+
+                                     using System;
+                                     using System.Collections.Generic;
+                                     using System.Linq;
+
+                                     public class TestMe
+                                     {
+                                         public static IEnumerable<(string Key, int Count)> GetGroupCounts(IEnumerable<string> words)
+                                         {
+                                             var result = from word in words
+                                                          group word by word.ToLower()
+                                                          into g   // <-- QueryContinuationSyntax starts here
+                                                          where g.Count() > 1
+                                                          select (Key: g.Key, Count: g.Count());
+
+                                             return result;
+                                         }
+                                     }
+
+                                     """;
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6073_LinqQueriesAreVerticallyAlignedAnalyzer();

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -640,6 +640,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "6. Spacing", "6. Spacing", 
 		Documentation\MiKo_6070.md = Documentation\MiKo_6070.md
 		Documentation\MiKo_6071.md = Documentation\MiKo_6071.md
 		Documentation\MiKo_6072.md = Documentation\MiKo_6072.md
+		Documentation\MiKo_6073.md = Documentation\MiKo_6073.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 545 rules that are currently provided by the analyzer.
+The following tables list all the 546 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -596,3 +596,4 @@ The following tables list all the 545 rules that are currently provided by the a
 |[MiKo_6070](/Documentation/MiKo_6070.md)|Surround Console statements with blank lines|&#x2713;|&#x2713;|
 |[MiKo_6071](/Documentation/MiKo_6071.md)|Surround local using statements with blank lines|&#x2713;|&#x2713;|
 |[MiKo_6072](/Documentation/MiKo_6072.md)|Surround base class calls with blank lines|&#x2713;|&#x2713;|
+|[MiKo_6073](/Documentation/MiKo_6073.md)|Align LINQ query clauses vertically|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Introduce analyzer and code fix to ensure all LINQ query clauses are vertically aligned for better readability

- Add documentation, localized resources, and comprehensive unit tests for the new rule

- Update README.md

- Refactor spacing analyzers to use a shared `NotVerticallyAligned` helpers for alignment checks

(resolves #1936)