### PR TITLE
MiKo_2030 now has a rudimentary codefix

### DIFF
--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2025_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2027_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2029_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2030_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2031_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2032_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\MiKo_2033_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -6828,6 +6828,15 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fix return comment.
+        /// </summary>
+        internal static string MiKo_2030_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_2030_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Documentation for a return value should start with a default phrase that provides a detailed description of what the returned value is. This approach helps clarify the purpose and use of the return value for developers..
         /// </summary>
         internal static string MiKo_2030_Description {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2438,6 +2438,9 @@ This ensures clarity and precision in your code.</value>
   <data name="MiKo_2029_Title" xml:space="preserve">
     <value>Do not use self-referencing 'cref' in &lt;inheritdoc&gt; documentation</value>
   </data>
+  <data name="MiKo_2030_CodeFixTitle" xml:space="preserve">
+    <value>Fix return comment</value>
+  </data>
   <data name="MiKo_2030_Description" xml:space="preserve">
     <value>Documentation for a return value should start with a default phrase that provides a detailed description of what the returned value is. This approach helps clarify the purpose and use of the return value for developers.</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
@@ -14,17 +14,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         private static readonly Pair[] ReplacementMap =
                                                         {
+                                                            new Pair("The a ", "A "),
+                                                            new Pair("The an ", "An "),
+                                                            new Pair("The the ", "The "),
+                                                            new Pair("The this ", "The "),
+                                                            new Pair("The always a ", "A "),
+                                                            new Pair("The always an ", "An "),
+                                                            new Pair("The always the ", "The "),
+                                                            new Pair("The always this ", "The "),
+                                                            new Pair("The always ", "The "),
                                                             new Pair("The return a ", "A "),
                                                             new Pair("The returns a ", "A "),
                                                             new Pair("The return an ", "An "),
                                                             new Pair("The returns an ", "An "),
                                                             new Pair("The return the ", "The "),
                                                             new Pair("The returns the ", "The "),
+                                                            new Pair("The return this ", "The "),
+                                                            new Pair("The returns this ", "The "),
                                                             new Pair("The return ", "The "),
                                                             new Pair("The returns ", "The "),
-                                                            new Pair("The a ", "A "),
-                                                            new Pair("The an ", "An "),
-                                                            new Pair("The the ", "The "),
                                                         };
 
         private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Documentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2030_CodeFixProvider)), Shared]
+    public sealed class MiKo_2030_CodeFixProvider : ReturnTypeDocumentationCodeFixProvider
+    {
+        private static readonly Pair[] ReplacementMap =
+                                                        {
+                                                            new Pair("The return a ", "A "),
+                                                            new Pair("The returns a ", "A "),
+                                                            new Pair("The return an ", "An "),
+                                                            new Pair("The returns an ", "An "),
+                                                            new Pair("The return the ", "The "),
+                                                            new Pair("The returns the ", "The "),
+                                                            new Pair("The return ", "The "),
+                                                            new Pair("The returns ", "The "),
+                                                        };
+
+        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
+
+        public override string FixableDiagnosticId => "MiKo_2030";
+
+        protected override Task<SyntaxNode> NonGenericCommentAsync(XmlElementSyntax comment, string memberName, TypeSyntax returnType, Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<SyntaxNode>(GetDefaultComment(comment));
+        }
+
+        protected override Task<SyntaxNode> GenericCommentAsync(XmlElementSyntax comment, string memberName, GenericNameSyntax returnType, Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<SyntaxNode>(GetDefaultComment(comment));
+        }
+
+        private static XmlElementSyntax GetDefaultComment(XmlElementSyntax comment)
+        {
+            var text = comment.GetTextTrimmed();
+
+            if (text.IsNullOrEmpty())
+            {
+                return CommentStartingWith(comment, "The " + Constants.TODO);
+            }
+
+            if (text.StartsWith("If", StringComparison.OrdinalIgnoreCase))
+            {
+                // we cannot fix that
+                return comment;
+            }
+
+            var fixedComment = CommentStartingWith(comment, "The ");
+
+            if (text.StartsWith("Return", StringComparison.OrdinalIgnoreCase))
+            {
+                // we have to remove the first word
+                return Comment(fixedComment, ReplacementMapKeys, ReplacementMap);
+            }
+
+            return fixedComment;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
@@ -22,6 +22,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("The returns the ", "The "),
                                                             new Pair("The return ", "The "),
                                                             new Pair("The returns ", "The "),
+                                                            new Pair("The a ", "A "),
+                                                            new Pair("The an ", "An "),
+                                                            new Pair("The the ", "The "),
                                                         };
 
         private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
@@ -53,15 +56,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return comment;
             }
 
