### PR TITLE
Bumped log4net and ReportGenerator versions

### DIFF
--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.11" />
-    <PackageReference Include="log4net" Version="3.3.0" />
+    <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ReportGenerator" Version="5.5.5" />
+    <PackageReference Include="ReportGenerator" Version="5.5.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- log4net v3.3.0 to v3.3.1

- ReportGenerator v5.5.5 to v5.5.6