### PR TITLE
Added new rule MiKo_1537 that reports methods starting with "Event"

### DIFF
--- a/Documentation/MiKo_1537.md
+++ b/Documentation/MiKo_1537.md
@@ -1,0 +1,60 @@
+﻿# MiKo_1537: Do not prefix methods with 'Event'
+
+## Cause
+
+A method name starts with the prefix `Event`.
+
+## Rule description
+
+Event handlers should be named starting with 'On' followed by the event name to show they handle events.
+
+### Rationale behind
+
+Prefixing method names with `Event` adds unnecessary noise to the name without providing any useful information.
+The `Event` prefix does not follow .NET naming conventions and makes the code harder to read and understand.
+
+The fact that a method handles an event is already communicated by following the established .NET naming convention of using the `On` prefix instead.
+Adding `Event` as a prefix to a method name is redundant and makes the name harder to read.
+
+For example, instead of naming a method `EventButtonClick`, it should be named `OnButtonClick`.
+
+Using `On` as a prefix for event handlers is a widely adopted convention throughout the .NET Framework and clearly communicates that a method responds to an event.
+A method named with `Event` as a prefix is confusing because it does not follow this established pattern, making the code feel inconsistent and harder to navigate.
+
+Avoiding the `Event` prefix provides several important benefits:
+
+- **Improved Readability**:
+  Method names without the `Event` prefix are shorter and easier to read.
+  Removing redundant prefixes reduces visual clutter and makes the code cleaner.
+
+- **Consistent Naming**:
+  Using `On` as a prefix for event handlers is consistent with the .NET Framework conventions and with the rest of the codebase.
+  Consistency makes it easier to understand the purpose of a method at a glance.
+
+- **Clear Method Purpose**:
+  A method named `OnButtonClick` immediately signals that it handles the `ButtonClick` event.
+  A method named `EventButtonClick` is ambiguous and does not clearly communicate its purpose.
+
+- **Better Code Navigation**:
+  Developers can quickly locate all event handlers in a file or project by scanning for the `On` prefix.
+  Using a non-standard prefix like `Event` makes this harder and slows down code navigation.
+
+- **Framework Alignment**:
+  The .NET Framework consistently uses the `On` prefix for event-related methods.
+  Following this pattern makes custom code feel integrated with platform conventions and signals adherence to established best practices.
+
+- **Professional Code Quality**:
+  Code that follows well-known naming conventions is easier to review, maintain, and hand over to other developers.
+  It signals that the code is written with care and respect for established standards.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the method to remove the `Event` prefix.
+If the method handles an event, rename it to start with `On` followed by the event name instead.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1537
+#pragma warning restore MiKo_1537
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -376,7 +376,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_CodeFixProvider.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_MethodPrefixedWithEventAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -376,6 +376,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_MethodPrefixedWithEventAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\ParameterNamingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\PropertyNamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -537,6 +537,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_MethodPrefixedWithEventAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5844,6 +5844,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Event&apos; prefix from method name.
+        /// </summary>
+        internal static string MiKo_1537_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1537_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Event handlers should be named starting with &apos;On&apos; followed by the event name to show they handle events..
+        /// </summary>
+        internal static string MiKo_1537_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1537_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove &apos;Event&apos; prefix from method name.
+        /// </summary>
+        internal static string MiKo_1537_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1537_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix methods with &apos;Event&apos;.
+        /// </summary>
+        internal static string MiKo_1537_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1537_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2108,6 +2108,18 @@ Naming the field based on what it represents, rather than what it implies, makes
   <data name="MiKo_1533_Title" xml:space="preserve">
     <value>Do not prefix fields with words that express intent or expectation</value>
   </data>
