### PR TITLE
Added rules MiKo_1534, MiKo_1535 and MiKo_1536 to enforce replacing the `have` prefix with `has` for local variables, parameters, and fields

### DIFF
--- a/Documentation/MiKo_1534.md
+++ b/Documentation/MiKo_1534.md
@@ -1,0 +1,46 @@
+﻿# MiKo_1534: Do not prefix local variables with `have`
+
+## Cause
+
+A local variable is prefixed with `have`.
+
+## Rule description
+
+Local variables that are prefixed with `have` are most likely indicators for boolean values.
+Such a prefix uses the wrong grammatical form - `have` should be `has` when used as a third-person singular indicator.
+Renaming the prefix from `have` to `has` makes the code grammatically correct and easier to read and understand.
+
+### Rationale behind
+
+The word `have` is the first-person or plural form of the verb.
+When used as a prefix on a variable name it reads incorrectly, for example `haveResult` instead of the grammatically correct `hasResult`.
+This small inconsistency adds unnecessary friction when reading the code.
+
+Correcting this prefix provides several important benefits:
+
+- **Grammatical Correctness**:
+  Using `has` instead of `have` produces a name that reads naturally in English.
+  A reader can understand the name immediately without having to mentally correct it.
+
+- **Improved Readability**:
+  A grammatically correct name is easier to read at a glance.
+  It matches the pattern of well-known boolean prefixes such as `is`, `has`, and `can`, which are immediately recognisable as indicators of a boolean value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the local variable so that its prefix changes from `have` to `has`.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1534
+#pragma warning restore MiKo_1534
+```

--- a/Documentation/MiKo_1535.md
+++ b/Documentation/MiKo_1535.md
@@ -1,0 +1,50 @@
+﻿# MiKo_1535: Do not prefix parameters with `have`
+
+## Cause
+
+A parameter is prefixed with `have`.
+
+## Rule description
+
+Parameters that are prefixed with `have` are most likely indicators for boolean values.
+Such a prefix uses the wrong grammatical form - `have` should be `has` when used as a third-person singular indicator.
+Renaming the prefix from `have` to `has` makes the code grammatically correct and easier to read and understand.
+
+### Rationale behind
+
+The word `have` is the first-person or plural form of the verb.
+When used as a prefix on a parameter name it reads incorrectly, for example `haveResult` instead of the grammatically correct `hasResult`.
+This small inconsistency adds unnecessary friction when reading the code.
+
+Correcting this prefix provides several important benefits:
+
+- **Grammatical Correctness**:
+  Using `has` instead of `have` produces a name that reads naturally in English.
+  A reader can understand the name immediately without having to mentally correct it.
+
+- **Improved Readability**:
+  A grammatically correct name is easier to read at a glance.
+  It matches the pattern of well-known boolean prefixes such as `is`, `has`, and `can`, which are immediately recognisable as indicators of a boolean value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Better API Communication**:
+  Parameter names are part of the contract of a method.
+  Clear names make it easy to see what value to pass without having to read the method body or documentation.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the parameter so that its prefix changes from `have` to `has`.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1535
+#pragma warning restore MiKo_1535
+```

