### PR TITLE
Applying own rules do codebase

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/Verbalizer.cs
@@ -569,9 +569,9 @@ namespace MiKoSolutions.Analyzers.Linguistics
                     }
 
                     if (word.EndsWith("oes", StringComparison.Ordinal)
-                    || word.EndsWith("shes", StringComparison.Ordinal)
-                    || word.EndsWith("sses", StringComparison.Ordinal)
-                    || word.EndsWith("tches", StringComparison.Ordinal))
+                     || word.EndsWith("shes", StringComparison.Ordinal)
+                     || word.EndsWith("sses", StringComparison.Ordinal)
+                     || word.EndsWith("tches", StringComparison.Ordinal))
                     {
                         return word.Substring(0, word.Length - 2);
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
@@ -33,8 +33,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return syntax;
             }
 
-            var fieldName = fieldDeclaration.Declaration.Variables.First().Identifier.ValueText;
-            var name = fieldName.WithoutSuffix(Constants.DependencyProperty.FieldSuffix);
+            var variable = fieldDeclaration.Declaration.Variables.First();
+            var name = variable.Identifier.ValueText.WithoutSuffix(Constants.DependencyProperty.FieldSuffix);
 
             var type = SyntaxFactory.ParseName(name);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzer.cs
@@ -44,7 +44,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(ReadOnlySpan<char> symbolName)
+        private static string FindBetterName(in ReadOnlySpan<char> symbolName)
         {
             var nameWithoutSuffix = symbolName.WithoutSuffixes(WrongSuffixes);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1526_DelegatePropertyNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1526_DelegatePropertyNameSuffixAnalyzer.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return Array.Empty<Diagnostic>();
         }
 
-        private static string FindBetterName(ReadOnlySpan<char> symbolName)
+        private static string FindBetterName(in ReadOnlySpan<char> symbolName)
         {
             var nameWithoutSuffix = symbolName.WithoutSuffixes(WrongSuffixes);
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6037_CodeFixProvider.cs
@@ -26,6 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 {
                     case ArgumentSyntax _:
                         foundArgument = true;
+
                         break;
 
                     case InvocationExpressionSyntax i when foundArgument:


### PR DESCRIPTION
- Adjust formatting/spacing in a spacing code fix and in `Verbalizer` conditional indentation

- Update methods to take `in ReadOnlySpan<char>

- Minor refactor in documentation code fix to avoid repeated chained access when extracting field variable name
