### PR TITLE
Improved detection of scenario phrases ("If", "When") in test method names

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer.cs
@@ -56,6 +56,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                    "NoLongerThrow",
                                                                };
 
+        private static readonly string[] SpecialConditionPhrases =
+                                                                   {
+                                                                       "If",
+                                                                       "When",
+                                                                   };
+
         public MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzer() : base(Id)
         {
         }
@@ -83,8 +89,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             var parts = methodName.Split(Constants.Underscores, StringSplitOptions.RemoveEmptyEntries);
             var first = true;
 
-            foreach (var part in parts)
+            for (int index = 0; index < parts.Length; index++)
             {
+                string part = parts[index];
+
                 if (part[0].IsUpperCaseOrNumber() is false)
                 {
                     return false;
@@ -98,9 +106,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     continue;
                 }
 
-                for (int index = 0, length = ExpectedOutcomeMarkers.Length; index < length; index++)
+                if (index is 1 && part.StartsWithAny(SpecialConditionPhrases))
                 {
-                    var marker = ExpectedOutcomeMarkers[index];
+                    return true;
+                }
+
+                for (int i = 0, length = ExpectedOutcomeMarkers.Length; i < length; i++)
+                {
+                    var marker = ExpectedOutcomeMarkers[i];
 
                     if (part.Contains(marker, StringComparison.OrdinalIgnoreCase))
                     {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -166,6 +166,7 @@ public class TestMe
         [TestCase("MethodName_SomeCondition_KeepsValue", "Method_name_keeps_value_if_some_condition")]
         [TestCase("MethodName_SomeCondition_DoesAlter", "Method_name_alters_if_some_condition")]
         [TestCase("MethodName_SomeCondition_DoesNotAlter", "Method_name_does_not_alter_if_some_condition")]
+        [TestCase("MethodName_WhenSomeCondition_ShowsStuff", "Method_name_shows_stuff_if_some_condition")]
         public void Code_gets_fixed_for_2_slashes_in_(string originalName, string fixedName) => VerifyCSharpFix(
                                                                                                             "class TestMe { [Test] public void " + originalName + "() { } }",
                                                                                                             "class TestMe { [Test] public void " + fixedName + "() { } }");


### PR DESCRIPTION
- Add `SpecialConditionPhrases` array to identify scenario phrases as the second part of test method names

- Update `HasIssue` logic to flag methods using these phrases

- Refactor loop for index-based checks

- Add test case for "When" scenario to verify correct detection and code fix