### PR TITLE
MiKo_1063 is now aware of more abbreviations

### DIFF
--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
@@ -109,6 +109,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly Pair[] Prefixes =
                                                   {
+                                                      new Pair("adpt", "adapter"),
                                                       new Pair("alt", "alternative"),
                                                       new Pair("app", "application"),
                                                       new Pair("appl", "application"),
@@ -221,6 +222,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new Pair("imp", "implementation"),
                                                       new Pair("impl", "implementation"),
                                                       new Pair("init", "initialize"),
+                                                      new Pair("inp", "input"),
                                                       new Pair("interv", "interval"),
                                                       new Pair("intf", "interface"),
                                                       new Pair("intfc", "interface"),
@@ -260,6 +262,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new Pair("ops", "operations"),
                                                       new Pair("opt", "option"),
                                                       new Pair("opts", "options"),
+                                                      new Pair("outp", "output"),
                                                       new Pair("para", "parameter"),
                                                       new Pair("param", "parameter"),
                                                       new Pair("params", "parameters"),
@@ -313,6 +316,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new Pair("std", "standard"),
                                                       new Pair("str", "string"),
                                                       new Pair("sts", "status"),
+                                                      new Pair("succ", "success"),
                                                       new Pair("svc", "service"),
                                                       new Pair("svr", "server"),
                                                       new Pair("syn", "syntax"),
@@ -343,6 +347,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly Pair[] OnlyMidTerms =
                                                       {
+                                                          new Pair("Adpt", "Adapter"),
                                                           new Pair("Alt", "Alternative"),
                                                           new Pair("App", "Application"),
                                                           new Pair("Appl", "Application"),
@@ -464,6 +469,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                           new Pair("Imp", "Implementation"),
                                                           new Pair("Impl", "Implementation"),
                                                           new Pair("Init", "Initialize"),
+                                                          new Pair("Inp", "Input"),
                                                           new Pair("Interv", "Interval"),
                                                           new Pair("Intf", "Interface"),
                                                           new Pair("Intfc", "Interface"),
@@ -502,6 +508,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                           new Pair("Ops", "Operations"),
                                                           new Pair("Opt", "Option"),
                                                           new Pair("Opts", "Options"),
+                                                          new Pair("Outp", "Output"),
                                                           new Pair("Para", "Parameter"),
                                                           new Pair("Param", "Parameter"),
                                                           new Pair("Params", "Parameters"),
@@ -555,6 +562,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                           new Pair("Std", "Standard"),
                                                           new Pair("Str", "String"),
                                                           new Pair("Sts", "Status"),
+                                                          new Pair("Succ", "Success"),
                                                           new Pair("Svc", "Service"),
                                                           new Pair("Svr", "Server"),
                                                           new Pair("Syn", "Syntax"),

--- a/MiKo.Analyzer.Tests/Linguistics/AbbreviationFinderTests.cs
+++ b/MiKo.Analyzer.Tests/Linguistics/AbbreviationFinderTests.cs
@@ -10,6 +10,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
     {
         private static readonly Pair[] Prefixes =
                                                   [
+                                                      new("adpt", "adapter"),
                                                       new("alt", "alternative"),
                                                       new("app", "application"),
                                                       new("appl", "application"),
@@ -122,6 +123,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new("imp", "implementation"),
                                                       new("impl", "implementation"),
                                                       new("init", "initialize"),
+                                                      new("inp", "input"),
                                                       new("interv", "interval"),
                                                       new("intf", "interface"),
                                                       new("intfc", "interface"),
@@ -161,6 +163,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new("ops", "operations"),
                                                       new("opt", "option"),
                                                       new("opts", "options"),
+                                                      new("outp", "output"),
                                                       new("para", "parameter"),
                                                       new("param", "parameter"),
                                                       new("params", "parameters"),
@@ -214,6 +217,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new("std", "standard"),
                                                       new("str", "string"),
                                                       new("sts", "status"),
+                                                      new("succ", "success"),
                                                       new("svc", "service"),
                                                       new("svr", "server"),
                                                       new("syn", "syntax"),
@@ -244,6 +248,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
 
         private static readonly Pair[] Postfixes =
                                                    [
+                                                       new("Adpt", "Adapter"),
                                                        new("Alt", "Alternative"),
                                                        new("App", "Application"),
                                                        new("Appl", "Application"),
@@ -365,6 +370,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                        new("Imp", "Implementation"),
                                                        new("Impl", "Implementation"),
                                                        new("Init", "Initialize"),
+                                                       new("Inp", "Input"),
                                                        new("Interv", "Interval"),
                                                        new("Intf", "Interface"),
                                                        new("Intfc", "Interface"),
@@ -403,6 +409,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                        new("Ops", "Operations"),
                                                        new("Opt", "Option"),
                                                        new("Opts", "Options"),
+                                                       new("Outp", "Output"),
                                                        new("Para", "Parameter"),
                                                        new("Param", "Parameter"),
                                                        new("Params", "Parameters"),
@@ -456,6 +463,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                        new("Std", "Standard"),
                                                        new("Str", "String"),
                                                        new("Sts", "Status"),
+                                                       new("Succ", "Success"),
                                                        new("Svc", "Service"),
                                                        new("Svr", "Server"),
                                                        new("Syn", "Syntax"),


### PR DESCRIPTION
- `adpt` for `adapter`

- `inp` for `input`

- `outp` for `output`

- `succ` for `success`