### PR TITLE
WithoutNumberSuffix now recognizes '_' between numbers and removes that as well

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -3925,7 +3925,9 @@ namespace MiKoSolutions.Analyzers
 
             while (end >= 0)
             {
-                if (value[end].IsNumber())
+                var c = value[end];
+
+                if (c.IsNumber() || c is '_')
                 {
                     end--;
                 }
@@ -3937,9 +3939,13 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            return end >= 0 && end <= totalLength
-                   ? value.Substring(0, end)
-                   : value;
+            if (end < 0)
+            {
+                // everything seems to be a number
+                return string.Empty;
+            }
+
+            return end <= totalLength ? value.Substring(0, end) : value;
         }
 
         /// <summary>
@@ -3963,7 +3969,9 @@ namespace MiKoSolutions.Analyzers
 
             while (end >= 0)
             {
-                if (value[end].IsNumber())
+                var c = value[end];
+
+                if (c.IsNumber() || c is '_')
                 {
                     end--;
                 }
@@ -3975,9 +3983,13 @@ namespace MiKoSolutions.Analyzers
                 }
             }
 
-            return end >= 0 && end <= totalLength
-                   ? value.Slice(0, end)
-                   : value;
+            if (end < 0)
+            {
+                // everything seems to be a number
+                return ReadOnlySpan<char>.Empty;
+            }
+
+            return end <= totalLength ? value.Slice(0, end) : value;
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -349,7 +349,24 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("abc42", ExpectedResult = "abc")]
         [TestCase("a1bc", ExpectedResult = "a1bc")]
         [TestCase("a1bc42", ExpectedResult = "a1bc")]
-        public static string WithoutNumberSuffix_returns_text_without_number_suffix_(string input) => input.WithoutNumberSuffix();
+        [TestCase("a1bc_42", ExpectedResult = "a1bc")]
+        [TestCase("a1bc_4_2", ExpectedResult = "a1bc")]
+        [TestCase("_4_2", ExpectedResult = "")]
+        public static string WithoutNumberSuffix_String_returns_text_without_number_suffix_(string input) => input.WithoutNumberSuffix();
+
+        [TestCase("", ExpectedResult = "")]
+        [TestCase("a", ExpectedResult = "a")]
+        [TestCase("a1", ExpectedResult = "a")]
+        [TestCase("ab", ExpectedResult = "ab")]
+        [TestCase("ab1", ExpectedResult = "ab")]
+        [TestCase("abc", ExpectedResult = "abc")]
+        [TestCase("abc42", ExpectedResult = "abc")]
+        [TestCase("a1bc", ExpectedResult = "a1bc")]
+        [TestCase("a1bc42", ExpectedResult = "a1bc")]
+        [TestCase("a1bc_42", ExpectedResult = "a1bc")]
+        [TestCase("a1bc_4_2", ExpectedResult = "a1bc")]
+        [TestCase("_4_2", ExpectedResult = "")]
+        public static string WithoutNumberSuffix_ReadOnlySpan_returns_text_without_number_suffix_(string input) => input.AsSpan().WithoutNumberSuffix().ToString();
 
         [Test]
         public static void WordsAsSpan_returns_words_in_method_name() => Assert.That("GetHashCode".WordsAsSpan().Select(_ => _.ToString()), Is.EquivalentTo(["Get", "Hash", "Code"]));


### PR DESCRIPTION
e.g. `V_1_2` becomes `V`