### PR TITLE
Added MiKo_3234 rule to prefer pattern matching over boolean Equals checks

### DIFF
--- a/Documentation/MiKo_3234.md
+++ b/Documentation/MiKo_3234.md
@@ -1,0 +1,52 @@
+﻿# MiKo_3234: Prefer pattern matching over boolean Equals checks
+
+## Cause
+
+An `Equals()` call result is compared to `true` using `== true` or `is true`.
+
+## Rule description
+
+Calling `.Equals(value) == true` is redundant - the boolean result is compared to `true` again, which is unnecessary.
+Using `is value` instead expresses the intent directly and makes the code easier to understand at a glance.
+
+### Rationale behind
+
+Writing `.Equals(value) == true` is a common mistake that adds unnecessary noise to the code.
+It forces the reader to mentally unwrap two levels of comparison instead of just reading what the code means.
+
+Following this rule provides several important benefits:
+
+- **Improved Readability**:
+  The `is value` pattern matching syntax reads like plain language.
+  It immediately makes clear what is being checked, without any redundant steps in between.
+
+- **Reduced Redundancy**:
+  Calling `.Equals()` and then comparing the result to `true` is doing the same check twice.
+  Removing this redundancy keeps the code concise and free of unnecessary clutter.
+
+- **Clearer Intent**:
+  Pattern matching with `is` makes the purpose of the comparison obvious.
+  There is no ambiguity about what value is being tested.
+
+- **Reduced Cognitive Load**:
+  When reading `.Equals(value) == true`, the brain has to process an extra step that adds no value.
+  Using `is value` removes that extra step and makes the code easier to follow at a glance.
+
+- **Better Code Quality**:
+  Avoiding redundant comparisons is a small but consistent signal of careful, clean code.
+  It shows awareness of what the language offers and a preference for simple, direct expressions.
+
+## How to fix violations
+
+To fix a violation of this rule, replace the redundant expression with the equivalent pattern matching syntax:
+- `.Equals(true) == true` → `is true`
+- `.Equals(false) == true` → `is false`
+- `.Equals(42) == true` → `is 42`
+- `.Equals("abc") == true` → `is "abc"`
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3234
+#pragma warning restore MiKo_3234
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -246,6 +246,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3228_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3229_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3231_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3234_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3501_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -350,6 +350,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3232_DoNotUseEmptyPropertyPatternInsideConditionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15155,6 +15155,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply &apos;is&apos; pattern.
+        /// </summary>
+        internal static string MiKo_3234_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3234_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Calling &apos;.Equals(value) == true&apos; is redundant - the boolean result is compared to &apos;true&apos; again, which is unnecessary. Using &apos;is value&apos; instead expresses the intent directly and makes the code easier to understand at a glance..
+        /// </summary>
+        internal static string MiKo_3234_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3234_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;is&apos; instead of &apos;Equals() ==&apos;.
+        /// </summary>
+        internal static string MiKo_3234_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3234_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer pattern matching over boolean Equals checks.
+        /// </summary>
+        internal static string MiKo_3234_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3234_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5299,6 +5299,18 @@ Instead, to avoid 'null', use a non-null pattern (such as "is { } something"), a
   <data name="MiKo_3233_Title" xml:space="preserve">
     <value>Do not use var patterns for null checks</value>
   </data>
