### PR TITLE
MiKo_2012 is now better able to fix a XAML default comment

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -134,7 +134,23 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (text.StartsWith("Interaction logic for"))
             {
                 // seems like this is the default comment for WPF controls
-                return Comment(comment, XmlText("Represents a TODO"));
+                var type = comment.GetEnclosing<TypeDeclarationSyntax>();
+                var name = type.GetName();
+
+                if (name.IsNullOrEmpty())
+                {
+                    return Comment(comment, XmlText("Represents a TODO"));
+                }
+
+                var fixedName = AbbreviationFinder.FindAndReplaceAllAbbreviations(name);
+                var nameSpan = type.IsKind(SyntaxKind.InterfaceDeclaration) && fixedName[0] == 'I'
+                               ? fixedName.AsSpan(1) // do not use the leading 'I' of interfaces
+                               : fixedName.AsSpan();
+
+                var article = ArticleProvider.GetArticleFor(nameSpan, FirstWordAdjustment.StartLowerCase);
+                var continuation = nameSpan.WordsAsSpan().Select(_ => _.Text.ToLowerCaseAt(0)).ConcatenatedWith(" ");
+
+                return Comment(comment, XmlText($"Represents {article}{continuation}."));
             }
 
             if (text.StartsWithAny(EmptyReplacementsMapKeys))

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -155,7 +155,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     if (summary.Contains(phrase, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (phrase.EndsWith(" used", StringComparison.Ordinal) && summary.Contains(" used in ", StringComparison.OrdinalIgnoreCase))
+                        if (phrase.EndsWith(" used", StringComparison.Ordinal) && summary.Contains(" used in ", StringComparison.Ordinal))
                         {
                             // ignore the specific phrase
                             continue;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -428,7 +428,31 @@ public class TestMe
 /// <summary>
 /// Interaction logic for TestMe.xaml
 /// </summary>
-public class TestMe
+public class TestMeCfg
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Represents a test me configuration.
+/// </summary>
+public class TestMeCfg
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_unfinished_XAML_like_code()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// Interaction logic for TestMe.xaml
+/// </summary>
+public class 
 {
 }
 ";
@@ -437,7 +461,31 @@ public class TestMe
 /// <summary>
 /// Represents a TODO
 /// </summary>
-public class TestMe
+public class 
+{
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_XAML_like_comment()
+        {
+            const string OriginalCode = @"
+/// <summary>
+/// Interaction logic for TestMe.xaml
+/// </summary>
+public interface ITestMeCfg
+{
+}
+";
+
+            const string FixedCode = @"
+/// <summary>
+/// Represents a test me configuration.
+/// </summary>
+public interface ITestMeCfg
 {
 }
 ";


### PR DESCRIPTION
- Improve XAML comment code fix by generating meaningful summaries from type names (with abbreviation expansion and article selection) instead of always using "Represents a TODO"

- Update analyzer logic for "used in" phrases to be case-sensitive

- Add tests for new summary generation behavior and edge cases