### PR TITLE
MiKo_3231 no longer reports on unrelated enum .Equals calls

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
@@ -22,11 +22,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                    && m.GetIdentifierName() is nameof(StringComparison)
                                                                                    && m.GetName() is nameof(StringComparison.Ordinal);
 
-        private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel)
+        private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments, in SyntaxNodeAnalysisContext context)
         {
             switch (arguments.Count)
             {
-                case 1 when arguments[0].IsString(semanticModel):
+                case 1 when arguments[0].IsString(context.SemanticModel):
                 case 2 when IsStringComparisonOrdinal(arguments[1].Expression):
                     return true;
 
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (IsStringComparisonOrdinal(arguments, context.SemanticModel))
+                if (IsStringComparisonOrdinal(arguments, context))
                 {
                     var argumentExpression = arguments[0].Expression;
                     var expression = maes.Expression;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
@@ -22,11 +22,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                                    && m.GetIdentifierName() is nameof(StringComparison)
                                                                                    && m.GetName() is nameof(StringComparison.Ordinal);
 
-        private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments)
+        private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments, SemanticModel semanticModel)
         {
             switch (arguments.Count)
             {
-                case 1:
+                case 1 when arguments[0].IsString(semanticModel):
                 case 2 when IsStringComparisonOrdinal(arguments[1].Expression):
                     return true;
 
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = invocation.ArgumentList.Arguments;
 
-                if (IsStringComparisonOrdinal(arguments))
+                if (IsStringComparisonOrdinal(arguments, context.SemanticModel))
                 {
                     var argumentExpression = arguments[0].Expression;
                     var expression = maes.Expression;

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzerTests.cs
@@ -23,6 +23,30 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                                                 ];
 
         [Test]
+        public void No_issue_is_reported_for_enum_equals() => No_issue_is_reported_for(@"
+using Bla
+{
+    public enum MyEnum
+    {
+        Value1,
+        Value2,
+        Value3,
+    }
+
+    public class TestMe
+    {
+        public MyEnum Value { get; set; }
+
+        public void DoSomething(TestMe other)
+        {
+            if (other.Value.Equals(MyEnum.Value1)
+            {
+            }
+        }
+    }
+}");
+
+        [Test]
         public void No_issue_is_reported_for_1_variable_of_type_([Values("bool", "char", "int", "object", "StringComparison")] string type) => No_issue_is_reported_for(@"
 public class TestMe
 {


### PR DESCRIPTION
- Improve `StringComparison.Ordinal` detection by enhancing argument checks with semantic analysis

- Update method signatures accordingly and add unit test to ensure `Equals` invocations of enums are not flagged