### PR TITLE
Code refactored to use 'DescendantNodes<T>(SyntaxKind)'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
@@ -191,7 +191,7 @@ namespace MiKoSolutions.Analyzers
 //// ncrunch: no coverage start
             if (value.IsKind(kind))
             {
-                results = new List<T> { (T)value };
+                results = new List<T>(8) { (T)value }; // avoid resizing most times
             }
 
             foreach (var node in value.DescendantNodes())

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3140,7 +3140,7 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static SyntaxNode WithUsing(this SyntaxNode value, string usingNamespace)
         {
-            var usings = value.DescendantNodes<UsingDirectiveSyntax>().ToList();
+            var usings = value.DescendantNodes<UsingDirectiveSyntax>(SyntaxKind.UsingDirective);
 
             if (usings.Exists(_ => _.Name?.ToFullString() == usingNamespace))
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -25,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             List<Diagnostic> issues = null;
 
-            foreach (var methodCall in syntax.DescendantNodes<MemberAccessExpressionSyntax>())
+            foreach (var methodCall in syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
             {
                 if (methodCall.GetName() is nameof(Debug.Assert))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3076_StaticMemberInitializerRefersToStaticMemberBelowOrInOtherPartAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3076_StaticMemberInitializerRefersToStaticMemberBelowOrInOtherPartAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -22,7 +23,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override IEnumerable<Diagnostic> Analyze(IFieldSymbol symbol, Compilation compilation)
         {
             var fieldSyntax = symbol.GetSyntax<FieldDeclarationSyntax>();
-            var identifierNames = fieldSyntax.DescendantNodes<IdentifierNameSyntax>().ToList();
+            var identifierNames = fieldSyntax.DescendantNodes<IdentifierNameSyntax>(SyntaxKind.IdentifierName);
 
             if (identifierNames.Count != 0)
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3118_TestMethodsDoNotUseSpecificLinqMethodsAnalyzer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -40,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var methodSyntax = symbol.GetSyntax();
 
-            foreach (var maes in methodSyntax.DescendantNodes<MemberAccessExpressionSyntax>())
+            foreach (var maes in methodSyntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
             {
                 if (maes.Parent is InvocationExpressionSyntax invocation)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_CodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var nodes = new List<SyntaxNode>();
 
-                foreach (var expression in method.DescendantNodes<MemberAccessExpressionSyntax>())
+                foreach (var expression in method.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
                 {
                     if (expression.Name.GetName() == nameof(GetHashCode))
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -28,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (symbol.GetSyntax<MethodDeclarationSyntax>() is MethodDeclarationSyntax method)
             {
                 var expressionsCount = 0;
-                var expressions = method.DescendantNodes<MemberAccessExpressionSyntax>();
+                var expressions = method.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
 
                 foreach (var expression in expressions)
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -29,9 +29,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (symbol.GetSyntax<MethodDeclarationSyntax>() is MethodDeclarationSyntax method)
             {
                 var expressionsCount = 0;
-                var expressions = method.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression);
 
-                foreach (var expression in expressions)
+                foreach (var expression in method.DescendantNodes<MemberAccessExpressionSyntax>())
                 {
                     switch (expression.GetName())
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 


### PR DESCRIPTION
- Replace multiple `DescendantNodes<T>()` calls with `DescendantNodes<T>(SyntaxKind.…)`

- Adjust `DescendantNodes<T>(SyntaxKind)` to preallocate list capacity when the starting node already matches the requested kind
