### PR TITLE
Refactored MiKo_3039 to avoid calling 'AnalyzeProperty' with 'null'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3039_PropertyInvokesLinqAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3039_PropertyInvokesLinqAnalyzer.cs
@@ -54,14 +54,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 AnalyzeProperty(body, propertyName, semanticModel, ref issues);
             }
 
-            if (property.GetGetter() is AccessorDeclarationSyntax getter)
+            if (property.GetGetter() is AccessorDeclarationSyntax getter && (getter.Body ?? (SyntaxNode)getter.ExpressionBody) is SyntaxNode getterBody)
             {
-                AnalyzeProperty(getter.Body ?? (SyntaxNode)getter.ExpressionBody, propertyName, semanticModel, ref issues);
+                AnalyzeProperty(getterBody, propertyName, semanticModel, ref issues);
             }
 
-            if (property.GetSetter() is AccessorDeclarationSyntax setter)
+            if (property.GetSetter() is AccessorDeclarationSyntax setter && (setter.Body ?? (SyntaxNode)setter.ExpressionBody) is SyntaxNode setterBody)
             {
-                AnalyzeProperty(setter.Body ?? (SyntaxNode)setter.ExpressionBody, propertyName, semanticModel, ref issues);
+                AnalyzeProperty(setterBody, propertyName, semanticModel, ref issues);
             }
 
             return issues?.ToArray() ?? Array.Empty<Diagnostic>();


### PR DESCRIPTION
Refactor property getter and setter analysis to ensure `AnalyzeProperty` is only called when a body exists