### PR TITLE
Improved MiKo_3029 to detect event registration in unregistration-named methods

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
@@ -14,6 +14,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3029";
 
+        private static readonly string[] UnregistrationMethodNames = { "Unregister", "Deregister", "Unsubscribe", "Desubscribe" };
+
         public MiKo_3029_EventRegistrationOrderAnalyzer() : base(Id)
         {
         }
@@ -66,7 +68,16 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return;
             }
 
-            AnalyzeAssignmentExpressions(context);
+            var methodName = method.GetName();
+
+            if (methodName.StartsWithAny(UnregistrationMethodNames, StringComparison.OrdinalIgnoreCase))
+            {
+                AnalyzeUnregistrationAssignmentExpressions(context);
+            }
+            else
+            {
+                AnalyzeAssignmentExpressions(context);
+            }
         }
 
         private void AnalyzeGetAccessorDeclaration(SyntaxNodeAnalysisContext context) => AnalyzeAssignmentExpressions(context);
@@ -196,6 +207,17 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             }
                         }
                     }
+                }
+            }
+        }
+
+        private void AnalyzeUnregistrationAssignmentExpressions(in SyntaxNodeAnalysisContext context)
+        {
+            foreach (var add in context.Node.DescendantNodes<AssignmentExpressionSyntax>())
+            {
+                if (add.IsKind(SyntaxKind.AddAssignmentExpression) && Is(MethodKind.EventAdd, add, context.SemanticModel))
+                {
+                    ReportDiagnostics(context, Issue(add));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzer.cs
@@ -72,7 +72,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (methodName.StartsWithAny(UnregistrationMethodNames, StringComparison.OrdinalIgnoreCase))
             {
-                AnalyzeUnregistrationAssignmentExpressions(context);
+                AnalyzeUnregistrationAssignments(context);
             }
             else
             {
@@ -85,6 +85,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private void AnalyzeSetAccessorDeclaration(SyntaxNodeAnalysisContext context) => AnalyzeAssignmentExpressions(context);
 
         private void AnalyzeAssignmentExpressions(in SyntaxNodeAnalysisContext context) => ReportDiagnostics(context, AnalyzeAssignments(context.Node, context.SemanticModel));
+
+        private void AnalyzeUnregistrationAssignments(in SyntaxNodeAnalysisContext context) => ReportDiagnostics(context, AnalyzeUnregistrationAssignments(context.Node, context.SemanticModel));
 
         private IEnumerable<Diagnostic> AnalyzeAssignments(SyntaxNode node, SemanticModel semanticModel)
         {
@@ -211,13 +213,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private void AnalyzeUnregistrationAssignmentExpressions(in SyntaxNodeAnalysisContext context)
+        private IEnumerable<Diagnostic> AnalyzeUnregistrationAssignments(SyntaxNode node, SemanticModel semanticModel)
         {
-            foreach (var add in context.Node.DescendantNodes<AssignmentExpressionSyntax>())
+            foreach (var assignment in node.DescendantNodes<AssignmentExpressionSyntax>())
             {
-                if (add.IsKind(SyntaxKind.AddAssignmentExpression) && Is(MethodKind.EventAdd, add, context.SemanticModel))
+                switch (assignment.Kind())
                 {
-                    ReportDiagnostics(context, Issue(add));
+                    case SyntaxKind.AddAssignmentExpression when Is(MethodKind.EventAdd, assignment, semanticModel):
+                    case SyntaxKind.SubtractAssignmentExpression when assignment.Right is LambdaExpressionSyntax && Is(MethodKind.EventRemove, assignment, semanticModel):
+                    {
+                        yield return Issue(assignment);
+
+                        break;
+                    }
                 }
             }
         }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzerTests.cs
@@ -12,6 +12,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     [TestFixture]
     public sealed class MiKo_3029_EventRegistrationOrderAnalyzerTests : CodeFixVerifier
     {
+        private static readonly string[] UnregistrationMethodNames =
+                                                                     [
+                                                                         "DeregisterEvents",
+                                                                         "DeRegisterEvents",
+                                                                         "DesubscribeEvents",
+                                                                         "DeSubscribeEvents",
+                                                                         "UnregisterEvents",
+                                                                         "UnRegisterEvents",
+                                                                         "UnsubscribeEvents",
+                                                                         "UnSubscribeEvents"
+                                                                     ];
+
         [Test]
         public void No_issue_is_reported_for_add_and_subtract_of_numbers() => No_issue_is_reported_for(@"
 using System;
@@ -90,6 +102,42 @@ using System;
 public class TestMe
 {
     public void DoSomething()
+    {
+        Console.CancelKeyPress -= OnCancelKeyPress;
+        Console.CancelKeyPress -= OnCancelKeyPress;
+        Console.CancelKeyPress -= OnCancelKeyPress;
+    }
+
+    private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_single_remove_only_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private void " + name + @"()
+    {
+        Console.CancelKeyPress -= OnCancelKeyPress;
+    }
+
+    private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_remove_only_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void " + name + @"()
     {
         Console.CancelKeyPress -= OnCancelKeyPress;
         Console.CancelKeyPress -= OnCancelKeyPress;
@@ -362,6 +410,66 @@ public class TestMe
     }
 
     private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_single_add_only_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void " + name + @"()
+    {
+        Console.CancelKeyPress += OnCancelKeyPress;
+    }
+
+    private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_for_multiple_add_only_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => An_issue_is_reported_for(3, @"
+using System;
+
+public class TestMe
+{
+    public void " + name + @"()
+    {
+        Console.CancelKeyPress += OnCancelKeyPress;
+        Console.CancelKeyPress += OnCancelKeyPress;
+        Console.CancelKeyPress += OnCancelKeyPress;
+    }
+
+    private void OnCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_multiple_remove_but_single_add_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public void " + name + @"()
+    {
+        Console.CancelKeyPress -= OnCancelKeyPress1;
+        Console.CancelKeyPress += OnCancelKeyPress2;
+        Console.CancelKeyPress -= OnCancelKeyPress1;
+    }
+
+    private void OnCancelKeyPress1(object sender, ConsoleCancelEventArgs e)
+    {
+    }
+
+    private void OnCancelKeyPress2(object sender, ConsoleCancelEventArgs e)
     {
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3029_EventRegistrationOrderAnalyzerTests.cs
@@ -475,6 +475,19 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void An_issue_is_reported_for_remove_with_lambda_in_methods_named_([ValueSource(nameof(UnregistrationMethodNames))] string name) => An_issue_is_reported_for(@"
+ using System;
+
+ public class TestMe
+ {
+     public void " + name + @"()
+     {
+         Console.CancelKeyPress -= (sender, args) => { };
+     }
+ }
+ ");
+
         protected override string GetDiagnosticId() => MiKo_3029_EventRegistrationOrderAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3029_EventRegistrationOrderAnalyzer();


### PR DESCRIPTION
- Add detection of methods with unregistration-related names (e.g., "Unregister", "Deregister", "Unsubscribe", "Desubscribe") and ensure they do not contain
  - event registration (`+=`) statements
  - lambda registration or unregistration statements

- Introduce targeted analysis for such methods and report diagnostics if event registration is found

- Expand test coverage to verify correct behavior for various unregistration method name variants and scenarios

(part of #1894)