### PR TITLE
Add new rule MiKo_3505 that reports about return statements being directly after try/catch blocks

### DIFF
--- a/Documentation/MiKo_3505.md
+++ b/Documentation/MiKo_3505.md
@@ -1,0 +1,48 @@
+﻿# MiKo_3505: Do not return values directly after try-catch blocks
+
+## Cause
+
+A value is returned immediately after a try-catch block, even though it could be returned directly from within the try block.
+
+## Rule description
+
+Avoid returning values immediately after a try-catch block when the value can be returned from within the try block instead.
+This makes the code easier to read and understand.
+
+### Rationale behind
+
+Returning a value immediately after a try-catch block instead of returning it from within the try block adds unnecessary structure.
+The return statement outside the block gives no additional benefit and makes the control flow harder to follow.
+
+Returning directly from within the try block provides several important benefits:
+
+- **Improved Readability**:
+  Returning directly from within the try block makes the code flow clearer.
+  Developers can immediately see what value is returned without having to look past the end of the block.
+
+- **Better Code Clarity**:
+  Direct returns make the control flow more obvious.
+  There is no ambiguity about what happens in each execution path.
+
+- **Clearer Intent**:
+  A return statement placed directly inside the try block communicates that the value is produced as part of the protected operation.
+  The code's purpose is more immediately obvious.
+
+- **Enhanced Maintainability**:
+  Code without unnecessary structure outside the try-catch block is easier to modify and refactor.
+  There are fewer moving parts to keep track of.
+
+- **Reduced Complexity**:
+  Removing the return statement from outside the block reduces the number of places a developer needs to look to understand the full control flow.
+  This lowers the cognitive load when reading the code.
+
+## How to fix violations
+
+To fix a violation of this rule, move the return statement inside the try block.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3505
+#pragma warning restore MiKo_3505
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -251,6 +251,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3502_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3503_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3505_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\ObjectCreationExpressionMaintainabilityCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\StringMaintainabilityCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UnitTestCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -357,6 +357,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3502_DoNotUseSuppressNullableWarningOnLinqCallAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3503_DoNotReturnVariableImmediatelyAfterTryCatchBlockAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3504_TrainWreckAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\ObjectCreationExpressionMaintainabilityAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UsePatternMatchingForBinaryExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\UsePatternMatchingForExpressionAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15278,6 +15278,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Return value inside try/catch block.
+        /// </summary>
+        internal static string MiKo_3505_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3505_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid returning values immediately after a try/catch block when the value can be returned from within the try block instead. This makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_3505_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3505_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Place return inside the try/catch block.
+        /// </summary>
+        internal static string MiKo_3505_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3505_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not return values directly after try-catch blocks.
+        /// </summary>
+        internal static string MiKo_3505_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3505_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Place and order method side-by-side with overloads.
         /// </summary>
         internal static string MiKo_4001_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5338,6 +5338,18 @@ Instead, to avoid 'null', use a non-null pattern (such as "is { } something"), a
   <data name="MiKo_3504_Title" xml:space="preserve">
     <value>Do not use train wrecks</value>
   </data>
+  <data name="MiKo_3505_CodeFixTitle" xml:space="preserve">
+    <value>Return value inside try/catch block</value>
+  </data>
+  <data name="MiKo_3505_Description" xml:space="preserve">
+    <value>Avoid returning values immediately after a try/catch block when the value can be returned from within the try block instead. This makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_3505_MessageFormat" xml:space="preserve">
+    <value>Place return inside the try/catch block</value>
+  </data>
+  <data name="MiKo_3505_Title" xml:space="preserve">
+    <value>Do not return values directly after try-catch blocks</value>
+  </data>
   <data name="MiKo_4001_CodeFixTitle" xml:space="preserve">
     <value>Place and order method side-by-side with overloads</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_CodeFixProvider.cs
@@ -48,15 +48,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                 return null; // remove the return statement
                                                                             }
 
-                                                                            switch (rewritten)
+                                                                            if (rewritten is TryStatementSyntax statement)
                                                                             {
-                                                                                case TryStatementSyntax statement:
-                                                                                    // move the return statement inside the try block
-                                                                                    return statement.WithBlock(UpdateBlock(statement.Block, returnStatement));
-
-                                                                                default:
-                                                                                    return rewritten;
+                                                                                // move the return statement inside the try block
+                                                                                return statement.WithBlock(UpdateBlock(statement.Block, returnStatement));
                                                                             }
+
+                                                                            return rewritten;
                                                                         });
 
                 return updatedRoot;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_CodeFixProvider.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3505_CodeFixProvider)), Shared]
