### PR TITLE
Fixed a bug introduced by PR!1951

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/LocationExtensions.cs
@@ -175,7 +175,7 @@ namespace MiKoSolutions.Analyzers
                 return null;
             }
 
-            return sourceText.ToString(TextSpan.FromBounds(lastIndexOfFirstSpace + 1, startUpText.Length + firstIndexOfNextSpace));
+            return sourceText.ToString(TextSpan.FromBounds(sourceSpanStart + lastIndexOfFirstSpace + 1, sourceSpanEnd + firstIndexOfNextSpace));
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
@@ -70,14 +70,12 @@ namespace MiKoSolutions.Analyzers.Extensions
         }
 
         [Test]
-        public static void GetSurroundingWord_returns_correct_word_when_location_is_beyond_200_characters()
+        public static void GetSurroundingWord_returns_correct_word_when_location_is_beyond_200_characters_([Values(0, 19, 20, 40)] int repeatCount)
         {
             const string Word = "SomeWord?param=value";
 
-            var prefix = string.Concat(Enumerable.Repeat("1234567890", 20)) + "12345678 ";
-            var source = prefix + Word + " some more suffix at the end";
-
-            Assert.That(prefix.Length, Is.EqualTo(209), "Precondition not met");
+            var prefix = string.Concat(Enumerable.Repeat("1234567890", repeatCount));
+            var source = prefix + " " + Word + " some more suffix at the end";
 
             var questionMarkIndex = source.IndexOf('?');
 

--- a/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/LocationExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
@@ -65,6 +67,26 @@ namespace MiKoSolutions.Analyzers.Extensions
                                      Assert.That(location4.IntersectsWith(location5), Is.False);
                                      Assert.That(location5.IntersectsWith(location4), Is.False);
                                  });
+        }
+
+        [Test]
+        public static void GetSurroundingWord_returns_correct_word_when_location_is_beyond_200_characters()
+        {
+            const string Word = "SomeWord?param=value";
+
+            var prefix = string.Concat(Enumerable.Repeat("1234567890", 20)) + "12345678 ";
+            var source = prefix + Word + " some more suffix at the end";
+
+            Assert.That(prefix.Length, Is.EqualTo(209), "Precondition not met");
+
+            var questionMarkIndex = source.IndexOf('?');
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var location = Location.Create(tree, TextSpan.FromBounds(questionMarkIndex, questionMarkIndex + 1));
+
+            var result = location.GetSurroundingWord();
+
+            Assert.That(result, Is.EqualTo(Word));
         }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
@@ -77,23 +77,11 @@ public class TestMe
 
         [Test]
         public void No_issue_is_reported_for_hyperlink() => No_issue_is_reported_for(@"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-// Those usings are used to have enough characters as 'preamble' to find the hyperlink in the documentation and not report an issue for the question mark in the hyperlink
-
-namespace MyNamespace
+/// <summary>
+/// See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-6.0.
+/// </summary>
+public class TestMe
 {
-    /// <summary>
-    /// See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-6.0.
-    /// </summary>
-    public class TestMe
-    {
-    }
 }");
 
         protected override string GetDiagnosticId() => MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.Id;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
@@ -77,11 +77,23 @@ public class TestMe
 
         [Test]
         public void No_issue_is_reported_for_hyperlink() => No_issue_is_reported_for(@"
-/// <summary>
-/// See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-6.0.
-/// </summary>
-public class TestMe
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+// Those usings are used to have enough characters as 'preamble' to find the hyperlink in the documentation and not report an issue for the question mark in the hyperlink
+
+namespace MyNamespace
 {
+    /// <summary>
+    /// See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-6.0.
+    /// </summary>
+    public class TestMe
+    {
+    }
 }");
 
         protected override string GetDiagnosticId() => MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzer.Id;


### PR DESCRIPTION
- Fix bug introduced by #1951 in `GetSurroundingWord` where indices were off when the location was more than 200 characters into the source text, causing wrong results or an `ArgumentOutOfRangeException`

- Add regression test to prevent reoccurrence
