### PR TITLE
Refactor variable naming analyzers to collect diagnostics in a 'List' instead of using 'yield return'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzer.cs
@@ -20,7 +20,27 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers) => AnalyzeIdentifiers(identifiers);
 
-        private IEnumerable<Diagnostic> AnalyzeIdentifiers(IEnumerable<SyntaxToken> identifiers) => identifiers.Where(_ => _.ValueText.EndsWithAny(WrongNames, StringComparison.OrdinalIgnoreCase) && _.ValueText.EndsWith("ransaction", StringComparison.OrdinalIgnoreCase) is false)
-                                                                                                               .Select(_ => Issue(_, CreateBetterNameProposal(Constants.Names.callback)));
+        private IEnumerable<Diagnostic> AnalyzeIdentifiers(in ReadOnlySpan<SyntaxToken> identifiers)
+        {
+            List<Diagnostic> issues = null;
+
+            for (int index = 0, length = identifiers.Length; index < length; index++)
+            {
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+
+                if (name.EndsWithAny(WrongNames, StringComparison.OrdinalIgnoreCase) && name.EndsWith("ransaction", StringComparison.OrdinalIgnoreCase) is false)
+                {
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(identifier, CreateBetterNameProposal(Constants.Names.callback)));
+                }
+            }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
+        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1071_BooleanLocalVariableNamedAsQuestionAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -25,8 +26,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            foreach (var identifier in identifiers)
+            List<Diagnostic> issues = null;
+
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
+                var identifier = identifiers[index];
                 var name = identifier.ValueText;
 
                 if (name.Length <= 5)
@@ -37,9 +41,16 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 if (name.StartsWithAny(Prefixes) && name.HasUpperCaseLettersAbove(1) && name.StartsWith("isInDesign", StringComparison.Ordinal) is false)
                 {
-                    yield return Issue(name, identifier);
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name, identifier));
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1084_VariablesWithNumberSuffixAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -27,21 +28,25 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var length = identifiers.Length;
+            List<Diagnostic> issues = null;
 
-            if (length > 0)
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
-                {
-                    var identifier = identifiers[index];
-                    var name = identifier.ValueText;
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
 
-                    if (name.EndsWithCommonNumber())
+                if (name.EndsWithCommonNumber())
+                {
+                    if (issues is null)
                     {
-                        yield return Issue(name, identifier, CreateBetterNameProposal(name.WithoutNumberSuffix()));
+                        issues = new List<Diagnostic>(1);
                     }
+
+                    issues.Add(Issue(name, identifier, CreateBetterNameProposal(name.WithoutNumberSuffix())));
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1511_ProxyVariablesAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,26 +18,30 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var length = identifiers.Length;
+            List<Diagnostic> issues = null;
 
-            if (length > 0)
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+
+                if (name.Contains("Proxy", StringComparison.OrdinalIgnoreCase))
                 {
-                    var identifier = identifiers[index];
-                    var name = identifier.ValueText;
+                    var betterName = FindBetterName(name);
 
-                    if (name.Contains("Proxy", StringComparison.OrdinalIgnoreCase))
+                    if (betterName != name)
                     {
-                        var betterName = FindBetterName(name);
-
-                        if (betterName != name)
+                        if (issues is null)
                         {
-                            yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                            issues = new List<Diagnostic>(1);
                         }
+
+                        issues.Add(Issue(name, identifier, betterName, CreateBetterNameProposal(betterName)));
                     }
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
 
         private static string FindBetterName(string name) => name.Length > 5

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1518_ReferenceVariablesAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,32 +18,36 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var length = identifiers.Length;
+            List<Diagnostic> issues = null;
 
-            if (length > 0)
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+
+                if (name is "reference" || name is "references")
                 {
-                    var identifier = identifiers[index];
-                    var name = identifier.ValueText;
+                    // currently, we cannot rename them
+                    continue;
+                }
 
-                    if (name is "reference" || name is "references")
+                if (name.Contains("Reference", StringComparison.OrdinalIgnoreCase))
+                {
+                    var betterName = FindBetterName(name);
+
+                    if (betterName != name)
                     {
-                        // currently, we cannot rename them
-                        continue;
-                    }
-
-                    if (name.Contains("Reference", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var betterName = FindBetterName(name);
-
-                        if (betterName != name)
+                        if (issues is null)
                         {
-                            yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                            issues = new List<Diagnostic>(1);
                         }
+
+                        issues.Add(Issue(name, identifier, betterName, CreateBetterNameProposal(betterName)));
                     }
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
 
         private static string FindBetterName(string name) => name.Length > 9

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1520_ToCopyVariablesAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,24 +18,28 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var length = identifiers.Length;
+            List<Diagnostic> issues = null;
 
-            if (length > 0)
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+                var nameSpan = name.AsSpan();
+
+                if (nameSpan.StartsWith("toCopy") || nameSpan.EndsWith("ToCopy"))
                 {
-                    var identifier = identifiers[index];
-                    var name = identifier.ValueText;
-                    var nameSpan = name.AsSpan();
+                    var betterName = FindBetterName(name);
 
-                    if (nameSpan.StartsWith("toCopy") || nameSpan.EndsWith("ToCopy"))
+                    if (issues is null)
                     {
-                        var betterName = FindBetterName(name);
-
-                        yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                        issues = new List<Diagnostic>(1);
                     }
+
+                    issues.Add(Issue(name, identifier, betterName, CreateBetterNameProposal(betterName)));
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
 
         private static string FindBetterName(string name)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,23 +18,27 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
         {
-            var length = identifiers.Length;
+            List<Diagnostic> issues = null;
 
-            if (length > 0)
+            for (int index = 0, length = identifiers.Length; index < length; index++)
             {
-                for (var index = 0; index < length; index++)
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+
+                if (name.StartsWithAny(Constants.Names.IntentPrefixes, StringComparison.OrdinalIgnoreCase))
                 {
-                    var identifier = identifiers[index];
-                    var name = identifier.ValueText;
+                    var betterName = FindBetterNameForShouldPrefix(name);
 
-                    if (name.StartsWithAny(Constants.Names.IntentPrefixes, StringComparison.OrdinalIgnoreCase))
+                    if (issues is null)
                     {
-                        var betterName = FindBetterNameForShouldPrefix(name);
-
-                        yield return Issue(name, identifier, betterName, CreateBetterNameProposal(betterName));
+                        issues = new List<Diagnostic>(1);
                     }
+
+                    issues.Add(Issue(name, identifier, betterName, CreateBetterNameProposal(betterName)));
                 }
             }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
         }
     }
 }


### PR DESCRIPTION
- Return `Enumerable.Empty<Diagnostic>()` when no issues are found

- Replace `foreach` loops with `for` loops for efficiency

- Add `System.Linq` imports as needed

- No changes to naming logic