### PR TITLE
MiKo_3080 is now aware of properties inherited from base classes

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -825,13 +825,13 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Gets all methods of a type.
+        /// Gets all methods of a type that can be referenced by name.
         /// </summary>
         /// <param name="value">
         /// The type whose methods are wanted.
         /// </param>
         /// <returns>
-        /// A collection of methods.
+        /// A collection of methods (that can be referenced by name).
         /// </returns>
         internal static IEnumerable<IMethodSymbol> GetMethodsIncludingInherited(this ITypeSymbol value) => value.GetMembersIncludingInherited<IMethodSymbol>();
 

--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -438,6 +438,17 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
+        /// Gets all events of a type that can be referenced by name.
+        /// </summary>
+        /// <param name="value">
+        /// The type whose events are wanted.
+        /// </param>
+        /// <returns>
+        /// A collection of events (that can be referenced by name).
+        /// </returns>
+        internal static IEnumerable<IEventSymbol> GetEventsIncludingInherited(this ITypeSymbol value) => value.GetMembersIncludingInherited<IEventSymbol>();
+
+        /// <summary>
         /// Gets all extension methods defined for the type.
         /// </summary>
         /// <param name="value">
@@ -492,6 +503,17 @@ namespace MiKoSolutions.Analyzers
 
             return Array.Empty<IFieldSymbol>();
         }
+
+        /// <summary>
+        /// Gets all fields of a type that can be referenced by name.
+        /// </summary>
+        /// <param name="value">
+        /// The type whose fields are wanted.
+        /// </param>
+        /// <returns>
+        /// A collection of fields (that can be referenced by name).
+        /// </returns>
+        internal static IEnumerable<IFieldSymbol> GetFieldsIncludingInherited(this ITypeSymbol value) => value.GetMembersIncludingInherited<IFieldSymbol>();
 
         /// <summary>
         /// Gets a <see cref="string"/> representation of the generic arguments for a type as T parameters.
@@ -803,6 +825,17 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
+        /// Gets all methods of a type.
+        /// </summary>
+        /// <param name="value">
+        /// The type whose methods are wanted.
+        /// </param>
+        /// <returns>
+        /// A collection of methods.
+        /// </returns>
+        internal static IEnumerable<IMethodSymbol> GetMethodsIncludingInherited(this ITypeSymbol value) => value.GetMembersIncludingInherited<IMethodSymbol>();
+
+        /// <summary>
         /// Gets a <see cref="string"/> representation of the method signature.
         /// </summary>
         /// <param name="value">
@@ -982,6 +1015,21 @@ namespace MiKoSolutions.Analyzers
             return Array.Empty<IMethodSymbol>();
         }
 
+        /// <summary>
+        /// Gets the direct properties of a type that can be referenced by name.
+        /// </summary>
+        /// <param name="value">
+        /// The type whose properties are wanted.
+        /// </param>
+        /// <returns>
+        /// A collection of properties (that can be referenced by name).
+        /// </returns>
+        /// <remarks>
+        /// <note type="important">
+        /// Indexers cannot be referenced by name and therefore are not part of the result.
+        /// Same applies for properties of any base type.
+        /// </note>
+        /// </remarks>
         internal static IReadOnlyList<IPropertySymbol> GetProperties(this ITypeSymbol value)
         {
             var properties = value.GetMembers<IPropertySymbol>();
@@ -993,6 +1041,22 @@ namespace MiKoSolutions.Analyzers
 
             return Array.Empty<IPropertySymbol>();
         }
+
+        /// <summary>
+        /// Gets all properties of a type that can be referenced by name.
+        /// </summary>
+        /// <param name="value">
+        /// The type whose properties are wanted.
+        /// </param>
+        /// <returns>
+        /// A collection of properties (that can be referenced by name).
+        /// </returns>
+        /// <remarks>
+        /// <note type="important">
+        /// Indexers cannot be referenced by name and therefore are not part of the result.
+        /// </note>
+        /// </remarks>
+        internal static IEnumerable<IPropertySymbol> GetPropertiesIncludingInherited(this ITypeSymbol value) => value.GetMembersIncludingInherited<IPropertySymbol>();
 
         /// <summary>
         /// Gets the return type of a property.
