### PR TITLE
Add types 'ReplacementMap' and 'Tripe' to cache replacements of similar strings

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -307,6 +307,20 @@ namespace MiKoSolutions.Analyzers
         /// <param name="value">
         /// The original text.
         /// </param>
+        /// <param name="map">
+        /// The key-value pairs for replacement.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
+        /// </returns>
+        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, ReplacementMap map) => value.ReplaceAllWithProbe(map.Pairs);
+
+        /// <summary>
+        /// Gets a <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
+        /// </summary>
+        /// <param name="value">
+        /// The original text.
+        /// </param>
         /// <param name="replacementPairs">
         /// The key-value pairs for replacement.
         /// </param>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -49,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReplacementMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.Designer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\CodeDetector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Documentation\CommentCodeFixProvider.cs" />
@@ -486,6 +487,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SpacingCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Spacing\SurroundedByBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StringBuilderCache.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Triple.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeNames.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -49,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Pluralizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Linguistics\Verbalizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Pair.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReplacementMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.Designer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Analyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\CodeDetector.cs" />

--- a/MiKo.Analyzer.Shared/ReplacementMap.cs
+++ b/MiKo.Analyzer.Shared/ReplacementMap.cs
@@ -1,0 +1,78 @@
+﻿using System;
+
+namespace MiKoSolutions.Analyzers
+{
+    /// <summary>
+    /// Represents a named map of terms and their replacements to look up and replace specific text fragments, such as terms within documentation comments.
+    /// This class cannot be inherited.
+    /// </summary>
+    public sealed class ReplacementMap
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplacementMap"/> class with an identifier and the terms to replace.
+        /// </summary>
+        /// <param name="id">
+        /// The identifier of the replacement map.
+        /// </param>
+        /// <param name="pairs">
+        /// The map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
+        /// </param>
+        /// <param name="keys">
+        /// The keys to look up the corresponding replacements in <paramref name="pairs"/> (see <see cref="Keys"/>).
+        /// </param>
+        public ReplacementMap(string id, Pair[] pairs, string[] keys)
+        {
+            Id = id;
+            Pairs = pairs;
+            Keys = keys;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplacementMap"/> class with an identifier and the terms to replace.
+        /// </summary>
+        /// <param name="id">
+        /// The identifier of the replacement map.
+        /// </param>
+        /// <param name="pairs">
+        /// The map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
+        /// </param>
+        /// <param name="keysSelector">
+        /// The callback that selects the keys to look up the corresponding replacements in <paramref name="pairs"/> (see <see cref="Keys"/>).
+        /// </param>
+        public ReplacementMap(string id, Pair[] pairs, Func<Pair[], string[]> keysSelector)
+        {
+            Id = id;
+            Pairs = pairs;
+            Keys = keysSelector(pairs);
+        }
+
+        /// <summary>
+        /// Gets the identifier of the replacement map.
+        /// </summary>
+        /// <value>
+        /// A <see cref="string"/> that contains the identifier of the replacement map.
+        /// </value>
+        public string Id { get; }
+
+#pragma warning disable CA1819
+        /// <summary>
+        /// Gets the map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
+        /// </summary>
+        /// <value>
+        /// An array of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
+        /// </value>
+        public Pair[] Pairs { get; }
+
+        /// <summary>
+        /// Gets or sets the keys use to look-up for their replacements in <see cref="Pairs"/>.
+        /// </summary>
+        /// <value>
+        /// An array of keys to look up the corresponding replacements in <see cref="Pairs"/>.
+        /// </value>
+        /// <remarks>
+        /// The keys do not need to contain all keys of <see cref="Pairs"/>. Instead, they can contain the most common sub-sequences of those keys to optimize searching.
+        /// </remarks>
+        public string[] Keys { get; set; }
+#pragma warning restore CA1819
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -14,6 +15,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 {
     public abstract class DocumentationCodeFixProvider : MiKoCodeFixProvider
     {
+        private static readonly ConcurrentDictionary<Triple, string> OriginalToReplacementMap = new ConcurrentDictionary<Triple, string>();
+
         /// <summary>
         /// Defines values that specify how to do a quick lookup.
         /// </summary>
@@ -66,8 +69,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static string GetPhraseProposal(Diagnostic issue) => issue.Properties.TryGetValue(Constants.AnalyzerCodeFixSharedData.Phrase, out var s) ? s : string.Empty;
 
-        //// ncrunch: rdi off
-        //// ncrunch: no coverage start
+//// ncrunch: rdi off
+//// ncrunch: no coverage start
 
         /// <summary>
         /// Creates an optimized array of terms for quick lookup by removing terms that are already covered by a shorter term according to the specified lookup mode.
@@ -344,9 +347,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// <param name="syntax">
         /// The XML element to update.
         /// </param>
-        /// <param name="lookupTerms">
-        /// The terms to search for in the comment text.
-        /// </param>
         /// <param name="replacementMap">
         /// The map of terms to their replacements.
         /// </param>
@@ -357,9 +357,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// <returns>
         /// The XML comment element with replaced text and combined text nodes.
         /// </returns>
-        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, in ReadOnlySpan<string> lookupTerms, in ReadOnlySpan<Pair> replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace)
+        protected static XmlElementSyntax Comment(XmlElementSyntax syntax, ReplacementMap replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace)
         {
-            var result = Comment<XmlElementSyntax>(syntax, lookupTerms, replacementMap, firstWordAdjustment);
+            var result = Comment<XmlElementSyntax>(syntax, replacementMap, firstWordAdjustment);
 
             return CombineTexts(result);
         }
@@ -372,9 +372,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// </typeparam>
         /// <param name="syntax">
         /// The syntax node to update.
-        /// </param>
-        /// <param name="lookupTerms">
-        /// The terms to search for in the text. Use <see cref="GetTermsForQuickLookup(Pair[],in StringComparison, in QuickLookupMode)"/> to optimize this array.
         /// </param>
         /// <param name="replacementMap">
         /// The map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
@@ -390,8 +387,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         /// This is the core text replacement method that performs pattern matching and substitution across all XML text nodes within the syntax tree.
         /// It performs a deep search through all <see cref="XmlTextSyntax"/> descendants and replaces matching phrases while respecting the minimum length optimization for performance.
         /// </remarks>
-        protected static T Comment<T>(T syntax, in ReadOnlySpan<string> lookupTerms, in ReadOnlySpan<Pair> replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace) where T : SyntaxNode
+        protected static T Comment<T>(T syntax, ReplacementMap replacementMap, in FirstWordAdjustment firstWordAdjustment = FirstWordAdjustment.KeepSingleLeadingSpace) where T : SyntaxNode
         {
+            var lookupTerms = replacementMap.Keys;
             var minimumLength = MinimumLength(lookupTerms);
 
             var textMap = CreateReplacementTextMap(minimumLength, lookupTerms, replacementMap, firstWordAdjustment);
@@ -436,7 +434,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return minimum;
             }
 
-            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, in ReadOnlySpan<string> lookupPhrases, in ReadOnlySpan<Pair> map, in FirstWordAdjustment adjustment)
+            Dictionary<XmlTextSyntax, XmlTextSyntax> CreateReplacementTextMap(in int minLength, in ReadOnlySpan<string> lookupPhrases, ReplacementMap map, FirstWordAdjustment adjustment)
             {
                 Dictionary<XmlTextSyntax, XmlTextSyntax> result = null;
 
@@ -464,27 +462,38 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         }
 
                         // the lookup-phrases are mostly upper-case, so compare ignoring case here
-                        if (originalText.ContainsAny(lookupPhrases, StringComparison.OrdinalIgnoreCase))
+                        var replaced = false;
+
+                        foreach (var lookupPhrase in lookupPhrases)
                         {
-                            var replacedText = originalText.AsCachedBuilder()
-                                                           .ReplaceAllWithProbe(map)
-                                                           .AdjustFirstWord(adjustment)
-                                                           .ToStringAndRelease();
-
-                            if (originalText.AsSpan().SequenceEqual(replacedText.AsSpan()))
+                            if (originalText.Contains(lookupPhrase, StringComparison.OrdinalIgnoreCase))
                             {
-                                // replacement with itself does not make any sense
-                                continue;
+                                var replacedText = OriginalToReplacementMap.GetOrAdd(
+                                                                                 new Triple(map.Id, lookupPhrase, originalText),
+                                                                                 _ => _.C.AsCachedBuilder().ReplaceAllWithProbe(map).AdjustFirstWord(adjustment).ToStringAndRelease());
+
+                                if (originalText.AsSpan().SequenceEqual(replacedText.AsSpan()))
+                                {
+                                    // replacement with itself does not make any sense
+                                    continue;
+                                }
+
+                                if (result is null)
+                                {
+                                    result = new Dictionary<XmlTextSyntax, XmlTextSyntax>(1);
+                                }
+
+                                result.Add(text, text.ReplaceToken(token, token.WithText(replacedText)));
+
+                                replaced = true;
+
+                                // no need to loop further over the tokens
+                                break;
                             }
+                        }
 
-                            if (result is null)
-                            {
-                                result = new Dictionary<XmlTextSyntax, XmlTextSyntax>(1);
-                            }
-
-                            result.Add(text, text.ReplaceToken(token, token.WithText(replacedText)));
-
-                            // no need to loop further over the tokens
+                        if (replaced)
+                        {
                             break;
                         }
                     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2001_CodeFixProvider.cs
@@ -17,13 +17,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = CreatePhrases().OrderDescendingByLengthAndText(_ => _.Key);
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
-
-        private static readonly Pair[] CleanUpMap = CreateCleanupPhrases().OrderDescendingByLengthAndText(_ => _.Key);
-
-        private static readonly string[] CleanUpMapKeys = GetTermsForQuickLookup(CleanUpMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2001_Replace", CreatePhrases().OrderDescendingByLengthAndText(_ => _.Key), _ => GetTermsForQuickLookup(_));
+        private static readonly ReplacementMap CleanUpMap = new ReplacementMap("MiKo_2001_Cleanup", CreateCleanupPhrases().OrderDescendingByLengthAndText(_ => _.Key), _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -38,9 +33,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax GetUpdatedSyntax(XmlElementSyntax syntax)
         {
-            var preparedComment = Comment(syntax, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
+            var preparedComment = Comment(syntax, ReplacementMap, FirstWordAdjustment.StartLowerCase);
             var fixedComment = CommentStartingWith(preparedComment, Constants.Comments.EventSummaryStartingPhrase);
-            var cleanedComment = Comment(fixedComment, CleanUpMapKeys, CleanUpMap);
+            var cleanedComment = Comment(fixedComment, CleanUpMap);
 
             return cleanedComment;
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2003_CodeFixProvider.cs
@@ -14,9 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMap();
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2003", CreateReplacementMap(), _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -31,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax GetUpdatedSyntax(XmlElementSyntax comment)
         {
-            return Comment(comment, ReplacementMapKeys, ReplacementMap);
+            return Comment(comment, ReplacementMap);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -56,36 +56,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] UsedToPhrases = CreateUsedToPhrases().ToArray();
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMap();
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2012_Replace", CreateReplacementMap(), _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap, Comparison);
-
-        private static readonly Pair[] EmptyReplacementsMap =
-                                                              {
-                                                                  new Pair("Called to "),
-                                                              };
-
-        private static readonly string[] EmptyReplacementsMapKeys = GetTermsForQuickLookup(EmptyReplacementsMap);
+        private static readonly ReplacementMap EmptyReplacementsMap = new ReplacementMap("MiKo_2012_Empty", new[] { new Pair("Called to ") }, _ => GetTermsForQuickLookup(_));
 
         private static readonly string[] GetSetReplacementPhrases = CreateGetSetReplacementPhrases().Distinct()
                                                                                                     .Except(new[] { "Gets or sets a value ", "Gets or sets ", "Gets a value ", "Sets a value ", "gets a value ", "sets a value " })
                                                                                                     .OrderDescendingByLengthAndText();
 
-        private static readonly Pair[] PreparationMap =
-                                                        {
-                                                            new Pair(Constants.Comments.SealedClassPhrase, "##SEALED##"),
-                                                            new Pair(Constants.Comments.FieldIsReadOnly, "##READONLY##"),
-                                                        };
+        private static readonly ReplacementMap PreparationMap = new ReplacementMap(
+                                                                               "MiKo_2012_Replacement",
+                                                                               new[]
+                                                                                   {
+                                                                                       new Pair(Constants.Comments.SealedClassPhrase, "##SEALED##"),
+                                                                                       new Pair(Constants.Comments.FieldIsReadOnly, "##READONLY##"),
+                                                                                   },
+                                                                               _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] PreparationMapKeys = GetTermsForQuickLookup(PreparationMap);
-
-        private static readonly Pair[] CleanupMap =
-                                                    {
-                                                        new Pair("##SEALED##", Constants.Comments.SealedClassPhrase),
-                                                        new Pair("##READONLY##", Constants.Comments.FieldIsReadOnly),
-                                                    };
-
-        private static readonly string[] CleanupMapKeys = GetTermsForQuickLookup(CleanupMap);
+        private static readonly ReplacementMap CleanupMap = new ReplacementMap(
+                                                                           "MiKo_2012_Cleanup",
+                                                                           new[]
+                                                                               {
+                                                                                   new Pair("##SEALED##", Constants.Comments.SealedClassPhrase),
+                                                                                   new Pair("##READONLY##", Constants.Comments.FieldIsReadOnly),
+                                                                               },
+                                                                           _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -119,9 +114,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax GetUpdatedSyntax(XmlElementSyntax comment, in FirstWordAdjustment startAdjustment)
         {
-            var preparedComment = Comment(comment, PreparationMapKeys, PreparationMap);
-            var updatedComment = Comment(preparedComment, ReplacementMapKeys, ReplacementMap, startAdjustment);
-            var cleanedComment = Comment(updatedComment, CleanupMapKeys, CleanupMap);
+            var preparedComment = Comment(comment, PreparationMap);
+            var updatedComment = Comment(preparedComment, ReplacementMap, startAdjustment);
+            var cleanedComment = Comment(updatedComment, CleanupMap);
 
             return cleanedComment;
         }
@@ -153,9 +148,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return Comment(comment, XmlText($"Represents {article}{continuation}."));
             }
 
-            if (text.StartsWithAny(EmptyReplacementsMapKeys))
+            if (text.StartsWithAny(EmptyReplacementsMap.Keys))
             {
-                return Comment(comment, EmptyReplacementsMapKeys, EmptyReplacementsMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
+                return Comment(comment, EmptyReplacementsMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
             }
 
             if (text.StartsWith("Called"))
@@ -173,11 +168,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static ReadOnlySpan<char> GetUpdatedSyntax(ref XmlElementSyntax comment, XmlTextSyntax textSyntax, in ReadOnlySpan<char> text)
         {
-            if (text.ContainsAny(ReplacementMapKeys, Comparison))
+            if (text.ContainsAny(ReplacementMap.Keys, Comparison))
             {
                 var adjustment = FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace;
 
-                if (text.StartsWithAny(ReplacementMapKeys, Comparison))
+                if (text.StartsWithAny(ReplacementMap.Keys, Comparison))
                 {
                     adjustment |= FirstWordAdjustment.MakeThirdPersonSingular;
                 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
@@ -13,9 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2016_CodeFixProvider)), Shared]
     public sealed class MiKo_2016_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
-        private static readonly Pair[] ReplacementMap = { new Pair("Gets called to ") };
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2016", new[] { new Pair("Gets called to ") }, _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2016";
 
@@ -34,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var preparedComment = MiKo_2019_CodeFixProvider.GetUpdatedSyntax(summary) as XmlElementSyntax ?? summary;
 
-                preparedComment = Comment(preparedComment, ReplacementMapKeys, ReplacementMap);
+                preparedComment = Comment(preparedComment, ReplacementMap);
 
                 return CommentStartingWith(preparedComment, Constants.Comments.AsynchronouslyStartingPhrase, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             map[2] = new Pair("whether that", "whether");
             map[3] = new Pair("whether whether", "whether");
 
-            return Comment(comment, new[] { firstWord }, map);
+            return Comment(comment, new ReplacementMap("MiKo_2018", map, new[] { firstWord }));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2019_CodeFixProvider.cs
@@ -106,44 +106,45 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                   "d-tor", // typo
                                                               };
 
-        private static readonly Pair[] CallbackReplacements = new[]
-                                                                  {
-                                                                      "A callback that is called",
-                                                                      "A callback which is called",
-                                                                      "A method that gets called",
-                                                                      "A method that is called",
-                                                                      "A method which gets called",
-                                                                      "A method which is called",
-                                                                      "Callback that is called",
-                                                                      "Callback which is called",
-                                                                      "Method that gets called",
-                                                                      "Method that is called",
-                                                                      "Method which gets called",
-                                                                      "Method which is called",
-                                                                      "The callback that is called",
-                                                                      "The callback which is called",
-                                                                      "The method gets called",
-                                                                      "The method is called",
-                                                                      "The method that gets called",
-                                                                      "The method that is called",
-                                                                      "The method which gets called",
-                                                                      "The method which is called",
-                                                                      "This method gets called",
-                                                                      "This method is called",
-                                                                  }.ToArray(_ => new Pair(_, "Gets called"));
+        private static readonly ReplacementMap CallbackReplacements = new ReplacementMap(
+                                                                                     "MiKo_2019_Replace",
+                                                                                     new[]
+                                                                                         {
+                                                                                             "A callback that is called",
+                                                                                             "A callback which is called",
+                                                                                             "A method that gets called",
+                                                                                             "A method that is called",
+                                                                                             "A method which gets called",
+                                                                                             "A method which is called",
+                                                                                             "Callback that is called",
+                                                                                             "Callback which is called",
+                                                                                             "Method that gets called",
+                                                                                             "Method that is called",
+                                                                                             "Method which gets called",
+                                                                                             "Method which is called",
+                                                                                             "The callback that is called",
+                                                                                             "The callback which is called",
+                                                                                             "The method gets called",
+                                                                                             "The method is called",
+                                                                                             "The method that gets called",
+                                                                                             "The method that is called",
+                                                                                             "The method which gets called",
+                                                                                             "The method which is called",
+                                                                                             "This method gets called",
+                                                                                             "This method is called",
+                                                                                         }.ToArray(_ => new Pair(_, "Gets called")),
+                                                                                     _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] CallbackPhrases = GetTermsForQuickLookup(CallbackReplacements);
-
-        private static readonly Pair[] CallbackReplacementsWithLy =
-                                                                    {
-                                                                        new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "called", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
-                                                                        new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "invoked", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
-
-                                                                        new Pair(Constants.Comments.RecursivelyStartingPhrase + "called", Constants.Comments.RecursivelyStartingPhrase + "runs"),
-                                                                        new Pair(Constants.Comments.RecursivelyStartingPhrase + "invoked", Constants.Comments.RecursivelyStartingPhrase + "runs"),
-                                                                    };
-
-        private static readonly string[] CallbackPhrasesWithLy = GetTermsForQuickLookup(CallbackReplacementsWithLy);
+        private static readonly ReplacementMap CallbackReplacementsWithLy = new ReplacementMap(
+                                                                                           "MiKo_2019_Ly",
+                                                                                           new[]
+                                                                                               {
+                                                                                                   new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "called", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
+                                                                                                   new Pair(Constants.Comments.AsynchronouslyStartingPhrase + "invoked", Constants.Comments.AsynchronouslyStartingPhrase + "runs"),
+                                                                                                   new Pair(Constants.Comments.RecursivelyStartingPhrase + "called", Constants.Comments.RecursivelyStartingPhrase + "runs"),
+                                                                                                   new Pair(Constants.Comments.RecursivelyStartingPhrase + "invoked", Constants.Comments.RecursivelyStartingPhrase + "runs"),
+                                                                                               },
+                                                                                           _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2019";
 
@@ -239,9 +240,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     return CommentStartingWith(summary, "Represents the ");
                 }
 
-                if (startText.StartsWithAny(CallbackPhrases))
+                if (startText.StartsWithAny(CallbackReplacements.Keys))
                 {
-                    return Comment(summary, CallbackPhrases, CallbackReplacements);
+                    return Comment(summary, CallbackReplacements);
                 }
 
                 var updatedSyntax = MiKo_2012_CodeFixProvider.GetUpdatedSyntax(summary);
@@ -253,7 +254,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                 if (text.StartsWith(Constants.Comments.AsynchronouslyStartingPhrase) || text.StartsWith(Constants.Comments.RecursivelyStartingPhrase))
                 {
-                    var updatedSummary = Comment(summary, CallbackPhrasesWithLy, CallbackReplacementsWithLy);
+                    var updatedSummary = Comment(summary, CallbackReplacementsWithLy);
 
                     if (ReferenceEquals(summary, updatedSummary) is false)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2021_CodeFixProvider.cs
@@ -9,19 +9,20 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2021_CodeFixProvider)), Shared]
     public sealed class MiKo_2021_CodeFixProvider : ParameterDocumentationCodeFixProvider
     {
-        private static readonly Pair[] ReplacementMap =
-                                                        {
-                                                            new Pair("Reference to a "),
-                                                            new Pair("Reference to an "),
-                                                            new Pair("Reference to the "),
-                                                            new Pair("Determines the "),
-                                                            new Pair("Determines to ", "value to "),
-                                                            new Pair("Either a "),
-                                                            new Pair("Either an "),
-                                                            new Pair("Either the "),
-                                                        };
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap(
+                                                                               "MiKo_2021",
+                                                                               new[]
+                                                                                   {
+                                                                                       new Pair("Reference to a "),
+                                                                                       new Pair("Reference to an "),
+                                                                                       new Pair("Reference to the "),
+                                                                                       new Pair("Determines the "),
+                                                                                       new Pair("Determines to ", "value to "),
+                                                                                       new Pair("Either a "),
+                                                                                       new Pair("Either an "),
+                                                                                       new Pair("Either the "),
+                                                                                   },
+                                                                               _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2021";
 
@@ -37,6 +38,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return CommentStartingWith(preparedComment, "The ");
         }
 
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap);
+        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMap);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2022_CodeFixProvider.cs
@@ -13,9 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = CreatePhrases().ToArray(_ => new Pair(_));
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2022", CreatePhrases().ToArray(_ => new Pair(_)), _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2022";
 
@@ -50,7 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap);
+        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMap);
 
 //// ncrunch: rdi off
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_CodeFixProvider.cs
@@ -36,10 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly Regex ShouldBeRegex = new Regex(@"\b(shall|should|can|could|must|may|might|would)\s+be\s+\w+\b", RegexOptions.Compiled, 250.Milliseconds());
 
-        private static readonly Pair OtherwisePair = new Pair(". Otherwise", "; otherwise");
-
-        private static readonly string[] OtherwisePairKey = { OtherwisePair.Key };
-        private static readonly Pair[] OtherwisePairArray = { OtherwisePair };
+        private static readonly ReplacementMap OtherwiseMap = new ReplacementMap("MiKo_2023_Otherwise", new[] { new Pair(". Otherwise", "; otherwise") }, _ => _.ToArray(__ => __.Key));
 
         private static readonly Lazy<MapData> MappedData = new Lazy<MapData>();
 
@@ -53,7 +50,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         protected override XmlElementSyntax Comment(Document document, XmlElementSyntax comment, ParameterSyntax parameter, in int index, Diagnostic issue)
         {
             // fix ". Otherwise ..." comments so that they will not get split
-            var mergedComment = Comment(comment, OtherwisePairKey, OtherwisePairArray);
+            var mergedComment = Comment(comment, OtherwiseMap);
 
             var firstSentence = SplitCommentAfterFirstSentence(mergedComment, out var partsAfterSentence);
 
@@ -199,10 +196,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var info = MappedData.Value.FindMatchingMapInfo(ReadOnlySpan<char>.Empty);
 
             var preparedComment = PrepareComment(comment);
-            var preparedComment2 = Comment(preparedComment, info.Keys, info.Map);
+            var preparedComment2 = Comment(preparedComment, info.Map);
             var preparedComment3 = ModifyElseOtherwisePart(preparedComment2);
 
-            return FixComment(preparedComment3, info.Keys, info.Map);
+            return FixComment(preparedComment3, info.Map);
         }
 
         private static XmlElementSyntax FixEmptyComment(XmlElementSyntax comment)
@@ -258,15 +255,15 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var prepared = comment.ReplaceNode(originalText, XmlText());
 
-            return FixComment(prepared, info.Keys, info.Map, finalCommentContinuation);
+            return FixComment(prepared, info.Map, finalCommentContinuation);
         }
 
-        private static XmlElementSyntax FixComment(XmlElementSyntax prepared, in ReadOnlySpan<string> replacementMapKeys, in ReadOnlySpan<Pair> replacementMap, string commentContinue = null)
+        private static XmlElementSyntax FixComment(XmlElementSyntax prepared, ReplacementMap replacementMap, string commentContinue = null)
         {
             var startFixed = CommentStartingWith(prepared, StartPhraseParts0, SeeLangword_True(), commentContinue ?? StartPhraseParts1);
             var bothFixed = CommentEndingWith(startFixed, EndPhraseParts0, SeeLangword_False(), EndPhraseParts1);
 
-            var fixedComment = Comment(bothFixed, replacementMapKeys, replacementMap);
+            var fixedComment = Comment(bothFixed, replacementMap);
 
             return fixedComment.WithTagsOnSeparateLines();
         }
@@ -329,16 +326,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private readonly ref struct ConcreteMapInfo
         {
-            public ConcreteMapInfo(Pair[] map, string[] keys, string[] uniqueKeys)
+            public ConcreteMapInfo(ReplacementMap map, string[] uniqueKeys)
             {
                 Map = map;
-                Keys = keys;
                 UniqueKeys = uniqueKeys;
             }
 
-            public Pair[] Map { get; }
-
-            public string[] Keys { get; }
+            public ReplacementMap Map { get; }
 
             public string[] UniqueKeys { get; }
         }
@@ -350,67 +344,55 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 #pragma warning disable SA1310 // Field should not contain underscore
 
             // a
-            private readonly Pair[] ReplacementMap_for_LowerCase_A;
-            private readonly Pair[] ReplacementMap_for_A;
-            private readonly string[] ReplacementMap_keys_for_A;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_A;
+            private readonly ReplacementMap ReplacementMap_for_A;
             private readonly string[] Unique_ReplacementMap_keys_for_A;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_A_Oo;
-            private readonly Pair[] ReplacementMap_for_A_Oo;
-            private readonly string[] ReplacementMap_keys_for_A_Oo;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_A_Oo;
+            private readonly ReplacementMap ReplacementMap_for_A_Oo;
             private readonly string[] Unique_ReplacementMap_keys_for_A_Oo;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_A_Parenthesis;
-            private readonly Pair[] ReplacementMap_for_A_Parenthesis;
-            private readonly string[] ReplacementMap_keys_for_A_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_A_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_A_Parenthesis;
             private readonly string[] Unique_ReplacementMap_keys_for_A_Parenthesis;
 
             // an
-            private readonly Pair[] ReplacementMap_for_LowerCase_An;
-            private readonly Pair[] ReplacementMap_for_An;
-            private readonly string[] ReplacementMap_keys_for_An;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_An;
+            private readonly ReplacementMap ReplacementMap_for_An;
             private readonly string[] Unique_ReplacementMap_keys_for_An;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_An_Oo;
-            private readonly Pair[] ReplacementMap_for_An_Oo;
-            private readonly string[] ReplacementMap_keys_for_An_Oo;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_An_Oo;
+            private readonly ReplacementMap ReplacementMap_for_An_Oo;
             private readonly string[] Unique_ReplacementMap_keys_for_An_Oo;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_An_Parenthesis;
-            private readonly Pair[] ReplacementMap_for_An_Parenthesis;
-            private readonly string[] ReplacementMap_keys_for_An_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_An_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_An_Parenthesis;
             private readonly string[] Unique_ReplacementMap_keys_for_An_Parenthesis;
 
             // the
-            private readonly Pair[] ReplacementMap_for_LowerCase_The;
-            private readonly Pair[] ReplacementMap_for_The;
-            private readonly string[] ReplacementMap_keys_for_The;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_The;
+            private readonly ReplacementMap ReplacementMap_for_The;
             private readonly string[] Unique_ReplacementMap_keys_for_The;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_The_Oo;
-            private readonly Pair[] ReplacementMap_for_The_Oo;
-            private readonly string[] ReplacementMap_keys_for_The_Oo;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_The_Oo;
+            private readonly ReplacementMap ReplacementMap_for_The_Oo;
             private readonly string[] Unique_ReplacementMap_keys_for_The_Oo;
 
-            private readonly Pair[] ReplacementMap_for_LowerCase_The_Parenthesis;
-            private readonly Pair[] ReplacementMap_for_The_Parenthesis;
-            private readonly string[] ReplacementMap_keys_for_The_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_The_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_The_Parenthesis;
             private readonly string[] Unique_ReplacementMap_keys_for_The_Parenthesis;
 
             // optional
-            private readonly Pair[] ReplacementMap_for_LowerCase_Optional;
-            private readonly Pair[] ReplacementMap_for_Optional;
-            private readonly string[] ReplacementMap_keys_for_Optional;
+            private readonly ReplacementMap ReplacementMap_for_LowerCase_Optional;
+            private readonly ReplacementMap ReplacementMap_for_Optional;
             private readonly string[] Unique_ReplacementMap_keys_for_Optional;
 
             // others
-            private readonly Pair[] ReplacementMap_for_Others;
-            private readonly string[] ReplacementMap_keys_for_Others;
+            private readonly ReplacementMap ReplacementMap_for_Others;
             private readonly string[] Unique_ReplacementMap_keys_for_Others;
 
             // (
-            private readonly Pair[] ReplacementMap_for_Parenthesis;
-            private readonly string[] ReplacementMap_keys_for_Parenthesis;
+            private readonly ReplacementMap ReplacementMap_for_Parenthesis;
             private readonly string[] Unique_ReplacementMap_keys_for_Parenthesis;
 
 #pragma warning restore SA1306 // Field should begin with lower-case letter
@@ -539,30 +521,30 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 var replacementMapKeysForLowerCaseOptional = SplitOutLowerCaseHashSet(replacementMapKeysForOptional);
 
                 // split the code into multiple lists
-                ReplacementMap_for_A = ToMapArray(replacementMapKeysForA, replacementMapCommon);
-                ReplacementMap_for_LowerCase_A = ToMapArray(replacementMapKeysForLowerCaseA, replacementMapCommon);
-                ReplacementMap_for_An = ToMapArray(replacementMapKeysForAn, replacementMapCommon);
-                ReplacementMap_for_LowerCase_An = ToMapArray(replacementMapKeysForLowerCaseAn, replacementMapCommon);
-                ReplacementMap_for_The = ToMapArray(replacementMapKeysForThe, replacementMapCommon);
-                ReplacementMap_for_LowerCase_The = ToMapArray(replacementMapKeysForLowerCaseThe, replacementMapCommon);
-                ReplacementMap_for_A_Parenthesis = ToMapArray(replacementMapKeysForA_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_LowerCase_A_Parenthesis = ToMapArray(replacementMapKeysForLowerCaseA_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_An_Parenthesis = ToMapArray(replacementMapKeysForAn_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_LowerCase_An_Parenthesis = ToMapArray(replacementMapKeysForLowerCaseAn_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_The_Parenthesis = ToMapArray(replacementMapKeysForThe_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_LowerCase_The_Parenthesis = ToMapArray(replacementMapKeysForLowerCaseThe_Parenthesis, replacementMapCommon);
-                ReplacementMap_for_A_Oo = ToMapArray(replacementMapKeysForA_Oo, replacementMapCommon);
-                ReplacementMap_for_LowerCase_A_Oo = ToMapArray(replacementMapKeysForLowerCaseA_Oo, replacementMapCommon);
-                ReplacementMap_for_An_Oo = ToMapArray(replacementMapKeysForAn_Oo, replacementMapCommon);
-                ReplacementMap_for_LowerCase_An_Oo = ToMapArray(replacementMapKeysForLowerCaseAn_Oo, replacementMapCommon);
-                ReplacementMap_for_The_Oo = ToMapArray(replacementMapKeysForThe_Oo, replacementMapCommon);
-                ReplacementMap_for_LowerCase_The_Oo = ToMapArray(replacementMapKeysForLowerCaseThe_Oo, replacementMapCommon);
+                ReplacementMap_for_A = ToMap("MiKo_2023_A", replacementMapKeysForA, replacementMapCommon);
+                ReplacementMap_for_LowerCase_A = ToMap("MiKo_2023_a", replacementMapKeysForLowerCaseA, replacementMapCommon);
+                ReplacementMap_for_An = ToMap("MiKo_2023_An", replacementMapKeysForAn, replacementMapCommon);
+                ReplacementMap_for_LowerCase_An = ToMap("MiKo_2023_an", replacementMapKeysForLowerCaseAn, replacementMapCommon);
+                ReplacementMap_for_The = ToMap("MiKo_2023_The", replacementMapKeysForThe, replacementMapCommon);
+                ReplacementMap_for_LowerCase_The = ToMap("MiKo_2023_the", replacementMapKeysForLowerCaseThe, replacementMapCommon);
+                ReplacementMap_for_A_Parenthesis = ToMap("MiKo_2023_A_(", replacementMapKeysForA_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_LowerCase_A_Parenthesis = ToMap("MiKo_2023_a_(", replacementMapKeysForLowerCaseA_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_An_Parenthesis = ToMap("MiKo_2023_An_(", replacementMapKeysForAn_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_LowerCase_An_Parenthesis = ToMap("MiKo_2023_an_(", replacementMapKeysForLowerCaseAn_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_The_Parenthesis = ToMap("MiKo_2023_The_(", replacementMapKeysForThe_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_LowerCase_The_Parenthesis = ToMap("MiKo_2023_the_(", replacementMapKeysForLowerCaseThe_Parenthesis, replacementMapCommon);
+                ReplacementMap_for_A_Oo = ToMap("MiKo_2023_A_Oo", replacementMapKeysForA_Oo, replacementMapCommon);
+                ReplacementMap_for_LowerCase_A_Oo = ToMap("MiKo_2023_a_Oo", replacementMapKeysForLowerCaseA_Oo, replacementMapCommon);
+                ReplacementMap_for_An_Oo = ToMap("MiKo_2023_An_Oo", replacementMapKeysForAn_Oo, replacementMapCommon);
+                ReplacementMap_for_LowerCase_An_Oo = ToMap("MiKo_2023_an_Oo", replacementMapKeysForLowerCaseAn_Oo, replacementMapCommon);
+                ReplacementMap_for_The_Oo = ToMap("MiKo_2023_The_Oo", replacementMapKeysForThe_Oo, replacementMapCommon);
+                ReplacementMap_for_LowerCase_The_Oo = ToMap("MiKo_2023_the_Oo", replacementMapKeysForLowerCaseThe_Oo, replacementMapCommon);
 
-                ReplacementMap_for_Optional = ToMapArray(replacementMapKeysForOptional, replacementMapCommon);
-                ReplacementMap_for_LowerCase_Optional = ToMapArray(replacementMapKeysForLowerCaseOptional, replacementMapCommon);
+                ReplacementMap_for_Optional = ToMap("MiKo_2023_Optional", replacementMapKeysForOptional, replacementMapCommon);
+                ReplacementMap_for_LowerCase_Optional = ToMap("MiKo_2023_optional", replacementMapKeysForLowerCaseOptional, replacementMapCommon);
 
-                ReplacementMap_for_Parenthesis = ToMapArray(replacementMapKeysForParenthesis, replacementMapCommon);
-                ReplacementMap_for_Others = ToMapArray(replacementMapKeysForOthers, replacementMapCommon);
+                ReplacementMap_for_Parenthesis = ToMap("MiKo_2023_(", replacementMapKeysForParenthesis, replacementMapCommon);
+                ReplacementMap_for_Others = ToMap("MiKo_2023_others", replacementMapKeysForOthers, replacementMapCommon);
 
                 Unique_ReplacementMap_keys_for_A = ToUnique(ReplacementMap_for_A);
                 Unique_ReplacementMap_keys_for_An = ToUnique(ReplacementMap_for_An);
@@ -578,22 +560,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 Unique_ReplacementMap_keys_for_Others = ToUnique(ReplacementMap_for_Others);
 
                 // now set keys here at the end as we want these keys sorted based on string contents (and only contain the smallest sub-sequences)
-                ReplacementMap_keys_for_A = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A);
-                ReplacementMap_keys_for_An = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An);
-                ReplacementMap_keys_for_The = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The);
-                ReplacementMap_keys_for_A_Parenthesis = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A_Parenthesis);
-                ReplacementMap_keys_for_An_Parenthesis = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An_Parenthesis);
-                ReplacementMap_keys_for_The_Parenthesis = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The_Parenthesis);
-                ReplacementMap_keys_for_A_Oo = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A_Oo);
-                ReplacementMap_keys_for_An_Oo = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An_Oo);
-                ReplacementMap_keys_for_The_Oo = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The_Oo);
-                ReplacementMap_keys_for_Optional = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Optional);
-                ReplacementMap_keys_for_Parenthesis = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Parenthesis);
-                ReplacementMap_keys_for_Others = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Others);
+                ReplacementMap_for_A.Keys = ReplacementMap_for_LowerCase_A.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A);
+                ReplacementMap_for_An.Keys = ReplacementMap_for_LowerCase_An.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An);
+                ReplacementMap_for_The.Keys = ReplacementMap_for_LowerCase_The.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The);
+                ReplacementMap_for_A_Parenthesis.Keys = ReplacementMap_for_LowerCase_A_Parenthesis.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A_Parenthesis);
+                ReplacementMap_for_An_Parenthesis.Keys = ReplacementMap_for_LowerCase_An_Parenthesis.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An_Parenthesis);
+                ReplacementMap_for_The_Parenthesis.Keys = ReplacementMap_for_LowerCase_The_Parenthesis.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The_Parenthesis);
+                ReplacementMap_for_A_Oo.Keys = ReplacementMap_for_LowerCase_A_Oo.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_A_Oo);
+                ReplacementMap_for_An_Oo.Keys = ReplacementMap_for_LowerCase_An_Oo.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_An_Oo);
+                ReplacementMap_for_The_Oo.Keys = ReplacementMap_for_LowerCase_The_Oo.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_The_Oo);
+                ReplacementMap_for_Optional.Keys = ReplacementMap_for_LowerCase_Optional.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Optional);
+                ReplacementMap_for_Parenthesis.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Parenthesis);
+                ReplacementMap_for_Others.Keys = GetTermsForQuickLookup(Unique_ReplacementMap_keys_for_Others);
 
                 return;
 
