### PR TITLE
Added new MiKo_1531–1533 analyzers and code fixes to discourage 'shall/should/will/would/could' prefixes for variables, parameters, and fields

### DIFF
--- a/Documentation/MiKo_1526.md
+++ b/Documentation/MiKo_1526.md
@@ -11,7 +11,7 @@ Their names should reflect that role by ending with the 'Callback' suffix.
 
 ### Rationale behind
 
-A delegate property is not just a value — it is something that gets called.
+A delegate property is not just a value - it is something that gets called.
 That is a fundamental part of its role in the code, and the name should make that clear.
 
 A name that does not end with `Callback` is a problem in two ways:
@@ -49,7 +49,7 @@ Using the `Callback` suffix consistently for all delegate properties provides se
 To fix a violation of this rule, rename the property so that its name ends with the `Callback` suffix.
 
 A better solution is to convert the property into a method, especially when the delegate is only ever invoked and never reassigned.
-At the call site, invoking the stored delegate and calling a method look identical — the delegate value is accessed through the property first, then invoked, but neither step is visible to the reader.
+At the call site, invoking the stored delegate and calling a method look identical - the delegate value is accessed through the property first, then invoked, but neither step is visible to the reader.
 A method makes that intent direct and explicit, removes the indirection of storing a delegate in a property, and makes the code easier to understand at a glance.
 
 ## How to suppress violations

--- a/Documentation/MiKo_1531.md
+++ b/Documentation/MiKo_1531.md
@@ -1,0 +1,48 @@
+﻿# MiKo_1531: Do not prefix local variables with 'should'
+
+## Cause
+
+A local variable is prefixed with `shall` or `should`.
+
+## Rule description
+
+Local variables that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
+Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand.
+
+### Rationale behind
+
+The words `shall` and `should` express a wish or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+Names with prefixes like `is`, `has`, or `can` make it clear that the variable holds a fact.
+
+Avoiding such prefixes provides several important benefits:
+
+- **Expresses State, not Intent**:
+  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A name using `is`, `has`, or `can` makes that clear right away.
+
+- **Improved Readability**:
+  A name that reads like a statement is easier to understand quickly.
+  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the local variable so that it no longer starts with `shall` or `should`.
+Choose a name that clearly describes what the variable represents.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1531
+#pragma warning restore MiKo_1531
+```

--- a/Documentation/MiKo_1531.md
+++ b/Documentation/MiKo_1531.md
@@ -1,31 +1,31 @@
-﻿# MiKo_1531: Do not prefix local variables with 'should'
+﻿# MiKo_1531: Do not prefix local variables with words that express intent or expectation
 
 ## Cause
 
-A local variable is prefixed with `shall` or `should`.
+A local variable is prefixed with `shall`, `should`, `will`, `would`, or `could`.
 
 ## Rule description
 
-Local variables that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Local variables that are prefixed with `shall`, `should`, `will`, `would`, or `could` are most likely indicators for boolean values.
 Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
 Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand.
 
 ### Rationale behind
 
-The words `shall` and `should` express a wish or a possibility, not a fact.
-When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
-This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+The words `shall`, `should`, `will`, `would`, and `could` express a wish, an expectation, or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*, *"will it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish or an expectation - it simply stores `true` or `false`.
 Names with prefixes like `is`, `has`, or `can` make it clear that the variable holds a fact.
 
 Avoiding such prefixes provides several important benefits:
 
 - **Expresses State, not Intent**:
-  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A boolean is either `true` or `false` - it holds a fact, not a wish or an expectation.
   A name using `is`, `has`, or `can` makes that clear right away.
 
 - **Improved Readability**:
   A name that reads like a statement is easier to understand quickly.
-  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+  Readers do not have to stop and think about whether the prefix describes a wish, an expectation, a possibility, or an actual value.
 
 - **Consistent Naming Conventions**:
   Using the same naming style across the codebase makes it easier to read and review code.
@@ -37,7 +37,7 @@ Avoiding such prefixes provides several important benefits:
 
 ## How to fix violations
 
-To fix a violation of this rule, rename the local variable so that it no longer starts with `shall` or `should`.
+To fix a violation of this rule, rename the local variable so that it no longer starts with `shall`, `should`, `will`, `would`, or `could`.
 Choose a name that clearly describes what the variable represents.
 
 ## How to suppress violations

--- a/Documentation/MiKo_1532.md
+++ b/Documentation/MiKo_1532.md
@@ -1,0 +1,52 @@
+﻿# MiKo_1532: Do not prefix parameters with 'should'
+
+## Cause
+
+A parameter is prefixed with `shall` or `should`.
+
+## Rule description
+
+Parameters that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
+Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand.
+
+### Rationale behind
+
+The words `shall` and `should` express a wish or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+Names with prefixes like `is`, `has`, or `can` make it clear that the parameter holds a fact.
+
+Avoiding such prefixes provides several important benefits:
+
+- **Expresses State, not Intent**:
+  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A name using `is`, `has`, or `can` makes that clear right away.
+
+- **Improved Readability**:
+  A name that reads like a statement is easier to understand quickly.
+  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Better API Communication**:
+  Parameter names are part of the contract of a method.
+  Clear names make it easy to see what value to pass without having to read the method body or documentation.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the parameter so that it no longer starts with `shall` or `should`.
+Choose a name that clearly describes what the parameter represents.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1532
+#pragma warning restore MiKo_1532
+```

--- a/Documentation/MiKo_1532.md
+++ b/Documentation/MiKo_1532.md
@@ -1,31 +1,31 @@
-﻿# MiKo_1532: Do not prefix parameters with 'should'
+﻿# MiKo_1532: Do not prefix parameters with words that express intent or expectation
 
 ## Cause
 
