### PR TITLE
Refactor underscore and spaces

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -41,6 +41,7 @@ namespace MiKoSolutions.Analyzers
         internal const string TODO = "TODO";
 
         internal const char Underscore = '_';
+        internal const char Space = ' ';
 
         internal const string CSharpFileExtension = ".cs";
 
@@ -49,7 +50,7 @@ namespace MiKoSolutions.Analyzers
         internal static readonly char[] TrailingSentenceMarkers = " \t.?!;:,".ToCharArray();
 
         internal static readonly string[] WhiteSpaces = { " ", "\t", "\r", "\n" };
-        internal static readonly char[] WhiteSpaceCharacters = { ' ', '\t', '\r', '\n' };
+        internal static readonly char[] WhiteSpaceCharacters = { Space, '\t', '\r', '\n' };
 
         internal static readonly string[] ParaTags = { "<para>", "<para />", "<para/>", "</para>" };
 
@@ -338,7 +339,7 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] MultiWhitespaceStrings = { "    ", "   ", "  " };
 
-            internal static readonly char[] Delimiters = { ' ', '.', ',', ';', ':', '!', '?', ')', ']', '>', '}' };
+            internal static readonly char[] Delimiters = { Space, '.', ',', ';', ':', '!', '?', ')', ']', '>', '}' };
             internal static readonly string[] UnusedPhrase = { "Unused.", "Unused", "This parameter is not used.", "This parameter is not used" };
             internal static readonly string[] FuturePhrase = { "Reserved for future usage.", "Reserved for future usage", "Reserved.", "Reserved", "future", };
 

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -42,6 +42,7 @@ namespace MiKoSolutions.Analyzers
 
         internal const char Underscore = '_';
         internal const char Space = ' ';
+        internal const string SingleSpace = " ";
 
         internal const string CSharpFileExtension = ".cs";
 
@@ -49,7 +50,7 @@ namespace MiKoSolutions.Analyzers
         internal static readonly char[] SentenceClauseMarkers = ",;".ToCharArray();
         internal static readonly char[] TrailingSentenceMarkers = " \t.?!;:,".ToCharArray();
 
-        internal static readonly string[] WhiteSpaces = { " ", "\t", "\r", "\n" };
+        internal static readonly string[] WhiteSpaces = { SingleSpace, "\t", "\r", "\n" };
         internal static readonly char[] WhiteSpaceCharacters = { Space, '\t', '\r', '\n' };
 
         internal static readonly string[] ParaTags = { "<para>", "<para />", "<para/>", "</para>" };
@@ -241,7 +242,7 @@ namespace MiKoSolutions.Analyzers
             internal const string ByteArrayReturnTypeStartingPhraseA = "A byte array containing ";
             internal const string ByteArrayReturnTypeStartingPhraseALowerCase = "a byte array containing ";
             internal const string Asynchronously = "Asynchronously";
-            internal const string AsynchronouslyStartingPhrase = Asynchronously + " ";
+            internal const string AsynchronouslyStartingPhrase = Asynchronously + SingleSpace;
             internal const string BooleanParameterEndingPhraseTemplate = "; otherwise, {0}.";
             internal const string BooleanParameterStartingPhraseTemplate = "{0} to ";
             internal const string BooleanReturnTypeEndingPhraseTemplate = "; otherwise, {0}.";
@@ -324,7 +325,7 @@ namespace MiKoSolutions.Analyzers
             internal const string ValueConverterSummaryStartingPhrase = "Represents a converter that converts ";
             internal const string ValuePhrase = "Value";
             internal const string MeaningPhrase = "Meaning";
-            internal const string ValueMeaningPhrase = ValuePhrase + " " + MeaningPhrase;
+            internal const string ValueMeaningPhrase = ValuePhrase + SingleSpace + MeaningPhrase;
             internal const string LessThanZero = "Less than zero";
             internal const string Zero = "Zero";
             internal const string GreaterThanZero = "Greater than zero";
@@ -335,9 +336,14 @@ namespace MiKoSolutions.Analyzers
             internal const string XmlElementStartingTag = "<";
             internal const char XmlElementStartingTagChar = '<';
 
-            internal const string SingleWhitespaceString = " ";
+            internal const string SingleWhitespaceString = SingleSpace;
 
-            internal static readonly string[] MultiWhitespaceStrings = { "    ", "   ", "  " };
+            internal static readonly string[] MultiWhitespaceStrings =
+                                                                       {
+                                                                           SingleSpace + SingleSpace + SingleSpace + SingleSpace,
+                                                                           SingleSpace + SingleSpace + SingleSpace,
+                                                                           SingleSpace + SingleSpace,
+                                                                       };
 
             internal static readonly char[] Delimiters = { Space, '.', ',', ';', ':', '!', '?', ')', ']', '>', '}' };
             internal static readonly string[] UnusedPhrase = { "Unused.", "Unused", "This parameter is not used.", "This parameter is not used" };
@@ -883,10 +889,10 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly string[] ExceptionCtorExceptionParamPhrase =
                                                                                   {
-                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(" ", @"<paramref name=""innerException""/>", @"<see langword=""null""/>", "<b>catch</b>"),
-                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(" ", @"<paramref name=""innerException"" />", @"<see langword=""null"" />", "<b>catch</b>"),
-                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(" ", @"<paramref name=""innerException"" />", @"<see langword=""null""/>", "<b>catch</b>"),
-                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(" ", @"<paramref name=""innerException""/>", @"<see langword=""null"" />", "<b>catch</b>"),
+                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(SingleSpace, @"<paramref name=""innerException""/>", @"<see langword=""null""/>", "<b>catch</b>"),
+                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(SingleSpace, @"<paramref name=""innerException"" />", @"<see langword=""null"" />", "<b>catch</b>"),
+                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(SingleSpace, @"<paramref name=""innerException"" />", @"<see langword=""null""/>", "<b>catch</b>"),
+                                                                                      ExceptionCtorExceptionParamPhraseTemplate.FormatWith(SingleSpace, @"<paramref name=""innerException""/>", @"<see langword=""null"" />", "<b>catch</b>"),
                                                                                   };
 
             internal static readonly string[] FactoryCreateMethodSummaryStartingPhrase =

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -134,7 +134,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     // get next word (separated by '_', or by ' ' for sentences)
                     var nextWordStartIndex = phraseEndIndex + 1;
