### PR TITLE
MiKo_1099 is now aware of out parameters as last parameters

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -2967,6 +2967,18 @@ namespace MiKoSolutions.Analyzers
         internal static bool IsOpenGeneric(this ITypeSymbol value) => value?.TypeKind is TypeKind.TypeParameter;
 
         /// <summary>
+        /// Determines whether a parameter is an "out" parameter.
+        /// </summary>
+        /// <param name="value">
+        /// The parameter to inspect.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the parameter is an "out" parameter; otherwise, <see langword="false"/>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsOut(this IParameterSymbol value) => value?.RefKind is RefKind.Out;
+
+        /// <summary>
         /// Determines whether a type is partial.
         /// </summary>
         /// <param name="value">

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_ParamDefaultPhraseAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter)
         {
-            if (parameter.RefKind is RefKind.Out)
+            if (parameter.IsOut())
             {
                 return false; // MiKo 2022
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_OutParamDefaultPhraseAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2022_OutParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind is RefKind.Out;
+        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.IsOut();
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         public MiKo_2023_BooleanParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.Type.IsBoolean()
-                                                                                     && parameter.RefKind != RefKind.Out
+                                                                                     && parameter.IsOut() is false
                                                                                      && parameter.GetEnclosingMethod().Name != nameof(IDisposable.Dispose);
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_EnumParamDefaultPhraseAnalyzer.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsEnum();
+        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.IsOut() is false && parameter.Type.IsEnum();
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public MiKo_2025_CancellationTokenParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
-        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.RefKind != RefKind.Out && parameter.Type.IsCancellationToken();
+        protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.IsOut() is false && parameter.Type.IsCancellationToken();
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment) => AnalyzePlainTextStartingPhrase(parameter, parameterComment, comment, Constants.Comments.CancellationTokenParameterPhrase);
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3005_TryMethodsAnalyzer.cs
@@ -34,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return null;
             }
 
