### PR TITLE
Added rule MiKo_6069 that reports and fixes object initializer expressions not positioned properly

### DIFF
--- a/Documentation/MiKo_6069.md
+++ b/Documentation/MiKo_6069.md
@@ -1,0 +1,51 @@
+﻿# MiKo_6069: Align object initializer expressions relative to opening brace
+
+## Cause
+
+An object initializer expression is not at the expected position relative to the opening brace `{`.
+
+## Rule description
+
+Code readability improves when object initializer expressions are placed consistently relative to the opening brace.
+This makes the code clearer and easier to follow.
+
+### Rationale behind
+
+Inconsistent placement of expressions in object initializers makes it harder to quickly read and understand what a piece of code is creating.
+When each expression is placed consistently relative to the opening brace, the structure of the initializer stands out immediately.
+
+Following a consistent placement rule for object initializer expressions provides several important benefits:
+
+- **Improved Readability**:
+  When all expressions in an object initializer start at a consistent position, the structure of the initializer is immediately visible.
+  This makes it easier to scan the list of assigned properties at a glance.
+
+- **Easier Code Reviews**:
+  Consistent positioning makes it straightforward to compare initializers when reviewing changes in version control.
+  Formatting differences do not distract from the actual logical changes being reviewed.
+
+- **Reduced Cognitive Load**:
+  Developers do not need to mentally adjust to varying indentation when reading through code.
+  Code that follows a predictable pattern requires less effort to understand.
+
+- **Cleaner Visual Alignment**:
+  Proper positioning ensures that all expressions align vertically in multi-line initializers.
+  This visual grouping makes it easier to recognize which properties belong together and to notice any that are missing.
+
+- **Better Consistency Across the Codebase**:
+  When all object initializers follow the same formatting rule, the code feels uniform.
+  This uniformity also makes it easier for developers new to the codebase to learn and follow its conventions.
+
+## How to fix violations
+
+To fix a violation of this rule, adjust the indentation of each object initializer expression so that it starts at the expected position.
+
+For single-line initializers, ensure there is exactly one space between the opening brace and the first expression, as well as between each consecutive expression.
+For multi-line initializers, ensure each expression is indented by exactly one indentation level from the column of the opening brace.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_6069
+#pragma warning restore MiKo_6069
+```

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxTokenExtensions.cs
@@ -737,6 +737,73 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
+        /// Creates a new syntax token with additional spaces at the end of its trailing trivia.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax token to modify.
+        /// </param>
+        /// <param name="additionalSpaces">
+        /// The number of additional spaces to add.
+        /// </param>
+        /// <returns>
+        /// A new syntax token with additional spaces at the end of its trailing trivia.
+        /// </returns>
+        internal static SyntaxToken WithAdditionalTrailingSpacesAtEnd(this in SyntaxToken value, in int additionalSpaces)
+        {
+            if (additionalSpaces is 0)
+            {
+                return value;
+            }
+
+            return value.WithAdditionalTrailingTrivia(WhiteSpaces(additionalSpaces));
+        }
+
+        /// <summary>
+        /// Creates a new syntax token with additional trailing trivia.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax token to modify.
+        /// </param>
+        /// <param name="trivia">
+        /// The trivia to add.
+        /// </param>
+        /// <returns>
+        /// A new syntax token with the additional trailing trivia.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static SyntaxToken WithAdditionalTrailingTrivia(this in SyntaxToken value, in SyntaxTrivia trivia) => value.WithTrailingTrivia(value.TrailingTrivia.Add(trivia));
+
+        /// <summary>
+        /// Creates a new syntax token with additional trailing trivia.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax token to modify.
+        /// </param>
+        /// <param name="trivia">
+        /// The trivia list to add.
+        /// </param>
+        /// <returns>
+        /// A new syntax token with the additional trailing trivia.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static SyntaxToken WithAdditionalTrailingTrivia(this in SyntaxToken value, in SyntaxTriviaList trivia) => value.WithTrailingTrivia(value.TrailingTrivia.AddRange(trivia));
+
+        /// <summary>
+        /// Creates a new syntax token with additional trailing trivia.
+        /// </summary>
+        /// <param name="value">
+        /// The syntax token to modify.
+        /// </param>
+        /// <param name="trivia">
+        /// The collection of trivia to add.
+        /// </param>
+        /// <returns>
+        /// A new syntax token with the additional trailing trivia.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static SyntaxToken WithAdditionalTrailingTrivia(this in SyntaxToken value, IEnumerable<SyntaxTrivia> trivia) => value.WithTrailingTrivia(value.TrailingTrivia.AddRange(trivia));
+
+        /// <summary>
         /// Creates a new syntax token with an end of line added as trailing trivia.
         /// </summary>
         /// <param name="value">

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -478,6 +478,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6066_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6067_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6068_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6069_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6072_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -646,6 +646,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6066_ExpressionElementsAreIndentedAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6067_TernaryOperatorsAreOnSameLineLikeWhenClausesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6068_PropertyPatternInConditionIsOnSameLineAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6070_ConsoleStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6071_UsingLocalDeclarationStatementSurroundedByBlankLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\MiKo_6072_BaseExpressionSurroundedByBlankLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -18961,6 +18961,42 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Align expression relative to opening brace.
+        /// </summary>
+        internal static string MiKo_6069_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_6069_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code readability improves when object initializer expressions are placed consistently relative to the opening brace. This makes the code clearer and easier to follow..
+        /// </summary>
+        internal static string MiKo_6069_Description {
+            get {
+                return ResourceManager.GetString("MiKo_6069_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align expression relative to opening brace.
+        /// </summary>
+        internal static string MiKo_6069_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_6069_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Align object initializer expressions relative to opening brace.
+        /// </summary>
+        internal static string MiKo_6069_Title {
+            get {
+                return ResourceManager.GetString("MiKo_6069_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Surround with blank lines.
         /// </summary>
         internal static string MiKo_6070_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -6579,6 +6579,18 @@ This style avoids dangling operators, aligns with common C# style guides and too
   <data name="MiKo_6068_Title" xml:space="preserve">
     <value>Place property patterns inside 'if' conditions on same line</value>
   </data>
+  <data name="MiKo_6069_CodeFixTitle" xml:space="preserve">
+    <value>Align expression relative to opening brace</value>
+  </data>
+  <data name="MiKo_6069_Description" xml:space="preserve">
+    <value>Code readability improves when object initializer expressions are placed consistently relative to the opening brace. This makes the code clearer and easier to follow.</value>
+  </data>
+  <data name="MiKo_6069_MessageFormat" xml:space="preserve">
+    <value>Align expression relative to opening brace</value>
+  </data>
+  <data name="MiKo_6069_Title" xml:space="preserve">
+    <value>Align object initializer expressions relative to opening brace</value>
+  </data>
   <data name="MiKo_6070_CodeFixTitle" xml:space="preserve">
     <value>Surround with blank lines</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var spaces = GetProposedSpaces(issue);
 
-                return expression.WithoutLeadingTrivia().WithLeadingSpaces(spaces);
+                return expression.WithLeadingSpaces(spaces);
             }
 
             return syntax;
@@ -57,33 +57,34 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     switch (index)
                     {
                         case -1: // should never happen as the syntax should be part of the initializer
-                            break;
+                            return root;
 
                         case 0:
-                        {
-                            // ensure that the open brace token has no trailing trivia
-                            if (openBraceToken.HasTrailingTrivia)
-                            {
-                                return root.ReplaceNode(initializer, initializer.WithOpenBraceToken(openBraceToken.WithoutTrailingTrivia()));
-                            }
-
-                            break;
-                        }
+                            return GetUpdatedSyntaxRoot(root, openBraceToken);
 
                         default:
-                        {
-                            var separator = expressions.GetSeparator(index - 1);
-
-                            // ensure that the separator token has no trailing trivia
-                            if (separator.HasTrailingTrivia)
-                            {
-                                return root.ReplaceToken(separator, separator.WithoutTrailingTrivia());
-                            }
-
-                            break;
-                        }
+                            return GetUpdatedSyntaxRoot(root, expressions.GetSeparator(index - 1));
                     }
                 }
+            }
+
+            return root;
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxRoot(SyntaxNode root, in SyntaxToken token)
+        {
+            if (token.HasTrailingTrivia)
+            {
+                // ensure that the token has no trailing trivia
+                var updatedToken = token.WithoutTrailingTrivia();
+
+                if (token.HasTrailingComment())
+                {
+                    updatedToken = updatedToken.WithTrailingSpace()
+                                               .WithAdditionalTrailingTrivia(token.TrailingTrivia.Where(_ => _.IsComment()));
+                }
+
+                return root.ReplaceToken(token, updatedToken);
             }
 
             return root;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_CodeFixProvider.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_6069_CodeFixProvider)), Shared]
+    public sealed class MiKo_6069_CodeFixProvider : SpacingCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_6069";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes) => syntaxNodes.OfType<AssignmentExpressionSyntax>().FirstOrDefault();
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
+        {
+            var updatedSyntax = GetUpdatedSyntax(syntax, issue);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxRootAsync(Document document, SyntaxNode root, SyntaxNode syntax, SyntaxAnnotation annotationOfSyntax, Diagnostic issue, CancellationToken cancellationToken)
+        {
+            var updatedSyntax = GetUpdatedSyntaxRoot(root, syntax);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        private static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax, Diagnostic issue)
+        {
+            if (syntax is AssignmentExpressionSyntax expression)
+            {
+                var spaces = GetProposedSpaces(issue);
+
+                return expression.WithoutLeadingTrivia().WithLeadingSpaces(spaces);
+            }
+
+            return syntax;
+        }
+
+        private static SyntaxNode GetUpdatedSyntaxRoot(SyntaxNode root, SyntaxNode syntax)
+        {
+            if (syntax is AssignmentExpressionSyntax a && a.Parent is InitializerExpressionSyntax initializer)
+            {
+                var openBraceToken = initializer.OpenBraceToken;
+
+                if (initializer.CloseBraceToken.IsOnSameLineAs(openBraceToken))
+                {
+                    var expressions = initializer.Expressions;
+                    var index = expressions.IndexOf(a);
+
+                    switch (index)
+                    {
+                        case -1: // should never happen as the syntax should be part of the initializer
+                            break;
+
+                        case 0:
+                        {
+                            // ensure that the open brace token has no trailing trivia
+                            if (openBraceToken.HasTrailingTrivia)
+                            {
+                                return root.ReplaceNode(initializer, initializer.WithOpenBraceToken(openBraceToken.WithoutTrailingTrivia()));
+                            }
+
+                            break;
+                        }
+
+                        default:
+                        {
+                            var separator = expressions.GetSeparator(index - 1);
+
+                            // ensure that the separator token has no trailing trivia
+                            if (separator.HasTrailingTrivia)
+                            {
+                                return root.ReplaceToken(separator, separator.WithoutTrailingTrivia());
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return root;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
@@ -68,7 +68,12 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                         else
                         {
                             // calculate for consecutive expressions
-                            spaces = AcceptedSpacesOnSameLine;
+                            var separator = expressions.GetSeparator(index - 1);
+
+                            if (expression.GetPositionWithinStartLine() != separator.GetPositionWithinEndLine() + AcceptedSpacesOnSameLine)
+                            {
+                                spaces = AcceptedSpacesOnSameLine;
+                            }
                         }
                     }
                     else

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
@@ -52,25 +52,26 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 for (var index = 0; index < count; index++)
                 {
                     var expression = expressions[index];
-                    var expressionPosition = expression.GetStartPosition();
-                    var expressionPositionCharacter = expressionPosition.Character;
                     var spaces = 0;
 
                     if (onSameLine)
                     {
-                        if (index is 0)
+                        var token = index is 0
+                                    ? openBraceToken
+                                    : expressions.GetSeparator(index - 1); // calculate for consecutive expressions
+
+                        var trailingTrivia = token.TrailingTrivia;
+
+                        if (trailingTrivia.Count is 0)
                         {
-                            if (expression.GetPositionWithinStartLine() != openBraceToken.GetPositionWithinEndLine() + AcceptedSpacesOnSameLine)
+                            if (expression.GetPositionWithinStartLine() != token.GetPositionWithinEndLine() + AcceptedSpacesOnSameLine)
                             {
                                 spaces = AcceptedSpacesOnSameLine;
                             }
                         }
                         else
                         {
-                            // calculate for consecutive expressions
-                            var separator = expressions.GetSeparator(index - 1);
-
-                            if (expression.GetPositionWithinStartLine() != separator.GetPositionWithinEndLine() + AcceptedSpacesOnSameLine)
+                            if (trailingTrivia.Any(_ => _.Span.Length != AcceptedSpacesOnSameLine && _.IsWhiteSpace()))
                             {
                                 spaces = AcceptedSpacesOnSameLine;
                             }
@@ -78,11 +79,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                     }
                     else
                     {
+                        var expressionPosition = expression.GetStartPosition();
+
                         if (expressionPosition.Line > openBracePosition.Line)
                         {
                             var expectedPosition = openBracePosition.Character + Constants.Indentation;
 
-                            if (expressionPositionCharacter != expectedPosition)
+                            if (expressionPosition.Character != expectedPosition)
                             {
                                 spaces = expectedPosition;
                             }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer : SpacingAnalyzer
+    {
+        public const string Id = "MiKo_6069";
+
+        private const int AcceptedSpacesOnSameLine = 1;
+
+        private static readonly SyntaxKind[] Expressions = { SyntaxKind.ObjectInitializerExpression };
+
+        public MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer() : base(Id)
+        {
+        }
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, Expressions);
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InitializerExpressionSyntax initializer)
+            {
+                var issues = AnalyzeNode(initializer);
+
+                if (issues.Count > 0)
+                {
+                    ReportDiagnostics(context, issues);
+                }
+            }
+        }
+
+        private IReadOnlyList<Diagnostic> AnalyzeNode(InitializerExpressionSyntax initializer)
+        {
+            List<Diagnostic> issues = null;
+
+            var expressions = initializer.Expressions;
+            var count = expressions.Count;
+
+            if (count > 0)
+            {
+                var openBraceToken = initializer.OpenBraceToken;
+                var openBracePosition = openBraceToken.GetStartPosition();
+                var onSameLine = openBraceToken.IsOnSameLineAs(initializer.CloseBraceToken);
+
+                for (var index = 0; index < count; index++)
+                {
+                    var expression = expressions[index];
+                    var expressionPosition = expression.GetStartPosition();
+                    var expressionPositionCharacter = expressionPosition.Character;
+                    var spaces = 0;
+
+                    if (onSameLine)
+                    {
+                        if (index is 0)
+                        {
+                            if (expression.GetPositionWithinStartLine() != openBraceToken.GetPositionWithinEndLine() + AcceptedSpacesOnSameLine)
+                            {
+                                spaces = AcceptedSpacesOnSameLine;
+                            }
+                        }
+                        else
+                        {
+                            // calculate for consecutive expressions
+                            spaces = AcceptedSpacesOnSameLine;
+                        }
+                    }
+                    else
+                    {
+                        if (expressionPosition.Line > openBracePosition.Line)
+                        {
+                            var expectedPosition = openBracePosition.Character + Constants.Indentation;
+
+                            if (expressionPositionCharacter != expectedPosition)
+                            {
+                                spaces = expectedPosition;
+                            }
+                        }
+                    }
+
+                    if (spaces > 0)
+                    {
+                        if (issues is null)
+                        {
+                            issues = new List<Diagnostic>(count);
+                        }
+
+                        issues.Add(Issue(expression, CreateProposalForSpaces(spaces)));
+                    }
+                }
+            }
+
+            return (IReadOnlyList<Diagnostic>)issues ?? Array.Empty<Diagnostic>();
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
         public void No_issue_is_reported_for_multiple_initializer_expression_on_same_line() => No_issue_is_reported_for(@"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -50,7 +50,7 @@ public class TestMe
         public void No_issue_is_reported_for_multiple_initializer_expression_on_other_line_but_indented() => No_issue_is_reported_for(@"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -184,7 +184,7 @@ public class TestMe
             const string OriginalCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -199,7 +199,7 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -292,7 +292,7 @@ public class TestMe
             const string OriginalCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -303,7 +303,7 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -320,7 +320,7 @@ public class TestMe
             const string OriginalCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -331,7 +331,7 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -348,7 +348,7 @@ public class TestMe
             const string OriginalCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 
@@ -359,7 +359,7 @@ public class TestMe
             const string FixedCode = @"
 public class TestMe
 {
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     public int Number { get; set; }
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
@@ -17,7 +17,19 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe { Number = 42 };
+    public static TestMe Create() => new TestMe { Number = 42 };
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_initializer_expression_on_same_line() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe { Number = 42, Name = ""some name"" };
 }
 ");
 
@@ -27,10 +39,26 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                      Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Number = 42,
+                                         };
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_initializer_expression_on_other_line_but_indented() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Number = 42,
+                                             Name = ""some name"",
+                                         };
 }
 ");
 
@@ -40,10 +68,10 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                          Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                                 Number = 42,
+                                         };
 }
 ");
 
@@ -53,10 +81,10 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                  Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                         Number = 42,
+                                         };
 }
 ");
 
@@ -68,10 +96,10 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                          Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                    Number = 42,
+                                         };
 }
 ";
 
@@ -80,10 +108,40 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                      Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Number = 42,
+                                         };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_other_line_but_indented()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe
+                                         {
+                                                 Number = 42,
+                                         };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Number = 42,
+                                         };
 }
 ";
 
@@ -98,10 +156,10 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                  Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                         Number = 42,
+                                         };
 }
 ";
 
@@ -110,10 +168,10 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                      Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Number = 42,
+                                         };
 }
 ";
 
@@ -130,11 +188,11 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                        Name = ""my name"",
-                                  Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                               Name = ""my name"",
+                                         Number = 42,
+                                         };
 }
 ";
 
@@ -145,11 +203,11 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe
-                                  {
-                                      Name = ""my name"",
-                                      Number = 42,
-                                  };
+    public static TestMe Create() => new TestMe
+                                         {
+                                             Name = ""my name"",
+                                             Number = 42,
+                                         };
 }
 ";
 
@@ -164,7 +222,7 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe {Number = 42 };
+    public static TestMe Create() => new TestMe {Number = 42 };
 }
 ";
 
@@ -173,7 +231,7 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe { Number = 42 };
+    public static TestMe Create() => new TestMe { Number = 42 };
 }
 ";
 
@@ -188,7 +246,7 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe {   Number = 42 };
+    public static TestMe Create() => new TestMe {   Number = 42 };
 }
 ";
 
@@ -197,7 +255,31 @@ public class TestMe
 {
     public int Number { get; set; }
 
-    public static Create() => new TestMe { Number = 42 };
+    public static TestMe Create() => new TestMe { Number = 42 };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_same_line_but_on_position_more_than_1_character_behind_open_brace_with_comment()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe {   /*comment*/ Number = 42 };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe { /*comment*/ Number = 42 };
 }
 ";
 
@@ -214,7 +296,7 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe {   Number = 42,      Name = ""some name"" };
+    public static TestMe Create() => new TestMe {   Number = 42,   /*comment*/   Name = ""some name"" };
 }
 ";
 
@@ -225,7 +307,35 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe { Number = 42, Name = ""some name"" };
+    public static TestMe Create() => new TestMe { Number = 42, /*comment*/ Name = ""some name"" };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expressions_on_same_line_but_with_additional_spaces_with_comment()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe {   Number = 42,      Name = ""some name"" };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe { Number = 42, Name = ""some name"" };
 }
 ";
 
@@ -242,7 +352,7 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe {Number = 42,Name = ""some name"" };
+    public static TestMe Create() => new TestMe {Number = 42,Name = ""some name"" };
 }
 ";
 
@@ -253,7 +363,7 @@ public class TestMe
 
     public int Number { get; set; }
 
-    public static Create() => new TestMe { Number = 42, Name = ""some name"" };
+    public static TestMe Create() => new TestMe { Number = 42, Name = ""some name"" };
 }
 ";
 

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
@@ -1,0 +1,269 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Spacing
+{
+    [TestFixture]
+    public sealed class MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_initializer_expression_on_same_line() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe { Number = 42 };
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_initializer_expression_on_other_line_but_indented() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                      Number = 42,
+                                  };
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_initializer_expression_on_other_line_but_more_indented() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                          Number = 42,
+                                  };
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_initializer_expression_on_other_line_but_outdented() => An_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                  Number = 42,
+                                  };
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_other_line_but_outdented()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                          Number = 42,
+                                  };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                      Number = 42,
+                                  };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_other_line_but_on_same_position_as_open_brace()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                  Number = 42,
+                                  };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                      Number = 42,
+                                  };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expressions_on_other_lines()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                        Name = ""my name"",
+                                  Number = 42,
+                                  };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe
+                                  {
+                                      Name = ""my name"",
+                                      Number = 42,
+                                  };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_same_line_but_on_position_0_character_behind_open_brace()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe {Number = 42 };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe { Number = 42 };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expression_on_same_line_but_on_position_more_than_1_character_behind_open_brace()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe {   Number = 42 };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static Create() => new TestMe { Number = 42 };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expressions_on_same_line_but_with_additional_spaces()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe {   Number = 42,      Name = ""some name"" };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe { Number = 42, Name = ""some name"" };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_initializer_expressions_on_same_line_but_with_no_spaces()
+        {
+            const string OriginalCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe {Number = 42,Name = ""some name"" };
+}
+";
+
+            const string FixedCode = @"
+public class TestMe
+{
+    public int Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static Create() => new TestMe { Number = 42, Name = ""some name"" };
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_6069_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6069_ObjectInitializerExpressionsAreIndentedBesideOpenBraceAnalyzerTests.cs
@@ -34,6 +34,28 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_initializer_expression_on_same_line_with_comment_before_first_expression() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe { /*comment*/ Number = 42 };
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_multiple_initializer_expressions_on_same_line_with_comment_before_subsequent_expression() => No_issue_is_reported_for(@"
+public class TestMe
+{
+    public string Name { get; set; }
+
+    public int Number { get; set; }
+
+    public static TestMe Create() => new TestMe { Number = 42, /*comment*/ Name = ""some name"" };
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_initializer_expression_on_other_line_but_indented() => No_issue_is_reported_for(@"
 public class TestMe
 {

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -656,6 +656,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "6. Spacing", "6. Spacing", 
 		Documentation\MiKo_6066.md = Documentation\MiKo_6066.md
 		Documentation\MiKo_6067.md = Documentation\MiKo_6067.md
 		Documentation\MiKo_6068.md = Documentation\MiKo_6068.md
+		Documentation\MiKo_6069.md = Documentation\MiKo_6069.md
 		Documentation\MiKo_6070.md = Documentation\MiKo_6070.md
 		Documentation\MiKo_6071.md = Documentation\MiKo_6071.md
 		Documentation\MiKo_6072.md = Documentation\MiKo_6072.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 561 rules that are currently provided by the analyzer.
+The following tables list all the 562 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -609,6 +609,7 @@ The following tables list all the 561 rules that are currently provided by the a
 |[MiKo_6066](/Documentation/MiKo_6066.md)|Indent rather than outdent collection expression elements|&#x2713;|&#x2713;|
 |[MiKo_6067](/Documentation/MiKo_6067.md)|Place ternary operators on same lines as their respective expressions|&#x2713;|&#x2713;|
 |[MiKo_6068](/Documentation/MiKo_6068.md)|Place property patterns inside 'if' conditions on same line|&#x2713;|&#x2713;|
+|[MiKo_6069](/Documentation/MiKo_6069.md)|Align object initializer expressions relative to opening brace|&#x2713;|&#x2713;|
 |[MiKo_6070](/Documentation/MiKo_6070.md)|Surround Console statements with blank lines|&#x2713;|&#x2713;|
 |[MiKo_6071](/Documentation/MiKo_6071.md)|Surround local using statements with blank lines|&#x2713;|&#x2713;|
 |[MiKo_6072](/Documentation/MiKo_6072.md)|Surround base class calls with blank lines|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add analyzer and code fix for object initializer expression alignment

- Add tests

- Updates documentation, README and resources

(resolves #2089)