@@ -3437,7 +3501,7 @@ namespace MiKoSolutions.Analyzers
         {
             string[] fieldNames = null;
 
-            foreach (var field in value.ContainingType.GetMembersIncludingInherited<IFieldSymbol>())
+            foreach (var field in value.ContainingType.GetFieldsIncludingInherited())
             {
                 if (fieldNames is null)
                 {
@@ -3477,7 +3541,7 @@ namespace MiKoSolutions.Analyzers
         {
             var valueName = value.Name;
 
-            return value.ContainingType.GetMembersIncludingInherited<IPropertySymbol>().Any(_ => string.Equals(valueName, _.Name, StringComparison.OrdinalIgnoreCase));
+            return value.ContainingType.GetPropertiesIncludingInherited().Any(_ => string.Equals(valueName, _.Name, StringComparison.OrdinalIgnoreCase));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3018_ObjectDisposedExceptionAnalyzer.cs
@@ -104,10 +104,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     {
                         if (methods is null)
                         {
-                            methods = symbol.ContainingType
-                                            .GetMembersIncludingInherited<IMethodSymbol>()
-                                            .Where(_ => _.Locations.Any(__ => __.IsInSource))
-                                            .ToLookup(_ => _.Name);
+                            methods = symbol.ContainingType.GetMethodsIncludingInherited()
+                                                           .Where(_ => _.Locations.Any(__ => __.IsInSource))
+                                                           .ToLookup(_ => _.Name);
                         }
 
                         if (methods.Contains(name) && methods[name].Any(DirectlyThrowsObjectDisposedException))

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
@@ -36,14 +36,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
         }
 
-        private static bool HasIssue(SwitchStatementSyntax switchStatement)
+        private static bool HasIssue(SwitchStatementSyntax switchStatement, ISymbol symbol)
         {
             if (switchStatement.DescendantNodes<ReturnStatementSyntax>().Any())
             {
                 return false;
             }
 
-            var usedIdentifiers = switchStatement.Sections.Select(_ => _.Statements.SelectMany(GetAssignmentIdentifierCandidates).ToHashSet()).ToList();
+            var usedIdentifiers = switchStatement.Sections.Select(_ => _.Statements.SelectMany(GetAssignmentIdentifierCandidates).ToHashSet()).Where(_ => _.Count > 0).ToList();
 
             if (usedIdentifiers.Count is 0)
             {
@@ -51,10 +51,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return false;
             }
 
-            return HasIssueWithVariable(switchStatement, usedIdentifiers)
-                || HasIssueWithProperty(switchStatement, usedIdentifiers)
-                || HasIssueWithField(switchStatement, usedIdentifiers)
-                || HasIssueWithParameter(switchStatement, usedIdentifiers);
+            return HasIssueWithVariable(usedIdentifiers, switchStatement)
+                || HasIssueWithProperty(usedIdentifiers, symbol)
+                || HasIssueWithField(usedIdentifiers, symbol)
+                || HasIssueWithParameter(usedIdentifiers, symbol);
         }
 
         private static bool HasIssue(IReadOnlyList<HashSet<string>> usedIdentifiers, HashSet<string> identifiers)
@@ -80,52 +80,46 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return identifierUsages.Count != 0;
         }
 
-        private static bool HasIssueWithParameter(SwitchStatementSyntax switchStatement, IReadOnlyList<HashSet<string>> usedIdentifiers)
+        private static bool HasIssueWithParameter(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
         {
-            var method = switchStatement.FirstAncestor<BaseMethodDeclarationSyntax>();
-
-            if (method is null)
+            if (symbol is IMethodSymbol method)
             {
-                // may be used in global context
-                return false;
+                var parameterNames = method.Parameters.Where(_ => _.RefKind is RefKind.Out || _.RefKind is RefKind.Ref).ToHashSet(_ => _.Name);
+
+                return HasIssue(usedIdentifiers, parameterNames);
             }
 
-            var parameterNames = method.ParameterList.Parameters.ToHashSet(_ => _.GetName());
-
-            return HasIssue(usedIdentifiers, parameterNames);
+            // may be used in global context
+            return false;
         }
 
-        private static bool HasIssueWithField(SwitchStatementSyntax switchStatement, IReadOnlyList<HashSet<string>> usedIdentifiers)
+        private static bool HasIssueWithField(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
         {
-            var type = switchStatement.FirstAncestor<BaseTypeDeclarationSyntax>();
-
-            if (type is null)
+            if (symbol is IMethodSymbol method)
             {
-                // may be used in global context
-                return false;
+                var fieldNames = method.ContainingType.GetFields().Where(_ => _.IsConst is false).ToHashSet(_ => _.Name);
+
+                return HasIssue(usedIdentifiers, fieldNames);
             }
 
-            var fieldNames = type.ChildNodes<BaseFieldDeclarationSyntax>().SelectMany(_ => _.Declaration.Variables).ToHashSet(_ => _.GetName());
-
-            return HasIssue(usedIdentifiers, fieldNames);
+            // may be used in global context
+            return false;
         }
 
-        private static bool HasIssueWithProperty(SwitchStatementSyntax switchStatement, IReadOnlyList<HashSet<string>> usedIdentifiers)
+        private static bool HasIssueWithProperty(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
         {
-            var type = switchStatement.FirstAncestor<BaseTypeDeclarationSyntax>();
-
-            if (type is null)
+            if (symbol is IMethodSymbol method)
             {
-                // may be used in global context
-                return false;
+                var propertyNames = method.ContainingType.GetPropertiesIncludingInherited().ToHashSet(_ => _.Name);
+
+                return HasIssue(usedIdentifiers, propertyNames);
             }
 
-            var propertyNames = type.ChildNodes<BasePropertyDeclarationSyntax>().ToHashSet(_ => _.GetName());
-
-            return HasIssue(usedIdentifiers, propertyNames);
+            // may be used in global context
+            return false;
         }
 
-        private static bool HasIssueWithVariable(SwitchStatementSyntax switchStatement, IReadOnlyList<HashSet<string>> usedIdentifiers)
+        private static bool HasIssueWithVariable(IReadOnlyList<HashSet<string>> usedIdentifiers, SwitchStatementSyntax switchStatement)
         {
             var variableNames = GetVariableNamesUntilHere(switchStatement).ToHashSet();
 
@@ -159,7 +153,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var switchStatement = (SwitchStatementSyntax)context.Node;
 
-            if (HasIssue(switchStatement))
+            if (HasIssue(switchStatement, context.ContainingSymbol))
             {
                 // keep in mind that 'while(true) { switch ... }' is a performance optimization to avoid recursive calls
                 if (switchStatement.AncestorsWithinMethods<WhileStatementSyntax>().None())

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer.cs
@@ -22,18 +22,27 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSwitchStatement, SyntaxKind.SwitchStatement);
 
-        private static bool IsNoDeclarationCore(SyntaxNode node)
+        private static IEnumerable<string> GetAssignmentIdentifierCandidates(SyntaxNode node)
         {
-            switch (node.RawKind)
-            {
-                case (int)SyntaxKind.MethodDeclaration:
-                case (int)SyntaxKind.ConstructorDeclaration:
-                case (int)SyntaxKind.IndexerDeclaration:
-                    return false;
+            var candidates = node.DescendantNodes<AssignmentExpressionSyntax>(SyntaxKind.SimpleAssignmentExpression)
+                                 .Select(_ => _.FirstChild<IdentifierNameSyntax>())
+                                 .WhereNotNull()
+                                 .Select(_ => _.GetName());
 
-                default:
-                    return true;
-            }
+            return candidates;
+        }
+
+        private static IEnumerable<string> GetVariableNamesUntilHere(SwitchStatementSyntax switchStatement)
+        {
+            return switchStatement.Ancestors()
+                                  .TakeWhile(IsNoDeclaration)
+                                  .SelectMany(_ => GetVariableNames(_, switchStatement));
+
+            IEnumerable<string> GetVariableNames(SyntaxNode node, SyntaxNode stopNode) => node.ChildNodes()
+                                                                                              .TakeWhile(_ => _ != stopNode)
+                                                                                              .OfType<LocalDeclarationStatementSyntax>()
+                                                                                              .SelectMany(_ => _.Declaration.Variables)
+                                                                                              .Select(_ => _.GetName());
         }
 
         private static bool HasIssue(SwitchStatementSyntax switchStatement, ISymbol symbol)
@@ -43,9 +52,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 return false;
             }
 
-            var usedIdentifiers = switchStatement.Sections.Select(_ => _.Statements.SelectMany(GetAssignmentIdentifierCandidates).ToHashSet()).Where(_ => _.Count > 0).ToList();
+            var usedIdentifiers = switchStatement.Sections.Select(_ => _.Statements.SelectMany(GetAssignmentIdentifierCandidates).ToHashSet()).ToList();
 
-            if (usedIdentifiers.Count is 0)
+            if (usedIdentifiers.All(_ => _.Count is 0))
             {
                 // for whatever reason we do not have any identifiers, so we do not have an issue here
                 return false;
@@ -80,19 +89,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return identifierUsages.Count != 0;
         }
 
-        private static bool HasIssueWithParameter(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
-        {
-            if (symbol is IMethodSymbol method)
-            {
-                var parameterNames = method.Parameters.Where(_ => _.RefKind is RefKind.Out || _.RefKind is RefKind.Ref).ToHashSet(_ => _.Name);
-
-                return HasIssue(usedIdentifiers, parameterNames);
-            }
-
-            // may be used in global context
-            return false;
-        }
-
         private static bool HasIssueWithField(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
         {
             if (symbol is IMethodSymbol method)
@@ -100,6 +96,19 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 var fieldNames = method.ContainingType.GetFields().Where(_ => _.IsConst is false).ToHashSet(_ => _.Name);
 
                 return HasIssue(usedIdentifiers, fieldNames);
+            }
+
+            // may be used in global context
+            return false;
+        }
+
+        private static bool HasIssueWithParameter(IReadOnlyList<HashSet<string>> usedIdentifiers, ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol method)
+            {
+                var parameterNames = method.Parameters.Where(_ => _.RefKind is RefKind.Out || _.RefKind is RefKind.Ref).ToHashSet(_ => _.Name);
+
+                return HasIssue(usedIdentifiers, parameterNames);
             }
 
             // may be used in global context
@@ -126,27 +135,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return HasIssue(usedIdentifiers, variableNames);
         }
 
-        private static IEnumerable<string> GetVariableNamesUntilHere(SwitchStatementSyntax switchStatement)
+        private static bool IsNoDeclarationCore(SyntaxNode node)
         {
-            return switchStatement.Ancestors()
-                                  .TakeWhile(IsNoDeclaration)
-                                  .SelectMany(_ => GetVariableNames(_, switchStatement));
+            switch (node.RawKind)
+            {
+                case (int)SyntaxKind.MethodDeclaration:
+                case (int)SyntaxKind.ConstructorDeclaration:
+                case (int)SyntaxKind.IndexerDeclaration:
+                    return false;
 
-            IEnumerable<string> GetVariableNames(SyntaxNode node, SyntaxNode stopNode) => node.ChildNodes()
-                                                                                              .TakeWhile(_ => _ != stopNode)
-                                                                                              .OfType<LocalDeclarationStatementSyntax>()
-                                                                                              .SelectMany(_ => _.Declaration.Variables)
-                                                                                              .Select(_ => _.GetName());
-        }
-
-        private static IEnumerable<string> GetAssignmentIdentifierCandidates(SyntaxNode node)
-        {
-            var candidates = node.DescendantNodes<AssignmentExpressionSyntax>(SyntaxKind.SimpleAssignmentExpression)
-                                 .Select(_ => _.FirstChild<IdentifierNameSyntax>())
-                                 .WhereNotNull()
-                                 .Select(_ => _.GetName());
-
-            return candidates;
+                default:
+                    return true;
+            }
         }
 
         private void AnalyzeSwitchStatement(SyntaxNodeAnalysisContext context)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3091_FinallyBlockRaisesEventAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3091_FinallyBlockRaisesEventAnalyzer.cs
@@ -35,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var semanticModel = context.SemanticModel;
 
             var method = context.GetEnclosingMethod();
-            var events = method.ContainingType.GetMembersIncludingInherited<IEventSymbol>().ToHashSet(_ => _.Name);
+            var events = method.ContainingType.GetEventsIncludingInherited().ToHashSet(_ => _.Name);
 
             foreach (var token in finallyBlock.DescendantTokens(SyntaxKind.IdentifierToken))
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3092_StatementInsideLockRaisesEventAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3092_StatementInsideLockRaisesEventAnalyzer.cs
@@ -59,7 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var eventName = token.ValueText;
 
             var method = context.GetEnclosingMethod();
-            var events = method.ContainingType.GetMembersIncludingInherited<IEventSymbol>().ToHashSet(_ => _.Name);
+            var events = method.ContainingType.GetEventsIncludingInherited().ToHashSet(_ => _.Name);
 
             if (events.Contains(eventName) && token.GetSymbol(context.SemanticModel) is IEventSymbol)
             {

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzerTests.cs
@@ -183,6 +183,61 @@ switch (value)
 ", languageVersion: LanguageVersion.CSharp9);
 
         [Test]
+        public void No_issue_is_reported_for_switch_that_assigns_to_variable_in_only_one_of_multiple_sections() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public object Create(StringComparison value)
+    {
+        object result = null;
+
+        switch (value)
+        {
+            case StringComparison.Ordinal:
+                result = new object();
+                break;
+
+            case StringComparison.OrdinalIgnoreCase:
+                break;
+
+            default:
+                break;
+        }
+
+        return result;
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_switch_that_assigns_in_none_of_multiple_sections() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    public object Create(StringComparison value)
+    {
+        object result = null;
+
+        switch (value)
+        {
+            case StringComparison.Ordinal:
+                break;
+
+            case StringComparison.OrdinalIgnoreCase:
+                break;
+
+            default:
+                break;
+        }
+
+        return result;
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_factory_that_assigns_return_value_to_variable_instead_of_returning_it_directly() => An_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzerTests.cs
@@ -356,6 +356,33 @@ public class TestMe
 ");
 
         [Test]
+        public void An_issue_is_reported_for_switch_that_determines_single_condition_and_keeps_information_in_same_property_of_base_class() => An_issue_is_reported_for(@"
+using System;
+
+public class TestMeBase
+{
+    public bool Ordinal { get; set; }
+}
+
+public class TestMe : TestMeBase
+{
+    public void DoStuff(StringComparison value)
+    {
+        switch (value)
+        {
+            case StringComparison.Ordinal:
+                Ordinal = true;
+                break;
+
+            case StringComparison.OrdinalIgnoreCase:
+                Ordinal = true;
+                break;
+        }
+    }
+}
+");
+
+        [Test]
         public void An_issue_is_reported_for_switch_that_determines_single_condition_and_keeps_information_in_same_field() => An_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Update `HasIssue*` methods in `MiKo_3080_SwitchReturnInsteadSwitchBreakAnalyzer` to accept `ISymbol`, improving accuracy

- Improve identifier collection logic in switch analysis

- Introduce extension methods for type symbols
  - `GetEventsIncludingInherited`
  - `GetFieldsIncludingInherited`
  - `GetMethodsIncludingInherited`
  - `GetPropertiesIncludingInherited`

- Refactor analyzers to use new extension methods instead of `GetMembersIncludingInherited<T>`

- Replace event member retrieval with new method in related analyzers for consistency