### PR TITLE
MiKo_1003 now performs a stricter validation of method names

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
@@ -55,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
             {
                 var methodName = method.Name;
 
-                var adjustedName = methodName.StartsWith(Prefix, StringComparison.Ordinal)
+                var adjustedName = methodName.StartsWith(Prefix, StringComparison.Ordinal) && methodName.Length > Prefix.Length && methodName[Prefix.Length].IsUpperCase()
                                    ? methodName.AsSpan(Prefix.Length)
                                    : methodName.AsSpan();
 
@@ -69,11 +69,17 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 }
                 else
                 {
-                    name = adjustedName.ToString();
+                    name = adjustedName.Length == methodName.Length
+                           ? methodName
+                           : adjustedName.ToString();
                 }
             }
 
-            return name.AsCachedBuilder().Without(Constants.Underscore).ToUpperCaseAt(0).ToStringAndRelease();
+            return name.AsCachedBuilder()
+                       .Without(Constants.Underscore + Prefix)
+                       .Without(Constants.Underscore)
+                       .ToUpperCaseAt(0)
+                       .ToStringAndRelease();
         }
 
         private static string FindProperNameInClass(IMethodSymbol method)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzerTests.cs
@@ -176,7 +176,7 @@ public class TestMe
 ");
 
         [Test]
-        public void Code_gets_fixed_for_method_([Values("TME_MyEvent", "myEvent")] string method)
+        public void Code_gets_fixed_for_method_([Values("TME_MyEvent", "myEvent", "TME_OnMyEvent")] string method)
         {
             const string Template = @"
 using System;
@@ -202,6 +202,10 @@ public class TestMe
 
         [TestCase("CommandBinding_OnCanExecute", "OnCanExecuteCommandBinding")]
         [TestCase("CommandBinding_OnExecuted", "OnExecutedCommandBinding")]
+        [TestCase("Image_OnPreviewMouseDown", "OnImagePreviewMouseDown")]
+        [TestCase("Image_OnMouseLeftButtonUp", "OnImageMouseLeftButtonUp")]
+        [TestCase("OnlineManager_OnChanged", "OnOnlineManagerChanged")]
+        [TestCase("ZoomOut_OnClick", "OnZoomOutClick")]
         public void Code_gets_fixed_for_method_(string originalMethod, string fixedMethod)
         {
             const string Template = @"


### PR DESCRIPTION
- Refine logic to enforce stricter validation of method names, ensuring proper prefix handling and formatting

- Update `name` assignment to handle edge cases and improve final name formatting

- Enhance test coverage by adding new test cases for various method name patterns