+  <data name="MiKo_3234_CodeFixTitle" xml:space="preserve">
+    <value>Apply 'is' pattern</value>
+  </data>
+  <data name="MiKo_3234_Description" xml:space="preserve">
+    <value>Calling '.Equals(value) == true' is redundant - the boolean result is compared to 'true' again, which is unnecessary. Using 'is value' instead expresses the intent directly and makes the code easier to understand at a glance.</value>
+  </data>
+  <data name="MiKo_3234_MessageFormat" xml:space="preserve">
+    <value>Use 'is' instead of 'Equals() =='</value>
+  </data>
+  <data name="MiKo_3234_Title" xml:space="preserve">
+    <value>Prefer pattern matching over boolean Equals checks</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3234_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3234_CodeFixProvider.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3234_CodeFixProvider)), Shared]
+    public sealed class MiKo_3234_CodeFixProvider : UsePatternMatchingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3234";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            foreach (var node in syntaxNodes)
+            {
+                if (node is IsPatternExpressionSyntax pattern)
+                {
+                    return pattern;
+                }
+            }
+
+            return base.GetSyntax(syntaxNodes);
+        }
+
+        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(IsPatternExpressionSyntax pattern)
+        {
+            var updatedOperand = GetUpdatedOperand(pattern.Expression, out var expressionForPattern);
+
+            if (expressionForPattern is null)
+            {
+                return pattern;
+            }
+
+            return IsPattern(updatedOperand, expressionForPattern);
+        }
+
+        protected override IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, ExpressionSyntax expression)
+        {
+            var updatedOperand = GetUpdatedOperand(operand, out var expressionForPattern);
+
+            return IsPattern(updatedOperand, expressionForPattern ?? expression);
+        }
+
+        private static ExpressionSyntax GetUpdatedOperand(ExpressionSyntax operand, out ExpressionSyntax expressionForPattern)
+        {
+            expressionForPattern = null;
+
+            var node = operand;
+
+            while (node != null)
+            {
+                switch (node)
+                {
+                    case ConditionalAccessExpressionSyntax c:
+                    {
+                        switch (c.WhenNotNull)
+                        {
+                            case ConditionalAccessExpressionSyntax nested:
+                            {
+                                node = nested;
+
+                                continue;
+                            }
+
+                            case InvocationExpressionSyntax i when i.GetName() is nameof(Equals):
+                            {
+                                var arguments = i.ArgumentList.Arguments;
+
+                                if (arguments.Count is 1)
+                                {
+                                    expressionForPattern = arguments[0].Expression;
+
+                                    return operand.ReplaceNode(c, c.Expression);
+                                }
+
+                                return operand;
+                            }
+
+                            default:
+                                return operand;
+                        }
+                    }
+
+                    case InvocationExpressionSyntax invocation when invocation.GetName() is nameof(Equals):
+                    {
+                        var arguments = invocation.ArgumentList.Arguments;
+
+                        if (arguments.Count is 1 && invocation.Expression is MemberAccessExpressionSyntax meas)
+                        {
+                            expressionForPattern = arguments[0].Expression;
+
+                            return operand.ReplaceNode(invocation, meas.Expression);
+                        }
+
+                        return operand;
+                    }
+
+                    default:
+                        return operand;
+                }
+            }
+
+            return operand;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs
@@ -1,0 +1,137 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3234";
+
+        public MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(AnalyzeEqualsExpression, SyntaxKind.EqualsExpression);
+            context.RegisterSyntaxNodeAction(AnalyzePatternExpression, SyntaxKind.IsPatternExpression);
+        }
+
+        private static bool HasIssue(BinaryExpressionSyntax node)
+        {
+            var left = node.Left;
+            var right = node.Right;
+
+            if (right.IsKind(SyntaxKind.TrueLiteralExpression))
+            {
+                return HasIssueCore(left);
+            }
+
+            if (left.IsKind(SyntaxKind.TrueLiteralExpression))
+            {
+                return HasIssueCore(right);
+            }
+
+            return false;
+        }
+
+        private static bool HasIssue(IsPatternExpressionSyntax node)
+        {
+            if (node.Pattern is ConstantPatternSyntax c && c.Expression.IsKind(SyntaxKind.TrueLiteralExpression))
+            {
+                return HasIssueCore(node.Expression);
+            }
+
+            return false;
+        }
+
+        private static bool HasIssueCore(SyntaxNode syntax)
+        {
+            switch (syntax)
+            {
+                case InvocationExpressionSyntax i when IsEqualsCall(i):
+                case ConditionalAccessExpressionSyntax c when IsEqualsCall(c):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsEqualsCall(ConditionalAccessExpressionSyntax expression)
+        {
+            var node = expression;
+
+            while (node != null)
+            {
+                switch (node.WhenNotNull)
+                {
+                    case ConditionalAccessExpressionSyntax c:
+                    {
+                        node = c;
+
+                        continue;
+                    }
+
+                    case InvocationExpressionSyntax i:
+                        return IsEqualsCall(i);
+                }
+
+                break;
+            }
+
+            return false;
+        }
+
+        private static bool IsEqualsCall(InvocationExpressionSyntax expression)
+        {
+            var name = expression.GetName();
+
+            if (name is nameof(Equals))
+            {
+                var arguments = expression.ArgumentList.Arguments;
+
+                if (arguments.Count is 1)
+                {
+                    var syntax = arguments[0].Expression;
+
+                    switch (syntax.Kind())
+                    {
+                        case SyntaxKind.TrueLiteralExpression:
+                        case SyntaxKind.FalseLiteralExpression:
+                        case SyntaxKind.NumericLiteralExpression:
+                        case SyntaxKind.NullLiteralExpression:
+                        case SyntaxKind.CharacterLiteralExpression:
+                        case SyntaxKind.StringLiteralExpression:
+                        // Attention! We cannot use pattern matching for UTF 8 strings as they are no constant values and can never be null!
+                        // case SyntaxKind.Utf8StringLiteralExpression:
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void AnalyzeEqualsExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BinaryExpressionSyntax node && HasIssue(node))
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
+        }
+
+        private void AnalyzePatternExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is IsPatternExpressionSyntax node && HasIssue(node))
+            {
+                ReportDiagnostics(context, Issue(node));
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
@@ -15,14 +15,26 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected UsePatternMatchingCodeFixProvider(in SyntaxKind syntaxKind = SyntaxKind.EqualsExpression) => m_syntaxKind = syntaxKind;
 
-        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.First(_ => _.IsKind(m_syntaxKind));
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.First(_ => _.IsKind(m_syntaxKind));
 
         protected sealed override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {
-            SyntaxNode updatedSyntax = GetUpdatedSyntax((BinaryExpressionSyntax)syntax);
+            var updatedSyntax = syntax;
+
+            if (syntax is BinaryExpressionSyntax binary)
+            {
+                updatedSyntax = GetUpdatedSyntax(binary);
+            }
+
+            if (syntax is IsPatternExpressionSyntax pattern)
+            {
+                updatedSyntax = GetUpdatedPatternSyntax(pattern);
+            }
 
             return Task.FromResult(updatedSyntax);
         }
+
+        protected virtual IsPatternExpressionSyntax GetUpdatedPatternSyntax(IsPatternExpressionSyntax pattern) => pattern;
 
         protected virtual IsPatternExpressionSyntax GetUpdatedPatternSyntax(ExpressionSyntax operand, ExpressionSyntax expression) => IsPattern(operand, expression);
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzerTests.cs
@@ -1,0 +1,2009 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_comparisons_via_([Values("==", "!=")] string @operator) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value " + @operator + @" true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_character_literal() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals('x'))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_null_literal() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(null))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_number() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(42))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_string_literal() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(""abc""))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_Equals_comparison_via_utf8_string_literal() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public ReadOnlySpan<byte> Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(""abc""u8))
+        {
+        }
+    }
+}
+");
+
+        [Test] // we cannot fix UTF8 strings as they are no constants usable for pattern matching
+        public void No_issue_is_reported_for_Equals_comparison_via_utf8_string_literal_compared_to_true() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public ReadOnlySpan<byte> Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(""abc""u8) is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_compared_to_false_via_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(" + value + @") == false)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_compared_to_false_via_method_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(" + value + @") == false)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_via_is_false_via_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(" + value + @") is false)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_via_is_false_via_method_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(" + value + @") is false)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_with_false_compared_to_via_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (false == a?.SubItem?.Value?.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_negative_conditional_nested_Equals_result_with_false_compared_to_via_method_([Values("true", "false")] string value) => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (false == a?.GetSubItem()?.Value?.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_compared_to_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(" + value + @") == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_compared_to_true_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(" + value + @") == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_via_is_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(" + value + @") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_via_is_true_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(" + value + @") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_with_true_compared_to_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.SubItem?.Value?.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_conditional_nested_Equals_result_with_true_compared_to_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.GetSubItem()?.Value?.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_comparison_via_character_literal_compared_to_true() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals('x') == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_comparison_via_null_literal_compared_to_true() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(null) == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_comparison_via_number_compared_to_true() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(42) == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_comparison_via_string_literal_compared_to_true() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(""abc"") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_result_compared_to_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(" + value + @") == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_result_via_is_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(" + value + @") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_Equals_result_with_true_compared_to_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.Value.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_compared_to_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals(" + value + @") == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_compared_to_true_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals(" + value + @") == true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_via_is_true_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals(" + value + @") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_via_is_true_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals(" + value + @") is true)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_with_true_compared_to_via_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.SubItem.Value.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_nested_Equals_result_with_true_compared_to_via_method_([Values("true", "false")] string value) => An_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public bool Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.GetSubItem().Value.Equals(" + value + @"))
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_false()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(false) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_false_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(false) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_false_via_method_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.GetSubItem()?.Value?.Equals(false))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_false_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.SubItem?.Value?.Equals(false))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(true) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(true) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_true_via_method_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.GetSubItem()?.Value?.Equals(true))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_true_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a?.SubItem?.Value?.Equals(true))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_is_false()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(false) is true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_is_false_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(false) is true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is false)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_is_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(true) is true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_is_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(true) is true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public bool? Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is true)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_number_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(42) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_number_compared_to_true_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.Value.Equals(42))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_number_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals(42) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_number_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals(42) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_number_compared_to_true()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(42) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_number_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(42) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is 42)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_character_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals('x') == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_character_literal_compared_to_true_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.Value.Equals('x'))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_character_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals('x') == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_character_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals('x') == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_character_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals('x') == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_character_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals('x') == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public char Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is 'x')
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_string_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(""abc"") == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_string_literal_compared_to_true_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.Value.Equals(""abc""))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_string_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals(""abc"") == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_string_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals(""abc"") == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_string_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(""abc"") == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_string_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(""abc"") == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public string Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is ""abc"")
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_null_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value.Equals(null) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_Equals_null_literal_compared_to_true_with_swapped_operands()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (true == a.Value.Equals(null))
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_null_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value.Equals(null) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.SubItem.Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_nested_Equals_null_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value.Equals(null) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a.GetSubItem().Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_null_literal_compared_to_true()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value?.Equals(null) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe SubItem { get; }
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.SubItem?.Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_conditional_nested_Equals_null_literal_compared_to_true_via_method()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value?.Equals(null) == true)
+        {
+        }
+    }
+}";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    public object Value { get; }
+
+    public TestMe GetSubItem() => null;
+
+    public void DoSomething(TestMe a)
+    {
+        if (a?.GetSubItem()?.Value is null)
+        {
+        }
+    }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3234_CodeFixProvider();
+
+        protected override string GetDiagnosticId() => MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -533,6 +533,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3231.md = Documentation\MiKo_3231.md
 		Documentation\MiKo_3232.md = Documentation\MiKo_3232.md
 		Documentation\MiKo_3233.md = Documentation\MiKo_3233.md