-                    var nextWordEndIndex = value.IndexOf('_', ' ', nextWordStartIndex) - 1;
+                    var nextWordEndIndex = value.IndexOf(Constants.Underscore, Constants.Space, nextWordStartIndex) - 1;
 
                     if (nextWordEndIndex > 0)
                     {
@@ -1468,7 +1468,7 @@ namespace MiKoSolutions.Analyzers
         /// </param>
         private static void TrimLeadingSpacesTo(this StringBuilder value, in int count)
         {
-            if (value[0] is ' ')
+            if (value[0] is Constants.Space)
             {
                 var whitespaces = value.CountLeadingWhitespaces();
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -3822,7 +3822,7 @@ namespace MiKoSolutions.Analyzers
                 if (firstSpace < 0)
                 {
                     // might happen if the text contains a <see> or some other XML element as second word; therefore we only return a space
-                    return " ".AsSpan();
+                    return Constants.SingleSpace.AsSpan();
                 }
 
                 return text.Slice(firstSpace);

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -113,9 +113,9 @@ namespace MiKoSolutions.Analyzers
             if (adjustment.HasSet(FirstWordAdjustment.KeepSingleLeadingSpace))
             {
                 // only keep it if there is already a leading space (otherwise it may be on the same line without any leading space, and we would fix it in a wrong way)
-                if (value.StartsWith(' '))
+                if (value.StartsWith(Constants.Space))
                 {
-                    return ' '.ConcatenatedWith(word, continuation);
+                    return Constants.Space.ConcatenatedWith(word, continuation);
                 }
             }
 
@@ -2093,7 +2093,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var c = text[index];
 
-                    if (c.IsUpperCase() || (c is '_' && index > 2))
+                    if (c.IsUpperCase() || (c is Constants.Underscore && index > 2))
                     {
                         return text.Slice(0, index);
                     }
@@ -2451,7 +2451,7 @@ namespace MiKoSolutions.Analyzers
 
             const string Separator = ", ";
 
-            var separatorForLast = ' '.ConcatenatedWith(lastSeparator, ' ');
+            var separatorForLast = Constants.Space.ConcatenatedWith(lastSeparator, Constants.Space);
 
             switch (count)
             {
@@ -3069,14 +3069,14 @@ namespace MiKoSolutions.Analyzers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsWhiteSpace(this in char value)
         {
-            if (value > ' ')
+            if (value > Constants.Space)
             {
                 return value >= 127 && char.IsWhiteSpace(value);
             }
 
             switch (value)
             {
-                case ' ':
+                case Constants.Space:
                 case '\t':
                 case '\r':
                 case '\n':
@@ -3730,7 +3730,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var value = values[valuesIndex];
 
-                    result[resultIndex++] = ' '.ConcatenatedWith(value, delimiter);
+                    result[resultIndex++] = Constants.Space.ConcatenatedWith(value, delimiter);
                     result[resultIndex++] = '('.ConcatenatedWith(value, delimiter);
                 }
             }
@@ -3837,7 +3837,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var c = text[index];
 
-                    if (c.IsUpperCase() || (c is '_' && index > 2))
+                    if (c.IsUpperCase() || (c is Constants.Underscore && index > 2))
                     {
                         return text.Slice(index);
                     }
@@ -3882,9 +3882,9 @@ namespace MiKoSolutions.Analyzers
             {
                 var word = words[index];
 
-                if (word.Contains(' '))
+                if (word.Contains(Constants.Space))
                 {
-                    foreach (var partialWord in word.Split(' '))
+                    foreach (var partialWord in word.Split(Constants.Space))
                     {
                         if (text.FirstWord().Equals(partialWord, StringComparison.OrdinalIgnoreCase))
                         {
@@ -3927,7 +3927,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var c = value[end];
 
-                if (c.IsNumber() || c is '_')
+                if (c.IsNumber() || c is Constants.Underscore)
                 {
                     end--;
                 }
@@ -3971,7 +3971,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var c = value[end];
 
-                if (c.IsNumber() || c is '_')
+                if (c.IsNumber() || c is Constants.Underscore)
                 {
                     end--;
                 }

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -847,7 +847,7 @@ namespace MiKoSolutions.Analyzers
                     {
                         var returnType = method.ReturnType.MinimalTypeName();
 
-                        sb.Append(returnType).Append(' ').Append(method.Name);
+                        sb.Append(returnType).Append(Constants.Space).Append(method.Name);
 
                         if (method.IsGenericMethod)
                         {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -24,7 +24,7 @@ namespace MiKoSolutions.Analyzers
         /// <summary>
         /// The XML comment exterior trivia with a trailing space, used for formatting XML documentation comments.
         /// </summary>
-        internal static readonly SyntaxTrivia XmlCommentExterior = SyntaxFactory.DocumentationCommentExterior(Constants.Comments.XmlCommentExterior + " ");
+        internal static readonly SyntaxTrivia XmlCommentExterior = SyntaxFactory.DocumentationCommentExterior(Constants.Comments.XmlCommentExterior + Constants.SingleSpace);
 
         /// <summary>
         /// Contains the standard XML comment start sequence consisting of an elastic carriage return line feed followed by the XML comment exterior trivia.
@@ -2225,7 +2225,7 @@ namespace MiKoSolutions.Analyzers
                     continue;
                 }
 
-                var space = i is 0 ? string.Empty : " ";
+                var space = i is 0 ? string.Empty : Constants.SingleSpace;
 
                 // replace 3rd person word by infinite word if configured
                 var continuation = originalText.AdjustFirstWord(firstWordAdjustment);

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
@@ -1519,6 +1519,6 @@ namespace MiKoSolutions.Analyzers
         /// A syntax trivia consisting of the specified number of spaces.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(' ', count));
+        private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(Constants.Space, count));
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -1150,6 +1150,6 @@ namespace MiKoSolutions.Analyzers
         /// A syntax trivia representing the specified number of white spaces.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(' ', count));
+        private static SyntaxTrivia WhiteSpaces(in int count) => SyntaxFactory.Whitespace(new string(Constants.Space, count));
     }
 }

--- a/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
@@ -146,7 +146,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                 case '{': return "CLOSING_BRACE";
                 case '<': return "OPENING_CHEVRON";
                 case '>': return "CLOSING_CHEVRON";
-                case ' ': return "SPACE";
+                case Constants.Space: return "SPACE";
                 case '.': return "DOT";
                 case '?': return "QUESTION_MARK";
                 case '!': return "EXCLAMATION_MARK";

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -1695,7 +1695,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var length = commentEndNodes.Length;
 
             // add a white space at the end of the comment in case we have further texts
-            if (length > 1 && commentEnd.Length > 0 && commentEnd[commentEnd.Length - 1] != ' ')
+            if (length > 1 && commentEnd.Length > 0 && commentEnd[commentEnd.Length - 1] != Constants.Space)
             {
                 commentEnd += " ";
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -1697,7 +1697,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // add a white space at the end of the comment in case we have further texts
             if (length > 1 && commentEnd.Length > 0 && commentEnd[commentEnd.Length - 1] != Constants.Space)
             {
-                commentEnd += " ";
+                commentEnd += Constants.SingleSpace;
             }
 
             if (commentEndNodes.FirstOrDefault() is XmlTextSyntax text)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -240,17 +240,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var c in conditions)
                 {
-                    var phrase = string.Concat(v, " ", c, " ");
+                    var phrase = string.Concat(v, Constants.SingleSpace, c, Constants.SingleSpace);
 
                     foreach (var s in starts)
                     {
-                        var phrase0 = string.Concat(s, " ", phrase);
+                        var phrase0 = string.Concat(s, Constants.SingleSpace, phrase);
 
                         foreach (var p in parts)
                         {
-                            var part = p + " ";
+                            var part = p + Constants.SingleSpace;
 
-                            var phrase1 = string.Concat(s, " ", part, phrase);
+                            var phrase1 = string.Concat(s, Constants.SingleSpace, part, phrase);
                             var phrase2 = phrase1 + part;
                             var phrase3 = phrase0 + part;
 
@@ -288,8 +288,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var c in rawConditions)
                 {
-                    var phrase = string.Concat(sp, " ", c, " ");
-                    var upperCasePhrase = string.Concat(up, " ", c, " ");
+                    var phrase = string.Concat(sp, Constants.SingleSpace, c, Constants.SingleSpace);
+                    var upperCasePhrase = string.Concat(up, Constants.SingleSpace, c, Constants.SingleSpace);
 
                     yield return phrase + "the ";
                     yield return phrase;
@@ -301,7 +301,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var c in conditions)
             {
-                var phrase = c + " ";
+                var phrase = c + Constants.SingleSpace;
 
                 yield return phrase + "the ";
                 yield return phrase;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ExceptionDocumentationCodeFixProvider.cs
@@ -148,7 +148,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static IEnumerable<string> GetParameterAsTextReference(string parameterName) => Constants.TrailingSentenceMarkers.Select(_ => ' '.ConcatenatedWith(parameterName, _));
+        private static IEnumerable<string> GetParameterAsTextReference(string parameterName) => Constants.TrailingSentenceMarkers.Select(_ => Constants.Space.ConcatenatedWith(parameterName, _));
 
         private static string GetParameterAsReference(string parameterName) => parameterName.SurroundedWithDoubleQuote();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var verb in verbs)
             {
-                results.Add(string.Concat(verb.ToUpperCaseAt(0), " "));
+                results.Add(string.Concat(verb.ToUpperCaseAt(0), Constants.SingleSpace));
 
                 foreach (var adverb in adverbs)
                 {
@@ -77,7 +77,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     foreach (var start in starts)
                     {
-                        results.Add(string.Concat(start, " ", end, " "));
+                        results.Add(string.Concat(start, Constants.SingleSpace, end, Constants.SingleSpace));
                     }
                 }
             }
@@ -98,11 +98,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var midTerm in midTerms)
                 {
-                    var begin = string.Concat(start, " ", midTerm, " ");
+                    var begin = string.Concat(start, Constants.SingleSpace, midTerm, Constants.SingleSpace);
 
                     foreach (var verb in verbsInfinite)
                     {
-                        results.Add(string.Concat(begin, verb, " "));
+                        results.Add(string.Concat(begin, verb, Constants.SingleSpace));
                     }
                 }
             }
@@ -113,7 +113,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var verb in verbsPresent)
                 {
-                    results.Add(string.Concat(start, " ", verb, " "));
+                    results.Add(string.Concat(start, Constants.SingleSpace, verb, Constants.SingleSpace));
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2006_CodeFixProvider.cs
@@ -42,7 +42,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (fieldDeclaration.IsReadOnly())
             {
-                readOnlyMarker = " " + Constants.Comments.FieldIsReadOnly;
+                readOnlyMarker = Constants.SingleSpace + Constants.Comments.FieldIsReadOnly;
             }
 
             var summary = Comment(XmlElement(Constants.XmlTag.Summary), SummaryText[0], SeeCref(type), SummaryText[1] + readOnlyMarker);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -148,7 +148,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                : fixedName.AsSpan();
 
                 var article = ArticleProvider.GetArticleFor(nameSpan, FirstWordAdjustment.StartLowerCase);
-                var continuation = nameSpan.WordsAsSpan().Select(_ => _.Text.ToLowerCaseAt(0)).ConcatenatedWith(" ");
+                var continuation = nameSpan.WordsAsSpan().Select(_ => _.Text.ToLowerCaseAt(0)).ConcatenatedWith(Constants.SingleSpace);
 
                 return Comment(comment, XmlText($"Represents {article}{continuation}."));
             }
@@ -309,11 +309,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var builder = StringBuilderCache.Acquire(startingPhrase.Length + remainingText.Length)
                                             .Append(startingPhrase)
                                             .Append(remainingText.ToLowerCaseAt(0))
-                                            .ReplaceAllWithProbe(GetSetReplacementPhrases, " ");
+                                            .ReplaceAllWithProbe(GetSetReplacementPhrases, Constants.SingleSpace);
 
             builder.ReplaceWithProbe(" only if ", " if ");
             builder.ReplaceWithProbe(" only when ", " when ");
-            builder.ReplaceWithProbe("  ", " ");
+            builder.ReplaceWithProbe(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace);
             builder.ReplaceWithProbe("indicating describes ", "indicating ");
             builder.ReplaceWithProbe("indicating describe ", "indicating ");
             builder.ReplaceWithProbe("indicating specifies ", "indicating ");
@@ -409,7 +409,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             builder.ReplaceWithProbe(" when set to TRUE then ", " whether ");
             builder.ReplaceWithProbe(" when set to TRUE, then ", " whether ");
             builder.ReplaceWithProbe(" only whether ", " whether ");
-            builder.ReplaceWithProbe("  ", " ");
+            builder.ReplaceWithProbe(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace);
 
             var replacedFixedText = builder.ToStringAndRelease();
 
@@ -918,7 +918,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var thirdPersonVerb = thirdPersonStart.ToLowerCaseAt(0);
                 var gerundVerb = gerundVerbs[word].ToLowerCaseAt(0);
 
-                var fix = thirdPersonStart + " ";
+                var fix = thirdPersonStart + Constants.SingleSpace;
 
                 for (var beginningIndex = 0; beginningIndex < beginningsLength; beginningIndex++)
                 {
@@ -927,18 +927,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     for (var middleIndex = 0; middleIndex < middlePartsLength; middleIndex++)
                     {
                         var middle = middleParts[middleIndex];
-                        var start = string.Concat(beginning, " ", middle, " ");
+                        var start = string.Concat(beginning, Constants.SingleSpace, middle, Constants.SingleSpace);
 
-                        yield return new Pair(string.Concat(start, verb, " "), fix);
-                        yield return new Pair(string.Concat(start, thirdPersonVerb, " "), fix);
+                        yield return new Pair(string.Concat(start, verb, Constants.SingleSpace), fix);
+                        yield return new Pair(string.Concat(start, thirdPersonVerb, Constants.SingleSpace), fix);
                     }
 
-                    yield return new Pair(string.Concat(beginning, " to ", noun, " "), fix);
-                    yield return new Pair(string.Concat(beginning, " to ", verb, " "), fix);
+                    yield return new Pair(string.Concat(beginning, " to ", noun, Constants.SingleSpace), fix);
+                    yield return new Pair(string.Concat(beginning, " to ", verb, Constants.SingleSpace), fix);
 
-                    yield return new Pair(string.Concat(beginning, " ", verb, " "), fix);
-                    yield return new Pair(string.Concat(beginning, " ", thirdPersonVerb, " "), fix);
-                    yield return new Pair(string.Concat(beginning, " ", gerundVerb, " "), fix);
+                    yield return new Pair(string.Concat(beginning, Constants.SingleSpace, verb, Constants.SingleSpace), fix);
+                    yield return new Pair(string.Concat(beginning, Constants.SingleSpace, thirdPersonVerb, Constants.SingleSpace), fix);
+                    yield return new Pair(string.Concat(beginning, Constants.SingleSpace, gerundVerb, Constants.SingleSpace), fix);
                 }
             }
 
@@ -978,7 +978,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 for (var middleIndex = 0; middleIndex < middlePartsLength; middleIndex++)
                 {
                     var middle = middleParts[middleIndex];
-                    var start = string.Concat(beginning, " ", middle, " ");
+                    var start = string.Concat(beginning, Constants.SingleSpace, middle, Constants.SingleSpace);
 
                     yield return new Pair(start + "contains ", Provides);
                     yield return new Pair(start + "contain ", Provides);
@@ -1022,15 +1022,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var conditional in conditionals)
                 {
-                    yield return string.Concat(subject, " ", conditional, " used to ");
-                    yield return string.Concat(subject, " ", conditional, " able to ");
-                    yield return string.Concat(subject, " ", conditional, " capable to ");
+                    yield return string.Concat(subject, Constants.SingleSpace, conditional, " used to ");
+                    yield return string.Concat(subject, Constants.SingleSpace, conditional, " able to ");
+                    yield return string.Concat(subject, Constants.SingleSpace, conditional, " capable to ");
                 }
 
                 // ReSharper disable once LoopCanBePartlyConvertedToQuery
                 foreach (var conjunction in conjunctions)
                 {
-                    var beginning = string.Concat(subject, " ", conjunction, " ");
+                    var beginning = string.Concat(subject, Constants.SingleSpace, conjunction, Constants.SingleSpace);
 
                     yield return string.Concat(beginning, "allows to ");
 
@@ -1071,8 +1071,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var setter in sets)
                     {
-                        starts.Add(getter + conjunction + setter + " ");
-                        starts.Add(setter + conjunction + getter + " ");
+                        starts.Add(getter + conjunction + setter + Constants.SingleSpace);
+                        starts.Add(setter + conjunction + getter + Constants.SingleSpace);
                     }
                 }
             }
@@ -1094,7 +1094,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var getter in gets)
                 {
-                    var phrase = getter + " " + continuation;
+                    var phrase = getter + Constants.SingleSpace + continuation;
 
                     yield return phrase;
                     yield return phrase + "about ";
@@ -1102,7 +1102,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var setter in sets)
                 {
-                    var phrase = setter + " " + continuation;
+                    var phrase = setter + Constants.SingleSpace + continuation;
 
                     yield return phrase;
                     yield return phrase + "about ";

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzer.cs
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static HashSet<string> GetSelfSymbolNames(ISymbol symbol)
         {
-            var names = new HashSet<string> { symbol.Name.ConcatenatedWith(' ') };
+            var names = new HashSet<string> { symbol.Name.ConcatenatedWith(Constants.Space) };
 
             switch (symbol)
             {
@@ -86,7 +86,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (interfaces.Length > 0)
                     {
-                        names.AddRange(interfaces.Select(_ => _.Name.ConcatenatedWith(' ')));
+                        names.AddRange(interfaces.Select(_ => _.Name.ConcatenatedWith(Constants.Space)));
                     }
 
                     break;
@@ -100,7 +100,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (interfaces.Length > 0)
                     {
-                        names.AddRange(interfaces.Select(_ => _.Name.ConcatenatedWith(' ')));
+                        names.AddRange(interfaces.Select(_ => _.Name.ConcatenatedWith(Constants.Space)));
                     }
 
                     break;
@@ -202,8 +202,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // safety check to see if we have really a summary XML (for whatever reason that could be null as tested with a real-life project)
             if (summaryXml != null)
             {
-                var startOffset = phrase.StartsWith(' ') ? 1 : 0; // we do not want to underline the first space
-                var endOffset = phrase.EndsWith(' ') ? 1 : 0; // we do not want to underline the last space
+                var startOffset = phrase.StartsWith(Constants.Space) ? 1 : 0; // we do not want to underline the first space
+                var endOffset = phrase.EndsWith(Constants.Space) ? 1 : 0; // we do not want to underline the last space
 
                 // let's find the phrase in the summary XML to report the issue at the correct location
                 foreach (var textToken in summaryXml.GetXmlTextTokens())

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -211,7 +211,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 yield return start + " which describes ";
                 yield return start + " which represents ";
 
-                yield return start + " ";
+                yield return start + Constants.SingleSpace;
 
                 yield return "Gets or sets ";
                 yield return "Gets or Sets ";

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -144,7 +144,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                    .Without("Enum")
                                                    .WithoutAbbreviations()
                                                    .AdjustFirstWord(FirstWordAdjustment.MakePlural)
-                                                   .SeparateWords(' ', FirstWordAdjustment.StartLowerCase);
+                                                   .SeparateWords(Constants.Space, FirstWordAdjustment.StartLowerCase);
                     }
                     else
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -165,7 +165,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var commentEnd = continuation.AsCachedBuilder()
                                                  .Append(startText)
                                                  .Without(ConstructorPhrases)
-                                                 .Append(' ')
+                                                 .Append(Constants.Space)
                                                  .Replace(" for ", " with ")
                                                  .TrimmedEnd()
                                                  .ToStringAndRelease();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -660,7 +660,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var optionalBooleanStart = StringBuilderCache.Acquire(optionalStart.Length + boolean.Length + 1)
                                                                      .Append(optionalStart)
                                                                      .Append(boolean)
-                                                                     .Append(' ')
+                                                                     .Append(Constants.Space)
                                                                      .WithoutMultipleWhiteSpaces()
                                                                      .TrimmedStart()
                                                                      .ToStringAndRelease();
@@ -736,7 +736,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var condition = conditions[conditionIndex];
 
                     // we have lots of loops, so cache data to avoid unnecessary calculations
-                    var end = condition.SurroundedWith(' '); // TODO RKN: Change string creation
+                    var end = condition.SurroundedWith(Constants.Space); // TODO RKN: Change string creation
 
                     // for performance reasons we use for loops here
                     for (var verbIndex = 0; verbIndex < verbsLength; verbIndex++)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -150,12 +150,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     if (shouldBeMatch.Success)
                     {
                         var shouldBeText = shouldBeMatch.Value;
-                        var newTextStart = ReplacementTo + Verbalizer.MakeInfiniteVerb(shouldBeText.ThirdWord()) + " ";
+                        var newTextStart = ReplacementTo + Verbalizer.MakeInfiniteVerb(shouldBeText.ThirdWord()) + Constants.SingleSpace;
 
                         // re-phrase the text to fix it later on
                         var updatedText = textTrimmed.AsCachedBuilder()
                                                      .ReplaceAllWithProbe(data.Map)
-                                                     .Without(" " + shouldBeText)
+                                                     .Without(Constants.SingleSpace + shouldBeText)
                                                      .TrimmedStart()
                                                      .WithoutStarting(Conditionals, StringComparison.OrdinalIgnoreCase)
                                                      .TrimmedStart()
@@ -742,7 +742,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     for (var verbIndex = 0; verbIndex < verbsLength; verbIndex++)
                     {
                         var verb = verbs[verbIndex];
-                        var middle = " " + verb + end; // TODO RKN: Change string creation
+                        var middle = Constants.SingleSpace + verb + end; // TODO RKN: Change string creation
 
                         // for performance reasons we use for loops here
                         for (var startIndex = 0; startIndex < startsCount; startIndex++)
@@ -769,8 +769,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 string[] CreateStartTermsWithOptionals()
                 {
-                    var startTerms = new[] { "A ", "An ", "The ", " " };
-                    var optionals = new[] { "Optional ", "(optional) ", "(Optional) ", "optional ", " " };
+                    var startTerms = new[] { "A ", "An ", "The ", Constants.SingleSpace };
+                    var optionals = new[] { "Optional ", "(optional) ", "(Optional) ", "optional ", Constants.SingleSpace };
 
                     var startTermsLength = startTerms.Length;
                     var optionalsLength = optionals.Length;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2031_CodeFixProvider.cs
@@ -114,7 +114,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             {
                                 if (newText.EndsWith('.') is false)
                                 {
-                                    newText += " "; // add extra space so that next XML syntax node is placed well
+                                    newText += Constants.SingleSpace; // add extra space so that next XML syntax node is placed well
                                 }
                             }
 
@@ -176,7 +176,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var end in ContinueTextParts)
                 {
-                    results.Add(start + " " + end);
+                    results.Add(start + Constants.SingleSpace + end);
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
@@ -156,15 +156,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var boolean in booleans)
                 {
-                    var begin = start + boolean + " ";
+                    var begin = start + boolean + Constants.SingleSpace;
 
                     foreach (var verb in verbs)
                     {
-                        var beginWithVerb = begin + verb + " ";
+                        var beginWithVerb = begin + verb + Constants.SingleSpace;
 
                         foreach (var condition in conditions)
                         {
-                            results.Add(beginWithVerb + condition + " ");
+                            results.Add(beginWithVerb + condition + Constants.SingleSpace);
                         }
                     }
                 }
@@ -172,7 +172,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var condition in conditions)
             {
-                results.Add("Indicates " + condition + " ");
+                results.Add("Indicates " + condition + Constants.SingleSpace);
             }
 
             results.AddRange(booleans);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -193,11 +193,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var middle in middles)
                 {
-                    var beginning = string.Concat(start, middle, " ");
+                    var beginning = string.Concat(start, middle, Constants.SingleSpace);
 
                     foreach (var text in TextParts)
                     {
-                        var beginningText = string.Concat(beginning, text, " ");
+                        var beginningText = string.Concat(beginning, text, Constants.SingleSpace);
 
                         yield return beginningText;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -74,7 +74,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
                     var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
-                    var startText = switchedText.AsCachedBuilder().Insert(0, ' ').TrimmedEnd().ToStringAndRelease();
+                    var startText = switchedText.AsCachedBuilder().Insert(0, Constants.Space).TrimmedEnd().ToStringAndRelease();
 
                     var updatedContents = contents.Remove(t);
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2034_CodeFixProvider.cs
@@ -73,7 +73,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     // get rid of the unwanted phrases and switch text parts
                     var parts = text.SplitBy(UnwantedResultTexts, options: StringSplitOptions.RemoveEmptyEntries);
-                    var switchedText = parts.ConcatenatedWith(" ").AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
+                    var switchedText = parts.ConcatenatedWith(Constants.SingleSpace).AdjustFirstWord(FirstWordAdjustment.StartLowerCase);
                     var startText = switchedText.AsCachedBuilder().Insert(0, Constants.Space).TrimmedEnd().ToStringAndRelease();
 
                     var updatedContents = contents.Remove(t);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -176,7 +176,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     var text = typeName.AsCachedBuilder()
                                        .AdjustFirstWord(FirstWordAdjustment.MakePlural)
-                                       .SeparateWords(' ', FirstWordAdjustment.StartLowerCase)
+                                       .SeparateWords(Constants.Space, FirstWordAdjustment.StartLowerCase)
                                        .ToStringAndRelease();
 
                     if (text.Length > 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -181,7 +181,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (text.Length > 0)
                     {
-                        startingPhrase = startingPhrase + text + " " + Constants.Comments.ThatContainsTerm + " ";
+                        startingPhrase = startingPhrase + text + Constants.SingleSpace + Constants.Comments.ThatContainsTerm + Constants.SingleSpace;
                     }
                 }
             }
@@ -402,31 +402,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var preposition in prepositions)
                     {
-                        var phrase = string.Concat(collection, " ", preposition, " ");
+                        var phrase = string.Concat(collection, Constants.SingleSpace, preposition, Constants.SingleSpace);
 
                         yield return phrase;
                         yield return phrase.ToUpperCaseAt(0);
 
                         foreach (var modification in modifications)
                         {
-                            var modificationPhrase = string.Concat(modification, " ", phrase);
+                            var modificationPhrase = string.Concat(modification, Constants.SingleSpace, phrase);
 
                             yield return modificationPhrase;
                             yield return modificationPhrase.ToUpperCaseAt(0);
 
                             foreach (var startingWord in startingWords)
                             {
-                                var shortStartingPhrase = string.Concat(startingWord, " ", collection, " ");
+                                var shortStartingPhrase = string.Concat(startingWord, Constants.SingleSpace, collection, Constants.SingleSpace);
 
                                 yield return shortStartingPhrase;
                                 yield return shortStartingPhrase.ToUpperCaseAt(0);
 
-                                var modifiedStartingPhrase = string.Concat(startingWord, " ", modificationPhrase);
+                                var modifiedStartingPhrase = string.Concat(startingWord, Constants.SingleSpace, modificationPhrase);
 
                                 yield return modifiedStartingPhrase;
                                 yield return modifiedStartingPhrase.ToUpperCaseAt(0);
 
-                                var startingPhrase = string.Concat(startingWord, " ", phrase);
+                                var startingPhrase = string.Concat(startingWord, Constants.SingleSpace, phrase);
 
                                 if (startingPhrase is Constants.Comments.CollectionReturnTypeStartingPhraseLowerCase)
                                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -25,8 +25,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Pair[] CleanupMap =
                                                     {
-                                                        new Pair(" commands for ", " "),
-                                                        new Pair(" command for ", " "),
+                                                        new Pair(" commands for ", Constants.SingleSpace),
+                                                        new Pair(" command for ", Constants.SingleSpace),
                                                         new Pair(" can in ", " can be used in "),
                                                         new Pair(" can with ", " can be used with "),
                                                         new Pair(" can wrapper for ", " can wrap "),
@@ -222,10 +222,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var middle in middleParts)
                 {
-                    results.Add(new Pair(string.Concat(start, " ", middle, " ")));
+                    results.Add(new Pair(string.Concat(start, Constants.SingleSpace, middle, Constants.SingleSpace)));
                 }
 
-                results.Add(new Pair(string.Concat(start, " ")));
+                results.Add(new Pair(string.Concat(start, Constants.SingleSpace)));
             }
 
             results.Add(new Pair("Offers to "));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
@@ -95,8 +95,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         foreach (var end in ends)
                         {
                             results.Add(start.IsNullOrWhiteSpace()
-                                        ? string.Concat(middle.ToUpperCaseAt(0), " ", end)
-                                        : string.Concat(start, preMiddle, " ", middle, " ", end));
+                                        ? string.Concat(middle.ToUpperCaseAt(0), Constants.SingleSpace, end)
+                                        : string.Concat(start, preMiddle, Constants.SingleSpace, middle, Constants.SingleSpace, end));
                         }
                     }
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_LangwordAnalyzer.cs
@@ -112,16 +112,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var phrase = Phrases[i];
                 var proposal = Proposal(phrase);
 
-                results.Add(new Pair('('.ConcatenatedWith(phrase, ' '), '('.ConcatenatedWith(proposal, ' ')));
+                results.Add(new Pair('('.ConcatenatedWith(phrase, Constants.Space), '('.ConcatenatedWith(proposal, Constants.Space)));
                 results.Add(new Pair('('.ConcatenatedWith(phrase, ')'), '('.ConcatenatedWith(proposal, ')')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, ')'), ' '.ConcatenatedWith(proposal, ')')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, ' '), ' '.ConcatenatedWith(proposal, ' ')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, '.'), ' '.ConcatenatedWith(proposal, '.')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, '?'), ' '.ConcatenatedWith(proposal, '?')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, '!'), ' '.ConcatenatedWith(proposal, '!')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, ','), ' '.ConcatenatedWith(proposal, ',')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, ';'), ' '.ConcatenatedWith(proposal, ';')));
