### PR TITLE
MiKo_3032 is now able to fix some more phrases

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxListExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxListExtensions.cs
@@ -412,38 +412,18 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Gets a <see cref="SyntaxList{T}"/> with all occurrences of the specified phrase replaced with the specified replacement.
-        /// </summary>
-        /// <param name="source">
-        /// The list in which to replace text.
-        /// </param>
-        /// <param name="phrase">
-        /// The phrase to be replaced.
-        /// </param>
-        /// <param name="replacement">
-        /// The text that replaces all occurrences of the phrase.
-        /// </param>
-        /// <returns>
-        /// A collection of XML node syntaxes with all occurrences of the phrase replaced with the replacement.
-        /// </returns>
-        internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, string phrase, string replacement) => source.ReplaceText(new[] { phrase }, replacement);
-
-        /// <summary>
         /// Gets a <see cref="SyntaxList{T}"/> with all occurrences of the specified phrases replaced with the specified replacement.
         /// </summary>
         /// <param name="source">
         /// The list in which to replace text.
         /// </param>
-        /// <param name="phrases">
-        /// The phrases to be replaced.
-        /// </param>
-        /// <param name="replacement">
-        /// The text that replaces all occurrences of the phrases.
+        /// <param name="replacementPhrases">
+        /// The phrases to be replaced where the <see cref="Pair.Key"/> is the phrase to replace and the <see cref="Pair.Value"/> is the text to replace with.
         /// </param>
         /// <returns>
         /// A collection of XML node syntaxes with all occurrences of the phrases replaced with the replacement.
         /// </returns>
-        internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, in ReadOnlySpan<string> phrases, string replacement)
+        internal static SyntaxList<XmlNodeSyntax> ReplaceText(this in SyntaxList<XmlNodeSyntax> source, in ReadOnlySpan<Pair> replacementPhrases)
         {
             var count = source.Count;
 
@@ -460,7 +440,14 @@ namespace MiKoSolutions.Analyzers
 
                 if (value is XmlTextSyntax text)
                 {
-                    result[index] = text.ReplaceText(phrases, replacement);
+                    XmlTextSyntax replacedText = text;
+
+                    foreach (var pair in replacementPhrases)
+                    {
+                        replacedText = replacedText.ReplaceText(pair.Key, pair.Value);
+                    }
+
+                    result[index] = replacedText;
                 }
             }
 
@@ -878,7 +865,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A collection of XML node syntaxes with the start texts removed from the first element, or the original list if no such text is present.
         /// </returns>