-A parameter is prefixed with `shall` or `should`.
+A parameter is prefixed with `shall`, `should`, `will`, `would`, or `could`.
 
 ## Rule description
 
-Parameters that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Parameters that are prefixed with `shall`, `should`, `will`, `would`, or `could` are most likely indicators for boolean values.
 Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
 Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand.
 
 ### Rationale behind
 
-The words `shall` and `should` express a wish or a possibility, not a fact.
-When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
-This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+The words `shall`, `should`, `will`, `would`, and `could` express a wish, an expectation, or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*, *"will it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish or an expectation - it simply stores `true` or `false`.
 Names with prefixes like `is`, `has`, or `can` make it clear that the parameter holds a fact.
 
 Avoiding such prefixes provides several important benefits:
 
 - **Expresses State, not Intent**:
-  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A boolean is either `true` or `false` - it holds a fact, not a wish or an expectation.
   A name using `is`, `has`, or `can` makes that clear right away.
 
 - **Improved Readability**:
   A name that reads like a statement is easier to understand quickly.
-  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+  Readers do not have to stop and think about whether the prefix describes a wish, an expectation, a possibility, or an actual value.
 
 - **Consistent Naming Conventions**:
   Using the same naming style across the codebase makes it easier to read and review code.
@@ -41,7 +41,7 @@ Avoiding such prefixes provides several important benefits:
 
 ## How to fix violations
 
-To fix a violation of this rule, rename the parameter so that it no longer starts with `shall` or `should`.
+To fix a violation of this rule, rename the parameter so that it no longer starts with `shall`, `should`, `will`, `would`, or `could`.
 Choose a name that clearly describes what the parameter represents.
 
 ## How to suppress violations

--- a/Documentation/MiKo_1533.md
+++ b/Documentation/MiKo_1533.md
@@ -1,20 +1,20 @@
-﻿# MiKo_1533: Do not prefix fields with 'should'
+﻿# MiKo_1533: Do not prefix fields with words that express intent or expectation
 
 ## Cause
 
-A field is prefixed with `shall` or `should`.
+A field is prefixed with `shall`, `should`, `will`, `would`, or `could`.
 
 ## Rule description
 
-Fields that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Fields that are prefixed with `shall`, `should`, `will`, `would`, or `could` are most likely indicators for boolean values.
 Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
 Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand.
 
 ### Rationale behind
 
-The words `shall` and `should` express a wish or a possibility, not a fact.
-When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
-This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+The words `shall`, `should`, `will`, `would`, and `could` express a wish, an expectation, or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*, *"will it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish or an expectation - it simply stores `true` or `false`.
 Names with prefixes like `is`, `has`, or `can` make it clear that the field holds a fact.
 
 Fields are often used in many places within a class, so a confusing name can cause problems throughout the whole type.
@@ -23,12 +23,12 @@ A clear name makes it easy to see right away what state the field holds.
 Avoiding such prefixes provides several important benefits:
 
 - **Expresses State, not Intent**:
-  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A boolean is either `true` or `false` - it holds a fact, not a wish or an expectation.
   A name using `is`, `has`, or `can` makes that clear right away.
 
 - **Improved Readability**:
   A name that reads like a statement is easier to understand quickly.
-  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+  Readers do not have to stop and think about whether the prefix describes a wish, an expectation, a possibility, or an actual value.
 
 - **Consistent Naming Conventions**:
   Using the same naming style across the codebase makes it easier to read and review code.
@@ -44,7 +44,7 @@ Avoiding such prefixes provides several important benefits:
 
 ## How to fix violations
 
-To fix a violation of this rule, rename the field so that it no longer starts with `shall` or `should`.
+To fix a violation of this rule, rename the field so that it no longer starts with `shall`, `should`, `will`, `would`, or `could`.
 Choose a name that clearly describes what the field represents.
 
 ## How to suppress violations

