### PR TITLE
MiKo_1090 / MiKo_1091 now ignore names starting with 'current'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzer.cs
@@ -18,6 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             {
                                                                 "old",
                                                                 "new",
+                                                                "current",
                                                                 "source",
                                                                 "target",
                                                                 "xml",

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzer.cs
@@ -18,6 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             {
                                                                 "old",
                                                                 "new",
+                                                                "current",
                                                                 "source",
                                                                 "target",
                                                                 "xml",

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_properly_named_parameter_([Values("comparer", "view", "item", "entity", "oldView", "newView", "xmlElement", "sourceView", "targetView", "sourceEntity", "targetEntity")] string name)
+        public void No_issue_is_reported_for_method_with_properly_named_parameter_([Values("comparer", "view", "item", "entity", "oldView", "newView", "currentView", "xmlElement", "sourceView", "targetView", "sourceEntity", "targetEntity")] string name)
             => No_issue_is_reported_for(@"
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_properly_named_variable_([Values("comparer", "view", "item", "entity", "xmlElement", "oldView", "newView", "sourceEntity", "targetEntity")] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_properly_named_variable_([Values("comparer", "view", "item", "entity", "xmlElement", "oldView", "newView", "currentView", "sourceEntity", "targetEntity")] string name) => No_issue_is_reported_for(@"
 
 public class TestMe
 {


### PR DESCRIPTION
- Allow `current*` as an accepted prefix

- Add test