-                Pair[] ToMapArray(HashSet<string> keys, Pair[] others)
+                ReplacementMap ToMap(string id, HashSet<string> keys, Pair[] others)
                 {
                     var sorted = keys.OrderDescendingByLengthAndText();
                     var results = new Pair[sorted.Length + others.Length];
@@ -605,10 +587,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                     Array.Copy(others, 0, results, sorted.Length, others.Length);
 
-                    return results;
+                    return new ReplacementMap(id, results, Array.Empty<string>()); // keys will be set later on
                 }
 
-                string[] ToUnique(IEnumerable<Pair> pairs) => new HashSet<string>(pairs.Select(_ => _.Key), StringComparer.OrdinalIgnoreCase).ToArray();
+                string[] ToUnique(ReplacementMap map) => new HashSet<string>(map.Pairs.Select(_ => _.Key), StringComparer.OrdinalIgnoreCase).ToArray();
 
                 HashSet<string> SplitOutLowerCaseHashSet(HashSet<string> hashSet)
                 {
@@ -690,7 +672,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 if (text.StartsWith("(", StringComparison.Ordinal))
                 {
-                    return new ConcreteMapInfo(ReplacementMap_for_Parenthesis, ReplacementMap_keys_for_Parenthesis, Unique_ReplacementMap_keys_for_Parenthesis);
+                    return new ConcreteMapInfo(ReplacementMap_for_Parenthesis, Unique_ReplacementMap_keys_for_Parenthesis);
                 }
 
                 if (text.StartsWith("A ", StringComparison.OrdinalIgnoreCase))
@@ -702,14 +684,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         switch (text[2])
                         {
                             case '(':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A_Parenthesis : ReplacementMap_for_A_Parenthesis, ReplacementMap_keys_for_A_Parenthesis, Unique_ReplacementMap_keys_for_A_Parenthesis);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A_Parenthesis : ReplacementMap_for_A_Parenthesis, Unique_ReplacementMap_keys_for_A_Parenthesis);
                             case 'O':
                             case 'o':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A_Oo : ReplacementMap_for_A_Oo, ReplacementMap_keys_for_A_Oo, Unique_ReplacementMap_keys_for_A_Oo);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A_Oo : ReplacementMap_for_A_Oo, Unique_ReplacementMap_keys_for_A_Oo);
                         }
                     }
 