--- a/Documentation/MiKo_1536.md
+++ b/Documentation/MiKo_1536.md
@@ -1,0 +1,53 @@
+﻿# MiKo_1536: Do not prefix fields with `have`
+
+## Cause
+
+A field is prefixed with `have`.
+
+## Rule description
+
+Fields that are prefixed with `have` are most likely indicators for boolean values.
+Such a prefix uses the wrong grammatical form - `have` should be `has` when used as a third-person singular indicator.
+Renaming the prefix from `have` to `has` makes the code grammatically correct and easier to read and understand.
+
+### Rationale behind
+
+The word `have` is the first-person or plural form of the verb.
+When used as a prefix on a field name it reads incorrectly, for example `haveResult` instead of the grammatically correct `hasResult`.
+This small inconsistency adds unnecessary friction when reading the code.
+
+Fields are often used in many places within a class, so a confusing name can cause problems throughout the whole type.
+A clear name makes it easy to see right away what state the field holds.
+
+Correcting this prefix provides several important benefits:
+
+- **Grammatical Correctness**:
+  Using `has` instead of `have` produces a name that reads naturally in English.
+  A reader can understand the name immediately without having to mentally correct it.
+
+- **Improved Readability**:
+  A grammatically correct name is easier to read at a glance.
+  It matches the pattern of well-known boolean prefixes such as `is`, `has`, and `can`, which are immediately recognisable as indicators of a boolean value.
+
+- **Consistent Naming Conventions**:
+  Using the same naming style across the codebase makes it easier to read and review code.
+  Names that follow a known pattern are quicker to understand, even in unfamiliar code.
+
+- **Easier Maintenance**:
+  When field names clearly show what they store, it is easier to find and update the related logic when something needs to change.
+  This lowers the risk of introducing bugs during maintenance.
+
+- **Less Mental Effort**:
+  When names are simple and follow a known pattern, less effort is needed to understand them.
+  This leaves more attention for understanding the actual logic.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the field so that its prefix changes from `have` to `has`.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1536
+#pragma warning restore MiKo_1536
+```

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -202,6 +202,8 @@ namespace MiKoSolutions.Analyzers
             internal const string MemberFieldPrefix = "_";
             internal const string AlternativeMemberFieldPrefix = "m_";
 
+            internal const string Have = "Have";
+
             internal static readonly string[] BaseClasses = { "Abstract", "Base" };
             internal static readonly string[] Models = { "Model", "Models", "model", "models" };
             internal static readonly string[] ViewModels = { "ViewModel", "ViewModels", "viewModel", "viewModels" };

--- a/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
         private const string Be = "Be";
         private const string Not = "Not";
         private const string Has = "Has";
-        private const string Have = "Have";
+        private const string Have = Constants.Markers.Have;
 
         private static readonly string[] SpecialThrowPhrases =
                                                                {
@@ -143,6 +143,47 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
                     return builder.ToStringAndRelease();
                 }
+            }
+
+            return name;
+        }
+
+        /// <summary>
+        /// Finds a better name for a symbol that uses "have" as prefix.
+        /// </summary>
+        /// <param name="name">
+        /// The name to analyze.
+        /// </param>
+        /// <param name="prefix">
+        /// The prefix to preserve in the name.
+        /// The default is <c>""</c>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the better name with corrected name.
+        /// </returns>
+        internal static string FindBetterNameForHavePrefix(string name, string prefix = "")
+        {
+            var startIndex = prefix.Length;
+
+            var nameSpan = name.AsSpan(prefix.Length);
+
+            if (nameSpan.StartsWith(Have, StringComparison.OrdinalIgnoreCase))
+            {
+                var nextWordPosition = startIndex + Have.Length;
+
+                var builder = StringBuilderCache.Acquire();
+
+                if (startIndex > 0)
+                {
+                    builder.Append(prefix);
+                }
+
+                builder.Append(Has);
+                builder.Append(name, nextWordPosition, name.Length - nextWordPosition);
+
+                builder.ToLowerCaseAt(prefix.Length);
+
+                return builder.ToStringAndRelease();
             }
 
             return name;

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -377,6 +377,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1534_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1535_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1536_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1538_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingCodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -537,6 +537,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1531_VariablesWithShouldPrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1532_ParametersWithShouldPrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1533_FieldsWithShouldPrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1534_VariablesWithHavePrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1535_ParametersWithHavePrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1536_FieldsWithHavePrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_MethodPrefixedWithEventAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1538_EventNamePrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -5844,6 +5844,117 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;have&apos; to &apos;has&apos;.
+        /// </summary>
+        internal static string MiKo_1534_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1534_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local variables that are prefixed with &apos;have&apos; are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - &apos;have&apos; should be &apos;has&apos; when used as a third-person singular indicator.
+        ///Renaming the prefix from &apos;have&apos; to &apos;has&apos; makes the code grammatically correct and easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1534_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1534_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1534_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1534_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix local variables with &apos;have&apos;.
+        /// </summary>
+        internal static string MiKo_1534_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1534_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;have&apos; to &apos;has&apos;.
+        /// </summary>
+        internal static string MiKo_1535_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1535_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters that are prefixed with &apos;have&apos; are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - &apos;have&apos; should be &apos;has&apos; when used as a third-person singular indicator.
+        ///Renaming the prefix from &apos;have&apos; to &apos;has&apos; makes the code grammatically correct and easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1535_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1535_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1535_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1535_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix parameters with &apos;have&apos;.
+        /// </summary>
+        internal static string MiKo_1535_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1535_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;have&apos; to &apos;has&apos;.
+        /// </summary>
+        internal static string MiKo_1536_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_1536_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fields that are prefixed with &apos;have&apos; are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - &apos;have&apos; should be &apos;has&apos; when used as a third-person singular indicator.
+        ///Renaming the prefix from &apos;have&apos; to &apos;has&apos; makes the code grammatically correct and easier to read and understand..
+        /// </summary>
+        internal static string MiKo_1536_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1536_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string MiKo_1536_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1536_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not prefix fields with &apos;have&apos;.
+        /// </summary>
+        internal static string MiKo_1536_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1536_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove &apos;Event&apos; prefix from method name.
         /// </summary>
         internal static string MiKo_1537_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2108,6 +2108,45 @@ Naming the field based on what it represents, rather than what it implies, makes
   <data name="MiKo_1533_Title" xml:space="preserve">
     <value>Do not prefix fields with words that express intent or expectation</value>
   </data>
+  <data name="MiKo_1534_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'have' to 'has'</value>
+  </data>
+  <data name="MiKo_1534_Description" xml:space="preserve">
+    <value>Local variables that are prefixed with 'have' are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - 'have' should be 'has' when used as a third-person singular indicator.
+Renaming the prefix from 'have' to 'has' makes the code grammatically correct and easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1534_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1534_Title" xml:space="preserve">
+    <value>Do not prefix local variables with 'have'</value>
+  </data>
+  <data name="MiKo_1535_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'have' to 'has'</value>
+  </data>
+  <data name="MiKo_1535_Description" xml:space="preserve">
+    <value>Parameters that are prefixed with 'have' are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - 'have' should be 'has' when used as a third-person singular indicator.
+Renaming the prefix from 'have' to 'has' makes the code grammatically correct and easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1535_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1535_Title" xml:space="preserve">
+    <value>Do not prefix parameters with 'have'</value>
+  </data>
+  <data name="MiKo_1536_CodeFixTitle" xml:space="preserve">
+    <value>Rename 'have' to 'has'</value>
+  </data>
+  <data name="MiKo_1536_Description" xml:space="preserve">
+    <value>Fields that are prefixed with 'have' are most likely indicators for boolean values. Such a prefix uses the wrong grammatical form - 'have' should be 'has' when used as a third-person singular indicator.
+Renaming the prefix from 'have' to 'has' makes the code grammatically correct and easier to read and understand.</value>
+  </data>
+  <data name="MiKo_1536_MessageFormat" xml:space="preserve">
+    <value>Rename '{0}' to '{1}'</value>
+  </data>
+  <data name="MiKo_1536_Title" xml:space="preserve">
+    <value>Do not prefix fields with 'have'</value>
+  </data>
   <data name="MiKo_1537_CodeFixTitle" xml:space="preserve">
     <value>Remove 'Event' prefix from method name</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -395,6 +395,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                             continue;
                         }
 
+                        // the lookup-phrases are mostly upper-case, so compare ignoring case here
                         if (originalText.ContainsAny(lookupPhrases, StringComparison.OrdinalIgnoreCase))
                         {
                             var replacedText = originalText.AsCachedBuilder()

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1534_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1534_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1534_CodeFixProvider)), Shared]
+    public sealed class MiKo_1534_CodeFixProvider : LocalVariableNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1534";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1534_VariablesWithHavePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1534_VariablesWithHavePrefixAnalyzer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1534_VariablesWithHavePrefixAnalyzer : LocalVariableNamingAnalyzer
+    {
+        public const string Id = "MiKo_1534";
+
+        public MiKo_1534_VariablesWithHavePrefixAnalyzer() : base(Id)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            List<Diagnostic> issues = null;
+
+            for (int index = 0, length = identifiers.Length; index < length; index++)
+            {
+                var identifier = identifiers[index];
+                var name = identifier.ValueText;
+
+                if (name.StartsWith(Constants.Markers.Have, StringComparison.OrdinalIgnoreCase))
+                {
+                    var betterName = NamesFinder.FindBetterNameForHavePrefix(name);
+
+                    if (issues is null)
+                    {
+                        issues = new List<Diagnostic>(1);
+                    }
+
+                    issues.Add(Issue(name, identifier, betterName, CreateBetterNameProposal(betterName)));
+                }
+            }
+
+            return issues ?? Enumerable.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1535_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1535_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1535_CodeFixProvider)), Shared]
+    public sealed class MiKo_1535_CodeFixProvider : ParameterNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1535";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1535_ParametersWithHavePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1535_ParametersWithHavePrefixAnalyzer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1535_ParametersWithHavePrefixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1535";
+
+        public MiKo_1535_ParametersWithHavePrefixAnalyzer() : base(Id, SymbolKind.Parameter)
+        {
+        }
+
+        protected override bool ShallAnalyze(IParameterSymbol symbol) => base.ShallAnalyze(symbol) && symbol.Name.StartsWith(Constants.Markers.Have, StringComparison.OrdinalIgnoreCase);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
+        {
+            var betterName = NamesFinder.FindBetterNameForHavePrefix(symbol.Name);
+
+            return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1536_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1536_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_1536_CodeFixProvider)), Shared]
+    public sealed class MiKo_1536_CodeFixProvider : FieldNamingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_1536";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1536_FieldsWithHavePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1536_FieldsWithHavePrefixAnalyzer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MiKoSolutions.Analyzers.Linguistics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1536_FieldsWithHavePrefixAnalyzer : NamingAnalyzer
+    {
+        public const string Id = "MiKo_1536";
+
+        public MiKo_1536_FieldsWithHavePrefixAnalyzer() : base(Id, SymbolKind.Field)
+        {
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation)
+        {
+            var name = symbol.Name;
+            var prefix = GetFieldPrefix(name);
+
+            if (name.AsSpan(prefix.Length).StartsWith(Constants.Markers.Have, StringComparison.OrdinalIgnoreCase))
+            {
+                var betterName = NamesFinder.FindBetterNameForHavePrefix(name, prefix);
+
+                return new[] { Issue(symbol, betterName, CreateBetterNameProposal(betterName)) };
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1534_VariablesWithHavePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1534_VariablesWithHavePrefixAnalyzerTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1534_VariablesWithHavePrefixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_variable_without_have_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int something = 42;
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_variable_with_prefix_([Values("have")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int " + name + @"Something = 42;
+        }
+    }
+}
+");
+
+        [TestCase("haveToStart", "hasToStart")]
+        public void Code_gets_fixed_for_variable_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething()
+        {
+            int ### = 42;
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1534_VariablesWithHavePrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1534_VariablesWithHavePrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1534_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1535_ParametersWithHavePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1535_ParametersWithHavePrefixAnalyzerTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1535_ParametersWithHavePrefixAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_parameter_without_have_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int something)
+        {
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_parameter_with_prefix_([Values("have")] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private void DoSomething(int " + name + @"Something)
+        {
+        }
+    }
+}
+");
+
+        [TestCase("haveToStart", "hasToStart")]
+        public void Code_gets_fixed_for_parameter_(string originalName, string fixedName)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private void DoSomething(int ###)
+        {
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", originalName), Template.Replace("###", fixedName));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1535_ParametersWithHavePrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1535_ParametersWithHavePrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1535_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1536_FieldsWithHavePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1536_FieldsWithHavePrefixAnalyzerTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1536_FieldsWithHavePrefixAnalyzerTests : CodeFixVerifier
+    {
+        private static readonly string[] FieldPrefixes = Constants.Markers.FieldPrefixes;
+
+        private static readonly string[] Prefixes = ["have"];
+
+        private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
+
+        [Test]
+        public void No_issue_is_reported_for_field_without_have_in_its_name() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int something;
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_field_with_prefix_([ValueSource(nameof(FieldPrefixes))] string prefix, [ValueSource(nameof(Prefixes))] string name) => An_issue_is_reported_for(@"
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        private int " + prefix + name + @"Something;
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_field_([ValueSource(nameof(CodeFixData))] TestCaseData data)
+        {
+            const string Template = @"
+namespace Bla
+{
+    public class TestMe
+    {
+        private int ###;
+    }
+}
+";
+
+            VerifyCSharpFix(Template.Replace("###", data.Wrong), Template.Replace("###", data.Fixed));
+        }
+
+        protected override string GetDiagnosticId() => MiKo_1536_FieldsWithHavePrefixAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1536_FieldsWithHavePrefixAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_1536_CodeFixProvider();
+
+        [ExcludeFromCodeCoverage]
+        private static IEnumerable<TestCaseData> CreateCodeFixData()
+        {
+            Pair[] pairs = [new("haveToStart", "hasToStart")];
+
+            foreach (var prefix in FieldPrefixes)
+            {
+                foreach (var pair in pairs)
+                {
+                    yield return new TestCaseData
+                                 {
+                                     Wrong = prefix + pair.Key,
+                                     Fixed = prefix + pair.Value,
+                                 };
+                }
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -247,6 +247,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1. Naming", "1. Naming", "{
 		Documentation\MiKo_1531.md = Documentation\MiKo_1531.md
 		Documentation\MiKo_1532.md = Documentation\MiKo_1532.md
 		Documentation\MiKo_1533.md = Documentation\MiKo_1533.md
+		Documentation\MiKo_1534.md = Documentation\MiKo_1534.md
+		Documentation\MiKo_1535.md = Documentation\MiKo_1535.md
+		Documentation\MiKo_1536.md = Documentation\MiKo_1536.md
 		Documentation\MiKo_1537.md = Documentation\MiKo_1537.md
 		Documentation\MiKo_1538.md = Documentation\MiKo_1538.md
 	EndProjectSection

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 554 rules that are currently provided by the analyzer.
+The following tables list all the 557 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -198,6 +198,9 @@ The following tables list all the 554 rules that are currently provided by the a
 |[MiKo_1531](/Documentation/MiKo_1531.md)|Do not prefix local variables with 'should'|&#x2713;|&#x2713;|
 |[MiKo_1532](/Documentation/MiKo_1532.md)|Do not prefix parameters with 'should'|&#x2713;|&#x2713;|
 |[MiKo_1533](/Documentation/MiKo_1533.md)|Do not prefix fields with 'should'|&#x2713;|&#x2713;|
+|[MiKo_1534](/Documentation/MiKo_1534.md)|Do not prefix local variables with 'have'|&#x2713;|&#x2713;|
+|[MiKo_1535](/Documentation/MiKo_1535.md)|Do not prefix parameters with 'have'|&#x2713;|&#x2713;|
+|[MiKo_1536](/Documentation/MiKo_1536.md)|Do not prefix fields with 'have'|&#x2713;|&#x2713;|
 |[MiKo_1537](/Documentation/MiKo_1537.md)|Do not prefix methods with 'Event'|&#x2713;|&#x2713;|
 |[MiKo_1538](/Documentation/MiKo_1538.md)|Do not prefix events with 'On'|&#x2713;|&#x2713;|
 


### PR DESCRIPTION
- Add analyzers, code fix providers, and unit tests for each rule

- Update documentation, resources and `README.md` to reflect the new rules

- Introduce `Constants.Markers.Have` and `FindBetterNameForHavePrefix` helper method for consistent naming

(resolves #2008)
