### PR TITLE
Added new rule MiKo_3233 to discourage 'is var' pattern for null checks

### DIFF
--- a/Documentation/MiKo_3233.md
+++ b/Documentation/MiKo_3233.md
@@ -1,0 +1,54 @@
+﻿# MiKo_3233: Do not use var patterns for null checks
+
+## Cause
+
+Code uses a `var` pattern (`is var something`) to match a value.
+
+## Rule description
+
+Using `is var something` always succeeds, even when the value is `null`.
+That means something can be `null` and any access on it will throw a `NullReferenceException`.
+Instead, to avoid `null`, use a non-null pattern (such as `is { } something`), a specific type (such as `is SomeType something`), or add an explicit `null` check after the pattern match.
+This keeps your code safe and makes your intent clear.
+
+### Rationale behind
+
+The `var` pattern looks like a safe way to capture a value, but it silently allows `null` to pass through.
+This mismatch between expectation and actual behavior can introduce subtle bugs that are hard to detect and diagnose.
+
+Using null-safe alternatives instead of `var` patterns provides several important benefits:
+
+- **Improved Safety**:
+  Null-safe patterns prevent `null` values from being used without an explicit check.
+  This reduces the risk of unexpected `NullReferenceException` errors at runtime.
+
+- **Clearer Intent**:
+  A non-null pattern or a type pattern clearly communicates that a valid, non-null value is expected.
+  Readers immediately understand what the code is testing for.
+
+- **Improved Readability**:
+  Patterns that express their intent directly are easier to read and reason about.
+  There is no need to mentally track whether a bound variable might be `null`.
+
+- **Reduced Cognitive Load**:
+  When a pattern guarantees a non-null value, developers do not need to keep track of potential `null` cases while reading through the code.
+  This makes it easier to follow the logic.
+
+- **Better Maintainability**:
+  Explicit null-safe patterns are less likely to be misunderstood or broken during future maintenance.
+  The code's purpose is obvious without requiring deep knowledge of pattern matching semantics.
+
+- **Fewer Hidden Bugs**:
+  The `var` pattern can silently accept `null` and pass it further into the code.
+  Replacing it with a safer alternative eliminates an entire category of potential null-related bugs.
+
+## How to fix violations
+
+To fix a violation of this rule, replace the `var` pattern with a non-null pattern, a specific type pattern, or add an explicit `null` check after the pattern match.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3233
+#pragma warning restore MiKo_3233
+```

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1926,6 +1926,73 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsNameOf(this InvocationExpressionSyntax value) => value.Expression.IsNameOf();
 
         /// <summary>
+        /// Determines whether the specified condition expression represents a null check for the given identifier.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition expression to inspect.
+        /// </param>
+        /// <param name="identifier">
+        /// The identifier to check against.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="condition"/> is a not-equal-to-<see langword="null"/> binary expression
+        /// or a not-<see langword="null"/> pattern expression that references <paramref name="identifier"/>;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsNullCheck(this ExpressionSyntax condition, IdentifierNameSyntax identifier) => condition.IsNullCheck(identifier.GetName());
+
+        /// <summary>
+        /// Determines whether the specified condition expression represents a null check for the given identifier.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition expression to inspect.
+        /// </param>
+        /// <param name="identifier">
+        /// The identifier to check against.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="condition"/> is a not-equal-to-<see langword="null"/> binary expression
+        /// or a not-<see langword="null"/> pattern expression that references <paramref name="identifier"/>;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsNullCheck(this ExpressionSyntax condition, string identifier)
+        {
+            switch (condition)
+            {
+                case BinaryExpressionSyntax b:
+                {
+                    if (b.IsKind(SyntaxKind.NotEqualsExpression))
+                    {
+                        if (b.Right.IsKind(SyntaxKind.NullLiteralExpression) && b.Left is IdentifierNameSyntax left)
+                        {
+                            return left.GetName() == identifier;
+                        }
+
+                        if (b.Left.IsKind(SyntaxKind.NullLiteralExpression) && b.Right is IdentifierNameSyntax right)
+                        {
+                            return right.GetName() == identifier;
+                        }
+                    }
+
+                    return false;
+                }
+
+                case IsPatternExpressionSyntax p:
+                {
+                    if (p.Pattern is UnaryPatternSyntax u && u.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.NullLiteralExpression) && p.Expression is IdentifierNameSyntax name)
+                    {
+                        return name.GetName() == identifier;
+                    }
+
+                    return false;
+                }
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// Determines whether a type syntax represents an object type.
         /// </summary>
         /// <param name="value">

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -349,6 +349,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3230_DoNotUseGuidsForIdentifiersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3232_DoNotUseEmptyPropertyPatternInsideConditionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15016,6 +15016,34 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using &quot;is var something&quot; always succeeds, even when the value is &apos;null&apos;. That means something can be &apos;null&apos; and any access on it will throw a &apos;NullReferenceException&apos;.
+        ///Instead, to avoid &apos;null&apos;, use a non-null pattern (such as &quot;is { } something&quot;), a specific type (such as &quot;is SomeType something&quot;), or add an explicit &apos;null&apos; check after the pattern match. This keeps your code safe and makes your intent clear..
+        /// </summary>
+        internal static string MiKo_3233_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3233_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use explicit type or null check.
+        /// </summary>
+        internal static string MiKo_3233_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3233_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not use var patterns for null checks.
+        /// </summary>
+        internal static string MiKo_3233_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3233_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5250,6 +5250,16 @@ This approach improves type safety and makes it harder to accidentally mix up di
   <data name="MiKo_3232_Title" xml:space="preserve">
     <value>Use null checks instead of empty property pattern</value>
   </data>
+  <data name="MiKo_3233_Description" xml:space="preserve">
+    <value>Using "is var something" always succeeds, even when the value is 'null'. That means something can be 'null' and any access on it will throw a 'NullReferenceException'.
+Instead, to avoid 'null', use a non-null pattern (such as "is { } something"), a specific type (such as "is SomeType something"), or add an explicit 'null' check after the pattern match. This keeps your code safe and makes your intent clear.</value>
+  </data>
+  <data name="MiKo_3233_MessageFormat" xml:space="preserve">
+    <value>Use explicit type or null check</value>
+  </data>
+  <data name="MiKo_3233_Title" xml:space="preserve">
+    <value>Do not use var patterns for null checks</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MethodReturnsNullAnalyzer.cs
@@ -128,43 +128,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static bool IsNullCheck(ExpressionSyntax condition, IdentifierNameSyntax identifier)
-        {
-            switch (condition)
-            {
-                case BinaryExpressionSyntax b:
-                {
-                    if (b.IsKind(SyntaxKind.NotEqualsExpression))
-                    {
-                        if (b.Right.IsKind(SyntaxKind.NullLiteralExpression) && b.Left is IdentifierNameSyntax left)
-                        {
-                            return left.GetName() == identifier.GetName();
-                        }
-
-                        if (b.Left.IsKind(SyntaxKind.NullLiteralExpression) && b.Right is IdentifierNameSyntax right)
-                        {
-                            return right.GetName() == identifier.GetName();
-                        }
-                    }
-
-                    return false;
-                }
-
-                case IsPatternExpressionSyntax p:
-                {
-                    if (p.Pattern is UnaryPatternSyntax u && u.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.NullLiteralExpression) && p.Expression is IdentifierNameSyntax name)
-                    {
-                        return name.GetName() == identifier.GetName();
-                    }
-
-                    return false;
-                }
-
-                default:
-                    return false;
-            }
-        }
-
         private bool CanBeIgnored(in SyntaxNodeAnalysisContext context)
         {
             if (context.CancellationToken.IsCancellationRequested)
@@ -268,8 +231,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 switch (grandParent)
                 {
-                    case BlockSyntax block when block.Parent is IfStatementSyntax i1 && IsNullCheck(i1.Condition, identifier):
-                    case IfStatementSyntax i2 when IsNullCheck(i2.Condition, identifier):
+                    case BlockSyntax block when block.Parent is IfStatementSyntax i1 && i1.Condition.IsNullCheck(identifier):
+                    case IfStatementSyntax i2 when i2.Condition.IsNullCheck(identifier):
                     {
                         // we seem to have a check for null that avoids returning null
                         return;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs
@@ -18,9 +18,27 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeVarPattern, SyntaxKind.VarPattern);
 
+        private static bool HasIssue(VarPatternSyntax pattern)
+        {
+            if (pattern.Designation is SingleVariableDesignationSyntax s && pattern.Parent is SyntaxNode parent)
+            {
+                if (parent.IsAnyKind(ParentKinds))
+                {
+                    if (parent.Parent is BinaryExpressionSyntax b && b.IsKind(SyntaxKind.LogicalAndExpression) && parent == b.Left && b.Right.IsNullCheck(s.Identifier.ValueText))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void AnalyzeVarPattern(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is VarPatternSyntax pattern && pattern.Parent.IsAnyKind(ParentKinds))
+            if (context.Node is VarPatternSyntax pattern && HasIssue(pattern))
             {
                 ReportDiagnostics(context, Issue(pattern.VarKeyword));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3233";
+
+        private static readonly SyntaxKind[] ParentKinds = { SyntaxKind.IsPatternExpression, SyntaxKind.NotPattern };
+
+        public MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeVarPattern, SyntaxKind.VarPattern);
+
+        private void AnalyzeVarPattern(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is VarPatternSyntax pattern && pattern.Parent.IsAnyKind(ParentKinds))
+            {
+                ReportDiagnostics(context, Issue(pattern.VarKeyword));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzerTests.cs
@@ -93,6 +93,40 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_var_pattern_in_is_pattern_in_if_condition_followed_by_a_null_check() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is var name && name != null)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_var_pattern_in_is_pattern_in_if_condition_followed_by_a_is_not_null_check() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is var name && name is not null)
+        {
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_var_pattern_in_is_pattern_in_if_condition() => An_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzerTests.cs
@@ -1,0 +1,157 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_empty_property_pattern_in_extended_property_pattern() => No_issue_is_reported_for(@"
+using System;
+using System.Xml;
+
+public class TestMe
+{
+    public static string GetPropertyName<T, TProperty>(Expression<Func<T, TProperty>> propertyLambda)
+    {
+        if (propertyLambda.Body is not MemberExpression
+            {
+                Member: PropertyInfo
+                {
+                    ReflectedType: { } reflectedType,
+                    Name: { } name
+                }
+            })
+        {
+            throw new ArgumentException(nameof(propertyLambda));
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_property_pattern_in_is_pattern_in_if_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is { } name)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_property_pattern_in_is_pattern_conditional_expression() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public string DoSomething(TestMe testee) => testee.Name is { } name ? name : "";
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_property_pattern_in_is_not_pattern_in_if_condition() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is not { } name)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_empty_property_pattern_in_is_not_pattern_in_conditional_expression() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public string DoSomething(TestMe testee) => testee.Name is not { } name ? "" : name;
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_var_pattern_in_is_pattern_in_if_condition() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is var name)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_var_pattern_in_is_pattern_conditional_expression() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public string DoSomething(TestMe testee) => testee.Name is var name ? name : "";
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_var_pattern_in_is_not_pattern_in_if_condition() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public void DoSomething(TestMe testee)
+    {
+        if (testee.Name is not var name)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_var_pattern_in_is_not_pattern_in_conditional_expression() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public string DoSomething(TestMe testee) => testee.Name is not var name ? "" : name;
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -529,6 +529,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3230.md = Documentation\MiKo_3230.md
 		Documentation\MiKo_3231.md = Documentation\MiKo_3231.md
 		Documentation\MiKo_3232.md = Documentation\MiKo_3232.md
+		Documentation\MiKo_3233.md = Documentation\MiKo_3233.md
 		Documentation\MiKo_3301.md = Documentation\MiKo_3301.md
 		Documentation\MiKo_3302.md = Documentation\MiKo_3302.md
 		Documentation\MiKo_3401.md = Documentation\MiKo_3401.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 546 rules that are currently provided by the analyzer.
+The following tables list all the 547 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -482,6 +482,7 @@ The following tables list all the 546 rules that are currently provided by the a
 |[MiKo_3230](/Documentation/MiKo_3230.md)|Do not use 'Guid' as type for identifiers|&#x2713;|\-|
 |[MiKo_3231](/Documentation/MiKo_3231.md)|Use pattern matching for ordinal string comparison equality checks|&#x2713;|&#x2713;|
 |[MiKo_3232](/Documentation/MiKo_3232.md)|Use null checks instead of empty property pattern|&#x2713;|\-|
+|[MiKo_3233](/Documentation/MiKo_3233.md)|Do not use var patterns for null checks|&#x2713;|\-|
 |[MiKo_3301](/Documentation/MiKo_3301.md)|Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |[MiKo_3302](/Documentation/MiKo_3302.md)|Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |[MiKo_3401](/Documentation/MiKo_3401.md)|Keep namespace hierarchies from becoming too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduce MiKo_3233 analyzer to detect and report usage of `is var` patterns in null checks, preventing potential `NullReferenceException`s

- Added analyzer implementation, unit tests, localized resources, and documentation

- Updated README

(resolves ##1977)