### PR TITLE
Change parameter 'clearArray' on 'ArrayPool.Return()' to its default value 'false'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamespaceNamingAnalyzer.cs
@@ -105,7 +105,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
             finally
             {
-                Pool.Return(rentedArray, clearArray: true);
+                Pool.Return(rentedArray);
             }
         }
     }


### PR DESCRIPTION
Change parameter `clearArray` on `ArrayPool.Return()` back to its default value `false` as there is no need to clear the namespaces array (as they do not contain sensitive information).