-                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A : ReplacementMap_for_A, ReplacementMap_keys_for_A, Unique_ReplacementMap_keys_for_A);
+                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_A : ReplacementMap_for_A, Unique_ReplacementMap_keys_for_A);
                 }
 
                 if (text.StartsWith("An ", StringComparison.OrdinalIgnoreCase))
@@ -721,14 +703,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         switch (text[3])
                         {
                             case '(':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An_Parenthesis : ReplacementMap_for_An_Parenthesis, ReplacementMap_keys_for_An_Parenthesis, Unique_ReplacementMap_keys_for_An_Parenthesis);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An_Parenthesis : ReplacementMap_for_An_Parenthesis, Unique_ReplacementMap_keys_for_An_Parenthesis);
                             case 'O':
                             case 'o':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An_Oo : ReplacementMap_for_An_Oo, ReplacementMap_keys_for_An_Oo, Unique_ReplacementMap_keys_for_An_Oo);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An_Oo : ReplacementMap_for_An_Oo, Unique_ReplacementMap_keys_for_An_Oo);
                         }
                     }
 
-                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An : ReplacementMap_for_An, ReplacementMap_keys_for_An, Unique_ReplacementMap_keys_for_An);
+                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_An : ReplacementMap_for_An, Unique_ReplacementMap_keys_for_An);
                 }
 
                 if (text.StartsWith("The ", StringComparison.OrdinalIgnoreCase))