-            var fixedComment = CommentStartingWith(comment, "The ");
+            var preparedComment = CommentStartingWith(comment, "The ");
 
-            if (text.StartsWith("Return", StringComparison.OrdinalIgnoreCase))
-            {
-                // we have to remove the first word
-                return Comment(fixedComment, ReplacementMapKeys, ReplacementMap);
-            }
-
-            return fixedComment;
+            return Comment(preparedComment, ReplacementMapKeys, ReplacementMap);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_CodeFixProvider.cs
@@ -28,17 +28,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override Task<SyntaxNode> NonGenericCommentAsync(XmlElementSyntax comment, string memberName, TypeSyntax returnType, Document document, CancellationToken cancellationToken)
         {
-            return WithDefaultCommentAsync(comment, returnType, document, cancellationToken);
+            return GetDefaultCommentAsync(comment, returnType, document, cancellationToken);
         }
 
         protected override Task<SyntaxNode> GenericCommentAsync(XmlElementSyntax comment, string memberName, GenericNameSyntax returnType, Document document, CancellationToken cancellationToken)
         {
-            return WithDefaultCommentAsync(comment, returnType, document, cancellationToken);
+            return GetDefaultCommentAsync(comment, returnType, document, cancellationToken);
         }
 
         protected abstract Task<XmlNodeSyntax[]> GetDefaultCommentAsync(TypeSyntax returnType, Document document, CancellationToken cancellationToken);
 
-        private async Task<SyntaxNode> WithDefaultCommentAsync(XmlElementSyntax comment, TypeSyntax returnType, Document document, CancellationToken cancellationToken)
+        private async Task<SyntaxNode> GetDefaultCommentAsync(XmlElementSyntax comment, TypeSyntax returnType, Document document, CancellationToken cancellationToken)
         {
             var texts = await GetDefaultCommentAsync(returnType, document, cancellationToken).ConfigureAwait(false);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using NUnit.Framework;
@@ -116,8 +117,97 @@ public class TestMe
 }
 ");
 
+        [Test]
+        public void Code_gets_fixed_for_empty_returns_on_same_line()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <returns></returns>
+    public object DoSomething(object o) { }
+}";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <returns>
+    /// The TODO
+    /// </returns>
+    public object DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_is_not_fixed_for_returns_starting_with_If()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    /// <summary />
+    /// <returns>
+    /// If something.
+    /// </returns>
+    public object DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(OriginalCode, OriginalCode);
+        }
+
+        [TestCase("Something.", "The something.")]
+        public void Code_gets_fixed_for_returns_(string originalText, string fixedText)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary />
+    /// <returns>
+    /// ###
+    /// </returns>
+    public object DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
+        [TestCase("return a something.", "A something.")]
+        [TestCase("Return a something.", "A something.")]
+        [TestCase("return an item.", "An item.")]
+        [TestCase("Return an item.", "An item.")]
+        [TestCase("return something.", "The something.")]
+        [TestCase("Return something.", "The something.")]
+        [TestCase("return the something.", "The something.")]
+        [TestCase("Return the something.", "The something.")]
+        [TestCase("returns a something.", "A something.")]
+        [TestCase("Returns a something.", "A something.")]
+        [TestCase("returns an item.", "An item.")]
+        [TestCase("Returns an item.", "An item.")]
+        [TestCase("returns something.", "The something.")]
+        [TestCase("Returns something.", "The something.")]
+        [TestCase("returns the something.", "The something.")]
+        [TestCase("Returns the something.", "The something.")]
+        public void Code_gets_fixed_for_returns_starting_with_Returns_(string originalText, string fixedText)
+        {
+            const string Template = @"
+public class TestMe
+{
+    /// <summary />
+    /// <returns>
+    /// ###
+    /// </returns>
+    public object DoSomething(object o) { }
+}";
+
+            VerifyCSharpFix(Template.Replace("###", originalText), Template.Replace("###", fixedText));
+        }
+
         protected override string GetDiagnosticId() => MiKo_2030_ReturnTypeDefaultPhraseAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_2030_ReturnTypeDefaultPhraseAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_2030_CodeFixProvider();
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -158,6 +158,9 @@ public class TestMe
         }
 
         [TestCase("Something.", "The something.")]
