### PR TITLE
Provide 'SyntaxKind' to 'DescendantNodes' calls

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -318,12 +318,12 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,ISet{string})"/>
         /// <seealso cref="GetXmlSyntax(SyntaxNode,string)"/>
-        /// <seealso cref="GetXmlSyntax(SyntaxNode,ISet{string})"/>
+        /// <seealso cref="GetXmlSyntax(DocumentationCommentTriviaSyntax,ISet{string})"/>
         internal static IEnumerable<XmlEmptyElementSyntax> GetEmptyXmlSyntax(this SyntaxNode value, string tag)
         {
             // we have to delve into the trivia to find the XML syntax nodes
             // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (var element in value.AllDescendantNodes<XmlEmptyElementSyntax>())
+            foreach (var element in value.AllDescendantNodes<XmlEmptyElementSyntax>(SyntaxKind.XmlEmptyElement))
             {
                 if (element.GetName() == tag)
                 {
@@ -346,12 +346,12 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,string)"/>
         /// <seealso cref="GetXmlSyntax(SyntaxNode,string)"/>
-        /// <seealso cref="GetXmlSyntax(SyntaxNode,ISet{string})"/>
+        /// <seealso cref="GetXmlSyntax(DocumentationCommentTriviaSyntax,ISet{string})"/>
         internal static IEnumerable<XmlEmptyElementSyntax> GetEmptyXmlSyntax(this SyntaxNode value, ISet<string> tags)
         {
             // we have to delve into the trivia to find the XML syntax nodes
             // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (var element in value.AllDescendantNodes<XmlEmptyElementSyntax>())
+            foreach (var element in value.AllDescendantNodes<XmlEmptyElementSyntax>(SyntaxKind.XmlEmptyElement))
             {
                 if (tags.Contains(element.GetName()))
                 {
@@ -827,12 +827,16 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,string)"/>
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,ISet{string})"/>
-        /// <seealso cref="GetXmlSyntax(SyntaxNode,ISet{string})"/>
+        /// <seealso cref="GetXmlSyntax(DocumentationCommentTriviaSyntax,ISet{string})"/>
         internal static IReadOnlyList<XmlElementSyntax> GetXmlSyntax(this SyntaxNode value, string tag)
         {
             List<XmlElementSyntax> elements = null;
 
-            foreach (var element in value.AllDescendantNodes<XmlElementSyntax>())
+            var descendantNodes = value is MemberDeclarationSyntax
+                                  ? value.AllDescendantNodes<XmlElementSyntax>(SyntaxKind.XmlElement)
+                                  : value.DescendantNodes<XmlElementSyntax>(SyntaxKind.XmlElement);
+
+            foreach (var element in descendantNodes)
             {
                 if (element.GetName() == tag)
                 {
@@ -863,12 +867,12 @@ namespace MiKoSolutions.Analyzers
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,string)"/>
         /// <seealso cref="GetEmptyXmlSyntax(SyntaxNode,ISet{string})"/>
         /// <seealso cref="GetXmlSyntax(SyntaxNode,string)"/>
-        internal static IReadOnlyList<XmlElementSyntax> GetXmlSyntax(this SyntaxNode value, ISet<string> tags)
+        internal static IReadOnlyList<XmlElementSyntax> GetXmlSyntax(this DocumentationCommentTriviaSyntax value, ISet<string> tags)
         {
             // we have to delve into the trivia to find the XML syntax nodes
             List<XmlElementSyntax> elements = null;
 
-            foreach (var element in value.AllDescendantNodes<XmlElementSyntax>())
+            foreach (var element in value.DescendantNodes<XmlElementSyntax>(SyntaxKind.XmlElement))
             {
                 if (tags.Contains(element.GetName()))
                 {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
@@ -38,10 +38,22 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The syntax node to get descendants from.
         /// </param>
+        /// <param name="kind">
+        /// One of the enumeration members that specifies the syntax kind to filter by.
+        /// </param>
         /// <returns>
         /// A sequence that contains all descendant nodes of the specified type.
         /// </returns>
-        internal static IEnumerable<T> AllDescendantNodes<T>(this SyntaxNode value) where T : SyntaxNode => value.AllDescendantNodes().OfType<T>();
+        internal static IEnumerable<T> AllDescendantNodes<T>(this SyntaxNode value, SyntaxKind kind) where T : SyntaxNode
+        {
+            foreach (var node in value.AllDescendantNodes())
+            {
+                if (node.IsKind(kind))
+                {
+                    yield return (T)node;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets all descendant nodes and tokens of the specified syntax node.
@@ -176,6 +188,12 @@ namespace MiKoSolutions.Analyzers
         {
             List<T> results = null;
 
+//// ncrunch: no coverage start
+            if (value.IsKind(kind))
+            {
+                results = new List<T> { (T)value };
+            }
+
             foreach (var node in value.DescendantNodes())
             {
                 if (node.RawKind != (int)kind)
@@ -190,6 +208,7 @@ namespace MiKoSolutions.Analyzers
 
                 results.Add((T)node);
             }
+//// ncrunch: no coverage end
 
             return (IReadOnlyList<T>)results ?? Array.Empty<T>();
         }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -840,7 +840,7 @@ namespace MiKoSolutions.Analyzers
                     return null;
                 }
 
-                var identifiers = condition.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>().ToHashSet(_ => _.GetName());
+                var identifiers = condition.DescendantNodes<IdentifierNameSyntax>(SyntaxKind.IdentifierName).ToHashSet(_ => _.GetName());
 
                 return parameters.FirstOrDefault(_ => identifiers.Contains(_.GetName()));
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -370,7 +370,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 Dictionary<XmlTextSyntax, XmlTextSyntax> result = null;
 
-                foreach (var text in syntax.DescendantNodesAndSelf().OfType<XmlTextSyntax>())
+                foreach (var text in syntax.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText))
                 {
                     Dictionary<SyntaxToken, SyntaxToken> tokenMap = null;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2040_CodeFixProvider.cs
@@ -80,7 +80,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var nodes = new List<XmlTextSyntax>();
 
-            foreach (var node in comment.DescendantNodes<XmlTextSyntax>())
+            foreach (var node in comment.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText))
             {
                 if (node.Parent.IsCode())
                 {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2211_CodeFixProvider.cs
@@ -21,17 +21,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return Task.FromResult(updatedSyntax);
         }
 
-        private static DocumentationCommentTriviaSyntax GetUpdatedSyntax(DocumentationCommentTriviaSyntax syntax)
+        private static DocumentationCommentTriviaSyntax GetUpdatedSyntax(DocumentationCommentTriviaSyntax comment)
         {
-            var remarks = syntax.GetXmlSyntax(Constants.XmlTag.Remarks)[0];
-            var summaries = syntax.GetXmlSyntax(Constants.XmlTag.Summary);
+            var remarks = comment.GetXmlSyntax(Constants.XmlTag.Remarks)[0];
+            var summaries = comment.GetXmlSyntax(Constants.XmlTag.Summary);
 
             // add remarks into summary
             if (summaries.Count is 0)
             {
                 var newSummary = SyntaxFactory.XmlSummaryElement(remarks.Content.ToArray());
 
-                return syntax.ReplaceNode(remarks, newSummary);
+                return comment.ReplaceNode(remarks, newSummary);
             }
             else
             {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzer.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             List<Diagnostic> results = null;
 
-            foreach (var tokens in comment.DescendantNodes<XmlTextSyntax>().Select(_ => _.TextTokens))
+            foreach (var tokens in comment.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText).Select(_ => _.TextTokens))
             {
                 var count = tokens.Count - 1;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2241_DocumentationUsesEmptyStringAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             List<Diagnostic> issues = null;
 
-            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
+            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText))
             {
                 var textTokens = xmlText.TextTokens;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2242_DocumentationUsesTextualRepresentationAnalyzer.cs
@@ -23,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             List<Diagnostic> issues = null;
 
-            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
+            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText))
             {
                 var textTokens = xmlText.TextTokens;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2245_DocumentationUsesNumbersInCodeAnalyzer.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             List<Diagnostic> issues = null;
 
-            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>())
+            foreach (var xmlText in comment.DescendantNodes<XmlTextSyntax>(SyntaxKind.XmlText))
             {
                 if (xmlText.Parent is XmlElementSyntax parent)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3090_FinallyBlockThrowsExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3090_FinallyBlockThrowsExceptionAnalyzer.cs
@@ -27,12 +27,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return;
             }
 
-            var method = context.GetEnclosingMethod();
+            var throwStatements = finallyBlock.DescendantNodes<ThrowStatementSyntax>(SyntaxKind.ThrowStatement);
 
-            var issues = finallyBlock.DescendantNodesAndSelf().OfType<ThrowStatementSyntax>()
-                                     .Select(_ => Issue(method.Name, _));
+            if (throwStatements.Count > 0)
+            {
+                var method = context.GetEnclosingMethod();
 
-            ReportDiagnostics(context, issues);
+                ReportDiagnostics(context, throwStatements.Select(_ => Issue(method.Name, _)));
+            }
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
@@ -60,7 +60,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 if (body != null)
                 {
-                    foreach (var statement in body.DescendantNodes<ExpressionStatementSyntax>())
+                    foreach (var statement in body.DescendantNodes<ExpressionStatementSyntax>(SyntaxKind.ExpressionStatement))
                     {
                         if (statement.Expression is InvocationExpressionSyntax i && ContainsAssertion(type, compilation, i, nestingLevel))
                         {
@@ -109,7 +109,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool ContainsAssertionDirectly(MethodDeclarationSyntax syntax)
         {
-            var nodes = syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
+            var nodes = (syntax.Body ?? (SyntaxNode)syntax.ExpressionBody).DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
 
             foreach (var node in nodes)
             {


### PR DESCRIPTION
- Refactor syntax traversal methods `DescendantNodes` and `AllDescendantNodes` to include `SyntaxKind` filtering for improved performance and precision

- Update analyzers and code fix providers to use the new `DescendantNodes<T>(SyntaxKind)` and `AllDescendantNodes<T>(SyntaxKind)` methods

- Update method signatures and XML documentation to reflect these changes, replacing `SyntaxNode` with `DocumentationCommentTriviaSyntax` where applicable