@@ -740,24 +722,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         switch (text[4])
                         {
                             case '(':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The_Parenthesis : ReplacementMap_for_The_Parenthesis, ReplacementMap_keys_for_The_Parenthesis, Unique_ReplacementMap_keys_for_The_Parenthesis);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The_Parenthesis : ReplacementMap_for_The_Parenthesis, Unique_ReplacementMap_keys_for_The_Parenthesis);
                             case 'O':
                             case 'o':
-                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The_Oo : ReplacementMap_for_The_Oo, ReplacementMap_keys_for_The_Oo, Unique_ReplacementMap_keys_for_The_Oo);
+                                return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The_Oo : ReplacementMap_for_The_Oo, Unique_ReplacementMap_keys_for_The_Oo);
                         }
                     }
 
-                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The : ReplacementMap_for_The, ReplacementMap_keys_for_The, Unique_ReplacementMap_keys_for_The);
+                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_The : ReplacementMap_for_The, Unique_ReplacementMap_keys_for_The);
                 }
 
                 if (text.StartsWith("Optional ", StringComparison.OrdinalIgnoreCase))
                 {
                     var lowerCase = text[0] is 'o';
 
-                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_Optional : ReplacementMap_for_Optional, ReplacementMap_keys_for_Optional, Unique_ReplacementMap_keys_for_Optional);
+                    return new ConcreteMapInfo(lowerCase ? ReplacementMap_for_LowerCase_Optional : ReplacementMap_for_Optional, Unique_ReplacementMap_keys_for_Optional);
                 }
 
-                return new ConcreteMapInfo(ReplacementMap_for_Others, ReplacementMap_keys_for_Others, Unique_ReplacementMap_keys_for_Others);
+                return new ConcreteMapInfo(ReplacementMap_for_Others, Unique_ReplacementMap_keys_for_Others);
             }
 
             private static HashSet<string> CreateStartTerms()

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2024_CodeFixProvider.cs
@@ -12,37 +12,37 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2024_CodeFixProvider)), Shared]
     public sealed class MiKo_2024_CodeFixProvider : ParameterDocumentationCodeFixProvider
     {
-        private static readonly Pair[] FlagsReplacementMap = CreateFlagsReplacementMapKeys().Select(_ => new Pair(_))
-                                                                                            .Concat(new[]
-                                                                                                        {
-                                                                                                            new Pair("Enum for", "specifies"),
-                                                                                                            new Pair("Enum indicating", "indicates"),
-                                                                                                            new Pair("enum indicating", "indicates"),
-                                                                                                            new Pair("Indicator for", "indicates"),
-                                                                                                            new Pair("Value indicating", "indicates"),
-                                                                                                            new Pair("value indicating", "indicates"),
-                                                                                                            new Pair("Value for", "specifies"),
-                                                                                                        })
-                                                                                            .ToArray();
+        private static readonly ReplacementMap FlagsReplacementMap = new ReplacementMap(
+                                                                                    "MiKo_2024_FlagsReplace",
+                                                                                    CreateFlagsReplacementMapKeys().Select(_ => new Pair(_))
+                                                                                                                   .Concat(new[]
+                                                                                                                               {
+                                                                                                                                   new Pair("Enum for", "specifies"),
+                                                                                                                                   new Pair("Enum indicating", "indicates"),
+                                                                                                                                   new Pair("enum indicating", "indicates"),
+                                                                                                                                   new Pair("Indicator for", "indicates"),
+                                                                                                                                   new Pair("Value indicating", "indicates"),
+                                                                                                                                   new Pair("value indicating", "indicates"),
+                                                                                                                                   new Pair("Value for", "specifies"),
+                                                                                                                               })
+                                                                                                                   .ToArray(),
+                                                                                    _ => _.ToArray(__ => __.Key));
 
-        private static readonly string[] FlagsReplacementMapKeys = FlagsReplacementMap.ToArray(_ => _.Key);
+        private static readonly ReplacementMap FlagsCleanupMap = new ReplacementMap(
+                                                                                "MiKo_2024_FlagsCleanup",
+                                                                                new[]
+                                                                                    {
+                                                                                        new Pair("umeration values that a ", "umeration members that specifies a "),
+                                                                                        new Pair("umeration values that an ", "umeration members that specifies an "),
+                                                                                        new Pair("umeration values that the ", "umeration members that specifies the "),
+                                                                                        new Pair("umeration members that a ", "umeration members that specifies a "),
+                                                                                        new Pair("umeration members that an ", "umeration members that specifies an "),
+                                                                                        new Pair("umeration members that the ", "umeration members that specifies the "),
+                                                                                        new Pair(" that toes ", " that specifies the value to "),
+                                                                                    },
+                                                                                _ => GetTermsForQuickLookup(_));
 
-        private static readonly Pair[] FlagsCleanupMap =
-                                                         {
-                                                             new Pair("umeration values that a ", "umeration members that specifies a "),
-                                                             new Pair("umeration values that an ", "umeration members that specifies an "),
-                                                             new Pair("umeration values that the ", "umeration members that specifies the "),
-                                                             new Pair("umeration members that a ", "umeration members that specifies a "),
-                                                             new Pair("umeration members that an ", "umeration members that specifies an "),
-                                                             new Pair("umeration members that the ", "umeration members that specifies the "),
-                                                             new Pair(" that toes ", " that specifies the value to "),
-                                                         };
-
-        private static readonly string[] FlagsCleanupMapKeys = GetTermsForQuickLookup(FlagsCleanupMap);
-
-        private static readonly Pair[] ReplacementMap = CreateReplacementMapKeys().ConcatenatedWith("Specifies", "Determines").ToArray(_ => new Pair(_));
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2024_Replace", CreateReplacementMapKeys().ConcatenatedWith("Specifies", "Determines").ToArray(_ => new Pair(_)), _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2024";
 
@@ -53,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var preparedComment = PrepareComment(comment, issue);
             var updatedComment = CommentStartingWith(preparedComment, phrase);
 
-            return Comment(updatedComment, FlagsCleanupMapKeys, FlagsCleanupMap);
+            return Comment(updatedComment, FlagsCleanupMap);
         }
 
         private static XmlElementSyntax PrepareComment(XmlElementSyntax comment, Diagnostic issue)
@@ -63,10 +63,10 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             // TODO RKN: Update comment base on whether we have a Flags enum or not (defined as part of the properties of the reported issue)
             if (isFlagged)
             {
-                return Comment(comment, FlagsReplacementMapKeys, FlagsReplacementMap, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular);
+                return Comment(comment, FlagsReplacementMap, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular);
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartLowerCase);
+            return Comment(comment, ReplacementMap, FirstWordAdjustment.StartLowerCase);
         }
 
         private static string[] CreateReplacementMapKeys() => new[]

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2026_StillUsedParamPhraseAnalyzer.cs
@@ -110,7 +110,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-        private Diagnostic[] Analyze(SyntaxNodeAnalysisContext context, SyntaxNode method, SyntaxNode methodBody, IMethodSymbol methodSymbol)
+        private Diagnostic[] Analyze(in SyntaxNodeAnalysisContext context, SyntaxNode method, SyntaxNode methodBody, IMethodSymbol methodSymbol)
         {
             var comments = method.GetDocumentationCommentTriviaSyntax();
             var commentsLength = comments.Length;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2030_CodeFixProvider.cs
@@ -12,30 +12,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2030_CodeFixProvider)), Shared]
     public sealed class MiKo_2030_CodeFixProvider : ReturnTypeDocumentationCodeFixProvider
     {
-        private static readonly Pair[] ReplacementMap =
-                                                        {
-                                                            new Pair("The a ", "A "),
-                                                            new Pair("The an ", "An "),
-                                                            new Pair("The the ", "The "),
-                                                            new Pair("The this ", "The "),
-                                                            new Pair("The always a ", "A "),
-                                                            new Pair("The always an ", "An "),
-                                                            new Pair("The always the ", "The "),
-                                                            new Pair("The always this ", "The "),
-                                                            new Pair("The always ", "The "),
-                                                            new Pair("The return a ", "A "),
-                                                            new Pair("The returns a ", "A "),
-                                                            new Pair("The return an ", "An "),
-                                                            new Pair("The returns an ", "An "),
-                                                            new Pair("The return the ", "The "),
-                                                            new Pair("The returns the ", "The "),
-                                                            new Pair("The return this ", "The "),
-                                                            new Pair("The returns this ", "The "),
-                                                            new Pair("The return ", "The "),
-                                                            new Pair("The returns ", "The "),
-                                                        };
-
-        private static readonly string[] ReplacementMapKeys = ReplacementMap.ToArray(_ => _.Key);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap(
+                                                                               "MiKo_2030",
+                                                                               new[]
+                                                                                   {
+                                                                                       new Pair("The a ", "A "),
+                                                                                       new Pair("The an ", "An "),
+                                                                                       new Pair("The the ", "The "),
+                                                                                       new Pair("The this ", "The "),
+                                                                                       new Pair("The always a ", "A "),
+                                                                                       new Pair("The always an ", "An "),
+                                                                                       new Pair("The always the ", "The "),
+                                                                                       new Pair("The always this ", "The "),
+                                                                                       new Pair("The always ", "The "),
+                                                                                       new Pair("The return a ", "A "),
+                                                                                       new Pair("The returns a ", "A "),
+                                                                                       new Pair("The return an ", "An "),
+                                                                                       new Pair("The returns an ", "An "),
+                                                                                       new Pair("The return the ", "The "),
+                                                                                       new Pair("The returns the ", "The "),
+                                                                                       new Pair("The return this ", "The "),
+                                                                                       new Pair("The returns this ", "The "),
+                                                                                       new Pair("The return ", "The "),
+                                                                                       new Pair("The returns ", "The "),
+                                                                                   },
+                                                                               _ => _.ToArray(__ => __.Key));
 
         public override string FixableDiagnosticId => "MiKo_2030";
 
@@ -66,7 +67,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var preparedComment = CommentStartingWith(comment, "The ");
 
-            return Comment(preparedComment, ReplacementMapKeys, ReplacementMap);
+            return Comment(preparedComment, ReplacementMap);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2033_CodeFixProvider.cs
@@ -41,28 +41,27 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                             new Pair("new string with", "#2#"),
                                                         };
 
-        private static readonly Pair[] CleanupMap =
-                                                    {
-                                                        new Pair("#1#", "new string value with"),
-                                                        new Pair("#2#", "new string with"),
-                                                        new Pair("that contains a new string value", "that contains the original value"),
-                                                        new Pair("that contains a new string", "that contains the original value"),
-                                                        new Pair("that contains a new", "that contains the original value"),
-                                                        new Pair("that contains the new string value", "that contains the original value"),
-                                                        new Pair("that contains the new string", "that contains the original value"),
-                                                        new Pair("that contains the new", "that contains the original value"),
-                                                        new Pair("that contains a formatted string", "that contains the formatted result"),
-                                                        new Pair("that contains the formatted string", "that contains the formatted result"),
-                                                        new Pair("that contains a ", "that contains the "),
-                                                        new Pair("that contains value ", "that contains the value "),
-                                                        new Pair(" string result ", " result "),
-                                                    };
+        private static readonly ReplacementMap CleanupMap = new ReplacementMap(
+                                                                           "MiKo_2033_Cleanup",
+                                                                           new[]
+                                                                               {
+                                                                                   new Pair("#1#", "new string value with"),
+                                                                                   new Pair("#2#", "new string with"),
+                                                                                   new Pair("that contains a new string value", "that contains the original value"),
+                                                                                   new Pair("that contains a new string", "that contains the original value"),
+                                                                                   new Pair("that contains a new", "that contains the original value"),
+                                                                                   new Pair("that contains the new string value", "that contains the original value"),
+                                                                                   new Pair("that contains the new string", "that contains the original value"),
+                                                                                   new Pair("that contains the new", "that contains the original value"),
+                                                                                   new Pair("that contains a formatted string", "that contains the formatted result"),
+                                                                                   new Pair("that contains the formatted string", "that contains the formatted result"),
+                                                                                   new Pair("that contains a ", "that contains the "),
+                                                                                   new Pair("that contains value ", "that contains the value "),
+                                                                                   new Pair(" string result ", " result "),
+                                                                               },
+                                                                           _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] CleanupMapKeys = GetTermsForQuickLookup(CleanupMap);
-
-        private static readonly Pair[] ReplacementMap = PreparationMap.Concat(CreateReplacementMapKeys().OrderDescendingByLengthAndText().Select(_ => new Pair(_))).ToArray();
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2033_Replace", PreparationMap.Concat(CreateReplacementMapKeys().OrderDescendingByLengthAndText().Select(_ => new Pair(_))).ToArray(), _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -164,17 +163,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
 
             // fix start text
