### PR TITLE
Add new rule MiKo_3126 to prevent mixing [Theory] with other test attributes

### DIFF
--- a/Documentation/MiKo_3126.md
+++ b/Documentation/MiKo_3126.md
@@ -1,0 +1,53 @@
+﻿# MiKo_3126: Theories should not have test attributes applied
+
+## Cause
+
+A test method is marked with `[Theory]` in addition to another test attribute such as `[Test]`, `[Fact]`, or `[TestCase]`.
+
+## Rule description
+
+Avoid marking a test method also with [Theory].
+
+While tests are example-based with specific inputs and expected outputs, [Theory] makes a general statement that holds true for all inputs satisfying certain assumptions, making it a fundamentally different kind of test.
+Use either a test attribute or [Theory] to keep the intent of each test method clear and easy to understand.
+
+### Rationale behind
+
+`[Theory]` and test attributes like `[Test]`, `[Fact]`, or `[TestCase]` serve fundamentally different purposes.
+A test attribute marks an example-based test that verifies behavior for specific, known inputs and expected outputs.
+`[Theory]`, on the other hand, makes a general statement that the tested behavior holds true for all valid inputs satisfying certain assumptions.
+
+When both are applied to the same method, the intent of the test becomes unclear.
+
+This rule provides several important benefits:
+
+- **Clearer Test Intent**:
+  A test method with only one kind of attribute immediately communicates its purpose.
+  Mixing a test attribute with `[Theory]` makes it unclear whether the test is example-based or theory-driven.
+
+- **Improved Readability**:
+  Tests with a single, well-chosen attribute are easier to read and understand at a glance.
+  Developers do not need to check for multiple attributes to determine what kind of test it is.
+
+- **Reduced Confusion**:
+  Applying both attributes to the same method can mislead developers about how the test runs and what it validates.
+  This creates a false understanding of the test behavior.
+
+- **Consistent Test Structure**:
+  A codebase where tests consistently use either a test attribute or `[Theory]` is easier to navigate.
+  Mixing both attributes makes it harder to quickly identify which tests are example-based and which are theory-driven.
+
+- **Easier Maintenance**:
+  When refactoring or extending tests, a single attribute makes the intended test type clear.
+  A test with both attributes requires more thought to decide how to change it correctly.
+
+## How to fix violations
+
+To fix a violation of this rule, remove the test attribute from test methods that are already marked with `[Theory]`.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3126
+#pragma warning restore MiKo_3126
+```

--- a/MiKo.Analyzer.Shared/Constants.cs
+++ b/MiKo.Analyzer.Shared/Constants.cs
@@ -1267,6 +1267,18 @@ namespace MiKoSolutions.Analyzers
             internal const string IValueConverter = "IValueConverter";
             internal const string IValueConverterFullName = "System.Windows.Data.IValueConverter";
 
+            internal const string FactAttribute = "Fact";
+            internal const string FactAttributeFullName = "FactAttribute";
+
+            internal const string TestAttribute = "Test";
+            internal const string TestAttributeFullName = "TestAttribute";
+
+            internal const string TestCaseAttribute = "TestCase";
+            internal const string TestCaseAttributeFullName = "TestCaseAttribute";
+
+            internal const string TheoryAttribute = "Theory";
+            internal const string TheoryAttributeFullName = "TheoryAttribute";
+
             internal static readonly string[] DefaultPropertyParameterNames = { DefaultPropertyParameterName };
 
             internal static readonly ISet<string> FlagsAttributeNames = new HashSet<string>
@@ -1291,16 +1303,16 @@ namespace MiKoSolutions.Analyzers
 
             internal static readonly ISet<string> TestMethodAttributeNames = new HashSet<string>
                                                                                  {
-                                                                                     "Test",
-                                                                                     "TestAttribute",
-                                                                                     "TestCase",
-                                                                                     "TestCaseAttribute",
+                                                                                     TestAttribute,
+                                                                                     TestAttributeFullName,
+                                                                                     TestCaseAttribute,
+                                                                                     TestCaseAttributeFullName,
                                                                                      "TestCaseSource",
                                                                                      "TestCaseSourceAttribute",
-                                                                                     "Theory",
-                                                                                     "TheoryAttribute",
-                                                                                     "Fact",
-                                                                                     "FactAttribute",
+                                                                                     TheoryAttribute,
+                                                                                     TheoryAttributeFullName,
+                                                                                     FactAttribute,
+                                                                                     FactAttributeFullName,
                                                                                      "TestMethod",
                                                                                      "TestMethodAttribute",
                                                                                  };

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -3039,8 +3039,21 @@ namespace MiKoSolutions.Analyzers
                 case DocumentationCommentTriviaSyntax _:
                     return value.RemoveNode(node, SyntaxRemoveOptions.AddElasticMarker);
 
-                case AttributeListSyntax a when a.IsOnSameLineAs(a.NextSibling()):
-                    return value.RemoveNode(node, SyntaxRemoveOptions.KeepLeadingTrivia);
+                case AttributeListSyntax a:
+                {
+                    var options = SyntaxRemoveOptions.KeepNoTrivia;
+
+                    if (a.NextSibling() is AttributeListSyntax next && a.IsOnSameLineAs(next))
+                    {
+                        options = SyntaxRemoveOptions.KeepLeadingTrivia;
+                    }
+                    else if (a.PreviousSibling() is AttributeListSyntax previous && a.IsOnSameLineAs(previous))
+                    {
+                        options = SyntaxRemoveOptions.KeepTrailingTrivia;
+                    }
+
+                    return value.RemoveNode(node, options);
+                }
 
                 default:
                     return value.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -175,6 +175,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\ReturnTypeDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\SummaryDocumentationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\XmlTextDocumentationCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\AttributeSyntaxCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\DoNotUseSuppressNullableWarningAnalyzerCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\LogicalConditionsSimplifierCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MaintainabilityCodeFixProvider.cs" />
@@ -231,6 +232,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3123_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3125_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3126_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -323,6 +323,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3123_TestMethodsDoNotCatchExceptionsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5076,6 +5076,21 @@ Use either [Test] or [TestCase] to keep tests clear and easy to understand.</val
   <data name="MiKo_3125_Title" xml:space="preserve">
     <value>NUnit tests should not have both [Test] and [TestCase] applied</value>
   </data>
+  <data name="MiKo_3126_CodeFixTitle" xml:space="preserve">
+    <value>Only keep [Theory]</value>
+  </data>
+  <data name="MiKo_3126_Description" xml:space="preserve">
+    <value>Avoid marking a test method also with [Theory].
+
+While tests are example-based with specific inputs and expected outputs, [Theory] makes a general statement that holds true for all inputs satisfying certain assumptions, making it a fundamentally different kind of test.
+Use either a test attribute or [Theory] to keep the intent of each test method clear and easy to understand.</value>
+  </data>
+  <data name="MiKo_3126_MessageFormat" xml:space="preserve">
+    <value>Only keep [Theory]</value>
+  </data>
+  <data name="MiKo_3126_Title" xml:space="preserve">
+    <value>Theories should not have test attributes applied</value>
+  </data>
   <data name="MiKo_3201_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -1927,22 +1927,27 @@ namespace MiKoSolutions.Analyzers.Rules
 
         private bool ReferencesTestAssemblies(Compilation compilation)
         {
-            if (compilation.GetTypeByMetadataName("NUnit.Framework.TestAttribute") != null)
+            if (compilation.GetTypeByMetadataName("NUnit.Framework." + Constants.Names.TestAttributeFullName) != null)
             {
                 return SupportsNUnit;
             }
 
-            if (compilation.GetTypeByMetadataName("NUnit.Framework.TestCaseAttribute") != null)
+            if (compilation.GetTypeByMetadataName("NUnit.Framework." + Constants.Names.TestCaseAttributeFullName) != null)
             {
                 return SupportsNUnit;
             }
 
-            if (compilation.GetTypeByMetadataName("Xunit.FactAttribute") != null)
+            if (compilation.GetTypeByMetadataName("NUnit.Framework." + Constants.Names.TheoryAttributeFullName) != null)
+            {
+                return SupportsNUnit;
+            }
+
+            if (compilation.GetTypeByMetadataName("Xunit." + Constants.Names.FactAttributeFullName) != null)
             {
                 return SupportsXUnit;
             }
 
-            if (compilation.GetTypeByMetadataName("Xunit.TheoryAttribute") != null)
+            if (compilation.GetTypeByMetadataName("Xunit." + Constants.Names.TheoryAttributeFullName) != null)
             {
                 return SupportsXUnit;
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/AttributeSyntaxCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/AttributeSyntaxCodeFixProvider.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    public abstract class AttributeSyntaxCodeFixProvider : MaintainabilityCodeFixProvider
+    {
+        protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<AttributeSyntax>().FirstOrDefault();
+
+        protected sealed override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(syntax);
+        }
+
+        protected sealed override Task<SyntaxNode> GetUpdatedSyntaxRootAsync(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue, CancellationToken cancellationToken)
+        {
+            var updatedSyntax = GetUpdatedSyntaxRoot(root, syntax);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxRoot(SyntaxNode root, SyntaxNode syntax)
+        {
+            if (syntax is AttributeSyntax)
+            {
+                var nodeToRemove = syntax.Parent is AttributeListSyntax attributeList && attributeList.Attributes.Count is 1
+                                       ? attributeList
+                                       : syntax;
+
+                return root.Without(nodeToRemove);
+            }
+
+            return root;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3125_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3125_CodeFixProvider.cs
@@ -1,46 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MiKoSolutions.Analyzers.Rules.Maintainability
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3125_CodeFixProvider)), Shared]
-    public sealed class MiKo_3125_CodeFixProvider : UnitTestCodeFixProvider
+    public sealed class MiKo_3125_CodeFixProvider : AttributeSyntaxCodeFixProvider
     {
         public override string FixableDiagnosticId => "MiKo_3125";
-
-        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<AttributeSyntax>().FirstOrDefault();
-
-        protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(syntax);
-        }
-
-        protected override Task<SyntaxNode> GetUpdatedSyntaxRootAsync(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue, CancellationToken cancellationToken)
-        {
-            var updatedSyntax = GetUpdatedSyntaxRoot(root, syntax);
-
-            return Task.FromResult(updatedSyntax);
-        }
-
-        private static SyntaxNode GetUpdatedSyntaxRoot(SyntaxNode root, SyntaxNode syntax)
-        {
-            if (syntax is AttributeSyntax)
-            {
-                var nodeToRemove = syntax.Parent is AttributeListSyntax attributeList && attributeList.Attributes.Count is 1
-                                   ? attributeList
-                                   : syntax;
-
-                return root.Without(nodeToRemove);
-            }
-
-            return root;
-        }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzer.cs
@@ -12,12 +12,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
     {
         public const string Id = "MiKo_3125";
 
-        private const string TestAttributeDefault = "Test";
-        private const string TestAttributeFullName = "TestAttribute";
-
-        private const string TestCaseAttributeDefault = "TestCase";
-        private const string TestCaseAttributeFullName = "TestCaseAttribute";
-
         public MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzer() : base(Id)
         {
         }
@@ -36,22 +30,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var attributeNames = attributes.ToHashSet(_ => _.AttributeClass?.Name);
 
-                if (attributeNames.Contains(TestAttributeDefault) || attributeNames.Contains(TestAttributeFullName))
+                if (attributeNames.Contains(Constants.Names.TestAttributeFullName) && attributeNames.Contains(Constants.Names.TestCaseAttributeFullName))
                 {
-                    if (attributeNames.Contains(TestCaseAttributeDefault) || attributeNames.Contains(TestCaseAttributeFullName))
+                    var method = symbol.GetSyntax<MethodDeclarationSyntax>();
+
+                    foreach (var attributeList in method.AttributeLists)
                     {
-                        var method = symbol.GetSyntax<MethodDeclarationSyntax>();
-
-                        foreach (var attributeList in method.AttributeLists)
+                        foreach (var attribute in attributeList.Attributes)
                         {
-                            foreach (var attribute in attributeList.Attributes)
-                            {
-                                var attributeName = attribute.Name;
+                            var attributeName = attribute.Name;
 
-                                if (IsTest(attributeName))
-                                {
-                                    return new[] { Issue(attributeName) };
-                                }
+                            if (IsTest(attributeName))
+                            {
+                                return new[] { Issue(attributeName) };
                             }
                         }
                     }
@@ -63,6 +54,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsTest(NameSyntax name) => IsTest(name.GetName());
 
-        private static bool IsTest(string name) => name is TestAttributeDefault || name is TestAttributeFullName;
+        private static bool IsTest(string name) => name is Constants.Names.TestAttribute || name is Constants.Names.TestAttributeFullName;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_CodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3126_CodeFixProvider)), Shared]
+    public sealed class MiKo_3126_CodeFixProvider : AttributeSyntaxCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3126";
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs
@@ -38,22 +38,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var attributeNames = attributes.ToHashSet(_ => _.AttributeClass?.Name);
 
-                if (attributeNames.Contains(Constants.Names.TheoryAttributeFullName))
+                if (attributeNames.Contains(Constants.Names.TheoryAttributeFullName) && attributeNames.Overlaps(TestAttributeNames))
                 {
-                    if (attributeNames.Except(Constants.Names.TheoryAttributeFullName).IsProperSubsetOf(TestAttributeNames))
+                    var method = symbol.GetSyntax<MethodDeclarationSyntax>();
+
+                    foreach (var attributeList in method.AttributeLists)
                     {
-                        var method = symbol.GetSyntax<MethodDeclarationSyntax>();
-
-                        foreach (var attributeList in method.AttributeLists)
+                        foreach (var attribute in attributeList.Attributes)
                         {
-                            foreach (var attribute in attributeList.Attributes)
-                            {
-                                var attributeName = attribute.Name;
+                            var attributeName = attribute.Name;
 
-                                if (IsTest(attributeName))
-                                {
-                                    return new[] { Issue(attributeName) };
-                                }
+                            if (IsTest(attributeName))
+                            {
+                                return new[] { Issue(attributeName) };
                             }
                         }
                     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3126";
+
+        private static readonly HashSet<string> TestAttributeNames = new HashSet<string>
+                                                                         {
+                                                                             Constants.Names.TestAttribute,
+                                                                             Constants.Names.TestAttributeFullName,
+                                                                             Constants.Names.TestCaseAttribute,
+                                                                             Constants.Names.TestCaseAttributeFullName,
+                                                                             Constants.Names.FactAttribute,
+                                                                             Constants.Names.FactAttributeFullName,
+                                                                         };
+
+        public MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer() : base(Id)
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override bool ShallAnalyze(IMethodSymbol symbol) => symbol.IsTestMethod();
+
+        protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
+        {
+            var attributes = symbol.GetAttributes();
+
+            if (attributes.Length > 0)
+            {
+                var attributeNames = attributes.ToHashSet(_ => _.AttributeClass?.Name);
+
+                if (attributeNames.Contains(Constants.Names.TheoryAttributeFullName))
+                {
+                    if (attributeNames.Except(Constants.Names.TheoryAttributeFullName).IsProperSubsetOf(TestAttributeNames))
+                    {
+                        var method = symbol.GetSyntax<MethodDeclarationSyntax>();
+
+                        foreach (var attributeList in method.AttributeLists)
+                        {
+                            foreach (var attribute in attributeList.Attributes)
+                            {
+                                var attributeName = attribute.Name;
+
+                                if (IsTest(attributeName))
+                                {
+                                    return new[] { Issue(attributeName) };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        private static bool IsTest(NameSyntax name) => IsTest(name.GetName());
+
+        private static bool IsTest(string name) => TestAttributeNames.Contains(name);
+    }
+}

--- a/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/TheoryAttribute.cs
+++ b/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/TheoryAttribute.cs
@@ -2,10 +2,10 @@
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
-// ReSharper disable once CheckNamespace : Fake for Xunit Fact
+// ReSharper disable once CheckNamespace : Fake for Xunit Theory
 namespace Xunit
 {
-    public class FactAttribute : Attribute
+    public class TheoryAttribute : Attribute
     {
     }
 }

--- a/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/TraitAttribute.cs
+++ b/MiKo.Analyzer.Tests/Helpers/AdditionalClasses/TraitAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+// ReSharper disable once CheckNamespace : Fake for Xunit Trait
+namespace Xunit
+{
+    public class TraitAttribute : Attribute
+    {
+    }
+}
+
+#pragma warning restore IDE0130 // Namespace does not match folder structure

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzerTests.cs
@@ -265,6 +265,43 @@ namespace Bla
         }
 
         [Test]
+        public void Code_gets_fixed_for_test_method_with_TestCase_and_Test_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42)][Test]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
         public void Code_gets_fixed_for_test_method_with_fully_named_Test_and_TestCase_attribute_as_different_attribute_lists_on_same_line()
         {
             const string OriginalCode = @"
@@ -278,6 +315,43 @@ namespace Bla
     public class TestMe
     {
         [TestAttribute][TestCaseAttribute(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCaseAttribute(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_TestCase_and_Test_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCaseAttribute(42)][TestAttribute]
         public void DoSomething(int i) { }
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzerTests.cs
@@ -1210,6 +1210,274 @@ namespace Bla
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Test_attribute_as_different_attribute_lists_when_Category_attribute_is_also_present() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Test]
+        [Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_TestCase_attribute_as_different_attribute_lists_when_Category_attribute_is_also_present() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42)]
+        [Category(""x"")]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_as_different_attribute_lists_when_Category_attribute_is_also_present_in_separate_list()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Test]
+        [Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_as_different_attribute_lists_when_Category_attribute_is_also_present_in_separate_list()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42)]
+        [Category(""x"")]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Category(""x"")]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_in_same_attribute_list_as_Category()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Test, Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_as_Category()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42), Category(""x"")]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Category(""x"")]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Category_in_same_attribute_list_and_Test_as_separate_attribute_list()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, Category(""x"")]
+        [Test]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, Category(""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Fact_attribute_as_different_attribute_lists_when_Trait_attribute_is_also_present_in_separate_list()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        [Fact]
+        [Trait(""Category"", ""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        [Trait(""Category"", ""x"")]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer();

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzerTests.cs
@@ -1,0 +1,1219 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_Test_attribute() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_Test_and_Combinatorial_attribute() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test, Combinatorial]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_TestCase_attribute() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_Fact_attribute() => No_issue_is_reported_for(@"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Fact]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_Theory_attribute() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_TestCase_attribute_as_different_attribute_lists() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_multiple_TestCase_attribute_as_different_attribute_lists() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(0815)]
+        [Theory]
+        [TestCase(42)]
+        [TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_first() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_between() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42), Theory, TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_last() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42), Theory]
+        public void DoSomething(int i) { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Test_attribute_as_different_attribute_lists() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Test]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Test_attribute_in_same_attribute_list_when_Theory_is_first() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, Test]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Test_attribute_in_same_attribute_list_when_Theory_is_last() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test, Theory]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Fact_attribute_as_different_attribute_lists() => An_issue_is_reported_for(@"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        [Fact]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Fact_attribute_in_same_attribute_list_when_Theory_is_first() => An_issue_is_reported_for(@"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory, Fact]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_Theory_and_Fact_attribute_in_same_attribute_list_when_Theory_is_last() => An_issue_is_reported_for(@"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Fact, Theory]
+        public void DoSomething() { }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_TestCase_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42)][Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory][TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_multiple_TestCase_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(0815)]
+        [Theory]
+        [TestCase(42)]
+        [TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [TestCase(42)]
+        [TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_first()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, TestCase(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_between()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42), Theory, TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, TestCase(4711)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_TestCase_attribute_in_same_attribute_list_when_Theory_is_last()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCase(42), Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        [Test]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory][Test]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Test_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test][Theory]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_in_same_attribute_list_when_Theory_is_first()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory, Test]
+        public void DoSomething() { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Test_attribute_in_same_attribute_list_when_Theory_is_last()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test, Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Fact_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        [Fact]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Fact_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Fact][Theory]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Fact_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory][Fact]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Fact_attribute_in_same_attribute_list_when_Theory_is_first()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory, Fact]
+        public void DoSomething() { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_Theory_and_Fact_attribute_in_same_attribute_list_when_Theory_is_last()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Fact, Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [Theory]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_TestCase_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        [TestCaseAttribute(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_TestCase_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestCaseAttribute(42)][TheoryAttribute]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_TestCase_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute][TestCaseAttribute(42)]
+        public void DoSomething(int i) { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething(int i) { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_Test_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        [TestAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_Test_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute][TestAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Test_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TestAttribute][TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_Fact_attribute_as_different_attribute_lists()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [TheoryAttribute]
+        [FactAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Fact_and_Theory_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [FactAttribute][TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_fully_named_Theory_and_Fact_attribute_as_different_attribute_lists_on_same_line()
+        {
+            const string OriginalCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [TheoryAttribute][FactAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+            const string FixedCode = @"
+using Xunit;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        [TheoryAttribute]
+        public void DoSomething() { }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3126_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -516,6 +516,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3123.md = Documentation\MiKo_3123.md
 		Documentation\MiKo_3124.md = Documentation\MiKo_3124.md
 		Documentation\MiKo_3125.md = Documentation\MiKo_3125.md
+		Documentation\MiKo_3126.md = Documentation\MiKo_3126.md
 		Documentation\MiKo_3201.md = Documentation\MiKo_3201.md
 		Documentation\MiKo_3202.md = Documentation\MiKo_3202.md
 		Documentation\MiKo_3203.md = Documentation\MiKo_3203.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 560 rules that are currently provided by the analyzer.
+The following tables list all the 561 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -466,6 +466,7 @@ The following tables list all the 560 rules that are currently provided by the a
 |[MiKo_3123](/Documentation/MiKo_3123.md)|Do not catch exceptions in test methods|&#x2713;|&#x2713;|
 |[MiKo_3124](/Documentation/MiKo_3124.md)|Do not use assertions in finally blocks in test methods|&#x2713;|&#x2713;|
 |[MiKo_3125](/Documentation/MiKo_3125.md)|NUnit tests should not have both [Test] and [TestCase] applied|&#x2713;|&#x2713;|
+|[MiKo_3126](/Documentation/MiKo_3126.md)|Theories should not have test attributes applied|&#x2713;|&#x2713;|
 |[MiKo_3201](/Documentation/MiKo_3201.md)|Invert if statements in short methods|&#x2713;|&#x2713;|
 |[MiKo_3202](/Documentation/MiKo_3202.md)|Use positive conditions when returning in all paths|&#x2713;|&#x2713;|
 |[MiKo_3203](/Documentation/MiKo_3203.md)|Invert if-continue statements when followed by single line|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add rule, code fix, documentation, and tests to ensure `[Theory]` is not combined with `[Fact]`, `[Test]`, or `[TestCase]`

- Refactor attribute name handling in `Constants` and analyzers for consistency

- Add `AttributeSyntaxCodeFixProvider` base class for attribute-removal code fixes

- Update project files, resources, and README

(resolves #2073)