-        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this in SyntaxList<XmlNodeSyntax> values, in ReadOnlySpan<string> startTexts)
+        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this in SyntaxList<XmlNodeSyntax> values, IEnumerable<string> startTexts)
         {
             if (values.Count > 0 && values[0] is XmlTextSyntax textSyntax)
             {

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxListExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxListExtensions.cs
@@ -412,13 +412,13 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Gets a <see cref="SyntaxList{T}"/> with all occurrences of the specified phrases replaced with the specified replacement.
+        /// Gets a <see cref="SyntaxList{T}"/> with all occurrences of the specified phrases replaced with the specified replacements.
         /// </summary>
         /// <param name="source">
         /// The list in which to replace text.
         /// </param>
         /// <param name="replacementPhrases">
-        /// The phrases to be replaced where the <see cref="Pair.Key"/> is the phrase to replace and the <see cref="Pair.Value"/> is the text to replace with.
+        /// The phrases to be replaced, where the <see cref="Pair.Key"/> is the phrase to replace and the <see cref="Pair.Value"/> is the text to replace with.
         /// </param>
         /// <returns>
         /// A collection of XML node syntaxes with all occurrences of the phrases replaced with the replacement.

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Documentation.cs
@@ -1804,7 +1804,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A collection of <see cref="XmlNodeSyntax"/> with the first matching starting text removed, or the original syntax list if none of the texts were found at the beginning.
         /// </returns>
-        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this XmlElementSyntax value, in ReadOnlySpan<string> startTexts) => value.Content.WithoutStartText(startTexts);
+        internal static SyntaxList<XmlNodeSyntax> WithoutStartText(this XmlElementSyntax value, IEnumerable<string> startTexts) => value.Content.WithoutStartText(startTexts);
 
         /// <summary>
         /// Creates a new XML text syntax from the specified XML text syntax without the specified starting texts.
@@ -1818,13 +1818,8 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A new <see cref="XmlTextSyntax"/> with the first matching starting text removed (after trimming leading whitespace), or the original syntax if none of the texts were found at the beginning.
         /// </returns>
-        internal static XmlTextSyntax WithoutStartText(this XmlTextSyntax value, in ReadOnlySpan<string> startTexts)
+        internal static XmlTextSyntax WithoutStartText(this XmlTextSyntax value, IEnumerable<string> startTexts)
         {
-            if (startTexts.Length is 0)
-            {
-                return value;
-            }
-
             var tokens = value.TextTokens;
 
             if (tokens.Count is 0)

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2032_CodeFixProvider.cs
@@ -21,7 +21,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private static readonly string[] GenericEndParts = Constants.Comments.BooleanTaskReturnTypeEndingPhraseTemplate.FormatWith("|").Split('|');
 
         private static readonly string[] Phrases = AlmostCorrectTaskReturnTypeStartingPhrases.ConcatenatedWith(
-                                                                                                           " if ",
                                                                                                            "A task that has the result ",
                                                                                                            "A task that completes with a result of ",
                                                                                                            "a task that completes with a result of ",
@@ -67,7 +66,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                                            "false",
                                                                                                            "Returns",
                                                                                                            "returns",
-                                                                                                           "will return")
+                                                                                                           "will return",
+                                                                                                           " else .")
                                                                                              .OrderDescendingByLengthAndText();
 
         private static readonly string[] SimpleStartingPhrases = CreateSimpleStartingPhrases().OrderDescendingByLengthAndText();
@@ -125,6 +125,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                      " Otherwise ",
                                                                      " Otherwise",
                                                                  };
+
+        private static readonly Pair[] CleanupMap =
+                                                    {
+                                                        new Pair(" if if ", " if "),
+                                                        new Pair(" if when ", " if "),
+                                                        new Pair(" orif ", " or if "),
+                                                        new Pair(" the value is .", ";"),
+
+                                                        // TODO RKN: special handling, needs rework (replace "button" with other texts, just keep the pattern)
+                                                        new Pair(" if the button is enabled, if the button is disabled", " if the button is enabled"),
+                                                    };
+
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2032";
@@ -245,7 +257,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             if (firstNode.IsPara())
             {
-                // clean up comment and remove first node (and any empty comment if the 1st node was the only one)
+                // clean up comment and remove first node (and any empty comment if the first node was the only one)
                 comment = comment.Without(firstNode).WithoutWhitespaceOnlyComment();
 
                 if (firstNode is XmlElementSyntax element)
@@ -279,18 +291,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return new[] { XmlText(startingPhrase + Constants.TODO + endingPhrase) };
             }
 
-            const string OrIfPhrase = " or if ";
-            const string OrIfReplacementPhrase = " orif ";
-
             // clean up comment and remove boolean <see langword="..."/> and <c>...</c>
             var adjustedComment = RemoveBooleansTags(comment);
 
-            var nodes = adjustedComment.WithoutStartText(DelimiterPhrases)
-                                       .WithoutStartText(SimpleStartingPhrases)
-                                       .WithoutStartText(OtherStartingPhrases)
-                                       .ReplaceText(OrIfPhrase, OrIfReplacementPhrase)
+            var nodes = adjustedComment.WithoutStartText(DelimiterPhrases.ConcatenatedWith(SimpleStartingPhrases).ConcatenatedWith(OtherStartingPhrases))
                                        .WithoutText(Phrases)
-                                       .WithoutText(" else .")
                                        .WithoutFirstXmlNewLine();
 
             if (nodes.Count is 0)