+        [TestCase("a something.", "A something.")]
+        [TestCase("an something.", "An something.")]
+        [TestCase("the something.", "The something.")]
         public void Code_gets_fixed_for_returns_(string originalText, string fixedText)
         {
             const string Template = @"

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2030_ReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -161,6 +161,17 @@ public class TestMe
         [TestCase("a something.", "A something.")]
         [TestCase("an something.", "An something.")]
         [TestCase("the something.", "The something.")]
+        [TestCase("this something.", "The something.")]
+        [TestCase("Always something.", "The something.")]
+        [TestCase("Always a something.", "A something.")]
+        [TestCase("Always an something.", "An something.")]
+        [TestCase("Always the something.", "The something.")]
+        [TestCase("always this something.", "The something.")]
+        [TestCase("always something.", "The something.")]
+        [TestCase("always a something.", "A something.")]
+        [TestCase("always an something.", "An something.")]
+        [TestCase("always the something.", "The something.")]
+        [TestCase("always this something.", "The something.")]
         public void Code_gets_fixed_for_returns_(string originalText, string fixedText)
         {
             const string Template = @"
@@ -184,6 +195,8 @@ public class TestMe
         [TestCase("Return something.", "The something.")]
         [TestCase("return the something.", "The something.")]
         [TestCase("Return the something.", "The something.")]
+        [TestCase("return this something.", "The something.")]
+        [TestCase("Return this something.", "The something.")]
         [TestCase("returns a something.", "A something.")]
         [TestCase("Returns a something.", "A something.")]
         [TestCase("returns an item.", "An item.")]
@@ -192,6 +205,8 @@ public class TestMe
         [TestCase("Returns something.", "The something.")]
         [TestCase("returns the something.", "The something.")]
         [TestCase("Returns the something.", "The something.")]
+        [TestCase("returns this something.", "The something.")]
+        [TestCase("Returns this something.", "The something.")]
         public void Code_gets_fixed_for_returns_starting_with_Returns_(string originalText, string fixedText)
         {
             const string Template = @"

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The following tables list all the 553 rules that are currently provided by the a
 |[MiKo_2027](/Documentation/MiKo_2027.md)|Document serialization constructor parameters with specific phrase|&#x2713;|&#x2713;|
 |[MiKo_2028](/Documentation/MiKo_2028.md)|Provide more information than just parameter name in documentation|&#x2713;|\-|
 |[MiKo_2029](/Documentation/MiKo_2029.md)|Do not use self-referencing 'cref' in &lt;inheritdoc&gt; documentation|&#x2713;|&#x2713;|
-|[MiKo_2030](/Documentation/MiKo_2030.md)|Start return value documentation with default phrase|&#x2713;|\-|
+|[MiKo_2030](/Documentation/MiKo_2030.md)|Start return value documentation with default phrase|&#x2713;|&#x2713;|
 |[MiKo_2031](/Documentation/MiKo_2031.md)|Use specific (starting) phrase for Task return value documentation|&#x2713;|&#x2713;|
 |[MiKo_2032](/Documentation/MiKo_2032.md)|Use specific phrase for Boolean return value documentation|&#x2713;|&#x2713;|
 |[MiKo_2033](/Documentation/MiKo_2033.md)|Start String return value documentation with default phrase|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Introduce `MiKo_2030_CodeFixProvider` to ensure return value documentation starts with a default phrase

- Update resources and `README.md`

- Add unit tests

- Rename method in `MiKo_2036_CodeFixProvider.cs` for consistency (`WithDefaultCommentAsync` -> `GetDefaultCommentAsync`)

(resolves #1938)