### PR TITLE
MiKo_2017 now underlines summary or value with issue

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_CodeFixProvider.cs
@@ -38,14 +38,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var type = SyntaxFactory.ParseName(name);
 
-            var readOnlyMarker = string.Empty;
+            var summary = Comment(XmlElement(Constants.XmlTag.Summary), SummaryText[0], SeeCref(type), SummaryText[1]);
 
             if (fieldDeclaration.IsReadOnly())
             {
-                readOnlyMarker = " " + Constants.Comments.FieldIsReadOnly;
+                var content = summary.Content.Add(XmlText(Constants.Comments.FieldIsReadOnly).WithLeadingXmlComment());
+
+                summary = summary.WithContent(content);
             }
 
-            var summary = Comment(XmlElement(Constants.XmlTag.Summary), SummaryText[0], SeeCref(type), SummaryText[1] + readOnlyMarker);
             var field = Comment(XmlElement(Constants.XmlTag.Value), ValueText[0], SeeCref(type), ValueText[1]);
 
             return syntax.WithoutTrivia()

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
@@ -62,7 +62,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         }
 
                         // underline comment instead of field declaration
-                        var summaryXml = comment.GetSummaryXmls()[0];
+                        var summaryXml = comment.GetSummaryXmls()[index];
 
                         issues.Add(Issue(symbol.Name, summaryXml.GetContentsLocation(), Constants.XmlTag.Summary, summaryPhrases[0]));
                     }
@@ -88,7 +88,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         }
 
                         // underline comment instead of field declaration
-                        var valueXml = comment.GetValueXmls()[0];
+                        var valueXml = comment.GetValueXmls()[index];
 
                         issues.Add(Issue(symbol.Name, valueXml.GetContentsLocation(), Constants.XmlTag.Value, valuePhrases[0]));
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzer.cs
@@ -61,7 +61,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             issues = new List<Diagnostic>(1);
                         }
 
-                        issues.Add(Issue(symbol, Constants.XmlTag.Summary, summaryPhrases[0]));
+                        // underline comment instead of field declaration
+                        var summaryXml = comment.GetSummaryXmls()[0];
+
+                        issues.Add(Issue(symbol.Name, summaryXml.GetContentsLocation(), Constants.XmlTag.Summary, summaryPhrases[0]));
                     }
                 }
             }
@@ -84,7 +87,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             issues = new List<Diagnostic>(1);
                         }
 
-                        issues.Add(Issue(symbol, Constants.XmlTag.Value, valuePhrases[0]));
+                        // underline comment instead of field declaration
+                        var valueXml = comment.GetValueXmls()[0];
+
+                        issues.Add(Issue(symbol.Name, valueXml.GetContentsLocation(), Constants.XmlTag.Value, valuePhrases[0]));
                     }
                 }
             }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2017_DependencyPropertyDefaultPhraseAnalyzerTests.cs
@@ -141,7 +141,8 @@ public class TestMe
     public int MyDependency { get; set; }
 
     /// <summary>
-    /// Identifies the <see cref=""MyDependency""/> dependency property. This field is read-only.
+    /// Identifies the <see cref=""MyDependency""/> dependency property.
+    /// This field is read-only.
     /// </summary>
     /// <value>
     /// The identifier for the <see cref=""MyDependency""/> dependency property.


### PR DESCRIPTION
- Place "This field is read-only." on a new line in the XML summary instead of appending it to the summary sentence

- Report analyzer diagnostics on the specific XML comment nodes (summary/value) rather than the field declaration for more precise feedback

- Update tests to reflect the new summary formatting