### PR TITLE
MiKo_2016 no longer reports on asynchronous test methods

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzer.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
         }
 
-        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsAsyncTaskBased();
+        protected override bool ShallAnalyze(ISymbol symbol) => symbol is IMethodSymbol method && method.IsAsyncTaskBased() && method.IsTestMethod() is false;
 
         protected override Diagnostic StartIssue(ISymbol symbol, Location location) => Issue(symbol.Name, location, Phrase);
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2016_AsyncMethodDefaultPhraseAnalyzerTests.cs
@@ -56,6 +56,37 @@ public class TestMe
         [TestCase("void")]
         [TestCase("Task")]
         [TestCase("Task<int>")]
+        public void No_issue_is_reported_for_async_test_method_without_Asynchronously_in_summary_(string returnType) => No_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    [Test]
+    public async " + returnType + @" DoSomething() { }
+}
+");
+
+        [TestCase("Task")]
+        [TestCase("Task<int>")]
+        public void No_issue_is_reported_for_Task_returning_test_method_without_Asynchronously_in_summary_(string returnType) => No_issue_is_reported_for(@"
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    [Test]
+    public " + returnType + @" DoSomething() { }
+}
+");
+
+        [TestCase("void")]
+        [TestCase("Task")]
+        [TestCase("Task<int>")]
         public void An_issue_is_reported_for_async_method_without_Asynchronously_in_summary_(string returnType) => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Test documentation is allowed to not start with phrase 'Asynchronously '.