-            contents = PrepareComment(comment).Content;
+            contents = Comment(comment, ReplacementMap).Content;
 
             // we have to replace the XmlText if it is part of the first item of context
             var updatedComment = Comment(comment, commentStart, SeeCref("string"), commentEnd, contents.ToArray());
 
-            return CleanupComment(updatedComment);
+            return Comment(updatedComment, CleanupMap);
         }
-
-        private static XmlElementSyntax PrepareComment(XmlElementSyntax comment) => Comment(comment, ReplacementMapKeys, ReplacementMap);
-
-        private static XmlElementSyntax CleanupComment(XmlElementSyntax comment) => Comment(comment, CleanupMapKeys, CleanupMap);
 
 //// ncrunch: rdi off
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2035_CodeFixProvider.cs
@@ -85,9 +85,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var adjustedComment = CommentWithContent(comment, comment.Content);
 
-            adjustedComment = Comment(adjustedComment, MappedData.Value.PreparationMapKeys, MappedData.Value.PreparationMap);
+            adjustedComment = Comment(adjustedComment, MappedData.Value.PreparationMap);
 
-            return Comment(adjustedComment, MappedData.Value.ReplacementMapKeys, MappedData.Value.ReplacementMap);
+            return Comment(adjustedComment, MappedData.Value.ReplacementMap);
         }
 
         private static XmlElementSyntax PrepareArrayComment(XmlElementSyntax comment, ArrayTypeSyntax arrayType)
@@ -97,14 +97,14 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 return PrepareByteArrayComment(comment);
             }
 
-            var preparedComment = Comment(comment, MappedData.Value.SpecialArrayReplacementMapKeys, MappedData.Value.SpecialArrayReplacementMap);
+            var preparedComment = Comment(comment, MappedData.Value.SpecialArrayReplacementMap);
 
             return PrepareComment(preparedComment);
         }
 
         private static XmlElementSyntax PrepareByteArrayComment(XmlElementSyntax comment)
         {
-            var preparedComment = Comment(comment, MappedData.Value.ByteArrayReplacementMapKeys, MappedData.Value.ByteArrayReplacementMap);
+            var preparedComment = Comment(comment, MappedData.Value.ByteArrayReplacementMap);
 
             var contents = preparedComment.Content;
             var count = contents.Count;
@@ -135,7 +135,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax CleanupComment(XmlElementSyntax comment)
         {
-            return Comment(comment, MappedData.Value.CleanupMapKeys, MappedData.Value.CleanupMap);
+            return Comment(comment, MappedData.Value.CleanupMap);
         }
 
         private static XmlElementSyntax GenericComment(XmlElementSyntax preparedComment, GenericNameSyntax returnType)
@@ -288,17 +288,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private sealed class MapData
         {
 #pragma warning disable SA1401 // Fields should be private
-            public readonly Pair[] ReplacementMap;
-            public readonly string[] ReplacementMapKeys;
-            public readonly Pair[] ByteArrayReplacementMap;
-            public readonly string[] SpecialArrayReplacementMapKeys;
-            public readonly Pair[] SpecialArrayReplacementMap;
-            public readonly string[] ByteArrayReplacementMapKeys;
+            public readonly ReplacementMap ReplacementMap;
+            public readonly ReplacementMap ByteArrayReplacementMap;
+            public readonly ReplacementMap SpecialArrayReplacementMap;
             public readonly string[] ByteArrayContinueTexts;
-            public readonly Pair[] PreparationMap;
-            public readonly string[] PreparationMapKeys;
-            public readonly Pair[] CleanupMap;
-            public readonly string[] CleanupMapKeys;
+            public readonly ReplacementMap PreparationMap;
+            public readonly ReplacementMap CleanupMap;
 #pragma warning restore SA1401 // Fields should be private
 
 #pragma warning disable CA1861
@@ -306,44 +301,52 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var phrases = CreatePhrases().ToHashSet(); // TODO RKN: Order by 'A', 'An ' and 'The '
 
-                ReplacementMap = AlmostCorrectTaskReturnTypeStartingPhrases.ConcatenatedWith("A task that can be used to await.", "A task that can be used to await", "A task to await.", "A task to await", "An awaitable task.", "An awaitable task")
-                                                                           .Concat(phrases)
-                                                                           .Select(_ => new Pair(_))
-                                                                           .OrderDescendingByLengthAndText(_ => _.Key);
+                ReplacementMap = new ReplacementMap(
+                                                "MiKo_2035_Replace",
+                                                AlmostCorrectTaskReturnTypeStartingPhrases.ConcatenatedWith(
+                                                                                                        "A task that can be used to await.",
+                                                                                                        "A task that can be used to await",
+                                                                                                        "A task to await.",
+                                                                                                        "A task to await",
+                                                                                                        "An awaitable task.",
+                                                                                                        "An awaitable task")
+                                                                                          .Concat(phrases)
+                                                                                          .Select(_ => new Pair(_))
+                                                                                          .OrderDescendingByLengthAndText(_ => _.Key),
+                                                _ => GetTermsForQuickLookup(_, quickLookupMode: QuickLookupMode.Contains));
 
-                ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap, quickLookupMode: QuickLookupMode.Contains);
-
-                ByteArrayReplacementMap = AlmostCorrectTaskReturnTypeStartingPhrases.ConcatenatedWith(
-                                                                                                  "A array of byte containing ",
-                                                                                                  "A array of byte that contains ",
-                                                                                                  "A array of byte which contains ",
-                                                                                                  "A array of bytes containing ",
-                                                                                                  "A array of bytes that contains ",
-                                                                                                  "A array of bytes which contains ",
-                                                                                                  "A array of ",
-                                                                                                  "A array with ",
-                                                                                                  "An array of byte containing ",
-                                                                                                  "An array of byte that contains ",
-                                                                                                  "An array of byte which contains ",
-                                                                                                  "An array of bytes containing ",
-                                                                                                  "An array of bytes that contains ",
-                                                                                                  "An array of bytes which contains ",
-                                                                                                  "An array of ",
-                                                                                                  "An array with ",
-                                                                                                  "Array of ",
-                                                                                                  "Array with ",
-                                                                                                  "The array of byte containing ",
-                                                                                                  "The array of byte that contains ",
-                                                                                                  "The array of byte which contains ",
-                                                                                                  "The array of bytes containing ",
-                                                                                                  "The array of bytes that contains ",
-                                                                                                  "The array of bytes which contains ",
-                                                                                                  "The array of ",
-                                                                                                  "The array with ")
-                                                                                    .Select(_ => new Pair(_))
-                                                                                    .OrderDescendingByLengthAndText(_ => _.Key);
-
-                ByteArrayReplacementMapKeys = GetTermsForQuickLookup(ByteArrayReplacementMap, quickLookupMode: QuickLookupMode.Contains);
+                ByteArrayReplacementMap = new ReplacementMap(
+                                                         "MiKo_2035_ByteArray_Replace",
+                                                         AlmostCorrectTaskReturnTypeStartingPhrases.ConcatenatedWith(
+                                                                                                                 "A array of byte containing ",
+                                                                                                                 "A array of byte that contains ",
+                                                                                                                 "A array of byte which contains ",
+                                                                                                                 "A array of bytes containing ",
+                                                                                                                 "A array of bytes that contains ",
+                                                                                                                 "A array of bytes which contains ",
+                                                                                                                 "A array of ",
+                                                                                                                 "A array with ",
+                                                                                                                 "An array of byte containing ",
+                                                                                                                 "An array of byte that contains ",
+                                                                                                                 "An array of byte which contains ",
+                                                                                                                 "An array of bytes containing ",
+                                                                                                                 "An array of bytes that contains ",
+                                                                                                                 "An array of bytes which contains ",
+                                                                                                                 "An array of ",
+                                                                                                                 "An array with ",
+                                                                                                                 "Array of ",
+                                                                                                                 "Array with ",
+                                                                                                                 "The array of byte containing ",
+                                                                                                                 "The array of byte that contains ",
+                                                                                                                 "The array of byte which contains ",
+                                                                                                                 "The array of bytes containing ",
+                                                                                                                 "The array of bytes that contains ",
+                                                                                                                 "The array of bytes which contains ",
+                                                                                                                 "The array of ",
+                                                                                                                 "The array with ")
+                                                                                                   .Select(_ => new Pair(_))
+                                                                                                   .OrderDescendingByLengthAndText(_ => _.Key),
+                                                         _ => GetTermsForQuickLookup(_, quickLookupMode: QuickLookupMode.Contains));
 
                 ByteArrayContinueTexts = new[]
                                              {
@@ -355,34 +358,25 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                  " which contains ",
                                              };
 
-                SpecialArrayReplacementMapKeys = new[]
-                                                     {
-                                                         Constants.Comments.CollectionReturnTypeStartingPhrase,
-                                                     };
+                SpecialArrayReplacementMap = new ReplacementMap("MiKo_2035_Special", new[] { new Pair(Constants.Comments.CollectionReturnTypeStartingPhrase, Constants.Comments.ArrayReturnTypeStartingPhraseA) }, _ => _.ToArray(__ => __.Key));
 
-                SpecialArrayReplacementMap = SpecialArrayReplacementMapKeys.ToArray(_ => new Pair(_, Constants.Comments.ArrayReturnTypeStartingPhraseA));
+                PreparationMap = new ReplacementMap("MiKo_2035_Prepare", new[] { new Pair("trivia array", "#1#") }, _ => _.ToArray(__ => __.Key));
 
-                PreparationMap = new[]
-                                     {
-                                         new Pair("trivia array", "#1#"),
-                                     };
-
-                PreparationMapKeys = PreparationMap.ToArray(_ => _.Key);
-
-                CleanupMap = new[]
-                                 {
-                                     new Pair("#1#", "trivia"),
-                                     new Pair("the modified set", "elements from the original set"),
-                                     new Pair("the the", "the"),
-                                     new Pair("a the", "the"),
-                                     new Pair("an the", "the"),
-                                     new Pair(" of gets ", " of "),
-                                     new Pair(" of get ", " of "),
-                                     new Pair(" contains gets ", " contains "),
-                                     new Pair(" contains get ", " contains "),
-                                 };
-
-                CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);
+                CleanupMap = new ReplacementMap(
+                                            "MiKo_2035_Cleanup",
+                                            new[]
+                                                {
+                                                    new Pair("#1#", "trivia"),
+                                                    new Pair("the modified set", "elements from the original set"),
+                                                    new Pair("the the", "the"),
+                                                    new Pair("a the", "the"),
+                                                    new Pair("an the", "the"),
+                                                    new Pair(" of gets ", " of "),
+                                                    new Pair(" of get ", " of "),
+                                                    new Pair(" contains gets ", " contains "),
+                                                    new Pair(" contains get ", " contains "),
+                                                },
+                                            _ => _.ToArray(__ => __.Key));
             }
 #pragma warning restore CA1861
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2038_CodeFixProvider.cs
@@ -19,32 +19,31 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] CommandStartingPhrases = CreateCommandStartingPhrases().Except(Constants.Comments.CommandSummaryStartingPhrase).ToArray();
 
