### PR TITLE
MiKo_2310 is now aware of more reasoning phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1069,7 +1069,16 @@ namespace MiKoSolutions.Analyzers
                                                                         "doesnt matter", // be able to detect typos
                                                                     };
 
-            internal static readonly string[] ReasoningPhrases = { "because", "reason", "so that", "to ensure", "ensuring", "for efficient", "verify", "for verification" };
+            internal static readonly string[] ReasoningPhrases =
+                                                                 {
+                                                                     "because", "reason", "so that",
+                                                                     "to ensure", "ensuring",
+                                                                     "to avoid", "avoiding",
+                                                                     "for efficient",
+                                                                     "verify", "for verification",
+                                                                     "otherwise",
+                                                                     "exactly", "why", "do not support",
+                                                                 };
 
             internal static readonly string[] LangwordReferences = { "true", "false", "null" };
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Spacing.cs
@@ -1224,7 +1224,7 @@ namespace MiKoSolutions.Analyzers
 
             for (; i > -1; i--)
             {
-                if (trivia[i].IsKind(SyntaxKind.WhitespaceTrivia) is false)
+                if (trivia[i].IsWhiteSpace() is false)
                 {
                     break;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2303_CommentDoesNotEndWithPeriodAnalyzer.cs
@@ -17,9 +17,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => DocumentationComment.EndsWithPeriod(comment);
 
-        protected override IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia)
-        {
-            return new[] { Issue(name, GetLastLocation(trivia, '.')) };
-        }
+        protected override IReadOnlyList<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => new[] { Issue(name, GetLastLocation(trivia, '.')) };
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2307_CommentContainsWasNotSuccessfulAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2307_CommentContainsWasNotSuccessfulAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -18,6 +17,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => DocumentationComment.ContainsPhrase(Constants.Comments.WasNotSuccessfulPhrase, comment);
 
-        protected override IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.WasNotSuccessfulPhrase).Select(_ => Issue(name, _));
+        protected override IReadOnlyList<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.WasNotSuccessfulPhrase).ToArray(_ => Issue(name, _));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2309_CommentContainsNtContractionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2309_CommentContainsNtContractionAnalyzer.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => DocumentationComment.ContainsPhrases(Constants.Comments.NotContractionPhrase, comment);
 