-                results.Add(new Pair(' '.ConcatenatedWith(phrase, ':'), ' '.ConcatenatedWith(proposal, ':')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, ')'), Constants.Space.ConcatenatedWith(proposal, ')')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, Constants.Space), Constants.Space.ConcatenatedWith(proposal, Constants.Space)));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, '.'), Constants.Space.ConcatenatedWith(proposal, '.')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, '?'), Constants.Space.ConcatenatedWith(proposal, '?')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, '!'), Constants.Space.ConcatenatedWith(proposal, '!')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, ','), Constants.Space.ConcatenatedWith(proposal, ',')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, ';'), Constants.Space.ConcatenatedWith(proposal, ';')));
+                results.Add(new Pair(Constants.Space.ConcatenatedWith(phrase, ':'), Constants.Space.ConcatenatedWith(proposal, ':')));
                 results.Add(new Pair('\''.ConcatenatedWith(phrase, '\''), proposal));
             }
 
@@ -139,7 +139,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var phrase = Phrases[i];
                 var proposal = Proposal(phrase);
 
-                results[i] = new Pair(' '.ConcatenatedWith(phrase), ' '.ConcatenatedWith(proposal));
+                results[i] = new Pair(Constants.Space.ConcatenatedWith(phrase), Constants.Space.ConcatenatedWith(proposal));
             }
 
             return results;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_CodeFixProvider.cs
