### PR TITLE
MiKo_2021 now fixes an empty parameter with 'The TODO'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -567,6 +567,11 @@ namespace MiKoSolutions.Analyzers
                 return string.Empty;
             }
 
+            if (value.Content.Count is 0)
+            {
+                return string.Empty;
+            }
+
             var builder = StringBuilderCache.Acquire();
 
             var trimmed = value.GetTextWithoutTrivia(builder)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
@@ -27,6 +27,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, in int index, Diagnostic issue)
         {
+            if (comment.GetTextTrimmed().IsNullOrEmpty())
+            {
+                return CommentStartingWith(comment, "The " + Constants.TODO);
+            }
+
             var preparedComment = PrepareComment(comment);
 
             return CommentStartingWith(preparedComment, "The ");

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
@@ -11,9 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2021";
 
-        public MiKo_2021_ParamDefaultPhraseAnalyzer() : base(Id)
-        {
-        }
+        public MiKo_2021_ParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter)
         {
@@ -26,15 +24,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (parameterType.IsEnum())
             {
-                return false; // MiKo 2023
+                return false; // MiKo 2024
             }
 
             if (parameterType.IsCancellationToken())
             {
-                return false; // MiKo 2024
+                return false; // MiKo 2025
             }
 
-            return parameterType.IsBoolean() is false;
+            if (parameterType.IsBoolean())
+            {
+                return false; // MiKo 2023
+            }
+
+            return true;
         }
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
@@ -9,9 +9,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public const string Id = "MiKo_2025";
 
-        public MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer() : base(Id)
-        {
-        }
+        public MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsCancellationToken();
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzerTests.cs
@@ -94,6 +94,7 @@ public class TestMe
 
         [TestCase("whatever.")]
         [TestCase("Whatever.")]
+        [TestCase("")]
         public void An_issue_is_reported_for_parameter_not_starting_with_article_(string comment) => An_issue_is_reported_for(@"
 public class TestMe
 {
@@ -102,6 +103,55 @@ public class TestMe
     public void DoSomething(object o) { }
 }
 ");
+
+        [Test]
+        public void Code_gets_fixed_for_empty_parameter_on_same_line()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'></param>
+    public void DoSomething(object o) { }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>
+    /// The TODO
+    /// </param>
+    public void DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_empty_parameter_on_separate_lines()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>
+    /// </param>
+    public void DoSomething(object o) { }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <param name='o'>
+    /// The TODO
+    /// </param>
+    public void DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
 
         [Test]
         public void Code_gets_fixed_for_parameter()

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzerTests.cs
@@ -61,6 +61,7 @@ public class TestMe
 
         [TestCase("whatever.")]
         [TestCase("Whatever.")]
+        [TestCase("")]
         public void An_issue_is_reported_for_CancellationToken_parameter_with_non_standard_phrase_(string comment) => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
@@ -86,8 +87,9 @@ public class TestMe
 }
 ");
 
-        [Test]
-        public void Code_gets_fixed_by_replacing_with_standard_phrase()
+        [TestCase("Whatever.")]
+        [TestCase("")]
+        public void Code_gets_fixed_by_replacing_phrase_(string phrase)
         {
             const string OriginalCode = @"
 using System;
@@ -96,7 +98,7 @@ using System.Threading;
 public class TestMe
 {
     /// <summary />
-    /// <param name='token'>Whatever.</param>
+    /// <param name='token'>###</param>
     public void DoSomething(CancellationToken token) { }
 }
 ";
@@ -114,11 +116,13 @@ public class TestMe
     public void DoSomething(CancellationToken token) { }
 }
 ";
-            VerifyCSharpFix(OriginalCode, FixedCode);
+
+            VerifyCSharpFix(OriginalCode.Replace("###", phrase), FixedCode);
         }
 
-        [Test]
-        public void Code_gets_fixed_by_replacing_with_standard_phrase_on_separate_lines()
+        [TestCase("Whatever.")]
+        [TestCase("")]
+        public void Code_gets_fixed_by_replacing_phrase_on_separate_lines_(string phrase)
         {
             const string OriginalCode = @"
 using System;
@@ -128,7 +132,7 @@ public class TestMe
 {
     /// <summary />
     /// <param name='token'>
-    /// Whatever.
+    /// ###
     /// </param>
     public void DoSomething(CancellationToken token) { }
 }
@@ -147,7 +151,8 @@ public class TestMe
     public void DoSomething(CancellationToken token) { }
 }
 ";
-            VerifyCSharpFix(OriginalCode, FixedCode);
+
+            VerifyCSharpFix(OriginalCode.Replace("###", phrase), FixedCode);
         }
 
         protected override string GetDiagnosticId() => MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.Id;


### PR DESCRIPTION
- Add checks in `SyntaxNodeExtensions.Documentation.cs` and `MiKo_2021_CodeFixProvider.cs` to handle empty parameter comments by inserting placeholder text ("The TODO").

- Update `MiKo_2021_ParamDefaultPhraseAnalyzer` and `MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer` to ensure empty parameters are analyzed

- Enhance test coverage with new and refactored test cases to verify fixes for empty parameter comments