+  <data name="MiKo_1537_CodeFixTitle" xml:space="preserve">
+    <value>Remove 'Event' prefix from method name</value>
+  </data>
+  <data name="MiKo_1537_Description" xml:space="preserve">
+    <value>Event handlers should be named starting with 'On' followed by the event name to show they handle events.</value>
+  </data>
+  <data name="MiKo_1537_MessageFormat" xml:space="preserve">
+    <value>Remove 'Event' prefix from method name</value>
+  </data>
+  <data name="MiKo_1537_Title" xml:space="preserve">
+    <value>Do not prefix methods with 'Event'</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1537_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1537_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1537_CodeFixProvider)), Shared]
+    public sealed class MiKo_1537_CodeFixProvider : NamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1537";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1537_MethodPrefixedWithEventAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1537";
+
+        public MiKo_1537_MethodPrefixedWithEventAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation)
+        {
+            const string Prefix = "Event";
+
+            var symbolName = symbol.Name;
+
+            if (symbolName.Length > Prefix.Length && symbolName.StartsWith(Prefix, StringComparison.Ordinal))
+            {
+                var betterName = "On".ConcatenatedWith(symbolName.AsSpan(Prefix.Length));
+
+                return new[] { Issue(symbol, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzerTests.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1537_MethodPrefixedWithEventAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_method_with_correct_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [TestCase("Event")]
+        public void An_issue_is_reported_for_method_starting_with_(string term) => An_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void " + term + @"Something(int something)
+        {
+        }
+    }
+}
+");
+
+        [TestCase("Event", "On")]
+        public void Code_gets_fixed_for_method_starting_with_(string originalTerm, string fixedTerm)
+        {
+            const string Template = """
+
+                                    namespace Bla
+                                    {
+                                        public class TestMe
+                                        {
+                                            private void ###Something(int something)
+                                            {
+                                            }
+                                        }
+                                    }
+
+                                    """;
+
+            VerifyCSharpFix(Template.Replace("###", originalTerm), Template.Replace("###", fixedTerm));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1537_MethodPrefixedWithEventAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1537_MethodPrefixedWithEventAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1537_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -247,6 +247,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1. Naming", "1. Naming", "{
 		Documentation\MiKo_1531.md = Documentation\MiKo_1531.md
 		Documentation\MiKo_1532.md = Documentation\MiKo_1532.md
 		Documentation\MiKo_1533.md = Documentation\MiKo_1533.md
+		Documentation\MiKo_1537.md = Documentation\MiKo_1537.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2. Documentation", "2. Documentation", "{572678B8-C70C-4E91-BE64-E688D7959CA6}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 552 rules that are currently provided by the analyzer.
+The following tables list all the 553 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -154,7 +154,7 @@ The following tables list all the 552 rules that are currently provided by the a
 |[MiKo_1119](/Documentation/MiKo_1119.md)|Do not include 'when_present' in test method names|&#x2713;|\-|
 |[MiKo_1200](/Documentation/MiKo_1200.md)|Name catch block exceptions consistently|&#x2713;|&#x2713;|
 |[MiKo_1201](/Documentation/MiKo_1201.md)|Name exception parameters consistently|&#x2713;|&#x2713;|
-|[MiKo_1300](/Documentation/MiKo_1300.md)|Name unimportant lambda parameters '_'|&#x2713;|&#x2713;|
+|[MiKo_1300](/Documentation/MiKo_1300.md)|Name unimportant lambda parameters `_`|&#x2713;|&#x2713;|
 |[MiKo_1400](/Documentation/MiKo_1400.md)|Use plural for namespace names|&#x2713;|\-|
 |[MiKo_1401](/Documentation/MiKo_1401.md)|Do not include technical language names in namespaces|&#x2713;|\-|
 |[MiKo_1402](/Documentation/MiKo_1402.md)|Do not name namespaces after WPF-specific design patterns|&#x2713;|\-|
@@ -198,6 +198,7 @@ The following tables list all the 552 rules that are currently provided by the a
 |[MiKo_1531](/Documentation/MiKo_1531.md)|Do not prefix local variables with 'should'|&#x2713;|&#x2713;|
 |[MiKo_1532](/Documentation/MiKo_1532.md)|Do not prefix parameters with 'should'|&#x2713;|&#x2713;|
 |[MiKo_1533](/Documentation/MiKo_1533.md)|Do not prefix fields with 'should'|&#x2713;|&#x2713;|
+|[MiKo_1537](/Documentation/MiKo_1537.md)|Do not prefix methods with 'Event'|&#x2713;|&#x2713;|
 
 ### Documentation
 


### PR DESCRIPTION
- Introduced analyzer and codefix to ensure methods are not prefixed with "Event" and instead use the "On" prefix for event handlers

- Updated documentation, Readme.md and resources

- Added unit tests to verify analyzer and code fix behavior

(resolves #2009)