### PR TITLE
MiKo_3108 now uses the method declaration directly

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
@@ -109,7 +109,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool ContainsAssertionDirectly(MethodDeclarationSyntax syntax)
         {
-            var nodes = (syntax.Body ?? (SyntaxNode)syntax.ExpressionBody).DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
+            var nodes = syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
 
             foreach (var node in nodes)
             {


### PR DESCRIPTION
Avoids `NullReferenceException`s due to missing bodies of method declarations.