### PR TITLE
Added new rule MiKo_3235 that reports 'ToList' calls on 'IEnumerable'

### DIFF
--- a/Documentation/MiKo_3235.md
+++ b/Documentation/MiKo_3235.md
@@ -1,0 +1,48 @@
+﻿# MiKo_3235: Do not call 'ToList' on an 'IEnumerable' parameter
+
+## Cause
+
+A method parameter is typed as `IEnumerable<T>`, but `.ToList()` is called on it directly inside the method.
+
+## Rule description
+
+A method parameter typed as `IEnumerable<T>` that is immediately converted via `.ToList()` signals that the method actually needs a stable, indexed collection.
+This creates an unnecessary copy, hides a performance cost, and risks issues with lazy or infinite sequences.
+Using `IReadOnlyList<T>` as the parameter type instead makes the intent explicit.
+
+### Rationale behind
+
+`IEnumerable<T>` is the most general interface for sequences and only promises that the sequence can be iterated once.
+When a method immediately calls `.ToList()` on such a parameter, it reveals that the method actually requires something more specific: a stable, reusable collection.
+
+Using `IReadOnlyList<T>` as the parameter type instead accurately expresses what the method needs and avoids several subtle problems.
+
+Changing the parameter type to `IReadOnlyList<T>` provides several important benefits:
+
+- **No unnecessary copy**:
+  In most cases, the caller already passes a `List<T>` or an array.
+  Calling `.ToList()` on an `IEnumerable<T>` creates a redundant copy of the data that serves no purpose.
+
+- **No hidden performance cost**:
+  The `.ToList()` call iterates the entire sequence to build a new list.
+  This cost is invisible to the caller and can be surprising, especially for large collections.
+
+- **Safer handling of lazy sequences**:
+  `IEnumerable<T>` can represent a lazy or even infinite sequence, for example one produced with `yield return`.
+  Calling `.ToList()` on such a sequence can cause the application to hang or crash.
+  Requiring `IReadOnlyList<T>` makes it clear that a fully materialized collection is expected.
+
+- **Clearer intent**:
+  A parameter typed as `IReadOnlyList<T>` immediately communicates that the method needs indexed access or a stable, reusable collection.
+  This makes the code easier to understand and reduces the chance of misuse.
+
+## How to fix violations
+
+To fix a violation of this rule, change the parameter type from `IEnumerable<T>` to `IReadOnlyList<T>` and remove the `.ToList()` call.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3235
+#pragma warning restore MiKo_3235
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -351,6 +351,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3232_DoNotUseEmptyPropertyPatternInsideConditionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3233_DoNotUseVarPatternInIsPatternAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3234_UsePatternMatchingForBooleanEqualsExpressionAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3301_ParenthesizedLambdaExpressionUsesExpressionBodyAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3302_SimpleLambdaExpressionIsUsedInsteadOfParenthesizedLambdaExpressionAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3401_NamespaceDepthAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -15410,6 +15410,34 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A method parameter typed as `IEnumerable&lt;T&gt;` that is immediately converted via `.ToList()` signals that the method actually needs a stable, indexed collection. This creates an unnecessary copy, hides a performance cost, and risks issues with lazy or infinite sequences.
+        ///Using `IReadOnlyList&lt;T&gt;` as the parameter type instead makes the intent explicit..
+        /// </summary>
+        internal static string MiKo_3235_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3235_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change &apos;{0}&apos; type to &apos;IReadOnlyList&apos;.
+        /// </summary>
+        internal static string MiKo_3235_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3235_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not call &apos;ToList&apos; on an &apos;IEnumerable&apos; parameter.
+        /// </summary>
+        internal static string MiKo_3235_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3235_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use lambda expression body.
         /// </summary>
         internal static string MiKo_3301_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5386,6 +5386,16 @@ Instead, to avoid 'null', use a non-null pattern (such as "is { } something"), a
   <data name="MiKo_3234_Title" xml:space="preserve">
     <value>Prefer pattern matching over boolean Equals checks</value>
   </data>
+  <data name="MiKo_3235_Description" xml:space="preserve">
+    <value>A method parameter typed as `IEnumerable&lt;T&gt;` that is immediately converted via `.ToList()` signals that the method actually needs a stable, indexed collection. This creates an unnecessary copy, hides a performance cost, and risks issues with lazy or infinite sequences.
+Using `IReadOnlyList&lt;T&gt;` as the parameter type instead makes the intent explicit.</value>
+  </data>
+  <data name="MiKo_3235_MessageFormat" xml:space="preserve">
+    <value>Change '{0}' type to 'IReadOnlyList'</value>
+  </data>
+  <data name="MiKo_3235_Title" xml:space="preserve">
+    <value>Do not call 'ToList' on an 'IEnumerable' parameter</value>
+  </data>
   <data name="MiKo_3301_CodeFixTitle" xml:space="preserve">
     <value>Use lambda expression body</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3235";