-        private static readonly Pair[] CommandReplacementMap = CreateCommandReplacementMapEntries(CommandStartingPhrases).OrderDescendingByLengthAndText(_ => _.Key);
+        private static readonly ReplacementMap CommandReplacementMap = new ReplacementMap("MiKo_2038_Replace", CreateCommandReplacementMapEntries(CommandStartingPhrases).OrderDescendingByLengthAndText(_ => _.Key), _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] CommandReplacementMapKeys = GetTermsForQuickLookup(CommandReplacementMap);
-
-        private static readonly Pair[] CleanupMap =
-                                                    {
-                                                        new Pair(" commands for ", Constants.SingleSpace),
-                                                        new Pair(" command for ", Constants.SingleSpace),
-                                                        new Pair(" can in ", " can be used in "),
-                                                        new Pair(" can with ", " can be used with "),
-                                                        new Pair(" can wrapper for ", " can wrap "),
-                                                        new Pair(" can be needed for ", " can support "),
-                                                        new Pair(" can need for ", " can support "),
-                                                        new Pair(" can a ", " can "),
-                                                        new Pair(" can an ", " can "),
-                                                        new Pair(" can the ", " can "),
-                                                        new Pair(" can extend of ", " can extend "),
-                                                        new Pair(" export and in ", " in "),
-                                                        new Pair(" in context menu usable extension of ", " be used within a context menu of "),
-                                                        new Pair(" in context menu useable extension of ", " be used within a context menu of "),
-                                                        new Pair(" in context-menu usable extension of ", " be used within a context menu of "),
-                                                        new Pair(" in context-menu useable extension of ", " be used within a context menu of "),
-                                                        new Pair(" can be used be used ", " can be used "),
-                                                    };
-
-        private static readonly string[] CleanupMapKeys = GetTermsForQuickLookup(CleanupMap);
+        private static readonly ReplacementMap CleanupMap = new ReplacementMap(
+                                                                           "MiKo_2038_Cleanup",
+                                                                           new[]
+                                                                               {
+                                                                                   new Pair(" commands for ", Constants.SingleSpace),
+                                                                                   new Pair(" command for ", Constants.SingleSpace),
+                                                                                   new Pair(" can in ", " can be used in "),
+                                                                                   new Pair(" can with ", " can be used with "),
+                                                                                   new Pair(" can wrapper for ", " can wrap "),
+                                                                                   new Pair(" can be needed for ", " can support "),
+                                                                                   new Pair(" can need for ", " can support "),
+                                                                                   new Pair(" can a ", " can "),
+                                                                                   new Pair(" can an ", " can "),
+                                                                                   new Pair(" can the ", " can "),
+                                                                                   new Pair(" can extend of ", " can extend "),
+                                                                                   new Pair(" export and in ", " in "),
+                                                                                   new Pair(" in context menu usable extension of ", " be used within a context menu of "),
+                                                                                   new Pair(" in context menu useable extension of ", " be used within a context menu of "),
+                                                                                   new Pair(" in context-menu usable extension of ", " be used within a context menu of "),
+                                                                                   new Pair(" in context-menu useable extension of ", " be used within a context menu of "),
+                                                                                   new Pair(" can be used be used ", " can be used "),
+                                                                               },
+                                                                           _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -56,9 +55,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             if (syntax is XmlElementSyntax element)
             {
-                var preparedComment = Comment(element, CommandReplacementMapKeys, CommandReplacementMap, FirstWordAdjustment.StartLowerCase);
+                var preparedComment = Comment(element, CommandReplacementMap, FirstWordAdjustment.StartLowerCase);
                 var updatedComment = CommentStartingWith(preparedComment, Constants.Comments.CommandSummaryStartingPhrase, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeInfinite);
-                var cleanedComment = Comment(updatedComment, CleanupMapKeys, CleanupMap);
+                var cleanedComment = Comment(updatedComment, CleanupMap);
 
                 return cleanedComment;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2039_CodeFixProvider.cs
@@ -17,19 +17,17 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static readonly string[] Parts = Constants.Comments.ExtensionMethodClassStartingPhraseTemplate.FormatWith("|").Split('|');
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMapKeys().OrderDescendingByLengthAndText().ToArray(_ => new Pair(_));
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2039", CreateReplacementMapKeys().OrderDescendingByLengthAndText().ToArray(_ => new Pair(_)), _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
         public override string FixableDiagnosticId => "MiKo_2039";
 
-        internal static bool CanFix(in ReadOnlySpan<char> text) => text.StartsWithAny(ReplacementMapKeys, StringComparison.OrdinalIgnoreCase);
+        internal static bool CanFix(in ReadOnlySpan<char> text) => text.StartsWithAny(ReplacementMap.Keys, StringComparison.OrdinalIgnoreCase);
 
         internal static SyntaxNode GetUpdatedSyntax(XmlElementSyntax syntax)
         {
-            var comment = Comment(syntax, ReplacementMapKeys, ReplacementMap);
+            var comment = Comment(syntax, ReplacementMap);
 
             return CommentStartingWith(comment, Parts[0], SeeLangword("static"), Parts[1]);
         }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2043_CodeFixProvider.cs
@@ -15,14 +15,16 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2043_CodeFixProvider)), Shared]
     public sealed class MiKo_2043_CodeFixProvider : SummaryDocumentationCodeFixProvider
     {
-        private static readonly Pair[] PreparationMap = CreatePreparationMap().OrderDescendingByLengthAndText(_ => _.Key);
+        private static readonly ReplacementMap PreparationMap = new ReplacementMap(
+                                                                               "MiKo_2043_Prepare",
+                                                                               CreatePreparationMap().OrderDescendingByLengthAndText(_ => _.Key),
+                                                                               _ => _.ToArray(__ => __.Key));
 
-        private static readonly string[] PreparationMapPhrases = PreparationMap.ToArray(_ => _.Key);
-
-        private static readonly Pair[] CleanUpMap = CreateCleanUpMap().Select(_ => new Pair(Constants.Comments.DelegateSummaryStartingPhrase + _.Key, Constants.Comments.DelegateSummaryStartingPhrase + _.Value))
-                                                                      .OrderDescendingByLengthAndText(_ => _.Key);
-
-        private static readonly string[] CleanUpPhrases = CleanUpMap.ToArray(_ => _.Key);
+        private static readonly ReplacementMap CleanUpMap = new ReplacementMap(
+                                                                           "MiKo_2043_Cleanup",
+                                                                           CreateCleanUpMap().Select(_ => new Pair(Constants.Comments.DelegateSummaryStartingPhrase + _.Key, Constants.Comments.DelegateSummaryStartingPhrase + _.Value))
+                                                                                             .OrderDescendingByLengthAndText(_ => _.Key),
+                                                                           _ => _.ToArray(__ => __.Key));
 
         public override string FixableDiagnosticId => "MiKo_2043";
 
@@ -40,11 +42,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 // fix if delegate only contains it's name followed by " delegate" (e.g. "MyDelegate delegate") and nothing else
                 var lookupTerm = d.GetName() + " delegate";
 
-                var preparedComment1 = Comment(comment, new[] { lookupTerm }, new[] { new Pair(lookupTerm, Constants.Comments.DelegateSummaryStartingPhrase + Constants.TODO) });
+                var preparedComment1 = Comment(comment, new ReplacementMap("MiKo_2043_Temp", new[] { new Pair(lookupTerm, Constants.Comments.DelegateSummaryStartingPhrase + Constants.TODO) }, new[] { lookupTerm }));
 
                 if (ReferenceEquals(preparedComment1, comment))
                 {
-                    preparedComment1 = Comment(comment, PreparationMapPhrases, PreparationMap, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
+                    preparedComment1 = Comment(comment, PreparationMap, FirstWordAdjustment.StartLowerCase | FirstWordAdjustment.MakeThirdPersonSingular | FirstWordAdjustment.KeepSingleLeadingSpace);
                 }
                 else
                 {
@@ -52,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
 
                 var preparedComment2 = CommentStartingWith(preparedComment1, Constants.Comments.DelegateSummaryStartingPhrase);
-                var fixedComment = Comment(preparedComment2, CleanUpPhrases, CleanUpMap);
+                var fixedComment = Comment(preparedComment2, CleanUpMap);
 
                 return fixedComment;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2050_CodeFixProvider.cs
@@ -16,16 +16,12 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2050_CodeFixProvider : OverallDocumentationCodeFixProvider
     {
 //// ncrunch: rdi off
-        private static readonly Pair[] TypeReplacementMap = CreateTypePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase).OrderDescendingByLengthAndText().ToArray(_ => new Pair(_));
+        private static readonly ReplacementMap TypeReplacementMap = new ReplacementMap(
+                                                                                   "MiKo_2050_Replace",
+                                                                                   CreateTypePhrases().Except(Constants.Comments.ExceptionTypeSummaryStartingPhrase).OrderDescendingByLengthAndText().ToArray(_ => new Pair(_)),
+                                                                                   _ => GetTermsForQuickLookup(_));
 
-        private static readonly string[] TypeReplacementMapKeys = GetTermsForQuickLookup(TypeReplacementMap);
-
-        private static readonly Pair[] TypeCleanupMap =
-                                                        {
-                                                            new Pair("when during", "when an error occurs during"),
-                                                        };
-
-        private static readonly string[] TypeCleanupMapKeys = GetTermsForQuickLookup(TypeCleanupMap);
+        private static readonly ReplacementMap TypeCleanupMap = new ReplacementMap("MiKo_2050_Cleanup", new[] { new Pair("when during", "when an error occurs during") }, _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -65,9 +61,9 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             {
                 var summary = summaries[0];
 
-                var preparedSummary = Comment(summary, TypeReplacementMapKeys, TypeReplacementMap, FirstWordAdjustment.StartLowerCase);
+                var preparedSummary = Comment(summary, TypeReplacementMap, FirstWordAdjustment.StartLowerCase);
                 var newSummary = CommentStartingWith(preparedSummary, Constants.Comments.ExceptionTypeSummaryStartingPhrase);
-                var updatedSummary = Comment(newSummary, TypeCleanupMapKeys, TypeCleanupMap);
+                var updatedSummary = Comment(newSummary, TypeCleanupMap);
 
                 return comment.ReplaceNode(summary, updatedSummary);
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -26,24 +26,24 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var mappedData = MappedData.Value;
 
-            return text.StartsWithAny(mappedData.TypeReplacementMapKeysAc, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysAf, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysAi, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysAn, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysAx, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysC, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysD, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysF, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysI, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysP, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysR, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysTheC, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysTheF, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysTheI, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysTheX, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysThis, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.TypeReplacementMapKeysOthers, StringComparison.OrdinalIgnoreCase)
-                || text.StartsWithAny(mappedData.InstancesReplacementMapKeys, StringComparison.OrdinalIgnoreCase);
+            return text.StartsWithAny(mappedData.TypeReplacementMapAc.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapAf.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapAi.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapAn.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapAx.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapC.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapD.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapF.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapI.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapP.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapR.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapTheC.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapTheF.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapTheI.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapTheX.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapThis.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.TypeReplacementMapOthers.Keys, StringComparison.OrdinalIgnoreCase)
+                || text.StartsWithAny(mappedData.InstancesReplacementMap.Keys, StringComparison.OrdinalIgnoreCase);
         }
 
         internal static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax)
@@ -63,7 +63,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
                             if (preparedComment == summary)
                             {
-                                preparedComment = Comment(summary, mappedData.InstancesReplacementMapKeys, mappedData.InstancesReplacementMap);
+                                preparedComment = Comment(summary, mappedData.InstancesReplacementMap);
                             }
 
                             var fixedComment = CommentStartingWith(preparedComment, Constants.Comments.FactorySummaryPhrase);
@@ -117,11 +117,11 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var startText = textTokens[0].ValueText.AsSpan().TrimStart();
 
-            var mapping = GetApplicableMapping(startText, mappedData);
+            var map = GetApplicableMap(startText, mappedData);
 
-            if (mapping != default)
+            if (map != null)
             {
-                updated = Comment(comment, mapping.Keys, mapping.Map);
+                updated = Comment(comment, map);
 
                 if (ReferenceEquals(updated, comment) is false)
                 {
@@ -130,7 +130,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            updated = Comment(comment, mappedData.TypeReplacementMapKeysOthers, mappedData.TypeReplacementMapOthers);
+            updated = Comment(comment, mappedData.TypeReplacementMapOthers);
 
             if (ReferenceEquals(updated, comment) is false)
             {
@@ -141,7 +141,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return comment;
         }
 
-        private static (string[] Keys, Pair[] Map) GetApplicableMapping(in ReadOnlySpan<char> startText, MapData mappedData)
+        private static ReplacementMap GetApplicableMap(in ReadOnlySpan<char> startText, MapData mappedData)
         {
             switch (startText[0])
             {
@@ -154,44 +154,44 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         {
                             case 'c':
                             case 'C':
-                                return (mappedData.TypeReplacementMapKeysAc, mappedData.TypeReplacementMapAc);
+                                return mappedData.TypeReplacementMapAc;
                             case 'f':
                             case 'F':
-                                return (mappedData.TypeReplacementMapKeysAf, mappedData.TypeReplacementMapAf);
+                                return mappedData.TypeReplacementMapAf;
                             case 'i':
                             case 'I':
-                                return (mappedData.TypeReplacementMapKeysAi, mappedData.TypeReplacementMapAi);
+                                return mappedData.TypeReplacementMapAi;
                             default:
-                                return (mappedData.TypeReplacementMapKeysAx, mappedData.TypeReplacementMapAx);
+                                return mappedData.TypeReplacementMapAx;
                         }
                     }
 
-                    return (mappedData.TypeReplacementMapKeysAn, mappedData.TypeReplacementMapAn);
+                    return mappedData.TypeReplacementMapAn;
                 }
 
                 case 'C':
                 case 'c':
-                    return (mappedData.TypeReplacementMapKeysC, mappedData.TypeReplacementMapC);
+                    return mappedData.TypeReplacementMapC;
 
                 case 'D':
                 case 'd':
-                    return (mappedData.TypeReplacementMapKeysD, mappedData.TypeReplacementMapD);
+                    return mappedData.TypeReplacementMapD;
 
                 case 'F':
                 case 'f':
-                    return (mappedData.TypeReplacementMapKeysF, mappedData.TypeReplacementMapF);
+                    return mappedData.TypeReplacementMapF;
 
                 case 'I':
                 case 'i':
-                    return (mappedData.TypeReplacementMapKeysI, mappedData.TypeReplacementMapI);
+                    return mappedData.TypeReplacementMapI;
 
                 case 'P':
                 case 'p':
-                    return (mappedData.TypeReplacementMapKeysP, mappedData.TypeReplacementMapP);
+                    return mappedData.TypeReplacementMapP;
 
                 case 'R':
                 case 'r':
-                    return (mappedData.TypeReplacementMapKeysR, mappedData.TypeReplacementMapR);
+                    return mappedData.TypeReplacementMapR;
 
                 case 'T':
                 case 't':
@@ -201,22 +201,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         {
                             case 'c':
                             case 'C':
-                                return (mappedData.TypeReplacementMapKeysTheC, mappedData.TypeReplacementMapTheC);
+                                return mappedData.TypeReplacementMapTheC;
                             case 'f':
                             case 'F':
-                                return (mappedData.TypeReplacementMapKeysTheF, mappedData.TypeReplacementMapTheF);
+                                return mappedData.TypeReplacementMapTheF;
                             case 'i':
                             case 'I':
-                                return (mappedData.TypeReplacementMapKeysTheI, mappedData.TypeReplacementMapTheI);
+                                return mappedData.TypeReplacementMapTheI;
                             default:
-                                return (mappedData.TypeReplacementMapKeysTheX, mappedData.TypeReplacementMapTheX);
+                                return mappedData.TypeReplacementMapTheX;
                         }
                     }
 
-                    return (mappedData.TypeReplacementMapKeysThis, mappedData.TypeReplacementMapThis);
+                    return mappedData.TypeReplacementMapThis;
 
                 default:
-                    return default;
+                    return null;
             }
         }
 
@@ -224,7 +224,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var mappedData = MappedData.Value;
 
-            var preparedComment = Comment(comment, mappedData.MethodReplacementMapKeys, mappedData.MethodReplacementMap);
+            var preparedComment = Comment(comment, mappedData.MethodReplacementMap);
 
             var content = preparedComment.Content;
 
@@ -246,7 +246,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         {
             var mappedData = MappedData.Value;
 
-            return Comment(comment, mappedData.CleanupReplacementMapKeys, mappedData.CleanupReplacementMap);
+            return Comment(comment, mappedData.CleanupReplacementMap);
         }
 
 //// ncrunch: rdi off
@@ -255,46 +255,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private sealed class MapData
         {
 #pragma warning disable SA1401 // Fields should be private
-            public readonly Pair[] TypeReplacementMapAc;
-            public readonly string[] TypeReplacementMapKeysAc;
-            public readonly Pair[] TypeReplacementMapAf;
-            public readonly string[] TypeReplacementMapKeysAf;
-            public readonly Pair[] TypeReplacementMapAi;
-            public readonly string[] TypeReplacementMapKeysAi;
-            public readonly Pair[] TypeReplacementMapAx;
-            public readonly string[] TypeReplacementMapKeysAx;
-            public readonly Pair[] TypeReplacementMapAn;
-            public readonly string[] TypeReplacementMapKeysAn;
-            public readonly Pair[] TypeReplacementMapC;
-            public readonly string[] TypeReplacementMapKeysC;
-            public readonly Pair[] TypeReplacementMapD;
-            public readonly string[] TypeReplacementMapKeysD;
-            public readonly Pair[] TypeReplacementMapF;
-            public readonly string[] TypeReplacementMapKeysF;
-            public readonly Pair[] TypeReplacementMapI;
-            public readonly string[] TypeReplacementMapKeysI;
-            public readonly Pair[] TypeReplacementMapP;
-            public readonly string[] TypeReplacementMapKeysP;
-            public readonly Pair[] TypeReplacementMapR;
-            public readonly string[] TypeReplacementMapKeysR;
-            public readonly Pair[] TypeReplacementMapTheC;
-            public readonly string[] TypeReplacementMapKeysTheC;
-            public readonly Pair[] TypeReplacementMapTheF;
-            public readonly string[] TypeReplacementMapKeysTheF;
-            public readonly Pair[] TypeReplacementMapTheI;
-            public readonly string[] TypeReplacementMapKeysTheI;
-            public readonly Pair[] TypeReplacementMapTheX;
-            public readonly string[] TypeReplacementMapKeysTheX;
-            public readonly Pair[] TypeReplacementMapThis;
-            public readonly string[] TypeReplacementMapKeysThis;
-            public readonly Pair[] TypeReplacementMapOthers;
-            public readonly string[] TypeReplacementMapKeysOthers;
-            public readonly Pair[] MethodReplacementMap;
-            public readonly string[] MethodReplacementMapKeys;
-            public readonly Pair[] InstancesReplacementMap;
-            public readonly string[] InstancesReplacementMapKeys;
-            public readonly Pair[] CleanupReplacementMap;
-            public readonly string[] CleanupReplacementMapKeys;
+            public readonly ReplacementMap TypeReplacementMapAc;
+            public readonly ReplacementMap TypeReplacementMapAf;
+            public readonly ReplacementMap TypeReplacementMapAi;
+            public readonly ReplacementMap TypeReplacementMapAx;
+            public readonly ReplacementMap TypeReplacementMapAn;
+            public readonly ReplacementMap TypeReplacementMapC;
+            public readonly ReplacementMap TypeReplacementMapD;
+            public readonly ReplacementMap TypeReplacementMapF;
+            public readonly ReplacementMap TypeReplacementMapI;
+            public readonly ReplacementMap TypeReplacementMapP;
+            public readonly ReplacementMap TypeReplacementMapR;
+            public readonly ReplacementMap TypeReplacementMapTheC;
+            public readonly ReplacementMap TypeReplacementMapTheF;
+            public readonly ReplacementMap TypeReplacementMapTheI;
+            public readonly ReplacementMap TypeReplacementMapTheX;
+            public readonly ReplacementMap TypeReplacementMapThis;
+            public readonly ReplacementMap TypeReplacementMapOthers;
+            public readonly ReplacementMap MethodReplacementMap;
+            public readonly ReplacementMap InstancesReplacementMap;
+            public readonly ReplacementMap CleanupReplacementMap;
 #pragma warning restore SA1401 // Fields should be private
 
             public MapData()
@@ -324,23 +304,23 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     GetDestinationList(typeKey.AsSpan()).Add(typeKey);
                 }
 
-                Initialize(typeKeysStartingWithAc, out TypeReplacementMapAc, out TypeReplacementMapKeysAc);
-                Initialize(typeKeysStartingWithAf, out TypeReplacementMapAf, out TypeReplacementMapKeysAf);
-                Initialize(typeKeysStartingWithAi, out TypeReplacementMapAi, out TypeReplacementMapKeysAi);
-                Initialize(typeKeysStartingWithAx, out TypeReplacementMapAx, out TypeReplacementMapKeysAx);
-                Initialize(typeKeysStartingWithAn, out TypeReplacementMapAn, out TypeReplacementMapKeysAn);
-                Initialize(typeKeysStartingWithC, out TypeReplacementMapC, out TypeReplacementMapKeysC);
-                Initialize(typeKeysStartingWithD, out TypeReplacementMapD, out TypeReplacementMapKeysD);
-                Initialize(typeKeysStartingWithF, out TypeReplacementMapF, out TypeReplacementMapKeysF);
-                Initialize(typeKeysStartingWithI, out TypeReplacementMapI, out TypeReplacementMapKeysI);
-                Initialize(typeKeysStartingWithP, out TypeReplacementMapP, out TypeReplacementMapKeysP);
-                Initialize(typeKeysStartingWithR, out TypeReplacementMapR, out TypeReplacementMapKeysR);
-                Initialize(typeKeysStartingWithTheC, out TypeReplacementMapTheC, out TypeReplacementMapKeysTheC);
-                Initialize(typeKeysStartingWithTheF, out TypeReplacementMapTheF, out TypeReplacementMapKeysTheF);
-                Initialize(typeKeysStartingWithTheI, out TypeReplacementMapTheI, out TypeReplacementMapKeysTheI);
-                Initialize(typeKeysStartingWithTheX, out TypeReplacementMapTheX, out TypeReplacementMapKeysTheX);
-                Initialize(typeKeysStartingWithThis, out TypeReplacementMapThis, out TypeReplacementMapKeysThis);
-                Initialize(typeKeysOther, out TypeReplacementMapOthers, out TypeReplacementMapKeysOthers);
+                Initialize("MiKo_2060_A_c", typeKeysStartingWithAc, out TypeReplacementMapAc);
+                Initialize("MiKo_2060_A_f", typeKeysStartingWithAf, out TypeReplacementMapAf);
+                Initialize("MiKo_2060_A_i", typeKeysStartingWithAi, out TypeReplacementMapAi);
+                Initialize("MiKo_2060_A_", typeKeysStartingWithAx, out TypeReplacementMapAx);
+                Initialize("MiKo_2060_An_", typeKeysStartingWithAn, out TypeReplacementMapAn);
+                Initialize("MiKo_2060_C", typeKeysStartingWithC, out TypeReplacementMapC);
+                Initialize("MiKo_2060_D", typeKeysStartingWithD, out TypeReplacementMapD);
+                Initialize("MiKo_2060_F", typeKeysStartingWithF, out TypeReplacementMapF);
+                Initialize("MiKo_2060_I", typeKeysStartingWithI, out TypeReplacementMapI);
+                Initialize("MiKo_2060_P", typeKeysStartingWithP, out TypeReplacementMapP);
+                Initialize("MiKo_2060_R", typeKeysStartingWithR, out TypeReplacementMapR);
+                Initialize("MiKo_2060_The_c", typeKeysStartingWithTheC, out TypeReplacementMapTheC);
+                Initialize("MiKo_2060_The_f", typeKeysStartingWithTheF, out TypeReplacementMapTheF);
+                Initialize("MiKo_2060_The_i", typeKeysStartingWithTheI, out TypeReplacementMapTheI);
+                Initialize("MiKo_2060_The_", typeKeysStartingWithTheX, out TypeReplacementMapTheX);
+                Initialize("MiKo_2060_This_", typeKeysStartingWithThis, out TypeReplacementMapThis);
+                Initialize("MiKo_2060_Other", typeKeysOther, out TypeReplacementMapOthers);
 
                 var methodKeys = CreateMethodReplacementMapKeys();
                 var methodKeysLength = methodKeys.Length;
@@ -356,27 +336,26 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     instancesReplacementMap[i] = new Pair(key, "instances of the ");
                 }
 
-                MethodReplacementMap = methodReplacementMap;
-                MethodReplacementMapKeys = GetTermsForQuickLookup(methodKeys, quickLookupMode: QuickLookupMode.Contains);
+                MethodReplacementMap = new ReplacementMap("MiKo_2060_methods", methodReplacementMap, _ => GetTermsForQuickLookup(_, quickLookupMode: QuickLookupMode.Contains));
+                InstancesReplacementMap = new ReplacementMap("MiKo_2060_instances", instancesReplacementMap, _ => GetTermsForQuickLookup(_, quickLookupMode: QuickLookupMode.Contains));
 
-                InstancesReplacementMap = instancesReplacementMap;
-                InstancesReplacementMapKeys = GetTermsForQuickLookup(methodKeys, quickLookupMode: QuickLookupMode.Contains);
-
-                CleanupReplacementMap = new[]
-                                            {
-                                                new Pair("classes", "types"),
-                                                new Pair("class", "type"),
-                                                new Pair("typeifi", "classifi"), // fix typo when 'class' in 'classification' or 'classified' gets changed into 'type'
-                                                new Pair(" based on ", " default values for "),
-                                                new Pair(" with for ", " with "),
-                                                new Pair(" with with ", " with "),
-                                                new Pair(" type with type.", " type with default values."),
-                                                new Pair(" type with that ", " type with default values that "),
-                                                new Pair(" type with which ", " type with default values which "),
-                                                new Pair(" creating creates ", " creating "),
-                                                new Pair(" creating create ", " creating "),
-                                            };
-                CleanupReplacementMapKeys = CleanupReplacementMap.ToArray(_ => _.Key);
+                CleanupReplacementMap = new ReplacementMap(
+                                                       "MiKo_2060_Cleanup",
+                                                       new[]
+                                                           {
+                                                               new Pair("classes", "types"),
+                                                               new Pair("class", "type"),
+                                                               new Pair("typeifi", "classifi"), // fix typo when 'class' in 'classification' or 'classified' gets changed into 'type'
+                                                               new Pair(" based on ", " default values for "),
+                                                               new Pair(" with for ", " with "),
+                                                               new Pair(" with with ", " with "),
+                                                               new Pair(" type with type.", " type with default values."),
+                                                               new Pair(" type with that ", " type with default values that "),
+                                                               new Pair(" type with which ", " type with default values which "),
+                                                               new Pair(" creating creates ", " creating "),
+                                                               new Pair(" creating create ", " creating "),
+                                                           },
+                                                       _ => _.ToArray(__ => __.Key));
 
                 return;
 
@@ -428,7 +407,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                         case 'T':
                         case 't':
                         {
-                            if (typeKey[2] == 'i')
+                            if (typeKey[2] is 'i')
                             {
                                 return typeKeysStartingWithThis;
                             }
@@ -447,18 +426,18 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                     }
                 }
 
