### PR TITLE
MiKo_3504 is now aware of fluent API call chains for methods named 'With' (such as in Roslyn)

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -183,9 +184,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 if (syntax.GetSymbol(semanticModel) is IMethodSymbol method)
                 {
-                    // TODO: Ignore others
-                    // ignore extension methods as they are allowed to be chained
-                    return method.IsExtensionMethod;
+                    if (method.IsExtensionMethod)
+                    {
+                        // ignore extension methods as they are allowed to be chained
+                        return true;
+                    }
+
+                    if (method.Name.StartsWith("With", StringComparison.Ordinal))
+                    {
+                        // ignore (Roslyn) methods that are defined as fluent API
+                        return true;
+                    }
+
+                    // TODO RKN: Ignore others
                 }
 
                 return false;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
@@ -23,27 +23,48 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_a_StringBuilder_build_chain() => No_issue_is_reported_for("""
-                                                                                                       using System;
-                                                                                                       using System.Text;
+        public void No_issue_is_reported_for_a_StringBuilder_call_chain() => No_issue_is_reported_for(@"
+using System;
+using System.Text;
 
-                                                                                                       public class TestMe
-                                                                                                       {
-                                                                                                           public void DoSomething()
-                                                                                                           {
-                                                                                                               var value = new StringBuilder()
-                                                                                                                                        .Append('A')
-                                                                                                                                        .Append('B')
-                                                                                                                                        .Append('C')
-                                                                                                                                        .Append('D')
-                                                                                                                                        .Append('E')
-                                                                                                                                        .Append('F')
-                                                                                                                                        .Append('G')
-                                                                                                                                        .ToString();
-                                                                                                           }
-                                                                                                       }
+public class TestMe
+{
+    public void DoSomething()
+    {
+        var value = new StringBuilder()
+                                 .Append('A')
+                                 .Append('B')
+                                 .Append('C')
+                                 .Append('D')
+                                 .Append('E')
+                                 .Append('F')
+                                 .Append('G')
+                                 .ToString();
+    }
+}
+");
 
-                                                                                                       """);
+        [Test]
+        public void No_issue_is_reported_for_a_Roslyn_call_chain() => No_issue_is_reported_for(@"
+using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+public class TestMe
+{
+    public RecursivePatternSyntax DoSomething(RecursivePatternSyntax node)
+    {
+        return node.WithoutTrivia()
+                   .WithType(null)
+                   .WithPropertyPatternClause(null)
+                   .WithDesignation(null)
+                   .WithPositionalPatternClause(null);
+    }
+}
+");
 
         [Test]
         public void No_issue_is_reported_for_event_registration_when_used_with_full_qualified_names() => No_issue_is_reported_for(@"


### PR DESCRIPTION
- Extend the ignore logic to skip chained method calls whose name starts with `With` (or `Without`)

- Rename the existing `StringBuilder` chain test

- Add new test case covering a `With*` call chain