+    public sealed class MiKo_3505_CodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3505";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<ReturnStatementSyntax>().FirstOrDefault();
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(syntax);
+        }
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxRootAsync(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue, CancellationToken cancellationToken)
+        {
+            var updatedSyntax = GetUpdatedSyntaxRoot(root, syntax);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxRoot(SyntaxNode root, SyntaxNode syntax)
+        {
+            if (syntax is ReturnStatementSyntax returnStatement && returnStatement.PreviousSibling() is TryStatementSyntax tryStatement)
+            {
+                var nodesToAdjust = new List<SyntaxNode>
+                                        {
+                                            tryStatement,
+                                            returnStatement,
+                                        };
+
+                var updatedRoot = root.ReplaceNodes(
+                                                nodesToAdjust,
+                                                (original, rewritten) =>
+                                                                        {
+                                                                            if (rewritten == returnStatement)
+                                                                            {
+                                                                                return null; // remove the return statement
+                                                                            }
+
+                                                                            switch (rewritten)
+                                                                            {
+                                                                                case TryStatementSyntax statement:
+                                                                                    // move the return statement inside the try block
+                                                                                    return statement.WithBlock(UpdateBlock(statement.Block, returnStatement));
+
+                                                                                default:
+                                                                                    return rewritten;
+                                                                            }
+                                                                        });
+
+                return updatedRoot;
+            }
+
+            return null;
+        }
+
+        private static BlockSyntax UpdateBlock(BlockSyntax block, ReturnStatementSyntax returnStatement)
+        {
+            var blockStatements = block.Statements.Add(returnStatement.WithAdditionalLeadingSpaces(Constants.Indentation));
+
+            return block.WithStatements(blockStatements);
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3505";
+
+        private static readonly SyntaxKind[] ProblematicCatchStatements = { SyntaxKind.ReturnStatement, SyntaxKind.ThrowStatement };
+
+        public MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeTryStatement, SyntaxKind.TryStatement);
+
+        private static bool HasIssue(CatchClauseSyntax catchClause)
+        {
+            var statements = catchClause.Block.Statements;
+
+            return statements.Count > 0 && statements.Last().IsAnyKind(ProblematicCatchStatements);
+        }
+
+        private void AnalyzeTryStatement(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is TryStatementSyntax node)
+            {
+                ReportDiagnostics(context, Analyze(node, context.SemanticModel));
+            }
+        }
+
+        private Diagnostic Analyze(TryStatementSyntax tryCatchBlock, SemanticModel semanticModel)
+        {
+            if (tryCatchBlock.NextSibling() is ReturnStatementSyntax returnStatement && tryCatchBlock.Catches.All(HasIssue))
+            {
+                var expression = returnStatement.Expression;
+
+                if (expression is LiteralExpressionSyntax || expression.IsEnum(semanticModel))
+                {
+                    return Issue(expression);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.cs
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 if (expression is LiteralExpressionSyntax || expression.IsEnum(semanticModel))
                 {
-                    return Issue(expression);
+                    return Issue(returnStatement.ReturnKeyword);
                 }
             }
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzerTests.cs
@@ -1,0 +1,2030 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_without_any_try_catch_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_without_any_try_catch_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_inside_try_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch
+        {
+           throw;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_inside_try_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch
+        {
+           throw;
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_swallows() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_swallows() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_swallow() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+        }
+        catch
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_swallow() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+        }
+        catch
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_the_catch_blocks_partly_fall_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+        catch
+        {
+            if (o == null)
+            {
+                return -2;
+            }
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_the_catch_blocks_partly_fall_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+        catch
+        {
+            if (o == null)
+            {
+                return StringComparison.CurrentCulture;
+            }
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+        catch
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+        catch
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_throws() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_throws() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_returns() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return -1;
+        }
+        catch
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_a_single_catch_block_returns() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_swallows() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_swallows() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_swallow() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_swallow() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_the_catch_blocks_partly_fall_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            if (o == null)
+            {
+                return -2;
+            }
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_the_catch_blocks_partly_fall_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            if (o == null)
+            {
+                return StringComparison.CurrentCulture;
+            }
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            if (o == null)
+            {
+                return -1;
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_partly_falls_through() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            if (o == null)
+            {
+                return StringComparison.OrdinalIgnoreCase;
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_throws() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_throws() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_returns() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return -1;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_a_single_catch_block_returns() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_throws() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_throws() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_returns() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_returns() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            return -1;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_throw() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_throw() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_return() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return -1;
+        }
+        catch
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_return() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_throws() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_throws() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_returns() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return -1;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_returns() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_throw() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_throw() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_return() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return -1;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_return() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_throws()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_throws()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_returns()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            return -1;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch
+        {
+            return -1;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_returns()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_throw()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_throw()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (ArgumentNullException)
+        {
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_return()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return -1;
+        }
+        catch
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (ArgumentNullException)
+        {
+            return -1;
+        }
+        catch
+        {
+            return -2;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_and_all_catch_blocks_return()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch
+        {
+            return StringComparison.CurrentCulture;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_throws()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_throws()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_returns()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return -1;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return -1;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_and_the_catch_block_with_when_filter_returns()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (Exception ex) when (ex is ArgumentNullException)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_throw()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_throw()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            throw;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_return()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return -1;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return -2;
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return -1;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return -2;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_catch_block_with_multiple_catch_blocks_with_when_filters_and_all_catch_blocks_return()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        catch (ArgumentNullException ex) when (ex.Message != null)
+        {
+            return StringComparison.OrdinalIgnoreCase;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException)
+        {
+            return StringComparison.CurrentCulture;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3505_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3505_DoNotReturnValueImmediatelyAfterTryCatchBlockAnalyzerTests.cs
@@ -806,6 +806,48 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_when_returning_a_value_inside_try_block_of_try_finally_block_without_catch_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        finally
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_when_returning_an_enum_value_inside_try_block_of_try_finally_block_without_catch_block() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        finally
+        {
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_when_returning_a_value_directly_after_try_catch_block_and_the_catch_block_throws() => An_issue_is_reported_for(@"
 using System;
 
@@ -1182,6 +1224,92 @@ public class TestMe
         catch (Exception ex) when (ex is InvalidOperationException)
         {
             return StringComparison.CurrentCulture;
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_finally_block_without_catch_block() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_finally_block_without_catch_block() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_a_value_directly_after_try_finally_block_without_catch_block_and_finally_block_has_statements() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+            DoSomething(null);
+        }
+
+        return 42;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_when_returning_an_enum_value_directly_after_try_finally_block_without_catch_block_and_finally_block_has_statements() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+            DoSomething(null);
         }
 
         return StringComparison.Ordinal;
@@ -2013,6 +2141,194 @@ public class TestMe
         catch (Exception ex) when (ex is InvalidOperationException)
         {
             return StringComparison.CurrentCulture;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_finally_block_without_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        finally
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_finally_block_without_catch_block()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        finally
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_a_value_directly_after_try_finally_block_without_catch_block_and_finally_block_has_statements()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+            DoSomething(null);
+        }
+
+        return 42;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return 42;
+        }
+        finally
+        {
+            DoSomething(null);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_when_returning_an_enum_value_directly_after_try_finally_block_without_catch_block_and_finally_block_has_statements()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+        }
+        finally
+        {
+            DoSomething(null);
+        }
+
+        return StringComparison.Ordinal;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public StringComparison DoSomething(object o)
+    {
+        try
+        {
+            DoSomething(null);
+
+            return StringComparison.Ordinal;
+        }
+        finally
+        {
+            DoSomething(null);
         }
     }
 }

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -537,6 +537,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3502.md = Documentation\MiKo_3502.md
 		Documentation\MiKo_3503.md = Documentation\MiKo_3503.md
 		Documentation\MiKo_3504.md = Documentation\MiKo_3504.md
+		Documentation\MiKo_3505.md = Documentation\MiKo_3505.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "4. Ordering", "4. Ordering", "{FCBF9905-EEB7-4800-B438-35BA6C797B31}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 547 rules that are currently provided by the analyzer.
+The following tables list all the 548 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -490,6 +490,7 @@ The following tables list all the 547 rules that are currently provided by the a
 |[MiKo_3502](/Documentation/MiKo_3502.md)|Do not suppress nullable warnings on Linq calls|&#x2713;|&#x2713;|
 |[MiKo_3503](/Documentation/MiKo_3503.md)|Do not assign variables in try-catch blocks that are returned directly outside|&#x2713;|&#x2713;|
 |[MiKo_3504](/Documentation/MiKo_3504.md)|Do not use train wrecks|&#x2713;|\-|
+|[MiKo_3505](/Documentation/MiKo_3505.md)|Do not return values directly after try-catch blocks|&#x2713;|&#x2713;|
 
 ### Ordering
 


### PR DESCRIPTION
- Introduce analyzer to detect cases where a value is returned immediately after a try-catch block, recommending the return be placed inside the try block

- Introduce code fix provider to fix the detected cases as refactoring

- Add extensive unit tests for various try-catch scenarios

- Update resources, documentation, project, and solution files to register and describe the new rule