--- a/Documentation/MiKo_1533.md
+++ b/Documentation/MiKo_1533.md
@@ -1,0 +1,55 @@
+﻿# MiKo_1533: Do not prefix fields with 'should'
+
+## Cause
+
+A field is prefixed with `shall` or `should`.
+
+## Rule description
+
+Fields that are prefixed with `shall` or `should` are most likely indicators for boolean values.
+Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
+Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand.
+
+### Rationale behind
+
+The words `shall` and `should` express a wish or a possibility, not a fact.
+When used as a prefix, they make a boolean name read like a question (*"shall it be online?"*) instead of a clear statement (*"it is online"*).
+This is confusing because a boolean does not express a wish - it simply stores `true` or `false`.
+Names with prefixes like `is`, `has`, or `can` make it clear that the field holds a fact.
+
+Fields are often used in many places within a class, so a confusing name can cause problems throughout the whole type.
+A clear name makes it easy to see right away what state the field holds.
+
+Avoiding such prefixes provides several important benefits:
+
+- **Expresses State, not Intent**:
+  A boolean is either `true` or `false` - it holds a fact, not a wish.
+  A name using `is`, `has`, or `can` makes that clear right away.
+
+- **Improved Readability**:
+  A name that reads like a statement is easier to understand quickly.
+  Readers do not have to stop and think about whether the prefix describes a wish, a possibility, or an actual value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Easier Maintenance**:
+  When field names clearly show what they store, it is easier to find and update the related logic when something needs to change.
+  This lowers the risk of introducing bugs during maintenance.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the field so that it no longer starts with `shall` or `should`.
+Choose a name that clearly describes what the field represents.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1533
+#pragma warning restore MiKo_1533
+```

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1631,6 +1631,9 @@ namespace MiKoSolutions.Analyzers
                                                               {
                                                                   "should",
                                                                   "shall",
+                                                                  "will",
+                                                                  "would",
+                                                                  "could",
                                                               };
         }
 

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1627,7 +1627,7 @@ namespace MiKoSolutions.Analyzers
                                                                                                                                                  },
                                                                                                                                              StringComparer.Ordinal);
 
-            internal static readonly string[] ShouldPrefixes =
+            internal static readonly string[] IntentPrefixes =
                                                               {
                                                                   "should",
                                                                   "shall",

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1626,6 +1626,12 @@ namespace MiKoSolutions.Analyzers
                                                                                                                                                      new KeyValuePair<string, string>("Decorator", "decorated"),
                                                                                                                                                  },
                                                                                                                                              StringComparer.Ordinal);
+
+            internal static readonly string[] ShouldPrefixes =
+                                                              {
+                                                                  "should",
+                                                                  "shall",
+                                                              };
         }
 
         internal static class AnalyzerCodeFixSharedData

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -3179,10 +3179,14 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The <see cref="string"/> to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// A <see cref="string"/> that contains the second word from the <see cref="string"/>.
         /// </returns>
-        public static string SecondWord(this string value) => SecondWord(value.AsSpan()).ToString();
+        public static string SecondWord(this string value, in WordBoundary boundary = WordBoundary.WhiteSpaces) => SecondWord(value.AsSpan(), boundary).ToString();
 
         /// <summary>
         /// Gets the second word from the span of characters.
@@ -3190,10 +3194,14 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The span of characters to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// The second word from the span.
         /// </returns>
-        public static ReadOnlySpan<char> SecondWord(this in ReadOnlySpan<char> value) => value.WithoutFirstWord().FirstWord();
+        public static ReadOnlySpan<char> SecondWord(this in ReadOnlySpan<char> value, in WordBoundary boundary = WordBoundary.WhiteSpaces) => value.WithoutFirstWord(boundary).FirstWord();
 
         /// <summary>
         /// Determines whether the <see cref="string"/> starts with the specified character.
@@ -3459,10 +3467,14 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The <see cref="string"/> to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// A <see cref="string"/> that contains the third word from the <see cref="string"/>.
         /// </returns>
-        public static string ThirdWord(this string value) => ThirdWord(value.AsSpan()).ToString();
+        public static string ThirdWord(this string value, in WordBoundary boundary = WordBoundary.WhiteSpaces) => ThirdWord(value.AsSpan(), boundary).ToString();
 
         /// <summary>
         /// Gets the third word from the span of characters.
@@ -3470,10 +3482,14 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The span of characters to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// The third word from the span.
         /// </returns>
-        public static ReadOnlySpan<char> ThirdWord(this in ReadOnlySpan<char> value) => value.WithoutFirstWord().WithoutFirstWord().FirstWord();
+        public static ReadOnlySpan<char> ThirdWord(this in ReadOnlySpan<char> value, in WordBoundary boundary = WordBoundary.WhiteSpaces) => value.WithoutFirstWord(boundary).WithoutFirstWord(boundary).FirstWord();
 
 #pragma warning disable CA1308
         /// <summary>
@@ -3736,11 +3752,15 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The <see cref="string"/> to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// A <see cref="string"/> that contains the original value with the first word removed.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string WithoutFirstWord(this string value) => WithoutFirstWord(value.AsSpan()).ToString();
+        public static string WithoutFirstWord(this string value, in WordBoundary boundary = WordBoundary.WhiteSpaces) => WithoutFirstWord(value.AsSpan(), boundary).ToString();
 
         /// <summary>
         /// Removes the first word from the span of characters.
@@ -3748,22 +3768,47 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The span of characters to process.
         /// </param>
+        /// <param name="boundary">
+        /// One of the enumeration members that specifies the word boundary method to use.
+        /// The default is <see cref="WordBoundary.WhiteSpaces"/>.
+        /// </param>
         /// <returns>
         /// The span of characters after the first word.
         /// </returns>
-        public static ReadOnlySpan<char> WithoutFirstWord(this in ReadOnlySpan<char> value)
+        public static ReadOnlySpan<char> WithoutFirstWord(this in ReadOnlySpan<char> value, in WordBoundary boundary = WordBoundary.WhiteSpaces)
         {
             var text = value.TrimStart();
 
-            var firstSpace = text.IndexOfAny(Constants.WhiteSpaceCharacters);
-
-            if (firstSpace < 0)
+            if (boundary is WordBoundary.WhiteSpaces)
             {
-                // might happen if the text contains a <see> or some other XML element as second word; therefore we only return a space
-                return " ".AsSpan();
+                var firstSpace = text.IndexOfAny(Constants.WhiteSpaceCharacters);
+
+                if (firstSpace < 0)
+                {
+                    // might happen if the text contains a <see> or some other XML element as second word; therefore we only return a space
+                    return " ".AsSpan();
+                }
+
+                return text.Slice(firstSpace);
             }
 
-            return text.Slice(firstSpace);
+            var textLength = text.Length;
+
+            if (textLength > 1)
+            {
+                // start at index 1 to skip first upper case character (and avoid return of empty word)
+                for (var index = 1; index < textLength; index++)
+                {
+                    var c = text[index];
+
+                    if (c.IsUpperCase() || (c is '_' && index > 2))
+                    {
+                        return text.Slice(index);
+                    }
+                }
+            }
+
+            return ReadOnlySpan<char>.Empty;
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -372,6 +372,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1528_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1529_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1530_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -533,6 +533,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1528_ArgParameterAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1529_MethodStartsWithThirdPersonSingularVerbAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1530_DependencyPropertyChangeHandlingMethodNamesAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5733,7 +5733,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        ///   Looks up a localized string similar to Rename to express a fact.
         /// </summary>
         internal static string MiKo_1531_CodeFixTitle {
             get {
@@ -5742,7 +5742,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local variables that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
+        ///   Looks up a localized string similar to Local variables that are prefixed with &apos;shall&apos;, &apos;should&apos;, &apos;will&apos;, &apos;would&apos;, or &apos;could&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
         ///Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand..
         /// </summary>
         internal static string MiKo_1531_Description {
@@ -5761,7 +5761,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not prefix local variables with &apos;should&apos;.
+        ///   Looks up a localized string similar to Do not prefix local variables with words that express intent or expectation.
         /// </summary>
         internal static string MiKo_1531_Title {
             get {
@@ -5770,7 +5770,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        ///   Looks up a localized string similar to Rename to express a fact.
         /// </summary>
         internal static string MiKo_1532_CodeFixTitle {
             get {
@@ -5779,7 +5779,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
+        ///   Looks up a localized string similar to Parameters that are prefixed with &apos;shall&apos;, &apos;should&apos;, &apos;will&apos;, &apos;would&apos;, or &apos;could&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
         ///Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand..
         /// </summary>
         internal static string MiKo_1532_Description {
@@ -5798,7 +5798,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not prefix parameters with &apos;should&apos;.
+        ///   Looks up a localized string similar to Do not prefix parameters with words that express intent or expectation.
         /// </summary>
         internal static string MiKo_1532_Title {
             get {
@@ -5807,7 +5807,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        ///   Looks up a localized string similar to Rename to express a fact.
         /// </summary>
         internal static string MiKo_1533_CodeFixTitle {
             get {
@@ -5816,7 +5816,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fields that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
+        ///   Looks up a localized string similar to Fields that are prefixed with &apos;shall&apos;, &apos;should&apos;, &apos;will&apos;, &apos;would&apos;, or &apos;could&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
         ///Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand..
         /// </summary>
         internal static string MiKo_1533_Description {
@@ -5835,7 +5835,7 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not prefix fields with &apos;should&apos;.
+        ///   Looks up a localized string similar to Do not prefix fields with words that express intent or expectation.
         /// </summary>
         internal static string MiKo_1533_Title {
             get {

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5733,6 +5733,117 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        /// </summary>
+        internal static string MiKo_1531_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1531_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local variables that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
+        ///Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1531_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1531_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1531_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1531_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix local variables with &apos;should&apos;.
+        /// </summary>
+        internal static string MiKo_1531_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1531_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        /// </summary>
+        internal static string MiKo_1532_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1532_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
+        ///Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1532_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1532_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1532_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1532_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix parameters with &apos;should&apos;.
+        /// </summary>
+        internal static string MiKo_1532_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1532_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace &apos;should&apos; prefix.
+        /// </summary>
+        internal static string MiKo_1533_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1533_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fields that are prefixed with &apos;shall&apos; or &apos;should&apos; are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
+        ///Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1533_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1533_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1533_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1533_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix fields with &apos;should&apos;.
+        /// </summary>
+        internal static string MiKo_1533_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1533_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2069,6 +2069,45 @@ Third-person verbs like "Creates" read like descriptions instead of commands, wh
   <data name="MiKo_1530_Title" xml:space="preserve">
     <value>Follow .NET Framework Design Guidelines for method names of DependencyPropertyChanged callbacks</value>
   </data>
+  <data name="MiKo_1531_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'should' prefix</value>
+  </data>
+  <data name="MiKo_1531_Description" xml:space="preserve">
+    <value>Local variables that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
+Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1531_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1531_Title" xml:space="preserve">
+    <value>Do not prefix local variables with 'should'</value>
+  </data>
+  <data name="MiKo_1532_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'should' prefix</value>
+  </data>
+  <data name="MiKo_1532_Description" xml:space="preserve">
+    <value>Parameters that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
+Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1532_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1532_Title" xml:space="preserve">
+    <value>Do not prefix parameters with 'should'</value>
+  </data>
+  <data name="MiKo_1533_CodeFixTitle" xml:space="preserve">
+    <value>Replace 'should' prefix</value>
+  </data>
+  <data name="MiKo_1533_Description" xml:space="preserve">
+    <value>Fields that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
+Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1533_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1533_Title" xml:space="preserve">
+    <value>Do not prefix fields with 'should'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2070,43 +2070,43 @@ Third-person verbs like "Creates" read like descriptions instead of commands, wh
     <value>Follow .NET Framework Design Guidelines for method names of DependencyPropertyChanged callbacks</value>
   </data>
   <data name="MiKo_1531_CodeFixTitle" xml:space="preserve">
-    <value>Replace 'should' prefix</value>
+    <value>Rename to express a fact</value>
   </data>
   <data name="MiKo_1531_Description" xml:space="preserve">
-    <value>Local variables that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
+    <value>Local variables that are prefixed with 'shall', 'should', 'will', 'would', or 'could' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the variable.
 Naming the variable based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
   </data>
   <data name="MiKo_1531_MessageFormat" xml:space="preserve">
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1531_Title" xml:space="preserve">
-    <value>Do not prefix local variables with 'should'</value>
+    <value>Do not prefix local variables with words that express intent or expectation</value>
   </data>
   <data name="MiKo_1532_CodeFixTitle" xml:space="preserve">
-    <value>Replace 'should' prefix</value>
+    <value>Rename to express a fact</value>
   </data>
   <data name="MiKo_1532_Description" xml:space="preserve">
-    <value>Parameters that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
+    <value>Parameters that are prefixed with 'shall', 'should', 'will', 'would', or 'could' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the parameter.
 Naming the parameter based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
   </data>
   <data name="MiKo_1532_MessageFormat" xml:space="preserve">
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1532_Title" xml:space="preserve">
-    <value>Do not prefix parameters with 'should'</value>
+    <value>Do not prefix parameters with words that express intent or expectation</value>
   </data>
   <data name="MiKo_1533_CodeFixTitle" xml:space="preserve">
-    <value>Replace 'should' prefix</value>
+    <value>Rename to express a fact</value>
   </data>
   <data name="MiKo_1533_Description" xml:space="preserve">
-    <value>Fields that are prefixed with 'shall' or 'should' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
+    <value>Fields that are prefixed with 'shall', 'should', 'will', 'would', or 'could' are most likely indicators for boolean values. Such prefixes describe a condition or intent rather than clearly expressing the purpose of the field.
 Naming the field based on what it represents, rather than what it implies, makes the code easier to read and understand.</value>
   </data>
   <data name="MiKo_1533_MessageFormat" xml:space="preserve">
     <value>Rename '{0}' to '{1}'</value>
   </data>
   <data name="MiKo_1533_Title" xml:space="preserve">
-    <value>Do not prefix fields with 'should'</value>
+    <value>Do not prefix fields with words that express intent or expectation</value>
   </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1531_CodeFixProvider)), Shared]
+    public sealed class MiKo_1531_CodeFixProvider : LocalVariableNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1531";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     var identifier = identifiers[index];
                     var name = identifier.ValueText;
 
-                    if (name.StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase))
+                    if (name.StartsWithAny(Constants.Names.IntentPrefixes, StringComparison.OrdinalIgnoreCase))
                     {
                         var betterName = FindBetterNameForShouldPrefix(name);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1531_VariablesWithShouldPrefixAnalyzer : LocalVariableNamingAnalyzer
+    {
+        public const string Id = "MiKo_1531";
+
+        public MiKo_1531_VariablesWithShouldPrefixAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            var length = identifiers.Length;
+
+            if (length > 0)
+            {
+                for (var index = 0; index < length; index++)
+                {
+                    var identifier = identifiers[index];
+                    var name = identifier.ValueText;
+
+                    if (name.StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var betterName = FindBetterNameForShouldPrefix(name);
+
+                        yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1532_CodeFixProvider)), Shared]
+    public sealed class MiKo_1532_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1532";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IParameterSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase);
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.StartsWithAny(Constants.Names.IntentPrefixes, StringComparison.OrdinalIgnoreCase);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1532_ParametersWithShouldPrefixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1532";
+
+        public MiKo_1532_ParametersWithShouldPrefixAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            var betterName = FindBetterNameForShouldPrefix(symbol.Name);
+
+            return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1533_CodeFixProvider)), Shared]
+    public sealed class MiKo_1533_CodeFixProvider : FieldNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1533";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
@@ -15,17 +15,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
-        protected override bool ShallAnalyze(IFieldSymbol symbol)
-        {
-            if (symbol is null)
-            {
-                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
-                return false;
-            }
-
-            return true;
-        }
-
         protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
         {
             var name = symbol.Name;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1533_FieldsWithShouldPrefixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1533";
+
+        public MiKo_1533_FieldsWithShouldPrefixAnalyzer() : base(Id, SymbolKind.Field)
+        {
+        }
+
+        protected override bool ShallAnalyze(IFieldSymbol symbol)
+        {
+            if (symbol is null)
+            {
+                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                return false;
+            }
+
+            return true;
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+            var prefix = GetFieldPrefix(name);
+
+            if (name.AsSpan(prefix.Length).StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = FindBetterNameForShouldPrefix(name, prefix);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var name = symbol.Name;
             var prefix = GetFieldPrefix(name);
 
-            if (name.AsSpan(prefix.Length).StartsWithAny(Constants.Names.ShouldPrefixes, StringComparison.OrdinalIgnoreCase))
+            if (name.AsSpan(prefix.Length).StartsWithAny(Constants.Names.IntentPrefixes, StringComparison.OrdinalIgnoreCase))
             {
                 var betterName = FindBetterNameForShouldPrefix(name, prefix);
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -146,6 +146,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         /// </returns>
         protected static string FindBetterNameForShouldPrefix(string name, string prefix = "")
         {
+            const string Be = "Be";
+            const string Not = "Not";
+            const string Is = "Is";
+
             var startIndex = prefix.Length;
 
             var nameSpan = name.AsSpan(prefix.Length);
@@ -164,21 +168,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                         builder.Append(prefix);
                     }
 
-                    if (secondWord.Equals("Be", StringComparison.Ordinal))
+                    if (secondWord.Equals(Be, StringComparison.Ordinal))
                     {
-                        builder.Append("Is");
+                        builder.Append(Is);
 
-                        nextWordPosition += 2; // skip 'Be'
+                        nextWordPosition += Be.Length; // skip 'Be'
                     }
-                    else if (secondWord.Equals("Not", StringComparison.Ordinal))
+                    else
                     {
-                        var thirdWord = nameSpan.ThirdWord(WordBoundary.UpperCaseCharacters);
-
-                        if (thirdWord.Equals("Be", StringComparison.Ordinal))
+                        if (secondWord.Equals(Not, StringComparison.Ordinal))
                         {
-                            builder.Append("IsNot");
+                            var thirdWord = nameSpan.ThirdWord(WordBoundary.UpperCaseCharacters);
 
-                            nextWordPosition += 5; // skip 'NotBe'
+                            if (thirdWord.Equals(Be, StringComparison.Ordinal))
+                            {
+                                builder.Append(Is + Not);
+
+                                nextWordPosition += Not.Length + Be.Length; // skip 'NotBe'
+                            }
                         }
                     }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -131,6 +131,68 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             return name;
         }
 
+        /// <summary>
+        /// Finds a better name for a symbol that uses "shall" or "should" as prefix.
+        /// </summary>
+        /// <param name="name">
+        /// The name to analyze.
+        /// </param>
+        /// <param name="prefix">
+        /// The prefix to preserve in the name.
+        /// The default is <c>""</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the better name with corrected name.
+        /// </returns>
+        protected static string FindBetterNameForShouldPrefix(string name, string prefix = "")
+        {
+            var startIndex = prefix.Length;
+
+            var nameSpan = name.AsSpan(prefix.Length);
+
+            foreach (var shouldPrefix in Constants.Names.ShouldPrefixes)
+            {
+                if (nameSpan.StartsWith(shouldPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var nextWordPosition = startIndex + shouldPrefix.Length;
+                    var secondWord = nameSpan.SecondWord(WordBoundary.UpperCaseCharacters);
+
+                    var builder = StringBuilderCache.Acquire();
+
+                    if (startIndex > 0)
+                    {
+                        builder.Append(prefix);
+                    }
+
+                    if (secondWord.Equals("Be", StringComparison.Ordinal))
+                    {
+                        builder.Append("Is");
+
+                        nextWordPosition += 2; // skip 'Be'
+                    }
+                    else if (secondWord.Equals("Not", StringComparison.Ordinal))
+                    {
+                        var thirdWord = nameSpan.ThirdWord(WordBoundary.UpperCaseCharacters);
+
+                        if (thirdWord.Equals("Be", StringComparison.Ordinal))
+                        {
+                            builder.Append("IsNot");
+
+                            nextWordPosition += 5; // skip 'NotBe'
+                        }
+                    }
+
+                    builder.Append(name, nextWordPosition, name.Length - nextWordPosition);
+
+                    builder.ToLowerCaseAt(prefix.Length);
+
+                    return builder.ToStringAndRelease();
+                }
+            }
+
+            return name;
+        }
+
 #pragma warning disable CA1021
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -156,7 +156,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             var nameSpan = name.AsSpan(prefix.Length);
 
-            foreach (var shouldPrefix in Constants.Names.ShouldPrefixes)
+            foreach (var shouldPrefix in Constants.Names.IntentPrefixes)
             {
                 if (nameSpan.StartsWith(shouldPrefix, StringComparison.OrdinalIgnoreCase))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -149,6 +149,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             const string Be = "Be";
             const string Not = "Not";
             const string Is = "Is";
+            const string Has = "Has";
+            const string Have = "Have";
 
             var startIndex = prefix.Length;
 
@@ -170,22 +172,31 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                     if (secondWord.Equals(Be, StringComparison.Ordinal))
                     {
-                        builder.Append(Is);
-
                         nextWordPosition += Be.Length; // skip 'Be'
+
+                        builder.Append(Is);
                     }
-                    else
+                    else if (secondWord.Equals(Have, StringComparison.Ordinal))
                     {
-                        if (secondWord.Equals(Not, StringComparison.Ordinal))
+                        nextWordPosition += Have.Length; // skip 'Have'
+
+                        builder.Append(Has);
+                    }
+                    else if (secondWord.Equals(Not, StringComparison.Ordinal))
+                    {
+                        var thirdWord = nameSpan.ThirdWord(WordBoundary.UpperCaseCharacters);
+
+                        if (thirdWord.Equals(Be, StringComparison.Ordinal))
                         {
-                            var thirdWord = nameSpan.ThirdWord(WordBoundary.UpperCaseCharacters);
+                            nextWordPosition += Not.Length + Be.Length; // skip 'NotBe'
 
-                            if (thirdWord.Equals(Be, StringComparison.Ordinal))
-                            {
-                                builder.Append(Is + Not);
+                            builder.Append(Is + Not);
+                        }
+                        else if (thirdWord.Equals(Have, StringComparison.Ordinal))
+                        {
+                            nextWordPosition += Not.Length + Have.Length; // skip 'NotHave'
 
-                                nextWordPosition += Not.Length + Be.Length; // skip 'NotBe'
-                            }
+                            builder.Append(Has + Not);
                         }
                     }
 

--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -27,15 +27,16 @@ namespace MiKoSolutions.Analyzers.Rules
         private static readonly CodeFixProvider[] AllCodeFixProviders = CreateAllCodeFixProviders();
 
         // [Timeout(1 * 60 * 60 * 1000)] // 1h
-        [Ignore("Shall be run manually")]
-        [Explicit]
-        [TestCase("TODO")]
-        public static void Performance_(string path)
+        [Test, Explicit, Ignore("Shall be run manually")]
+        public static void Performance()
         {
 //// ncrunch: no coverage start
-            var files = Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)
-                                 .Where(_ => _.EndsWithAny(Constants.GeneratedCSharpFileExtensions, StringComparison.OrdinalIgnoreCase) is false);
-            var sources = files.ToHashSet(File.ReadAllText).ToArray();
+            var files1 = Directory.EnumerateFiles(@"TODO", "*.cs", SearchOption.AllDirectories);
+            var files2 = Directory.EnumerateFiles(@"TODO", "*.cs", SearchOption.AllDirectories);
+            var sources = files1.Concat(files2)
+                                .Where(_ => _.EndsWithAny(Constants.GeneratedCSharpFileExtensions, StringComparison.OrdinalIgnoreCase) is false)
+                                .ToHashSet(File.ReadAllText)
+                                .ToArray();
 
             var results = DiagnosticVerifier.GetDiagnostics(sources, LanguageVersion.LatestMajor, AllAnalyzers.Cast<DiagnosticAnalyzer>().ToArray(), true);
 
@@ -412,7 +413,7 @@ namespace MiKoSolutions.Analyzers.Rules
         {
             var markdownBuilder = new StringBuilder().AppendLine()
                                                      .AppendLine("## Available Rules")
-                                                     .AppendLine(CultureInfo.CurrentCulture, $"The following tables lists all the {AllAnalyzers.Length} rules that are currently provided by the analyzer.");
+                                                     .AppendLine(CultureInfo.CurrentCulture, $"The following tables list all the {AllAnalyzers.Length} rules that are currently provided by the analyzer.");
 
             var category = string.Empty;
             var tableFormat = "|{0}|{1}|{2}|{3}|" + Environment.NewLine;
@@ -427,6 +428,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
                     markdownBuilder.AppendLine()
                                    .AppendLine("### " + category)
+                                   .AppendLine()
                                    .AppendFormat(CultureInfo.CurrentCulture, tableFormat, "ID", "Title", "Enabled by default", "CodeFix available")
                                    .AppendFormat(CultureInfo.CurrentCulture, tableFormat, ":-", ":----", ":----------------:", ":---------------:");
                 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzerTests.cs
@@ -26,7 +26,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_variable_with_prefix_([Values("shall", "should")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_variable_with_prefix_([Values("shall", "should", "will", "would", "could")] string name) => An_issue_is_reported_for(@"
 using NUnit.Framework;
 
 namespace Bla
@@ -42,13 +42,30 @@ namespace Bla
 }
 ");
 
+        [TestCase("couldBeNotOnline", "isNotOnline")]
+        [TestCase("couldBeOnline", "isOnline")]
+        [TestCase("couldConnect", "connect")]
+        [TestCase("couldHaveState", "hasState")]
+        [TestCase("couldNotBeOnline", "isNotOnline")]
         [TestCase("shallBeOnline", "isOnline")]
         [TestCase("shallConnect", "connect")]
+        [TestCase("shallHaveState", "hasState")]
         [TestCase("shallNotConnect", "notConnect")]
         [TestCase("shouldBeNotOnline", "isNotOnline")]
         [TestCase("shouldBeOnline", "isOnline")]
         [TestCase("shouldConnect", "connect")]
+        [TestCase("shouldHaveState", "hasState")]
         [TestCase("shouldNotBeOnline", "isNotOnline")]
+        [TestCase("willBeOnline", "isOnline")]
+        [TestCase("willConnect", "connect")]
+        [TestCase("willHaveState", "hasState")]
+        [TestCase("willNotConnect", "notConnect")]
+        [TestCase("wouldBeNotOnline", "isNotOnline")]
+        [TestCase("wouldBeOnline", "isOnline")]
+        [TestCase("wouldConnect", "connect")]
+        [TestCase("wouldHaveState", "hasState")]
+        [TestCase("wouldNotBeOnline", "isNotOnline")]
+        [TestCase("wouldNotHaveState", "hasNotState")]
         public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzerTests.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1531_VariablesWithShouldPrefixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_variable_without_should_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_with_prefix_([Values("shall", "should")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int " + name + @"Something = 42;
+        }
+    }
+}
+");
+
+        [TestCase("shallBeOnline", "isOnline")]
+        [TestCase("shallConnect", "connect")]
+        [TestCase("shallNotConnect", "notConnect")]
+        [TestCase("shouldBeNotOnline", "isNotOnline")]
+        [TestCase("shouldBeOnline", "isOnline")]
+        [TestCase("shouldConnect", "connect")]
+        [TestCase("shouldNotBeOnline", "isNotOnline")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int ### = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1531_VariablesWithShouldPrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1531_VariablesWithShouldPrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1531_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_parameter_with_prefix_([Values("shall", "should")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_with_prefix_([Values("shall", "should", "will", "would", "could")] string name) => An_issue_is_reported_for(@"
 using NUnit.Framework;
 
 namespace Bla
@@ -40,13 +40,30 @@ namespace Bla
 }
 ");
 
+        [TestCase("couldBeNotOnline", "isNotOnline")]
+        [TestCase("couldBeOnline", "isOnline")]
+        [TestCase("couldConnect", "connect")]
+        [TestCase("couldHaveState", "hasState")]
+        [TestCase("couldNotBeOnline", "isNotOnline")]
         [TestCase("shallBeOnline", "isOnline")]
         [TestCase("shallConnect", "connect")]
+        [TestCase("shallHaveState", "hasState")]
         [TestCase("shallNotConnect", "notConnect")]
         [TestCase("shouldBeNotOnline", "isNotOnline")]
         [TestCase("shouldBeOnline", "isOnline")]
         [TestCase("shouldConnect", "connect")]
+        [TestCase("shouldHaveState", "hasState")]
         [TestCase("shouldNotBeOnline", "isNotOnline")]
+        [TestCase("willBeOnline", "isOnline")]
+        [TestCase("willConnect", "connect")]
+        [TestCase("willHaveState", "hasState")]
+        [TestCase("willNotConnect", "notConnect")]
+        [TestCase("wouldBeNotOnline", "isNotOnline")]
+        [TestCase("wouldBeOnline", "isOnline")]
+        [TestCase("wouldConnect", "connect")]
+        [TestCase("wouldHaveState", "hasState")]
+        [TestCase("wouldNotBeOnline", "isNotOnline")]
+        [TestCase("wouldNotHaveState", "hasNotState")]
         public void Code_gets_fixed_for_parameter_(string originalName, string fixedName)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1532_ParametersWithShouldPrefixAnalyzerTests.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1532_ParametersWithShouldPrefixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_parameter_without_should_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_with_prefix_([Values("shall", "should")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int " + name + @"Something)
+        {
+        }
+    }
+}
+");
+
+        [TestCase("shallBeOnline", "isOnline")]
+        [TestCase("shallConnect", "connect")]
+        [TestCase("shallNotConnect", "notConnect")]
+        [TestCase("shouldBeNotOnline", "isNotOnline")]
+        [TestCase("shouldBeOnline", "isOnline")]
+        [TestCase("shouldConnect", "connect")]
+        [TestCase("shouldNotBeOnline", "isNotOnline")]
+        public void Code_gets_fixed_for_parameter_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int ###)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1532_ParametersWithShouldPrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1532_ParametersWithShouldPrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1532_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzerTests.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
 
-        private static readonly string[] Prefixes = ["shall", "should"];
+        private static readonly string[] Prefixes = ["shall", "should", "will", "would", "could"];
 
         private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
 
@@ -72,13 +72,30 @@ namespace Bla
         {
             Pair[] pairs =
                            [
+                               new("couldBeNotOnline", "isNotOnline"),
+                               new("couldBeOnline", "isOnline"),
+                               new("couldConnect", "connect"),
+                               new("couldHaveState", "hasState"),
+                               new("couldNotBeOnline", "isNotOnline"),
                                new("shallBeOnline", "isOnline"),
                                new("shallConnect", "connect"),
+                               new("shallHaveState", "hasState"),
                                new("shallNotConnect", "notConnect"),
                                new("shouldBeNotOnline", "isNotOnline"),
                                new("shouldBeOnline", "isOnline"),
                                new("shouldConnect", "connect"),
+                               new("shouldHaveState", "hasState"),
                                new("shouldNotBeOnline", "isNotOnline"),
+                               new("willBeOnline", "isOnline"),
+                               new("willConnect", "connect"),
+                               new("willHaveState", "hasState"),
+                               new("willNotConnect", "notConnect"),
+                               new("wouldBeNotOnline", "isNotOnline"),
+                               new("wouldBeOnline", "isOnline"),
+                               new("wouldConnect", "connect"),
+                               new("wouldHaveState", "hasState"),
+                               new("wouldNotBeOnline", "isNotOnline"),
+                               new("wouldNotHaveState", "hasNotState"),
                            ];
 
             foreach (var prefix in FieldPrefixes)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1533_FieldsWithShouldPrefixAnalyzerTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1533_FieldsWithShouldPrefixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
+
+        private static readonly string[] Prefixes = ["shall", "should"];
+
+        private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
+
+        [Test]
+        public void No_issue_is_reported_for_field_without_should_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int something;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_prefix_([ValueSource(nameof(FieldPrefixes))] string prefix, [ValueSource(nameof(Prefixes))] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private int " + prefix + name + @"Something;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_field_([ValueSource(nameof(CodeFixData))] TestCaseData data)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int ###;
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", data.Wrong), Template.Replace("###", data.Fixed));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1533_FieldsWithShouldPrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1533_FieldsWithShouldPrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1533_CodeFixProvider();
+
+        [ExcludeFromCodeCoverage]
+        private static IEnumerable<TestCaseData> CreateCodeFixData()
+        {
+            Pair[] pairs =
+                           [
+                               new("shallBeOnline", "isOnline"),
+                               new("shallConnect", "connect"),
+                               new("shallNotConnect", "notConnect"),
+                               new("shouldBeNotOnline", "isNotOnline"),
+                               new("shouldBeOnline", "isOnline"),
+                               new("shouldConnect", "connect"),
+                               new("shouldNotBeOnline", "isNotOnline"),
+                           ];
+
+            foreach (var prefix in FieldPrefixes)
+            {
+                foreach (var pair in pairs)
+                {
+                    yield return new TestCaseData
+                                     {
+                                         Wrong = prefix + pair.Key,
+                                         Fixed = prefix + pair.Value,
+                                     };
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -244,6 +244,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1. Naming", "1. Naming", "{
 		Documentation\MiKo_1528.md = Documentation\MiKo_1528.md
 		Documentation\MiKo_1529.md = Documentation\MiKo_1529.md
 		Documentation\MiKo_1530.md = Documentation\MiKo_1530.md
+		Documentation\MiKo_1531.md = Documentation\MiKo_1531.md
+		Documentation\MiKo_1532.md = Documentation\MiKo_1532.md
+		Documentation\MiKo_1533.md = Documentation\MiKo_1533.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2. Documentation", "2. Documentation", "{572678B8-C70C-4E91-BE64-E688D7959CA6}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 548 rules that are currently provided by the analyzer.
+The following tables list all the 551 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -195,6 +195,9 @@ The following tables list all the 548 rules that are currently provided by the a
 |[MiKo_1528](/Documentation/MiKo_1528.md)|Do not prefix parameters with 'arg'|&#x2713;|&#x2713;|
 |[MiKo_1529](/Documentation/MiKo_1529.md)|Do not prefix methods with 3rd person singular verb|&#x2713;|&#x2713;|
 |[MiKo_1530](/Documentation/MiKo_1530.md)|Follow .NET Framework Design Guidelines for method names of DependencyPropertyChanged callbacks|&#x2713;|&#x2713;|
+|[MiKo_1531](/Documentation/MiKo_1531.md)|Do not prefix local variables with 'should'|&#x2713;|&#x2713;|
+|[MiKo_1532](/Documentation/MiKo_1532.md)|Do not prefix parameters with 'should'|&#x2713;|&#x2713;|
+|[MiKo_1533](/Documentation/MiKo_1533.md)|Do not prefix fields with 'should'|&#x2713;|&#x2713;|
 
 ### Documentation
 


### PR DESCRIPTION
- Introduce rules to flag `shall`/`should`/`will`/`would`/`could` prefixes in local variables, parameters, and fields

- Provide code fix providers for each rule

- Add unit tests for each rule

- Update resources, constants, and string utilities to support new naming logic

- Update README and documentation

- Minor improvements to test and documentation infrastructure