### PR TITLE
Add new rule MiKo_1539 that reports on names without vowels

### DIFF
--- a/Documentation/MiKo_1539.md
+++ b/Documentation/MiKo_1539.md
@@ -1,0 +1,52 @@
+﻿# MiKo_1539: Names shall contain vowels
+
+## Cause
+
+A name consists entirely of consonants and contains no vowels.
+
+## Rule description
+
+Names consisting entirely of consonants without any vowels are hard to read and understand.
+For example, a name like `tsprg` gives no clear indication of its purpose or meaning.
+Using descriptive names that include vowels improves code readability.
+
+### Rationale behind
+
+Names that contain no vowels are very hard to read and understand.
+It is not clear what such a name means or what purpose it serves.
+This forces other developers to spend extra time trying to figure out the intent behind the name.
+
+Using names that include vowels makes the code more readable and easier to work with.
+
+Following this rule provides several important benefits:
+
+- **Improved Readability**:
+  Names with vowels are easier to read and pronounce.
+  Developers can quickly understand what a name refers to without having to guess or decode it.
+
+- **Clearer Intent**:
+  A name that can be read as a word or phrase communicates its purpose directly.
+  This reduces the need for additional comments or documentation to explain what something does.
+
+- **Reduced Cognitive Load**:
+  When names are readable, developers do not need to stop and puzzle over what a name means.
+  This makes it easier to focus on understanding the logic of the code.
+
+- **Better Maintainability**:
+  Code with meaningful, readable names is easier to maintain and change.
+  Finding and updating the right parts of the code becomes less error-prone.
+
+- **Fewer Misunderstandings**:
+  Unreadable names can lead to mistakes when developers misinterpret what a variable, method, or type represents.
+  Clear names reduce the chance of introducing bugs caused by misunderstanding.
+
+## How to fix violations
+
+To fix a violation of this rule, rename the identifier so that its name contains at least one vowel and clearly describes its purpose.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_1539
+#pragma warning restore MiKo_1539
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -542,9 +542,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1536_FieldsWithHavePrefixAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1537_MethodPrefixedWithEventAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1538_EventNamePrefixAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\MiKo_1539_NoVowelInNameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamespaceNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\NamingLengthAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\OverallNameAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Naming\TypeSyntaxNamingAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4001_MethodsWithSameNameOrderedPerParametersAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Ordering\MiKo_4002_MethodsWithSameNameOrderedSideBySideAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -6027,6 +6027,33 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Names consisting entirely of consonants without any vowels are hard to read and understand. For example, a name like &apos;tsprg&apos; gives no clear indication of its purpose or meaning. Using descriptive names that include vowels improves code readability..
+        /// </summary>
+        internal static string MiKo_1539_Description {
+            get {
+                return ResourceManager.GetString("MiKo_1539_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add vowels to name to make it readable.
+        /// </summary>
+        internal static string MiKo_1539_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_1539_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Names shall contain vowels.
+        /// </summary>
+        internal static string MiKo_1539_Title {
+            get {
+                return ResourceManager.GetString("MiKo_1539_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix malformed XML.
         /// </summary>
         internal static string MiKo_2000_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -2171,6 +2171,15 @@ Renaming the prefix from 'have' to 'has' makes the code grammatically correct an
   <data name="MiKo_1538_Title" xml:space="preserve">
     <value>Do not prefix events with 'On'</value>
   </data>
+  <data name="MiKo_1539_Description" xml:space="preserve">
+    <value>Names consisting entirely of consonants without any vowels are hard to read and understand. For example, a name like 'tsprg' gives no clear indication of its purpose or meaning. Using descriptive names that include vowels improves code readability.</value>
+  </data>
+  <data name="MiKo_1539_MessageFormat" xml:space="preserve">
+    <value>Add vowels to name to make it readable</value>
+  </data>
+  <data name="MiKo_1539_Title" xml:space="preserve">
+    <value>Names shall contain vowels</value>
+  </data>
   <data name="MiKo_2000_CodeFixTitle" xml:space="preserve">
     <value>Fix malformed XML</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1063_AbbreviationsInNameAnalyzer.cs
@@ -9,94 +9,13 @@ using MiKoSolutions.Analyzers.Linguistics;
 namespace MiKoSolutions.Analyzers.Rules.Naming
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class MiKo_1063_AbbreviationsInNameAnalyzer : LocalVariableNamingAnalyzer
+    public sealed class MiKo_1063_AbbreviationsInNameAnalyzer : OverallNameAnalyzer
     {
         public const string Id = "MiKo_1063";
 
         public MiKo_1063_AbbreviationsInNameAnalyzer() : base(Id)
         {
         }
-
-        protected override void InitializeCore(CompilationStartAnalysisContext context)
-        {
-            InitializeCore(context, SymbolKind.Namespace, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field, SymbolKind.Parameter);
-
-            base.InitializeCore(context);
-        }
-
-        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
-        {
-            if (identifiers.Length is 0)
-            {
-                return Array.Empty<Diagnostic>();
-            }
-
-            List<Diagnostic> overallIssues = null;
-
-            foreach (var identifier in identifiers)
-            {
-                var symbol = identifier.GetSymbol(semanticModel);
-
-                if (symbol is null)
-                {
-                    // code seems to be obfuscated or contains no valid symbol, so ignore it silently
-                    continue;
-                }
-
-                var issues = AnalyzeName(symbol);
-
-                if (issues.Length is 0)
-                {
-                    continue;
-                }
-
-                if (overallIssues is null)
-                {
-                    overallIssues = new List<Diagnostic>(issues.Length);
-                }
-
-                overallIssues.AddRange(issues);
-            }
-
-            return (IEnumerable<Diagnostic>)overallIssues ?? Array.Empty<Diagnostic>();
-        }
-
-        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol?.IsExtern is false && base.ShallAnalyze(symbol);
-
-        protected override bool ShallAnalyze(IParameterSymbol symbol)
-        {
-            if (base.ShallAnalyze(symbol))
-            {
-                if (symbol.ContainingSymbol is IMethodSymbol method)
-                {
-                    if (method.IsExtern)
-                    {
-                        return false;
-                    }
-
-                    if (method.IsInterfaceImplementation())
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamespaceSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation) => AnalyzeName(symbol);
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(IEventSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
-
-        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation)
         {
@@ -108,26 +27,11 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                     return Array.Empty<Diagnostic>();
 
                 default:
-                    return AnalyzeName(symbol);
+                    return base.AnalyzeName(symbol, compilation);
             }
         }
 
-        private Diagnostic[] AnalyzeName(ISymbol symbol) => AnalyzeName(symbol.Name, symbol);
-
-        private Diagnostic[] AnalyzeName(IFieldSymbol symbol)
-        {
-            var symbolName = symbol.Name;
-
-            // remove any field marker
-            var fieldPrefix = GetFieldPrefix(symbolName);
-            var prefixLength = fieldPrefix.Length;
-
-            return prefixLength > 0
-                   ? AnalyzeName(symbolName.Substring(prefixLength), symbol, fieldPrefix)
-                   : AnalyzeName(symbolName, symbol);
-        }
-
-        private Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "")
+        protected override Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "")
         {
             var findings = AbbreviationFinder.Find(symbolName);
             var findingsLength = findings.Length;

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_1539_NoVowelInNameAnalyzer : OverallNameAnalyzer
+    {
+        public const string Id = "MiKo_1539";
+
+        public MiKo_1539_NoVowelInNameAnalyzer() : base(Id)
+        {
+        }
+
+        protected override Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "") => HasIssue(symbolName)
+                                                                                                              ? new[] { Issue(symbol) }
+                                                                                                              : Array.Empty<Diagnostic>();
+
+        private static bool HasIssue(string name)
+        {
+            if (name.Length <= 1)
+            {
+                return false;
+            }
+
+            switch (name)
+            {
+                case Constants.LambdaIdentifiers.FallbackUnderscores2:
+                case Constants.LambdaIdentifiers.FallbackUnderscores3:
+                case Constants.LambdaIdentifiers.FallbackUnderscores4:
+                    return false;
+
+                default:
+                    return name.AsSpan().IndexOfAny("AEIOUaeiou".AsSpan()) < 0;
+            }
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,27 +15,30 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         {
         }
 
+        // overridden as it is not important how the prefix looks like, so we can save some memory by not creating a new string for the field name
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol.Name, symbol);
+
         protected override Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "") => HasIssue(symbolName)
                                                                                                               ? new[] { Issue(symbol) }
                                                                                                               : Array.Empty<Diagnostic>();
 
         private static bool HasIssue(string name)
         {
-            if (name.Length <= 1)
+            if (name.Length > 1 && name.AsSpan().IndexOfAny("AEIOUaeiou".AsSpan()) < 0)
             {
-                return false;
+                switch (name)
+                {
+                    case Constants.LambdaIdentifiers.FallbackUnderscores2:
+                    case Constants.LambdaIdentifiers.FallbackUnderscores3:
+                    case Constants.LambdaIdentifiers.FallbackUnderscores4:
+                        return false;
+
+                    default:
+                        return true;
+                }
             }
 
-            switch (name)
-            {
-                case Constants.LambdaIdentifiers.FallbackUnderscores2:
-                case Constants.LambdaIdentifiers.FallbackUnderscores3:
-                case Constants.LambdaIdentifiers.FallbackUnderscores4:
-                    return false;
-
-                default:
-                    return name.AsSpan().IndexOfAny("AEIOUaeiou".AsSpan()) < 0;
-            }
+            return false;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/OverallNameAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/OverallNameAnalyzer.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    public abstract class OverallNameAnalyzer : LocalVariableNamingAnalyzer
+    {
+        protected OverallNameAnalyzer(string diagnosticId) : base(diagnosticId)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context)
+        {
+            InitializeCore(context, SymbolKind.Namespace, SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Event, SymbolKind.Field, SymbolKind.Parameter);
+
+            base.InitializeCore(context);
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeIdentifiers(SemanticModel semanticModel, ITypeSymbol type, params SyntaxToken[] identifiers)
+        {
+            List<Diagnostic> overallIssues = null;
+
+            foreach (var identifier in identifiers)
+            {
+                var symbol = identifier.GetSymbol(semanticModel);
+
+                if (symbol is null)
+                {
+                    // code seems to be obfuscated or contains no valid symbol, so ignore it silently
+                    continue;
+                }
+
+                var issues = AnalyzeName(symbol);
+
+                if (issues.Length is 0)
+                {
+                    continue;
+                }
+
+                if (overallIssues is null)
+                {
+                    overallIssues = new List<Diagnostic>(issues.Length);
+                }
+
+                overallIssues.AddRange(issues);
+            }
+
+            return (IEnumerable<Diagnostic>)overallIssues ?? Array.Empty<Diagnostic>();
+        }
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol?.IsExtern is false && base.ShallAnalyze(symbol);
+
+        protected override bool ShallAnalyze(IParameterSymbol symbol)
+        {
+            if (base.ShallAnalyze(symbol))
+            {
+                if (symbol.ContainingSymbol is IMethodSymbol method)
+                {
+                    if (method.IsExtern)
+                    {
+                        return false;
+                    }
+
+                    if (method.IsInterfaceImplementation())
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamespaceSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(INamedTypeSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IPropertySymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IEventSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IFieldSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected override IEnumerable<Diagnostic> AnalyzeName(IParameterSymbol symbol, Compilation compilation) => AnalyzeName(symbol);
+
+        protected abstract Diagnostic[] AnalyzeName(string symbolName, ISymbol symbol, string prefix = "");
+
+        private Diagnostic[] AnalyzeName(ISymbol symbol) => AnalyzeName(symbol.Name, symbol);
+
+        private Diagnostic[] AnalyzeName(IFieldSymbol symbol)
+        {
+            var symbolName = symbol.Name;
+
+            // remove any field marker
+            var fieldPrefix = GetFieldPrefix(symbolName);
+            var prefixLength = fieldPrefix.Length;
+
+            return prefixLength > 0
+                   ? AnalyzeName(symbolName.Substring(prefixLength), symbol, fieldPrefix)
+                   : AnalyzeName(symbolName, symbol);
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1539_NoVowelInNameAnalyzerTests.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Naming
+{
+    [TestFixture]
+    public sealed class MiKo_1539_NoVowelInNameAnalyzerTests : CodeFixVerifier
+    {
+        private const string LowerCaseVowels = "aeiou";
+        private const string LowerCaseConstants = "bcdfghjklmnpqrstvwxyz";
+
+        private const string UpperCaseVowels = "AEIOU";
+        private const string UpperCaseConstants = "BCDFGHJKLMNPQRSTVWXYZ";
+
+        [TestCaseSource(nameof(LowerCaseVowels))]
+        [TestCaseSource(nameof(LowerCaseConstants))]
+        [TestCaseSource(nameof(UpperCaseVowels))]
+        [TestCaseSource(nameof(UpperCaseConstants))]
+        [TestCase(Constants.Underscore)]
+        public void No_issue_is_reported_for_local_variable_named_(char c) => No_issue_is_reported_for(@"
+public class TestMe
+    {
+        public void DoSomething()
+        {
+            var " + c + @" = 1;
+        }
+    }
+");
+
+        [TestCase(Constants.LambdaIdentifiers.Default)]
+        [TestCase(Constants.LambdaIdentifiers.FallbackUnderscores2)]
+        [TestCase(Constants.LambdaIdentifiers.FallbackUnderscores3)]
+        [TestCase(Constants.LambdaIdentifiers.FallbackUnderscores4)]
+        public void No_issue_is_reported_for_local_variable_named_(string s) => No_issue_is_reported_for(@"
+public class TestMe
+    {
+        public void DoSomething()
+        {
+            var " + s + @" = 1;
+        }
+    }
+");
+
+        [Test, Combinatorial]
+        public void No_issue_is_reported_for_local_variable_named_(
+                                                               [ValueSource(nameof(LowerCaseVowels))] char c1,
+                                                               [ValueSource(nameof(LowerCaseConstants))] char c2)
+            => No_issue_is_reported_for(@"
+public class TestMe
+    {
+        public void DoSomething()
+        {
+            var " + c1 + c2 + @" = 1;
+        }
+    }
+");
+
+        [Test, Combinatorial]
+        public void An_issue_is_reported_for_local_variable_named_(
+                                                               [ValueSource(nameof(LowerCaseConstants))] char c1,
+                                                               [ValueSource(nameof(LowerCaseConstants))] char c2)
+            => An_issue_is_reported_for(@"
+public class TestMe
+    {
+        public void DoSomething()
+        {
+            var " + c1 + c2 + @" = 1;
+        }
+    }
+");
+
+        protected override string GetDiagnosticId() => MiKo_1539_NoVowelInNameAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_1539_NoVowelInNameAnalyzer();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -252,6 +252,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1. Naming", "1. Naming", "{
 		Documentation\MiKo_1536.md = Documentation\MiKo_1536.md
 		Documentation\MiKo_1537.md = Documentation\MiKo_1537.md
 		Documentation\MiKo_1538.md = Documentation\MiKo_1538.md
+		Documentation\MiKo_1539.md = Documentation\MiKo_1539.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2. Documentation", "2. Documentation", "{572678B8-C70C-4E91-BE64-E688D7959CA6}"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 557 rules that are currently provided by the analyzer.
+The following tables list all the 558 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -203,6 +203,7 @@ The following tables list all the 557 rules that are currently provided by the a
 |[MiKo_1536](/Documentation/MiKo_1536.md)|Do not prefix fields with 'have'|&#x2713;|&#x2713;|
 |[MiKo_1537](/Documentation/MiKo_1537.md)|Do not prefix methods with 'Event'|&#x2713;|&#x2713;|
 |[MiKo_1538](/Documentation/MiKo_1538.md)|Do not prefix events with 'On'|&#x2713;|&#x2713;|
+|[MiKo_1539](/Documentation/MiKo_1539.md)|Names shall contain vowels|&#x2713;|\-|
 
 ### Documentation
 


### PR DESCRIPTION
- Add analyzer to enforce the rule

- Add unit tests

- Refactor shared logic into a new `OverallNameAnalyzer` base class

- Update `MiKo_1063_AbbreviationsInNameAnalyzer` to use the new base class

- Update documentation, README and resources

(resolves #1813)