-                void Initialize(List<string> keys, out Pair[] map, out string[] mapKeys)
+                void Initialize(string id, List<string> keys, out ReplacementMap map)
                 {
                     keys.Sort(AscendingStringComparer.Default);
 
-                    map = new Pair[keys.Count];
+                    var pairs = new Pair[keys.Count];
 
                     for (var i = keys.Count - 1; i >= 0; i--)
                     {
-                        map[i] = new Pair(keys[i]);
+                        pairs[i] = new Pair(keys[i]);
                     }
 
-                    mapKeys = GetTermsForQuickLookup(keys, quickLookupMode: QuickLookupMode.Contains);
+                    map = new ReplacementMap(id, pairs, _ => GetTermsForQuickLookup(_, quickLookupMode: QuickLookupMode.Contains));
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2072_CodeFixProvider.cs
@@ -13,8 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMap();
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2072", CreateReplacementMap(), _ => GetTermsForQuickLookup(_));
 
 //// ncrunch: rdi default
 
@@ -29,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         private static XmlElementSyntax GetUpdatedSyntax(XmlElementSyntax comment)
         {
-            return Comment(comment, ReplacementMapKeys, ReplacementMap);
+            return Comment(comment, ReplacementMap);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2073_CodeFixProvider.cs
@@ -55,7 +55,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             map[1] = new Pair("whether if", "whether");
             map[2] = new Pair("whether whether", "whether");
 
-            return Comment(comment, new[] { firstWord }, map);
+            return Comment(comment, new ReplacementMap("MiKo_2073", map, new[] { firstWord }));
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2074_CodeFixProvider.cs
@@ -9,18 +9,19 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2074_CodeFixProvider)), Shared]
     public sealed class MiKo_2074_CodeFixProvider : ParameterDocumentationCodeFixProvider
     {
-        private static readonly Pair[] ReplacementMap =
-                                                        {
-                                                            new Pair("to search to seek", "to seek"),
-                                                            new Pair("to search for to seek", "to seek"),
-                                                            new Pair("to look up to seek", "to seek"),
-                                                            new Pair("to look-up to seek", "to seek"),
-                                                            new Pair("to check to seek", "to seek"),
-                                                            new Pair("to check for to seek", "to seek"),
-                                                            new Pair("to check if contained to seek", "to seek"),
-                                                        };
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap(
+                                                                               "MiKo_2074",
+                                                                               new[]
+                                                                                   {
+                                                                                       new Pair("to search to seek", "to seek"),
+                                                                                       new Pair("to search for to seek", "to seek"),
+                                                                                       new Pair("to look up to seek", "to seek"),
+                                                                                       new Pair("to look-up to seek", "to seek"),
+                                                                                       new Pair("to check to seek", "to seek"),
+                                                                                       new Pair("to check for to seek", "to seek"),
+                                                                                       new Pair("to check if contained to seek", "to seek"),
+                                                                                   },
+                                                                               _ => GetTermsForQuickLookup(_));
 
         public override string FixableDiagnosticId => "MiKo_2074";
 
@@ -36,7 +37,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var updatedComment = CommentEndingWith(comment, phrase);
 
-            return Comment(updatedComment, ReplacementMapKeys, ReplacementMap);
+            return Comment(updatedComment, ReplacementMap);
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2080_CodeFixProvider.cs
@@ -35,13 +35,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
             var data = MappedData.Value;
 
-            var preparedComment = Comment(comment, data.PreparationMapKeys, data.PreparationMap);
-            var preparedComment1 = Comment(preparedComment, data.TypeGuidReplacementMapKeys, data.TypeGuidReplacementMap);
-            var preparedComment2 = Comment(preparedComment1, data.ReplacementMapKeys, data.ReplacementMap);
+            var preparedComment = Comment(comment, data.PreparationMap);
+            var preparedComment1 = Comment(preparedComment, data.TypeGuidReplacementMap);
+            var preparedComment2 = Comment(preparedComment1, data.ReplacementMap);
 
             var fixedComment = CommentStartingWith(preparedComment2, phrase);
 
-            return Comment(fixedComment, data.CleanupMapKeys, data.CleanupMap);
+            return Comment(fixedComment, data.CleanupMap);
         }
 
 //// ncrunch: rdi off