-            if (method.ReturnType.IsBoolean() && method.Parameters.Any() && method.Parameters.Last().RefKind is RefKind.Out)
+            if (method.ReturnType.IsBoolean() && method.Parameters.Any() && method.Parameters.Last().IsOut())
             {
                 return null;
             }

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0004_MethodParameterCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0004_MethodParameterCountAnalyzer.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
                 if (parametersCount > MaxParametersCount && symbol.IsInterfaceImplementation() is false)
                 {
-                    var outParametersCount = parameters.Count(_ => _.RefKind is RefKind.Out);
+                    var outParametersCount = parameters.Count(_ => _.IsOut());
                     var count = parametersCount - outParametersCount;
 
                     if (count > MaxParametersCount)

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzer.cs
@@ -62,7 +62,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
             for (var index = 0; index < parametersLength; index++)
             {
-                if (parameters[index].RefKind is RefKind.Out)
+                if (parameters[index].IsOut())
                 {
                     if (outParameterIndex is -1)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer.cs
@@ -18,23 +18,22 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation)
         {
-            foreach (var methods in symbol.GetNamedMethods().Where(ShallAnalyze).GroupBy(_ => _.Name))
-            {
-                if (methods.MoreThan(1))
-                {
-                    // order by number of parameters, so that we get the one with the most parameters as first one (acts as reference)
-                    var methodsWithSameName = methods.OrderByDescending(_ => _.Parameters.Length).ToList();
+            var issues = symbol.GetNamedMethods()
+                               .Where(ShallAnalyze)
+                               .GroupBy(_ => _.Name)
+                               .Where(_ => _.MoreThan(1)) // we have more than 1 method with the name, so inspect the parameters
+                               .SelectMany(AnalyzeMethods)
+                               .ToArray();
 
-                    // we have more than 1 method with the name, so inspect the parameters
-                    foreach (var diagnostic in AnalyzeMethods(methodsWithSameName))
-                    {
-                        yield return diagnostic;
-                    }
-                }
-            }
+            return issues;
         }
 
         private static void RemoveIdenticalParameters(List<IParameterSymbol> referenceParameters, List<IParameterSymbol> otherParameters)
+        {
+            RemoveIdenticalParameters(referenceParameters, otherParameters, (r, o) => true);
+        }
+
+        private static void RemoveIdenticalParameters(List<IParameterSymbol> referenceParameters, List<IParameterSymbol> otherParameters, Func<IParameterSymbol, IParameterSymbol, bool> comparer)
         {
             var otherIndex = 0;
             var referenceIndex = 0;
@@ -47,7 +46,9 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 var otherParameter = otherParameters[otherIndex];
                 var referenceParameter = referenceParameters[referenceIndex];
 
-                if (otherParameter.Name == referenceParameter.Name && otherParameter.Type.Equals(referenceParameter.Type, SymbolEqualityComparer.Default))
+                if (otherParameter.Name == referenceParameter.Name
+                 && otherParameter.Type.Equals(referenceParameter.Type, SymbolEqualityComparer.Default)
+                 && comparer(referenceParameter, otherParameter))
                 {
                     // remove this one
                     indices.Push(referenceIndex);
@@ -70,8 +71,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             }
         }
 
-        private IEnumerable<Diagnostic> AnalyzeMethods(List<IMethodSymbol> methods)
+        private IEnumerable<Diagnostic> AnalyzeMethods(IEnumerable<IMethodSymbol> methodsWithSameName)
         {
+            // order by number of parameters, so that we get the one with the most parameters as first one (acts as reference)
+            var methods = methodsWithSameName.OrderByDescending(_ => _.Parameters.Length).ToList();
+
             var referenceMethod = methods[0];
 
             foreach (var otherMethod in methods.Skip(1)) // skip the longest method as that one acts as reference
@@ -81,20 +85,33 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
                 if (referenceParameters.Count == otherParameters.Count)
                 {
+                    // strip shared trailing parameters first to avoid skewing the forward comparison
                     referenceParameters.Reverse();
                     otherParameters.Reverse();
 
                     RemoveIdenticalParameters(referenceParameters, otherParameters);
 
+                    // change back to original order
                     referenceParameters.Reverse();
                     otherParameters.Reverse();
                 }
 
                 RemoveIdenticalParameters(referenceParameters, otherParameters);
 
+                // strip shared trailing out-parameters (e.g. 'out int result') before forward traversal
+                referenceParameters.Reverse();
+                otherParameters.Reverse();
+
+                RemoveIdenticalParameters(referenceParameters, otherParameters, (r, o) => r.IsOut() && o.IsOut());
+
+                // change back to original order
+                referenceParameters.Reverse();
+                otherParameters.Reverse();
+
                 var referenceIndex = 0;
                 var otherIndex = 0;
 
+                // now compare the remaining parameters
                 while (otherIndex < otherParameters.Count && referenceIndex < referenceParameters.Count)
                 {
                     var otherParameter = otherParameters[otherIndex];

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzerTests.cs
@@ -110,7 +110,7 @@ public interface IDoSomething
 }");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_string_value_and_char_param_while_longer_has_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this string value, char c) => false;
@@ -120,7 +120,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_2() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_char_param_while_longer_has_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, char c) => false;
@@ -130,7 +130,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_3() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_string_finding_while_longer_has_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, string finding) => false;
@@ -140,7 +140,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_4() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_string_value_and_string_finding_and_comparison_while_longer_has_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this string value, string finding, StringComparison comparison) => false;
@@ -150,7 +150,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_5() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_string_finding_and_comparison_while_longer_has_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, string finding, StringComparison comparison) => false;
@@ -160,7 +160,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_6() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_with_same_parameter_count_when_one_uses_string_finding_and_other_uses_ReadOnlySpan_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, string finding, Func<char, bool> nextCharValidationCallback, StringComparison comparison) => false;
@@ -170,7 +170,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_1_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_string_value_and_char_param_while_longer_has_string_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this string value, char c) => false;
@@ -180,7 +180,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_2_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_char_param_while_longer_has_string_finding() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, char c) => false;
@@ -190,7 +190,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_3_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_string_finding_as_subset_of_longer() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, string finding) => false;
@@ -200,7 +200,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_4_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_string_value_and_string_finding_and_comparison_while_longer_has_additional_callback() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this string value, string finding, StringComparison comparison) => false;
@@ -210,7 +210,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_DoSomething_5_1() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overloads_when_shorter_has_ReadOnlySpan_value_and_string_finding_and_comparison_while_longer_has_additional_callback() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool DoSomething(this ReadOnlySpan<char> value, string finding, StringComparison comparison) => false;
@@ -236,6 +236,24 @@ public class TestMe
     public static bool DoSomething(int value) => false;
 
     public static bool DoSomething(int value1, int value2) => false;
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_type_with_6_similar_named_methods_if_all_follow_naming_scheme_and_last_is_an_out_parameter() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public bool DoSomething() => true;
+
+    public bool DoSomething(out int result) => true;
+
+    public bool DoSomething(int i, out int result) => true;
+
+    public bool DoSomething(int i, int j, out int result) => true;
+
+    public bool DoSomething(int i, int j, int k, out int result) => true;
+
+    public bool DoSomething(int i, int j, int k, int l, out int result) => true;
 }
 ");
 


### PR DESCRIPTION
- Add `IsOut` extension method to `SymbolExtensions` for encapsulating "out" parameter checks

- Update analyzer classes to use `IsOut`, simplifying logic and ensuring consistent "out" parameter identification

- Refactor `MiKo_1099_ParametersOnOverloadsNameSchemeAnalyzer` to include handling of shared trailing "out" parameters

- Add tests