### PR TITLE
Consolidated MiKo_1044's "ShallAnalyze" method with parent

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1044_CommandSuffixAnalyzer.cs
@@ -27,15 +27,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override bool ShallAnalyze(IMethodSymbol symbol)
         {
-            if (symbol is null)
+            if (base.ShallAnalyze(symbol) is false)
             {
-                // code seems to be obfuscated or contains no valid symbol, so ignore it silently
-                return false;
-            }
-
-            if (symbol.AssociatedSymbol is IPropertySymbol)
-            {
-                // ignore property getters or setters as they are already reported
                 return false;
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/NamingAnalyzer.cs
@@ -529,12 +529,12 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 return false;
             }
 
-            if (symbol.CanBeReferencedByName is false)
+            if (symbol.IsOverride)
             {
                 return false;
             }
 
-            if (symbol.IsOverride)
+            if (symbol.CanBeReferencedByName is false)
             {
                 return false;
             }


### PR DESCRIPTION
- Refactor `ShallAnalyze` method in `MiKo_1044_CommandSuffixAnalyzer` to leverage the base implementation for early exits

- Reorder condition checks in `NamingAnalyzer.ShallAnalyze` to evaluate `symbol.IsOverride` before `symbol.CanBeReferencedByName` to slightly improve performance