### PR TITLE
Refactored MiKo_3504 to ignore types named '...Builder' as they most likely follow the builder pattern

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -206,9 +205,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 if (syntax.GetTypeSymbol(semanticModel) is INamedTypeSymbol type)
                 {
-                    if (type.Name is nameof(StringBuilder))
+                    if (type.Name.AsSpan().EndsWith("Builder"))
                     {
-                        // ignore string builders
+                        // ignore builders
                         return true;
                     }
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3504_TrainWreckAnalyzerTests.cs
@@ -45,6 +45,35 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_a_builder_call_chain() => No_issue_is_reported_for(@"
+using System;
+
+public interface ISomeBuilder
+{
+    ISomeBuilder Append();
+
+    object Build();
+}
+
+public class TestMe
+{
+    private ISomeBuilder Builder { get; set; }
+
+    public void DoSomething()
+    {
+        var value = Builder.Append()
+                           .Append()
+                           .Append()
+                           .Append()
+                           .Append()
+                           .Append()
+                           .Append()
+                           .Build();
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_a_Roslyn_call_chain() => No_issue_is_reported_for(@"
 using System;
 
@@ -2498,7 +2527,7 @@ public class TestMeD
 }
 ");
 
-        //// TODO RKN: Implement tests for method invocations, be aware of builder patterns
+        //// TODO RKN: Implement tests for method invocations
 
         protected override string GetDiagnosticId() => MiKo_3504_TrainWreckAnalyzer.Id;
 


### PR DESCRIPTION
- Generalize train wreck analyzer to ignore all builder-pattern types (types ending with "Builder") instead of only `StringBuilder`

- Update comments accordingly and added a test to ensure builder call chains are not reported

- Adjust TODO comment to reflect new handling of builder patterns