### PR TITLE
MiKo_3227 is now able to fix 'nameof()'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.cs
@@ -35,6 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 case LiteralExpressionSyntax literal: return IsResponsibleNode(literal.Kind());
                 case PrefixUnaryExpressionSyntax unary: return IsResponsibleNode(unary.Operand.Kind());
                 case MemberAccessExpressionSyntax maes: return maes.IsConst(semanticModel);
+                case InvocationExpressionSyntax i: return i.IsNameOf();
                 default:
                     return false;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
@@ -59,6 +59,17 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return true; // enum is on wrong side, so swap sides
             }
 
+            // we probably have a 'nameof'
+            if (expression is InvocationExpressionSyntax right && right.IsNameOf())
+            {
+                return false; // we are already on the correct sides
+            }
+
+            if (operand is InvocationExpressionSyntax left && left.IsNameOf())
+            {
+                return true; // enum is on wrong side, so swap sides
+            }
+
             return false;
         }
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
@@ -121,6 +121,38 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void An_issue_is_reported_for_a_left_sided_comparison_using_nameof() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (nameof(DoSomething) == a)
+            return true;
+        else
+            return false;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_a_right_sided_comparison_using_nameof() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool DoSomething(string a)
+    {
+        if (a == nameof(DoSomething))
+            return true;
+        else
+            return false;
+    }
+}
+");
+
         [TestCase("class TestMe { bool Do(int a) { return (a == 42); } }", "class TestMe { bool Do(int a) { return (a is 42); } }")]
         [TestCase("class TestMe { bool Do(int a) { return (42 == a); } }", "class TestMe { bool Do(int a) { return (a is 42); } }")]
         [TestCase("class TestMe { bool Do(int a) => a == 42; }", "class TestMe { bool Do(int a) => a is 42; }")]
@@ -136,10 +168,15 @@ public class TestMe
         [TestCase("class TestMe { bool Do(char a) => a == 'X'; }", "class TestMe { bool Do(char a) => a is 'X'; }")]
         [TestCase("class TestMe { bool Do(char a) => 'X' == a; }", "class TestMe { bool Do(char a) => a is 'X'; }")]
 
-        [TestCase(@"class TestMe { bool Do(string a) { return (a == ""some text""); } }", @"class TestMe { bool Do(string a) { return (a is ""some text""); } }")]
-        [TestCase(@"class TestMe { bool Do(string a) { return (""some text"" == a); } }", @"class TestMe { bool Do(string a) { return (a is ""some text""); } }")]
-        [TestCase(@"class TestMe { bool Do(string a) => a == ""some text""; }", @"class TestMe { bool Do(string a) => a is ""some text""; }")]
-        [TestCase(@"class TestMe { bool Do(string a) => ""some text"" == a; }", @"class TestMe { bool Do(string a) => a is ""some text""; }")]
+        [TestCase("""class TestMe { bool Do(string a) { return (a == "some text"); } }""", """class TestMe { bool Do(string a) { return (a is "some text"); } }""")]
+        [TestCase("""class TestMe { bool Do(string a) { return ("some text" == a); } }""", """class TestMe { bool Do(string a) { return (a is "some text"); } }""")]
+        [TestCase("""class TestMe { bool Do(string a) => a == "some text"; }""", """class TestMe { bool Do(string a) => a is "some text"; }""")]
+        [TestCase("""class TestMe { bool Do(string a) => "some text" == a; }""", """class TestMe { bool Do(string a) => a is "some text"; }""")]
+
+        [TestCase("class TestMe { bool Do(string a) { return (a == nameof(Do)); } }", "class TestMe { bool Do(string a) { return (a is nameof(Do)); } }")]
+        [TestCase("class TestMe { bool Do(string a) { return (nameof(Do) == a); } }", "class TestMe { bool Do(string a) { return (a is nameof(Do)); } }")]
+        [TestCase("class TestMe { bool Do(string a) => a == nameof(Do); }", "class TestMe { bool Do(string a) => a is nameof(Do); }")]
+        [TestCase("class TestMe { bool Do(string a) => nameof(Do) == a; }", "class TestMe { bool Do(string a) => a is nameof(Do); }")]
 
         [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (a == StringComparison.Ordinal); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is StringComparison.Ordinal); } }")]
         [TestCase("using System; class TestMe { bool Do(StringComparison a) { return (StringComparison.Ordinal == a); } }", "using System; class TestMe { bool Do(StringComparison a) { return (a is StringComparison.Ordinal); } }")]


### PR DESCRIPTION
- Enhance analyzer and code fix to recognize `nameof` expressions as literals in equality comparisons

- Improve logic to ensure correct side swapping for `nameof` comparisons

- Add unit tests for both detection and code fix scenarios involving `nameof`

- Update string test cases to use raw string literals