### PR TITLE
Duplicated code into 2 separate branches to have better overview about timing and call numbers when performance tracing

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationAnalyzer.cs
@@ -416,7 +416,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 returnTypeFullyQualified = returnTypeSymbol.FullyQualifiedName(false);
             }
 
-            var intermediateResult = Enumerable.Empty<string>();
+            string[] result;
 
             if (returnTypeSymbol.TryGetGenericArguments(out var arguments))
             {
@@ -432,17 +432,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var argument = arguments[0].FullyQualifiedName(false); // we are interested in the fully qualified name without any alias used, such as 'System.Int32' instead of 'int'
 
 //// ncrunch: rdi off
-                intermediateResult = intermediateResult.Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeWithTs, argument)).Take(1)) // for the phrases to show to the user
-                                                       .Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeWithGenericCount, argument))); // for the real check
+                result = Array.Empty<string>()
+                              .Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeWithTs, argument)).Take(1)) // for the phrases to show to the user
+                              .Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeWithGenericCount, argument))) // for the real check
+                              .Distinct() // Note: we cannot change to hashset as we want the first one as text to show to the user
+                              .ToArray();
             }
             else
             {
-                intermediateResult = intermediateResult.Concat(startingPhrases.Select(_ => _.FormatWith(returnType, Constants.TODO)).Take(1)) // for the phrases to show to the user
-                                                       .Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeFullyQualified, Constants.TODO))); // for the real check
+                result = Array.Empty<string>()
+                              .Concat(startingPhrases.Select(_ => _.FormatWith(returnType, Constants.TODO)).Take(1)) // for the phrases to show to the user
+                              .Concat(startingPhrases.Select(_ => _.FormatWith(returnTypeFullyQualified, Constants.TODO))) // for the real check
+                              .Distinct() // Note: we cannot change to hashset as we want the first one as text to show to the user
+                              .ToArray();
             }
-
-            var result = intermediateResult.Distinct()
-                                           .ToArray();
 
 //// ncrunch: rdi default
 


### PR DESCRIPTION
- Remove shared `intermediateResult` enumerable and instead compute `result` directly

- Move `Distinct().ToArray()` into each branch so each path is self-contained

