### PR TITLE
MiKo_3504 is now aware of conditional access expressions (such as 'A?.B')

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
@@ -121,6 +121,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (expression)
             {
+                case ConditionalAccessExpressionSyntax _:
                 case ElementAccessExpressionSyntax _:
                 case IdentifierNameSyntax _:
                 case InvocationExpressionSyntax _:
@@ -136,6 +137,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (syntax)
             {
+                case ConditionalAccessExpressionSyntax conditional when IsTrainWreck(conditional, semanticModel):
                 case ElementAccessExpressionSyntax access when IsTrainWreck(access, semanticModel):
                 case InvocationExpressionSyntax invocation when IsTrainWreck(invocation, semanticModel):
                 case MemberAccessExpressionSyntax member when IsTrainWreck(member, semanticModel):
@@ -145,6 +147,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     return false;
             }
         }
+
+        private static bool IsTrainWreck(ConditionalAccessExpressionSyntax level1, SemanticModel semanticModel) => IsTrainWreck(level1, AllowedDepth, semanticModel);
 
         private static bool IsTrainWreck(ElementAccessExpressionSyntax level1, SemanticModel semanticModel) => IsTrainWreck(level1, AllowedDepth, semanticModel);
 
@@ -203,6 +207,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             switch (expression)
             {
+                case ConditionalAccessExpressionSyntax c:
+                {
+                    return c.WhenNotNull;
+                }
+
                 case MemberAccessExpressionSyntax m:
                 {
                     if (m.Expression is ElementAccessExpressionSyntax next)

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
@@ -255,6 +255,34 @@ public class TestMeC
 ");
 
         [Test]
+        public void No_issue_is_reported_for_accessing_3_array_elements_in_a_row_when_being_an_argument() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA[] A { get; }
+
+    public void DoSomething()
+    {
+        DoSomething(A[1].B[2].C[3]);
+    }
+
+    private void DoSomething(int value)
+    {
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB[] B { get; }
+}
+
+public class TestMeB
+{
+    public int[] C { get; }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_accessing_3_array_elements_in_a_row_when_invoking_a_method_when_being_an_argument() => No_issue_is_reported_for(@"
 
 public class TestMe
@@ -297,6 +325,35 @@ public class TestMe
     public void DoSomething()
     {
         var value = A.B.C.D;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public int D { get; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_accessing_4_properties_in_a_row_when_assigning_a_value_using_conditional_access() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public void DoSomething()
+    {
+        var value = A?.B?.C?.D;
     }
 }
 
@@ -676,6 +733,38 @@ public class TestMeB
 public class TestMeC
 {
     public int D { get; }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_accessing_4_properties_in_a_row_via_conditional_access_when_being_used_in_if_condition() => No_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public int DoSomething()
+    {
+        if (A?.B?.C?.D != null)
+            return 42;
+
+        return 0;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public object D { get; }
 }
 ");
 
@@ -1277,6 +1366,40 @@ public class TestMeD
 ");
 
         [Test]
+        public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_assigning_a_value_when_using_conditional_access() => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public void DoSomething()
+    {
+        var value = A?.B?.C?.D?.E;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public TestMeD D { get; }
+}
+
+public class TestMeD
+{
+    public int E { get; }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_being_an_argument() => An_issue_is_reported_for(@"
 
 public class TestMe
@@ -1311,6 +1434,44 @@ public class TestMeC
 public class TestMeD
 {
     public int E { get; }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_accessing_5_array_elements_in_a_row_when_being_an_argument() => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA[] A { get; }
+
+    public void DoSomething()
+    {
+        DoSomething(A[1].B[2].C[3].D[4].E[5]);
+    }
+
+    private void DoSomething(int value)
+    {
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB[] B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC[] C { get; }
+}
+
+public class TestMeC
+{
+    public TestMeD[] D { get; }
+}
+
+public class TestMeD
+{
+    public int[] E { get; }
 }
 ");
 
@@ -1738,6 +1899,43 @@ public class TestMeD
 ");
 
         [Test]
+        public void An_issue_is_reported_for_accessing_5_properties_in_a_row_via_conditional_access_when_being_used_in_if_condition() => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public int DoSomething()
+    {
+        if (A?.B?.C?.D?.E != null)
+            return 42;
+
+        return 0;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public TestMeD D { get; }
+}
+
+public class TestMeD
+{
+    public object E { get; }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_being_used_in_if_condition() => An_issue_is_reported_for(@"
 
 public class TestMe
@@ -2128,6 +2326,43 @@ public class TestMeD
 ");
 
         [Test]
+        public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_being_used_in_conditional_access_and_pattern_in_if_condition() => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public int DoSomething()
+    {
+        if (A?.B?.C?.D?.E is { })
+            return 42;
+
+        return 0;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public TestMeD D { get; }
+}
+
+public class TestMeD
+{
+    public object E { get; }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_being_used_in_recursive_pattern_in_if_condition() => An_issue_is_reported_for(@"
 
 public class TestMe
@@ -2137,13 +2372,59 @@ public class TestMe
     public int DoSomething()
     {
         if (A.B.C.D.E is not MemberExpression
-            {
-                Member: PropertyInfo
-                {
-                    ReflectedType: { } reflectedType,
-                    Name: { } name
-                }
-            })
+                             {
+                                 Member: PropertyInfo
+                                 {
+                                     ReflectedType: { } reflectedType,
+                                     Name: { } name
+                                 }
+                             })
+        {
+            return 42;
+        }
+
+        return 0;
+    }
+}
+
+public class TestMeA
+{
+    public TestMeB B { get; }
+}
+
+public class TestMeB
+{
+    public TestMeC C { get; }
+}
+
+public class TestMeC
+{
+    public TestMeD D { get; }
+}
+
+public class TestMeD
+{
+    public object E { get; }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_accessing_5_properties_in_a_row_when_being_used_in_conditional_access_and_recursive_pattern_in_if_condition() => An_issue_is_reported_for(@"
+
+public class TestMe
+{
+    public TestMeA A { get; }
+
+    public int DoSomething()
+    {
+        if (A?.B?.C?.D?.E is not MemberExpression
+                                 {
+                                     Member: PropertyInfo
+                                     {
+                                         ReflectedType: { } reflectedType,
+                                         Name: { } name
+                                     }
+                                 })
         {
             return 42;
         }
@@ -2174,7 +2455,6 @@ public class TestMeD
 ");
 
         //// TODO RKN: Implement tests for method invocations, be aware of builder patterns
-        //// TODO RKN: Implement tests for conditional access expressions A?.B?.C?.D...
 
         protected override string GetDiagnosticId() => MiKo_3504_TrainWreckAnalyzer.Id;
 


### PR DESCRIPTION
- Add conditional access (`?.`) to train-wreck detection

- Add unit tests covering conditional access (`A?.B?.C...`) scenarios
