### PR TITLE
Refactored MiKo_5016 'Analyze' to explicit iteration instead of LINQ

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
@@ -170,9 +170,9 @@ namespace MiKoSolutions.Analyzers
         /// One of the enumeration members that specifies the syntax kind to filter by.
         /// </param>
         /// <returns>
-        /// A sequence that contains all descendant nodes of the specified type and syntax kind.
+        /// A collection of syntax nodes that contains all descendant nodes of the specified type and syntax kind.
         /// </returns>
-        internal static IEnumerable<T> DescendantNodes<T>(this SyntaxNode value, in SyntaxKind kind) where T : SyntaxNode
+        internal static IReadOnlyList<T> DescendantNodes<T>(this SyntaxNode value, in SyntaxKind kind) where T : SyntaxNode
         {
             List<T> results = null;
 
@@ -191,7 +191,7 @@ namespace MiKoSolutions.Analyzers
                 results.Add((T)node);
             }
 
-            return results ?? Enumerable.Empty<T>();
+            return (IReadOnlyList<T>)results ?? Array.Empty<T>();
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static IEnumerable<string> GetAssignmentIdentifierCandidates(SyntaxNode node)
         {
-            var candidates = node.DescendantNodes<AssignmentExpressionSyntax>(_ => _.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            var candidates = node.DescendantNodes<AssignmentExpressionSyntax>(SyntaxKind.SimpleAssignmentExpression)
                                  .Select(_ => _.FirstChild<IdentifierNameSyntax>())
                                  .WhereNotNull()
                                  .Select(_ => _.GetName());

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer.cs
@@ -23,7 +23,9 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             SemanticModel semanticModel = null;
 
-            foreach (var node in syntax.DescendantNodes<MemberAccessExpressionSyntax>(_ => _.IsKind(SyntaxKind.SimpleMemberAccessExpression)))
+            List<Diagnostic> issues = null;
+
+            foreach (var node in syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
             {
                 var name = node.GetName();
 
@@ -45,10 +47,17 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
                     if (type != null && type.Name != "HashSet" && type.Name != "ISet")
                     {
-                        yield return Issue(maes);
+                        if (issues is null)
+                        {
+                            issues = new List<Diagnostic>(1);
+                        }
+
+                        issues.Add(Issue(maes));
                     }
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
     }
 }


### PR DESCRIPTION
- Refactor `DescendantNodes<T>` to return `IReadOnlyList<T>` and update consumers to use new overload with `SyntaxKind` parameter

- Refactor diagnostic collection in `MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer` to use a list for improved type safety and performance