+
+        public MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.ContainingType?.TypeKind is TypeKind.Class && symbol.Parameters.Any(IsIEnumerable);
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        {
+            var methodDeclaration = symbol.GetSyntax();
+
+            var invocations = methodDeclaration.DescendantNodes<InvocationExpressionSyntax>(SyntaxKind.InvocationExpression);
+            int invocationsCount = invocations.Count;
+
+            if (invocationsCount > 0)
+            {
+                var parameterNames = symbol.Parameters.Where(IsIEnumerable).ToDictionary(_ => _.Name);
+
+                for (var index = 0; index < invocationsCount; index++)
+                {
+                    var invocation = invocations[index];
+
+                    if (invocation.Expression is MemberAccessExpressionSyntax m && m.GetName() is nameof(Enumerable.ToList))
+                    {
+                        if (parameterNames.TryGetValue(m.GetIdentifierName(), out var parameter))
+                        {
+                            var parameterSyntax = parameter.GetSyntax();
+
+                            return new[] { Issue(parameterSyntax.Type) };
+                        }
+                    }
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static bool IsIEnumerable(IParameterSymbol parameter) => parameter.Type.OriginalDefinition.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T;
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzerTests.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_methods_with_no_IEnumerable_parameter() => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_methods_with_IEnumerable_parameter() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething(IEnumerable<int> values)
+        {
+            foreach (var value in values)
+            {
+                Console.WriteLine(value);
+            }
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_methods_with_IEnumerable_parameter_and_unrelated_ToList_call() => No_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public List<int> DoSomething(IEnumerable<int> values)
+        {
+            List<int> results = new List<int>();
+
+            foreach (var value in values)
+            {
+                if (value > 42)
+                {
+                    results.Add(value);
+                }
+            }
+
+            return results.ToList();
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_methods_with_IEnumerable_parameter_and_ToList_call_on_it() => An_issue_is_reported_for(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        public void DoSomething(IEnumerable<int> values)
+        {
+            var valuesList = values.ToList();
+
+            foreach (var value in valuesList)
+            {
+                Console.WriteLine(value);
+            }
+        }
+    }
+}
+");
+
+        protected override string GetDiagnosticId() => MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -540,6 +540,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3232.md = Documentation\MiKo_3232.md
 		Documentation\MiKo_3233.md = Documentation\MiKo_3233.md
 		Documentation\MiKo_3234.md = Documentation\MiKo_3234.md
+		Documentation\MiKo_3235.md = Documentation\MiKo_3235.md
 		Documentation\MiKo_3301.md = Documentation\MiKo_3301.md
 		Documentation\MiKo_3302.md = Documentation\MiKo_3302.md
 		Documentation\MiKo_3401.md = Documentation\MiKo_3401.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 558 rules that are currently provided by the analyzer.
+The following tables list all the 559 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -493,6 +493,7 @@ The following tables list all the 558 rules that are currently provided by the a
 |[MiKo_3232](/Documentation/MiKo_3232.md)|Use null checks instead of empty property pattern|&#x2713;|\-|
 |[MiKo_3233](/Documentation/MiKo_3233.md)|Do not use var patterns for null checks|&#x2713;|\-|
 |[MiKo_3234](/Documentation/MiKo_3234.md)|Prefer pattern matching over boolean Equals checks|&#x2713;|\-|
+|[MiKo_3235](/Documentation/MiKo_3235.md)|Do not call 'ToList' on an 'IEnumerable' parameter|&#x2713;|\-|
 |[MiKo_3301](/Documentation/MiKo_3301.md)|Use lambda expression bodies instead of parenthesized lambda expression blocks for single statements|&#x2713;|&#x2713;|
 |[MiKo_3302](/Documentation/MiKo_3302.md)|Use simple lambda expression bodies instead of parenthesized lambda expression bodies for single parameters|&#x2713;|&#x2713;|
 |[MiKo_3401](/Documentation/MiKo_3401.md)|Keep namespace hierarchies from becoming too deep|&#x2713;|\-|


### PR DESCRIPTION
- Add analyzer to detect and discourage `.ToList()` calls on `IEnumerable<T>` parameters, recommending `IReadOnlyList<T>` instead

- Add unit tests

- Update documentation, `README.md`, resources and project file

(resolves #2038)