### PR TITLE
Fixed MiKo_3227 code fix producing ill-transformed output when comparing a property access against a `nameof` expression

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/UsePatternMatchingCodeFixProvider.cs
@@ -19,19 +19,17 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected sealed override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {
-            var updatedSyntax = syntax;
-
-            if (syntax is BinaryExpressionSyntax binary)
+            switch (syntax)
             {
-                updatedSyntax = GetUpdatedSyntax(binary);
-            }
+                case BinaryExpressionSyntax binary:
+                    return Task.FromResult<SyntaxNode>(GetUpdatedSyntax(binary));
 
-            if (syntax is IsPatternExpressionSyntax pattern)
-            {
-                updatedSyntax = GetUpdatedPatternSyntax(pattern);
-            }
+                case IsPatternExpressionSyntax pattern:
+                    return Task.FromResult<SyntaxNode>(GetUpdatedPatternSyntax(pattern));
 
-            return Task.FromResult(updatedSyntax);
+                default:
+                    return Task.FromResult(syntax);
+            }
         }
 
         protected virtual IsPatternExpressionSyntax GetUpdatedPatternSyntax(IsPatternExpressionSyntax pattern) => pattern;
@@ -48,6 +46,17 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (operand is LiteralExpressionSyntax)
             {
                 return true; // literal is on wrong side, so swap sides
+            }
+
+            // we probably have a 'nameof'
+            if (expression is InvocationExpressionSyntax right && right.IsNameOf())
+            {
+                return false; // we are already on the correct sides
+            }
+
+            if (operand is InvocationExpressionSyntax left && left.IsNameOf())
+            {
+                return true; // enum is on wrong side, so swap sides
             }
 
             if (expression is PrefixUnaryExpressionSyntax)
@@ -67,17 +76,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
 
             if (operand is MemberAccessExpressionSyntax)
-            {
-                return true; // enum is on wrong side, so swap sides
-            }
-
-            // we probably have a 'nameof'
-            if (expression is InvocationExpressionSyntax right && right.IsNameOf())
-            {
-                return false; // we are already on the correct sides
-            }
-
-            if (operand is InvocationExpressionSyntax left && left.IsNameOf())
             {
                 return true; // enum is on wrong side, so swap sides
             }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzerTests.cs
@@ -246,6 +246,38 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_nameof_on_property()
+        {
+            const string OriginalCode = @"
+public record Dto
+{
+    public string Name { get; set; }
+    public string Other { get; set; }
+}
+
+public class TestMe
+{
+    public bool DoSomething(Dto dto) => dto.Name == nameof(System.Linq) && dto.Other == nameof(System);
+}
+";
+
+            const string FixedCode = @"
+public record Dto
+{
+    public string Name { get; set; }
+    public string Other { get; set; }
+}
+
+public class TestMe
+{
+    public bool DoSomething(Dto dto) => dto.Name is nameof(System.Linq) && dto.Other is nameof(System);
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3227_UsePatternMatchingForLiteralEqualsExpressionAnalyzer();


### PR DESCRIPTION
- `nameof` now takes precedence over property access when determining operand order in the resulting `is ` pattern

- Add regression test to cover this case