@@ -100,7 +100,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var article in articles)
                 {
-                    var start = verb + " " + article + " method ";
+                    var start = verb + Constants.SingleSpace + article + " method ";
 
                     foreach (var action in actions)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2049_WillBePhraseAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private const string WillPhrase = "will";
         private const string NeverPhrase = "never";
-        private const string WillNeverPhrase = WillPhrase + " " + NeverPhrase;
+        private const string WillNeverPhrase = WillPhrase + Constants.SingleSpace + NeverPhrase;
 
         private static readonly string WillPhraseStartUpperCase = WillPhrase.ToUpperCaseAt(0);
         private static readonly string WillNeverPhraseStartUpperCase = WillNeverPhrase.ToUpperCaseAt(0);
@@ -163,8 +163,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
                 }
 
-                issues.AddRange(AnalyzeForSpecialPhrase(token, WillNeverPhraseStartUpperCase, _ => NeverPhraseStartUpperCase + " " + Verbalizer.MakeThirdPersonSingularVerb(_)));
-                issues.AddRange(AnalyzeForSpecialPhrase(token, WillNeverPhrase, _ => NeverPhrase + " " + Verbalizer.MakeThirdPersonSingularVerb(_)));
+                issues.AddRange(AnalyzeForSpecialPhrase(token, WillNeverPhraseStartUpperCase, _ => NeverPhraseStartUpperCase + Constants.SingleSpace + Verbalizer.MakeThirdPersonSingularVerb(_)));
+                issues.AddRange(AnalyzeForSpecialPhrase(token, WillNeverPhrase, _ => NeverPhrase + Constants.SingleSpace + Verbalizer.MakeThirdPersonSingularVerb(_)));
             }
 
             return issues;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -230,7 +230,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var verb in verbs)
                 {
-                    var middle = string.Concat(" ", verb, " ");
+                    var middle = string.Concat(Constants.SingleSpace, verb, Constants.SingleSpace);
 
                     var begin = string.Concat(start, middle);
                     var beginLowerCase = begin.ToLowerCaseAt(0);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -788,7 +788,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     set.Add(" to provide " + continuation);
                     set.Add(" to " + continuation);
 
-                    set.Add(" " + continuation);
+                    set.Add(Constants.SingleSpace + continuation);
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2070_CodeFixProvider.cs
@@ -93,12 +93,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var startText = GetCorrectStartText(summary);
                         var remainingText = valueText.WithoutFirstWord().WithoutFirstWords(BeginningConditions).ToString(); // TODO RKN: Use Span and create a ConcatenatedWith
 
-                        var newText = string.Concat(" ", startText, " ", remainingText);
+                        var newText = string.Concat(Constants.SingleSpace, startText, Constants.SingleSpace, remainingText);
 
                         if (contents.Count > 1 && contents[1].IsKind(SyntaxKind.XmlText) is false)
                         {
                             // we have another non-text, so add a space
-                            newText = newText.TrimEnd() + " ";
+                            newText = newText.TrimEnd() + Constants.SingleSpace;
                         }
 
                         return summary.ReplaceToken(token, token.WithText(newText));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static Pair[] CreateReplacementMap()
         {
-            const string SyncPhrase = Constants.Comments.TryStartingPhrase + " ";
+            const string SyncPhrase = Constants.Comments.TryStartingPhrase + Constants.SingleSpace;
 
             var lowerCasePhrase = SyncPhrase.ToLowerCaseAt(0);
             var asyncPhrase = Constants.Comments.AsynchronouslyStartingPhrase + lowerCasePhrase;
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             foreach (var startingWord in startingWords)
             {
-                var phrase = startingWord + " ";
+                var phrase = startingWord + Constants.SingleSpace;
                 var alternativePhrase = startingWord + " to ";
 
                 result[resultIndex++] = new Pair(phrase, SyncPhrase);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2075_CodeFixProvider : XmlTextDocumentationCodeFixProvider
     {
         private static readonly Pair[] ReplacementMap = Constants.Comments.ActionTerms.Select(_ => new Pair(_, Constants.Comments.CallbackTerm))
-                                                                 .ConcatenatedWith(new Pair(Constants.Comments.CallbackTerm + " " + Constants.Comments.CallbackTerm, Constants.Comments.CallbackTerm))
+                                                                 .ConcatenatedWith(new Pair(Constants.Comments.CallbackTerm + Constants.SingleSpace + Constants.Comments.CallbackTerm, Constants.Comments.CallbackTerm))
                                                                  .ToArray();
 
         public override string FixableDiagnosticId => "MiKo_2075";

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2076_CodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (element.StartTag.IsOnSameLineAs(element.EndTag))
             {
-                startText = XmlText(" " + Constants.Comments.DefaultStartingPhrase);
+                startText = XmlText(Constants.SingleSpace + Constants.Comments.DefaultStartingPhrase);
 
                 // no trailing '///' to add because the text is located on the same line
                 endText = XmlText(".");

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2079_PropertiesDocumentationShouldNotStateObviousAnalyzer.cs
@@ -91,7 +91,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     foreach (var continuation in ContinuationPhrases)
                     {
-                        var phrase = obviousPhrase + " " + continuation;
+                        var phrase = obviousPhrase + Constants.SingleSpace + continuation;
 
                         result.Add(phrase);
                         result.Add(phrase + ".");

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -207,11 +207,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var verb in verbs)
                     {
-                        var begin = start + " " + verb;
+                        var begin = start + Constants.SingleSpace + verb;
 
                         foreach (var continuation in continuations)
                         {
-                            results.Add(begin + continuation + " ");
+                            results.Add(begin + continuation + Constants.SingleSpace);
                         }
                     }
                 }
@@ -220,7 +220,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var continuation in continuations)
                     {
-                        var end = continuation + " ";
+                        var end = continuation + Constants.SingleSpace;
 
                         results.Add(start + " control" + end);
                         results.Add(start + " control," + end);
@@ -235,7 +235,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     {
                         if (continuation.IsNullOrEmpty() is false)
                         {
-                            var end = continuation + " ";
+                            var end = continuation + Constants.SingleSpace;
 
                             results.Add(start + end);
                             results.Add(start + "," + end);
@@ -256,11 +256,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var type in types)
                     {
-                        var begin = start + type + " ";
+                        var begin = start + type + Constants.SingleSpace;
 
                         foreach (var continuation in continuations)
                         {
-                            keys.Add(begin + continuation + " ");
+                            keys.Add(begin + continuation + Constants.SingleSpace);
                         }
                     }
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -97,7 +97,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                         var replacement = enumType.AsCachedBuilder()
                                                   .Without(TypesSuffixes)
-                                                  .SeparateWords(' ', firstWordHandling)
+                                                  .SeparateWords(Constants.Space, firstWordHandling)
                                                   .Without(KindEndings)
                                                   .Insert(0, "The ")
                                                   .Append(isPlural ? " are " : " is ")

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -124,11 +124,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 foreach (var continuation in continuations)
                 {
-                    yield return string.Concat(start, ", ", continuation, " ");
-                    yield return string.Concat(start, " ", continuation, " ");
+                    yield return string.Concat(start, ", ", continuation, Constants.SingleSpace);
+                    yield return string.Concat(start, Constants.SingleSpace, continuation, Constants.SingleSpace);
                 }
 
-                yield return start + " ";
+                yield return start + Constants.SingleSpace;
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] Triggers = Array.Empty<string>()
                                                          .Union(new[] { " -", "--", "---", "*" }.SelectMany(_ => Constants.Comments.Delimiters, (_, delimiter) => delimiter.ConcatenatedWith(_, Constants.Space)))
-                                                         .Union(new[] { "1", "2", "3", "a", "b", "c", "A", "B", "C" }.SelectMany(_ => Delimiters, (_, delimiter) => string.Concat(" ", _, delimiter, " ")))
+                                                         .Union(new[] { "1", "2", "3", "a", "b", "c", "A", "B", "C" }.SelectMany(_ => Delimiters, (_, delimiter) => string.Concat(Constants.SingleSpace, _, delimiter, Constants.SingleSpace)))
                                                          .Union(new[] { " -- ", " --- ", " * ", " ** ", " *** " })
                                                          .ToArray(AscendingStringComparer.Default);
 //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2204_DocumentationShallUseListAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] Delimiters = { ".)", ".", ")", ":" };
 
         private static readonly string[] Triggers = Array.Empty<string>()
-                                                         .Union(new[] { " -", "--", "---", "*" }.SelectMany(_ => Constants.Comments.Delimiters, (_, delimiter) => delimiter.ConcatenatedWith(_, ' ')))
+                                                         .Union(new[] { " -", "--", "---", "*" }.SelectMany(_ => Constants.Comments.Delimiters, (_, delimiter) => delimiter.ConcatenatedWith(_, Constants.Space)))
                                                          .Union(new[] { "1", "2", "3", "a", "b", "c", "A", "B", "C" }.SelectMany(_ => Delimiters, (_, delimiter) => string.Concat(" ", _, delimiter, " ")))
                                                          .Union(new[] { " -- ", " --- ", " * ", " ** ", " *** " })
                                                          .ToArray(AscendingStringComparer.Default);

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2207_SummaryShallBeShortAnalyzer.cs
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var builder = StringBuilderCache.Acquire();
 
             var summary = xml.GetTextWithoutTrivia(builder)
-                             .ReplaceWithProbe(" - ", " ")
+                             .ReplaceWithProbe(" - ", Constants.SingleSpace)
                              .ReplaceWithProbe(" />", "/>")
                              .ReplaceWithProbe(" </", "</")
                              .ReplaceWithProbe("> <", "><")

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2208_CodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 dictionary.Add(phrase + "a ", upperCase ? "A " : "a ");
                 dictionary.Add(phrase + "an ", upperCase ? "An " : "an ");
-                dictionary.Add(phrase, phrase.FirstWord() + " ");
+                dictionary.Add(phrase, phrase.FirstWord() + Constants.SingleSpace);
             }
 
             var map = dictionary.Select(_ => new Pair(_.Key, _.Value)).ToList();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2215_SentencesShallBeShortAnalyzer.cs
@@ -56,7 +56,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 foreach (var syntax in node.DescendantNodes(_ => _.IsCode() is false, true).OfType<XmlTextSyntax>())
                 {
-                    builder.Append(' ').Append(syntax).Append(' ');
+                    builder.Append(Constants.Space).Append(syntax).Append(Constants.Space);
                 }
 
                 var specificComment = builder.WithoutXmlCommentExterior().Trim();

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
@@ -141,7 +141,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var text = StringBuilderCache.Acquire(Constants.Comments.XmlCommentExterior.Length + (2 * tag.Length) + 6 + description.Length)
                                          .Append(Constants.Comments.XmlCommentExterior)
-                                         .Append(' ')
+                                         .Append(Constants.Space)
                                          .Append('<').Append(tag).Append('>')
                                          .Append(description)
                                          .Append('<').Append('/').Append(tag).Append('>')

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2313_CodeFixProvider.cs
@@ -115,7 +115,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (TryFindComments(comments, commentTag, otherFoundCommentTags, out var index, out var count))
             {
-                var phrase = comments.Skip(index + 1).Take(count - 1).ConcatenatedWith(" ");
+                var phrase = comments.Skip(index + 1).Take(count - 1).ConcatenatedWith(Constants.SingleSpace);
 
                 // remove the processed items as we do not need to re-process them
                 comments.RemoveRange(index, count);
@@ -228,7 +228,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
             else
             {
-                var parts = comments.Skip(index + 1).Take(takes).ConcatenatedWith(" ");
+                var parts = comments.Skip(index + 1).Take(takes).ConcatenatedWith(Constants.SingleSpace);
 
                 return new Pair(comments[index].TrimEnd(':'), parts);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -67,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     var replacement = replacementCallback(nextWord.ToString());
 
                     var finalReplacement = adjective.Length > 0
-                                           ? adjective.ConcatenatedWith(' ', replacement.ToLowerCaseAt(0))
+                                           ? adjective.ConcatenatedWith(Constants.Space, replacement.ToLowerCaseAt(0))
                                            : replacement;
 
                     var finalLocation = CreateLocation(token, start, end);
@@ -141,7 +141,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     if (trimmedTerm.Length == term.Length)
                     {
-                        // we could not trim, so we probably will not find it (as we get the terms with a ' ' character at the end
+                        // we could not trim, so we probably will not find it (as we get the terms with a Constants.Space character at the end
                         continue;
                     }
 
@@ -156,7 +156,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         var end = offset + tokenText.Length;
                         var start = end - trimmedTerm.Length;
 
-                        if (trimmedTerm.StartsWith(' '))
+                        if (trimmedTerm.StartsWith(Constants.Space))
                         {
                             start += Offset; // we do not want to underline the first char
                         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/ReturnTypeDocumentationCodeFixProvider.cs
@@ -149,7 +149,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 {
                     foreach (var operation in operations)
                     {
-                        var middle = string.Concat(" ", continuation, " ", operation);
+                        var middle = string.Concat(Constants.SingleSpace, continuation, Constants.SingleSpace, operation);
 
                         foreach (var sentence in sentences)
                         {
@@ -157,7 +157,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                             foreach (var verb in finalVerbs)
                             {
-                                var final = string.Concat(beginning, verb, " ");
+                                var final = string.Concat(beginning, verb, Constants.SingleSpace);
 
                                 results.Add(final);
                                 results.Add(final.ToUpperCaseAt(0));

--- a/MiKo.Analyzer.Shared/Rules/Documentation/XmlTextDocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/XmlTextDocumentationCodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (endingTerm != null && text.EndsWith(endingTerm, StringComparison.OrdinalIgnoreCase))
             {
-                var ending = ' '.ConcatenatedWith(endingTerm);
+                var ending = Constants.Space.ConcatenatedWith(endingTerm);
 
                 if (text.EndsWith(ending, StringComparison.OrdinalIgnoreCase))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -174,7 +174,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     finalText.Add(suffix);
                 }
 
-                return args.WithArguments(arguments.Add(Argument(StringLiteral(finalText.ConcatenatedWith(" ")))));
+                return args.WithArguments(arguments.Add(Argument(StringLiteral(finalText.ConcatenatedWith(Constants.SingleSpace)))));
             }
 
             // let's see if we have the special case 'Is.Not.Null'
@@ -203,7 +203,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     finalText.Add(suffix);
                 }
 
-                return args.WithArguments(arguments.Add(Argument(StringLiteral(finalText.ConcatenatedWith(" ")))));
+                return args.WithArguments(arguments.Add(Argument(StringLiteral(finalText.ConcatenatedWith(Constants.SingleSpace)))));
             }
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/ObjectCreationExpressionMaintainabilityCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/ObjectCreationExpressionMaintainabilityCodeFixProvider.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             foreach (var argument in arguments)
             {
-                if (argument.Contains(' '))
+                if (argument.Contains(Constants.Space))
                 {
                     // textual (string) message
                     return argument;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6041_CodeFixProvider.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                 if (leadingComment.Length > 0)
                 {
-                    var comment = SyntaxFactory.Comment(Constants.Comments.CommentExterior + " " + leadingComment.ConcatenatedWith(" "));
+                    var comment = SyntaxFactory.Comment(Constants.Comments.CommentExterior + Constants.SingleSpace + leadingComment.ConcatenatedWith(Constants.SingleSpace));
 
                     updatedSyntax = updatedSyntax.WithTrailingTrivia(SyntaxFactory.Space, comment, SyntaxFactory.CarriageReturnLineFeed);
                 }


### PR DESCRIPTION
* Replaced hardcoded space (`' '`), underscore (`'_'`), and single-space string (`" "`) literals with the reusable constants `Constants.Space`, `Constants.Underscore`, and `Constants.SingleSpace` throughout the codebase

* Updated string manipulation, concatenation, formatting, whitespace handling, and delimiter logic across multiple files to use these constants

* Improved consistency, readability, and maintainability while eliminating magic characters