### PR TITLE
Remove in modifiers, refactor to check for single item in collection

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -370,7 +370,7 @@ namespace MiKoSolutions.Analyzers.Rules
         /// The diagnostic issue to report.
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, Diagnostic issue)
+        protected static void ReportDiagnostics(SyntaxNodeAnalysisContext context, Diagnostic issue)
         {
             if (issue != null)
             {
@@ -417,7 +417,7 @@ namespace MiKoSolutions.Analyzers.Rules
         /// <param name="issues">
         /// The diagnostic issues to report.
         /// </param>
-        protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, Diagnostic[] issues)
+        protected static void ReportDiagnostics(SyntaxNodeAnalysisContext context, Diagnostic[] issues)
         {
             for (int index = 0, length = issues.Length; index < length; index++)
             {
@@ -439,11 +439,39 @@ namespace MiKoSolutions.Analyzers.Rules
         /// <param name="issues">
         /// The diagnostic issues to report.
         /// </param>
-        protected static void ReportDiagnostics(in SyntaxNodeAnalysisContext context, IReadOnlyList<Diagnostic> issues)
+        protected static void ReportDiagnostics(SyntaxNodeAnalysisContext context, IReadOnlyList<Diagnostic> issues)
         {
-            for (int index = 0, count = issues.Count; index < count; index++)
+            switch (issues.Count)
             {
-                ReportDiagnostics(context, issues[index]);
+                case 0:
+                    return;
+
+                case 1:
+                {
+                    var issue = issues[0];
+
+                    if (issue != null)
+                    {
+                        context.ReportDiagnostic(issue);
+                    }
+
+                    break;
+                }
+
+                default:
+                {
+                    for (int index = 0, count = issues.Count; index < count; index++)
+                    {
+                        var issue = issues[index];
+
+                        if (issue != null)
+                        {
+                            context.ReportDiagnostic(issue);
+                        }
+                    }
+
+                    break;
+                }
             }
         }
 
@@ -1923,7 +1951,7 @@ namespace MiKoSolutions.Analyzers.Rules
             ReportDiagnosticsEnumerable(context, issues);
         }
 
-        private static void ReportDiagnostics(in SymbolAnalysisContext context, Diagnostic[] array)
+        private static void ReportDiagnostics(SymbolAnalysisContext context, Diagnostic[] array)
         {
             for (int index = 0, length = array.Length; index < length; index++)
             {
@@ -1936,7 +1964,7 @@ namespace MiKoSolutions.Analyzers.Rules
             }
         }
 
-        private static void ReportDiagnostics(in SymbolAnalysisContext context, IReadOnlyList<Diagnostic> list)
+        private static void ReportDiagnostics(SymbolAnalysisContext context, IReadOnlyList<Diagnostic> list)
         {
             for (int index = 0, count = list.Count; index < count; index++)
             {
@@ -1949,7 +1977,7 @@ namespace MiKoSolutions.Analyzers.Rules
             }
         }
 
-        private static void ReportDiagnosticsEnumerable(in SymbolAnalysisContext context, IEnumerable<Diagnostic> issues)
+        private static void ReportDiagnosticsEnumerable(SymbolAnalysisContext context, IEnumerable<Diagnostic> issues)
         {
             foreach (var issue in issues)
             {
@@ -1966,7 +1994,7 @@ namespace MiKoSolutions.Analyzers.Rules
             }
         }
 
-        private static void ReportDiagnosticsEnumerable(in SyntaxNodeAnalysisContext context, IEnumerable<Diagnostic> issues)
+        private static void ReportDiagnosticsEnumerable(SyntaxNodeAnalysisContext context, IEnumerable<Diagnostic> issues)
         {
             foreach (var issue in issues)
             {


### PR DESCRIPTION
- Refactor diagnostic reporting methods to remove `[in]` parameters from context arguments

- Optimize `ReportDiagnostics` for `IReadOnlyList<Diagnostic>` by handling empty and single-item cases more efficiently

- No functional changes