@@ -300,8 +305,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
 
             nodes = nodes.WithStartText(startingPhrase) // keep starting text and ensure that first character of original text is now lower-case
-                         .ReplaceText(OrIfReplacementPhrase, OrIfPhrase)
-                         .ReplaceText(" if when ", " if ");
+                         .ReplaceText(CleanupMap);
 
             // clean up comment and remove last node if it is ending with a dot
             if (nodes.LastOrDefault() is XmlTextSyntax sentenceEnding)

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -455,7 +455,7 @@ public class TestMe
               "If the dialog exists at call time, the value is True.",
               "If the dialog does not exist at call time, the value is False.",
               """<see langword="true"/> if the dialog exists at call time; otherwise, <see langword="false"/>.""")]
-        public void Code_gets_fixed_for_Boolean_method_with_repeated_par_phrase_(string originalComment1, string originalComment2, string fixedComment)
+        public void Code_gets_fixed_for_Boolean_method_with_repeated_para_phrase_(string originalComment1, string originalComment2, string fixedComment)
         {
             var originalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2032_BooleanReturnTypeDefaultPhraseAnalyzerTests.cs
@@ -411,6 +411,86 @@ public class TestMe
             VerifyCSharpFix(originalCode, FixedCode);
         }
 
+        [TestCase("True, if the button is enabled, False if the button is disabled.", """<see langword="true"/> if the button is enabled; otherwise, <see langword="false"/>.""")]
+        public void Code_gets_fixed_for_Boolean_method_with_repeated_phrase_(string originalComment, string fixedComment)
+        {
+            var originalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    /// <returns>" + originalComment + @"</returns>
+    public bool DoSomething(object o) => throw new NotSupportedException();
+}
+";
+
+            var fixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    /// <returns>
+    /// " + fixedComment + @"
+    /// </returns>
+    public bool DoSomething(object o) => throw new NotSupportedException();
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [TestCase(
+              "If the Velocity options are available the value is true.",
+              "If the Velocity options are not available the value is false.",
+              """<see langword="true"/> if the Velocity options are available; otherwise, <see langword="false"/>.""")]
+        [TestCase(
+              "If the button to delete State Machine is available to the user the value is True.",
+              "If the button to delete State Machine is not available to the user the value is False.",
+              """<see langword="true"/> if the button to delete State Machine is available to the user; otherwise, <see langword="false"/>.""")]
+        [TestCase(
+              "If the dialog exists at call time, the value is True.",
+              "If the dialog does not exist at call time, the value is False.",
+              """<see langword="true"/> if the dialog exists at call time; otherwise, <see langword="false"/>.""")]
+        public void Code_gets_fixed_for_Boolean_method_with_repeated_par_phrase_(string originalComment1, string originalComment2, string fixedComment)
+        {
+            var originalCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    /// <returns>
+    /// <para>" + originalComment1 + @"</para>
+    /// <para>" + originalComment2 + @"</para>
+    /// </returns>
+    public bool DoSomething(object o) => throw new NotSupportedException();
+}
+";
+
+            var fixedCode = @"
+using System;
+using System.Threading.Tasks;
+
+public class TestMe
+{
+    /// <summary>Does something.</summary>
+    /// <returns>
+    /// <para>
+    /// " + fixedComment + @"
+    /// </para>
+    /// </returns>
+    public bool DoSomething(object o) => throw new NotSupportedException();
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
         [TestCase(@"<see langword=""false""/> in any other case.")]
         [TestCase(@"<see langword=""false""/> in any other cases.")]
         [TestCase(@"<see langword=""false""/> in any of the other cases.")]


### PR DESCRIPTION
- Add new tests covering repeated phrases and `<para>`-split true/false descriptions

- Update codedfix provider to apply additional cleanup replacements during middle-part extraction

- Refactor `WithoutStartText` which now accepts `IEnumerable<string>`, and `SyntaxList<XmlNodeSyntax>.ReplaceText` now applies a `Pair`-based replacement map