@@ -50,84 +50,83 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         private sealed class MapData
         {
 #pragma warning disable SA1401 // Fields should be private
-            public readonly Pair[] ReplacementMap;
-            public readonly string[] ReplacementMapKeys;
-            public readonly string[] TypeGuidReplacementMapKeys;
-            public readonly Pair[] TypeGuidReplacementMap;
-            public readonly string[] PreparationMapKeys;
-            public readonly Pair[] PreparationMap;
-            public readonly string[] CleanupMapKeys;
-            public readonly Pair[] CleanupMap;
+            public readonly ReplacementMap ReplacementMap;
+            public readonly ReplacementMap TypeGuidReplacementMap;
+            public readonly ReplacementMap PreparationMap;
+            public readonly ReplacementMap CleanupMap;
 #pragma warning restore SA1401 // Fields should be private
 
 #pragma warning disable CA1861
             public MapData()
             {
-                ReplacementMap = CreateReplacementMapPairs().OrderDescendingByLengthAndText(_ => _.Key) // get longest items first as shorter items may be part of the longer ones and would cause problems
-                                                            .Concat(new[] { new Pair("Factory ", "a factory ") })
-                                                            .ToArray();
+                ReplacementMap = new ReplacementMap(
+                                                "MiKo_2080_Replace",
+                                                CreateReplacementMapPairs().OrderDescendingByLengthAndText(_ => _.Key) // get longest items first as shorter items may be part of the longer ones and would cause problems
+                                                                           .Concat(new[] { new Pair("Factory ", "a factory ") })
+                                                                           .ToArray(),
+                                                _ => GetTermsForQuickLookup(_.ToArray(__ => __.Key)));
 
-                var keys = ReplacementMap.ToArray(_ => _.Key);
+                var typeGuidReplacementMapKeys = new[]
+                                                     {
+                                                         "A Type GUID for ",
+                                                         "A Type GUID of ",
+                                                         "A Type Guid for ",
+                                                         "A Type Guid of ",
+                                                         "A TypeGuid for ",
+                                                         "A TypeGuid of ",
+                                                         "The Type GUID for ",
+                                                         "The Type GUID of ",
+                                                         "The Type Guid for ",
+                                                         "The Type Guid of ",
+                                                         "The TypeGuid for ",
+                                                         "The TypeGuid of ",
+                                                         "Type GUID for ",
+                                                         "Type GUID of ",
+                                                         "Type Guid for ",
+                                                         "Type Guid of ",
+                                                         "TypeGuid for ",
+                                                         "TypeGuid of ",
+                                                         "TypeGuids for ", // typo
+                                                         "TypeGuids of ", // typo
+                                                     };
 
-                ReplacementMapKeys = GetTermsForQuickLookup(keys);
+                TypeGuidReplacementMap = new ReplacementMap(
+                                                        "MiKo_2080_TypeGuid",
+                                                        typeGuidReplacementMapKeys.Select(_ => new Pair(_, "The unique identifier for the type of "))
+                                                                                  .OrderDescendingByLengthAndText(_ => _.Key),
+                                                        typeGuidReplacementMapKeys.ToArray(AscendingStringComparer.Default));
 
-                TypeGuidReplacementMapKeys = new[]
-                                                 {
-                                                     "A Type GUID for ",
-                                                     "A Type GUID of ",
-                                                     "A Type Guid for ",
-                                                     "A Type Guid of ",
-                                                     "A TypeGuid for ",
-                                                     "A TypeGuid of ",
-                                                     "The Type GUID for ",
-                                                     "The Type GUID of ",
-                                                     "The Type Guid for ",
-                                                     "The Type Guid of ",
-                                                     "The TypeGuid for ",
-                                                     "The TypeGuid of ",
-                                                     "Type GUID for ",
-                                                     "Type GUID of ",
-                                                     "Type Guid for ",
-                                                     "Type Guid of ",
-                                                     "TypeGuid for ",
-                                                     "TypeGuid of ",
-                                                     "TypeGuids for ", // typo
-                                                     "TypeGuids of ", // typo
-                                                 }.ToArray(AscendingStringComparer.Default);
+                PreparationMap = new ReplacementMap(
+                                                "MiKo_2080_Prepare",
+                                                new[]
+                                                    {
+                                                        new Pair("uperset", "#1#"), // prepare 'superset' as the 'set' would get replaced
+                                                        new Pair("uper-set", "#2#"), // prepare 'super-set' as the 'set' would get replaced
+                                                        new Pair("ubset", "#3#"), // prepare 'subset' as the 'set' would get replaced
+                                                        new Pair("ub-set", "#4#"), // prepare 'sub-set' as the 'set' would get replaced
+                                                    },
+                                                _ => _.ToArray(__ => __.Key));
 
-                TypeGuidReplacementMap = TypeGuidReplacementMapKeys.Select(_ => new Pair(_, "The unique identifier for the type of "))
-                                                                   .OrderDescendingByLengthAndText(_ => _.Key);
-
-                PreparationMap = new[]
-                                     {
-                                         new Pair("uperset", "#1#"), // prepare 'superset' as the 'set' would get replaced
-                                         new Pair("uper-set", "#2#"), // prepare 'super-set' as the 'set' would get replaced
-                                         new Pair("ubset", "#3#"), // prepare 'subset' as the 'set' would get replaced
-                                         new Pair("ub-set", "#4#"), // prepare 'sub-set' as the 'set' would get replaced
-                                     };
-
-                PreparationMapKeys = PreparationMap.ToArray(_ => _.Key);
-
-                CleanupMap = new[]
-                                 {
-                                     new Pair("#1#", "uperset"), // restore 'superset' as the 'set' would get replaced
-                                     new Pair("#2#", "uper-set"), // restore 'super-set' as the 'set' would get replaced
-                                     new Pair("#3#", "ubset"), // restore 'subset' as the 'set' would get replaced
-                                     new Pair("#4#", "ub-set"), // restore 'sub-set' as the 'set' would get replaced
-
-                                     new Pair(" a the ", " the "),
-                                     new Pair(" an the ", " the "),
-                                     new Pair(" the the ", " the "),
-                                     new Pair("The a ", "The "),
-                                     new Pair("The an ", "The "),
-                                     new Pair("The the ", "The "),
-                                     new Pair(" from from ", " from "),
-                                     new Pair(" whether if ", " whether "),
-                                     new Pair(" whether when ", " whether "),
-                                     new Pair(" whether whether ", " whether "),
-                                 };
-
-                CleanupMapKeys = CleanupMap.ToArray(_ => _.Key);
+                CleanupMap = new ReplacementMap(
+                                            "MiKo_2080_Cleanup",
+                                            new[]
+                                                {
+                                                    new Pair("#1#", "uperset"), // restore 'superset' as the 'set' would get replaced
+                                                    new Pair("#2#", "uper-set"), // restore 'super-set' as the 'set' would get replaced
+                                                    new Pair("#3#", "ubset"), // restore 'subset' as the 'set' would get replaced
+                                                    new Pair("#4#", "ub-set"), // restore 'sub-set' as the 'set' would get replaced
+                                                    new Pair(" a the ", " the "),
+                                                    new Pair(" an the ", " the "),
+                                                    new Pair(" the the ", " the "),
+                                                    new Pair("The a ", "The "),
+                                                    new Pair("The an ", "The "),
+                                                    new Pair("The the ", "The "),
+                                                    new Pair(" from from ", " from "),
+                                                    new Pair(" whether if ", " whether "),
+                                                    new Pair(" whether when ", " whether "),
+                                                    new Pair(" whether whether ", " whether "),
+                                                },
+                                            _ => _.ToArray(__ => __.Key));
             }
 #pragma warning restore CA1861
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2082_CodeFixProvider.cs
@@ -17,9 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
 //// ncrunch: rdi off
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMapKeys().ToArray(_ => new Pair(_));
-
-        private static readonly string[] ReplacementMapKeys = GetTermsForQuickLookup(ReplacementMap);
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap("MiKo_2082", CreateReplacementMapKeys().ToArray(_ => new Pair(_)), _ => GetTermsForQuickLookup(_));
 
         private static readonly string[] TypesSuffixes = { "Types", "Type", "Enum" };
 
@@ -111,7 +109,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                 }
             }
 
-            return Comment(comment, ReplacementMapKeys, ReplacementMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace);
+            return Comment(comment, ReplacementMap, FirstWordAdjustment.StartUpperCase | FirstWordAdjustment.KeepSingleLeadingSpace);
         }
 
 //// ncrunch: rdi off

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/AttributeSyntaxCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/AttributeSyntaxCodeFixProvider.cs
@@ -29,8 +29,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             if (syntax is AttributeSyntax)
             {
                 var nodeToRemove = syntax.Parent is AttributeListSyntax attributeList && attributeList.Attributes.Count is 1
-                                       ? attributeList
-                                       : syntax;
+                                   ? attributeList
+                                   : syntax;
 
                 return root.Without(nodeToRemove);
             }

--- a/MiKo.Analyzer.Shared/Triple.cs
+++ b/MiKo.Analyzer.Shared/Triple.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+// for performance reasons we switch of RDI and NCrunch instrumentation
+//// ncrunch: rdi off
+//// ncrunch: no coverage start
+namespace MiKoSolutions.Analyzers
+{
+    public readonly struct Triple : IEquatable<Triple>
+    {
+#pragma warning disable CA1051 // made as field instead of property for performance reasons
+        public readonly string A; // made as field instead of property for performance reasons
+        public readonly string B; // made as field instead of property for performance reasons
+        public readonly string C; // made as field instead of property for performance reasons
+#pragma warning restore CA1051
+
+        /// <summary>
+        /// Contains the pre-calculated hash code as the strings <see cref="A"/>, <see cref="B"/> and <see cref="C"/> will not change anymore after the constructor is finished.
+        /// </summary>
+        private readonly int m_hashCode;
+
+        public Triple(string a, string b, string c)
+        {
+            A = a;
+            B = b;
+            C = c;
+
+            m_hashCode = CalculateHashCode(A, B, C);
+        }
+
+        public static bool operator ==(in Triple left, in Triple right) => left.Equals(right);
+
+        public static bool operator !=(in Triple left, in Triple right) => left.Equals(right) is false;
+
+        public bool Equals(Triple other) => A.AsSpan().SequenceEqual(other.A.AsSpan())
+                                         && B.AsSpan().SequenceEqual(other.B.AsSpan())
+                                         && C.AsSpan().SequenceEqual(other.C.AsSpan());
+
+        public override bool Equals(object obj) => obj is Triple other && Equals(other);
+
+        public override int GetHashCode() => m_hashCode;
+
+        public override string ToString() => string.Concat(A, ": ", B, " -> ", C);
+
+        private static int CalculateHashCode(string a, string b, string c)
+        {
+            unchecked
+            {
+                var hashCode = a?.GetHashCode() ?? 0;
+
+                hashCode = (hashCode * 397) ^ (b?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (c?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Refactor replacement logic by introducing
  - class `ReplacementMap` for managing term replacements and lookup keys
  - struct `Triple` for efficient caching

- Update all code fix providers to use `ReplacementMap`

- Centralize and optimize replacement operations

- Add a `ConcurrentDictionary` as cache for documentation updates