### PR TITLE
Rewritten 'QuickDiff' to speed up string comparisons

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -4347,21 +4347,8 @@ namespace MiKoSolutions.Analyzers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool QuickDiff(in char* a, in char* b, in int index)
         {
-            int charA = *(a + index);
-
-            if ((uint)(charA - 'a') <= 'z' - 'a')
-            {
-                charA -= DifferenceBetweenUpperAndLowerCaseAscii;
-            }
-
-            int charB = *(b + index);
-
-            if ((uint)(charB - 'a') <= 'z' - 'a') // see 'IsAsciiLetterLower', inlined for performance reasons
-            {
-                charB -= DifferenceBetweenUpperAndLowerCaseAscii;
-            }
-
-            return charA != charB;
+            // the following code will work for ASCII but not exotic unicode, however we assume that the language is English so it is sufficient for our purposes
+            return (*(a + index) | DifferenceBetweenUpperAndLowerCaseAscii) != (*(b + index) | DifferenceBetweenUpperAndLowerCaseAscii);
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -39,7 +39,7 @@ namespace MiKoSolutions.Analyzers
                                                        (?!\w)                     # no word character after
                                                    ";
 
-        private const int QuickSubstringProbeLengthThreshold = 4;
+        private const int QuickStartSubstringProbeLengthThreshold = 4;
 
         private static readonly char[] GenericTypeArgumentSeparator = { ',' };
 
@@ -4375,20 +4375,18 @@ namespace MiKoSolutions.Analyzers
             }
 
             // both are at least of similar length, so perform a quick compare first
-            if (value.Length > QuickSubstringProbeLengthThreshold)
+            switch (comparison)
             {
-                switch (comparison)
-                {
-                    case StringComparison.Ordinal:
-                        return QuickStartSubstringProbeOrdinal(value, other);
+                // this is the most likely case, so we put it first
+                case StringComparison.OrdinalIgnoreCase:
+                    return QuickStartSubstringProbeOrdinalIgnoreCase(value, other);
 
-                    case StringComparison.OrdinalIgnoreCase:
-                        return QuickStartSubstringProbeOrdinalIgnoreCase(value, other);
-                }
+                case StringComparison.Ordinal:
+                    return QuickStartSubstringProbeOrdinal(value, other);
+
+                default:
+                    return true; // continue to check
             }
-
-            // continue to check
-            return true;
         }
 
         /// <summary>
@@ -4408,7 +4406,7 @@ namespace MiKoSolutions.Analyzers
         {
             var length = Math.Min(value.Length, other.Length);
 
-            if (length < QuickSubstringProbeLengthThreshold)
+            if (length < QuickStartSubstringProbeLengthThreshold)
             {
                 return true;
             }
@@ -4433,7 +4431,7 @@ namespace MiKoSolutions.Analyzers
         {
             var length = Math.Min(value.Length, other.Length);
 
-            if (length < QuickSubstringProbeLengthThreshold)
+            if (length < QuickStartSubstringProbeLengthThreshold)
             {
                 return true;
             }


### PR DESCRIPTION
Rewritten 'QuickDiff' to use bitwise OR for ASCII case-insensitive comparison, improving performance and simplifying code.

**Important Note:**
This approach only supports ASCII characters (_but that is intended_).