-        protected override IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia)
+        protected override IReadOnlyList<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia)
         {
             var locations = GetAllLocations(trivia, Constants.Comments.NotContractionPhrase, StringComparison.OrdinalIgnoreCase);
 
@@ -48,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            return (IEnumerable<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzer.cs
@@ -16,17 +16,41 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => CommentHasIssue(comment);
-
-        protected override IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.IntentionallyPhrase, StringComparison.OrdinalIgnoreCase).Select(_ => Issue(name, _));
-
-        private static bool CommentHasIssue(in ReadOnlySpan<char> comment)
+        protected override IEnumerable<Diagnostic> AnalyzeCommentTrivia(string name, SyntaxTrivia[] triviaToAnalyze, SemanticModel semanticModel)
         {
-            var c = comment.ToString();
-
-            if (c.ContainsAny(Constants.Comments.IntentionallyPhrase, StringComparison.OrdinalIgnoreCase))
+            foreach (var trivia in triviaToAnalyze.GroupBy(_ => _.Token))
             {
-                return c.ContainsAny(Constants.Comments.ReasoningPhrases, StringComparison.OrdinalIgnoreCase) is false;
+                var sb = StringBuilderCache.Acquire();
+
+                foreach (var t in trivia)
+                {
+                    sb.Append(t.ToString());
+                }
+
+                var comment = sb.ToStringAndRelease();
+
+                if (CommentHasIssue(comment))
+                {
+                    foreach (var t in trivia)
+                    {
+                        var locations = GetAllLocations(t, Constants.Comments.IntentionallyPhrase, StringComparison.OrdinalIgnoreCase);
+
+                        for (int index = 0, locationsCount = locations.Count; index < locationsCount; index++)
+                        {
+                            yield return Issue(name, locations[index]);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => false; // we've overridden AnalyzeCommentTrivia, so this is not used
+
+        private static bool CommentHasIssue(string comment)
+        {
+            if (comment.ContainsAny(Constants.Comments.IntentionallyPhrase, StringComparison.OrdinalIgnoreCase))
+            {
+                return comment.ContainsAny(Constants.Comments.ReasoningPhrases, StringComparison.OrdinalIgnoreCase) is false;
             }
 
             return false;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -18,6 +17,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected override bool CommentHasIssue(in ReadOnlySpan<char> comment, SemanticModel semanticModel) => DocumentationComment.ContainsPhrases(Constants.Comments.WhichIsToTerms, comment);
 
-        protected override IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase).Select(_ => Issue(name, _, Constants.Comments.ToTerm));
+        protected override IReadOnlyList<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => GetAllLocations(trivia, Constants.Comments.WhichIsToTerms, StringComparison.OrdinalIgnoreCase).ToArray(_ => Issue(name, _, Constants.Comments.ToTerm));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/SingleLineCommentAnalyzer.cs
@@ -41,18 +41,80 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected virtual bool CommentHasIssue(in SyntaxTrivia trivia, SemanticModel semanticModel)
         {
             var comment = trivia.ToFullString()
-                                .AsSpan()
-                                .Slice(2) // removes the leading '//'
+                                .AsSpan(2) // removes the leading '//'
                                 .Trim(); // gets rid of all (leading or trailing) whitespaces to ease comment comparisons
 
             return CommentHasIssue(comment, semanticModel);
         }
 
-        protected virtual IEnumerable<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => new[] { Issue(name, trivia) };
+        protected virtual IReadOnlyList<Diagnostic> CollectIssues(string name, in SyntaxTrivia trivia) => new[] { Issue(name, trivia) };
 
         protected virtual bool ShallAnalyze(IMethodSymbol symbol) => true;
 
         protected virtual bool ShallAnalyze(in SyntaxTrivia trivia) => trivia.IsSingleLineComment();
+
+        protected virtual IEnumerable<Diagnostic> AnalyzeCommentTrivia(string name, SyntaxTrivia[] triviaToAnalyze, SemanticModel semanticModel)
+        {
+            for (int index = 0, count = triviaToAnalyze.Length; index < count; index++)
+            {
+                var trivia = triviaToAnalyze[index];
+
+                if (IgnoreMultipleLines && trivia.IsSpanningMultipleLines())
+                {
+                    continue;
+                }
+
+                if (CommentHasIssue(trivia, semanticModel))
+                {
+                    foreach (var issue in CollectIssues(name, trivia))
+                    {
+                        yield return issue;
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(BaseMethodDeclarationSyntax node, SemanticModel semanticModel)
+        {
+            var triviaToAnalyze = FindTriviaToAnalyze(node);
+
+            if (triviaToAnalyze.Length is 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var name = node.GetName();
+
+            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(BaseFieldDeclarationSyntax node, SemanticModel semanticModel)
+        {
+            var triviaToAnalyze = FindTriviaToAnalyze(node);
+
+            if (triviaToAnalyze.Length is 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var name = node.GetName();
+
+            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
+        }
+
+        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(AccessorDeclarationSyntax node, SemanticModel semanticModel)
+        {
+            var triviaToAnalyze = FindTriviaToAnalyze(node);
+
+            if (triviaToAnalyze.Length is 0)
+            {
+                return Array.Empty<Diagnostic>();
+            }
+
+            var name = node.GetName();
+
+            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
+        }
 
         private void AnalyzeComment(SyntaxNodeAnalysisContext context)
         {
@@ -105,76 +167,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             if (issues.IsEmptyArray() is false)
             {
                 ReportDiagnostics(context, issues);
-            }
-        }
-
-        private bool AnalyzeComment(in SyntaxTrivia trivia, SemanticModel semanticModel)
-        {
-            if (IgnoreMultipleLines && trivia.IsSpanningMultipleLines())
-            {
-                return false; // ignore comment is multi-line comment (could also have with empty lines in between the different comment lines)
-            }
-
-            return CommentHasIssue(trivia, semanticModel);
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(BaseMethodDeclarationSyntax node, SemanticModel semanticModel)
-        {
-            var triviaToAnalyze = FindTriviaToAnalyze(node);
-
-            if (triviaToAnalyze.Length is 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var name = node.GetName();
-
-            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(BaseFieldDeclarationSyntax node, SemanticModel semanticModel)
-        {
-            var triviaToAnalyze = FindTriviaToAnalyze(node);
-
-            if (triviaToAnalyze.Length is 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var name = node.GetName();
-
-            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(AccessorDeclarationSyntax node, SemanticModel semanticModel)
-        {
-            var triviaToAnalyze = FindTriviaToAnalyze(node);
-
-            if (triviaToAnalyze.Length is 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            var name = node.GetName();
-
-            return AnalyzeCommentTrivia(name, triviaToAnalyze, semanticModel);
-        }
-
-        private IEnumerable<Diagnostic> AnalyzeCommentTrivia(string name, SyntaxTrivia[] triviaToAnalyze, SemanticModel semanticModel)
-        {
-            for (int index = 0, count = triviaToAnalyze.Length; index < count; index++)
-            {
-                var trivia = triviaToAnalyze[index];
-
-                var hasIssue = AnalyzeComment(trivia, semanticModel);
-
-                if (hasIssue)
-                {
-                    foreach (var issue in CollectIssues(name, trivia))
-                    {
-                        yield return issue;
-                    }
-                }
             }
         }
 

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6033_CaseBlockBracesAreOnSamePositionLikeCaseKeywordAnalyzer.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6047_SwitchExpressionBracesAreOnSamePositionLikeSwitchKeywordAnalyzer.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace MiKoSolutions.Analyzers.Rules.Spacing
 {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6050_MultilineArgumentsAreIndentedToRightAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
@@ -34,6 +34,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   "doesnt matter", // check for typo
                                                               ];
 
+        private static readonly string[] ReasoningPhrases =
+                                                            [
+                                                                "reason: we like it this way",
+                                                                "reason is we like it this way",
+                                                                "because we like it this way",
+                                                                "so that we like it this way",
+                                                                "to avoid issues",
+                                                                "as we want that exactly so why that is possible",
+                                                                "as we do not support it",
+                                                                "otherwise we fail",
+                                                                "as we have issues otherwise",
+                                                            ];
+
         [Test]
         public void No_issue_is_reported_for_undocumented_class() => No_issue_is_reported_for(@"
 public class TestMe
@@ -58,37 +71,28 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_reason_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
     {
-        // " + comment + @", reason: we like it this way
+        // " + comment + ", " + reason + @"
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_because_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_on_separate_line_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
     {
-        // " + comment + @" because we like it this way
+        // " + comment + @"
+        // " + reason + @"
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_so_that_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public void DoSomething()
-    {
-        // " + comment + @" so that we like it this way
-    }
-}");
-
-        [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_reason_in_catch_block_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_in_catch_block_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -99,13 +103,13 @@ public class TestMe
         }
         catch
         {
-            // " + comment + @", reason: we like it this way
+            // " + comment + " " + reason + @"
         }
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_because_in_catch_block_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_in_catch_block_on_separate_line_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -116,51 +120,46 @@ public class TestMe
         }
         catch
         {
-            // " + comment + @" because we like it this way
+            // " + comment + @"
+            // " + reason + @"
         }
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_reason_on_property_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_on_property_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public int SomeValue
     {
         get
         {
-            // " + comment + @" because we like it this way
+            // " + comment + " " + reason + @"
             return 42;
         }
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_because_on_property_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_on_property_on_separate_line_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public int SomeValue
     {
         get
         {
-            // " + comment + @" because we like it this way
+            // " + comment + @"
+            // " + reason + @"
             return 42;
         }
     }
 }");
 
         [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_reason_on_field_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_intentionally_comment_on_field_([ValueSource(nameof(IntentionalPhrases))] string comment, [ValueSource(nameof(ReasoningPhrases))] string reason) => No_issue_is_reported_for(@"
 public class TestMe
 {
-    public int MyField; // " + comment + @", reason: we like it this way
-}");
-
-        [Test]
-        public void No_issue_is_reported_for_intentionally_comment_with_because_on_field_([ValueSource(nameof(IntentionalPhrases))] string comment) => No_issue_is_reported_for(@"
-public class TestMe
-{
-    public int MyField; // " + comment + @" because we like it this way
+    public int MyField; // " + comment + ", " + reason + @"
 }");
 
         [Test]


### PR DESCRIPTION
- Add new reasoning phrases to `Constants.cs`

- Refactor MiKo_2310 analyzer to check for reasoning phrases on related comments placed on separate lines

- Add and consolidate tests

- Refactor multiple analyzers to return `IReadOnlyList` instead of `IEnumerable`

- Clean up unused namespaces