+		Documentation\MiKo_3234.md = Documentation\MiKo_3234.md
 		Documentation\MiKo_3301.md = Documentation\MiKo_3301.md
 		Documentation\MiKo_3302.md = Documentation\MiKo_3302.md
 		Documentation\MiKo_3401.md = Documentation\MiKo_3401.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 551 rules that are currently provided by the analyzer.
+The following tables list all the 552 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -486,6 +486,7 @@ The following tables list all the 551 rules that are currently provided by the a
 |[MiKo_3231](/Documentation/MiKo_3231.md)|Use pattern matching for ordinal string comparison equality checks|&#x2713;|&#x2713;|
 |[MiKo_3232](/Documentation/MiKo_3232.md)|Use null checks instead of empty property pattern|&#x2713;|\-|
 |[MiKo_3233](/Documentation/MiKo_3233.md)|Do not use var patterns for null checks|&#x2713;|\-|
+|[MiKo_3234](/Documentation/MiKo_3234.md)|Prefer pattern matching over boolean Equals checks|&#x2713;|\-|
 |[MiKo_3301](/Documentation/MiKo_3301.md)|Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |[MiKo_3302](/Documentation/MiKo_3302.md)|Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |[MiKo_3401](/Documentation/MiKo_3401.md)|Keep namespace hierarchies from becoming too deep|&#x2713;|\-|


### PR DESCRIPTION
- Introduce **MiKo_3234** rule and code fix to encourage `is value` over `.Equals(value) == true` or `.Equals(value) is true` for improved readability and reduced redundancy

- Add tests to validate the analyzer and code fix functionality

- Update documentation, README.md and localized resources for the new rule

(resolves #2006)