### PR TITLE
Refactor 'ContainsAnyOrdinal' to do a quick probe first

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -18,11 +18,6 @@ namespace MiKoSolutions.Analyzers
     internal static class StringBuilderExtensions
     {
         /// <summary>
-        /// The minimum length threshold used for optimized substring probing operations.
-        /// </summary>
-        private const int QuickSubstringProbeLengthThreshold = 8;
-
-        /// <summary>
         /// The shared character array pool used for temporary buffer allocations to improve performance and reduce memory allocations.
         /// </summary>
         private static readonly ArrayPool<char> SharedPool = ArrayPool<char>.Shared;
@@ -347,7 +342,7 @@ namespace MiKoSolutions.Analyzers
                     continue;
                 }
 
-                var replaceStartIndex = QuickSubstringProbe(textSpan, pair.Key.AsSpan());
+                var replaceStartIndex = textSpan.QuickSubstringProbeOrdinal(pair.Key.AsSpan());
 
                 if (replaceStartIndex is -1)
                 {
@@ -398,7 +393,7 @@ namespace MiKoSolutions.Analyzers
             {
                 var oldValue = texts[index];
 
-                var replaceStartIndex = QuickSubstringProbe(textSpan, oldValue.AsSpan());
+                var replaceStartIndex = textSpan.QuickSubstringProbeOrdinal(oldValue.AsSpan());
 
                 if (replaceStartIndex is -1)
                 {
@@ -451,7 +446,7 @@ namespace MiKoSolutions.Analyzers
             char[] text = null;
             var textSpan = GetTextAsRentedArray(ref value, ref text);
 
-            var replaceStartIndex = QuickSubstringProbe(textSpan, oldValue.AsSpan());
+            var replaceStartIndex = textSpan.QuickSubstringProbeOrdinal(oldValue.AsSpan());
 
             // we do not need the text anymore
             if (text != null)
@@ -1295,133 +1290,6 @@ namespace MiKoSolutions.Analyzers
             var pluralWord = Verbalizer.MakeThirdPersonSingularVerb(word);
 
             value.Insert(whitespacesBefore, pluralWord);
-        }
-
-        /// <summary>
-        /// Determines the starting position where the specified text could potentially occur within the given text, using a quick probe optimization.
-        /// </summary>
-        /// <param name="source">
-        /// The text to search within.
-        /// </param>
-        /// <param name="substring">
-        /// The text to search for.
-        /// </param>
-        /// <returns>
-        /// The zero-based starting position where the specified text might occur, or <c>-1</c> if it does not occur.
-        /// </returns>
-        private static int QuickSubstringProbe(in ReadOnlySpan<char> source, in ReadOnlySpan<char> substring)
-        {
-            if (substring.Length is 0)
-            {
-                // cannot be part in the replacement as the substring is zero
-                return -1;
-            }
-
-            var delta = source.Length - substring.Length;
-
-            if (delta < 0)
-            {
-                // cannot be part in the replacement as the substring is too long to fit within the source
-                return -1;
-            }
-
-            var startChar = substring[0];
-
-            // Performance-Note:
-            // - restrict the search space upfront so that IndexOf never overshoots delta
-            var searchSpace = source.Slice(0, delta + 1);
-
-            // Performance-Note:
-            // - fast-exit: if startChar is not present at all in the valid window,
-            //   there is no point iterating; IndexOf is a tight single-comparison loop even without SIMD
-            var startIndex = searchSpace.IndexOf(startChar);
-
-            if (startIndex < 0)
-            {
-                return -1;
-            }
-
-            // Performance-Note:
-            // - fast-exit: if the substring is below the threshold, it is short enough to still fit inside the source
-            if (substring.Length < QuickSubstringProbeLengthThreshold)
-            {
-                return startIndex;
-            }
-
-            var lastIndex = substring.Length - 1;
-            var endChar = substring[lastIndex];
-
-            // Performance-Note:
-            // - fast-exit: if endChar does not appear anywhere in the valid end-character window, no complete match is possible
-            var endCharLastIndex = source.Slice(startIndex + lastIndex, delta - startIndex + 1).LastIndexOf(endChar);
-
-            if (endCharLastIndex < 0)
-            {
-                return -1;
-            }
-
-            // Performance-Note:
-            // - tighten delta to the last position where endChar actually appears,
-            //   so the loop never scans positions that cannot possibly yield a match
-            var effectiveDelta = startIndex + endCharLastIndex;
-
-            // Performance-Note:
-            // - if the substring is short enough, we can skip checking an extra probe character and just check the start and end characters;
-            // - note that most times the else part is run as the substring is often long enough
-            if (substring.Length <= 2 * QuickSubstringProbeLengthThreshold)
-            {
-                for (var offset = startIndex; offset <= effectiveDelta; offset++)
-                {
-                    var index = searchSpace.Slice(offset, effectiveDelta - offset + 1).IndexOf(startChar);
-
-                    if (index < 0)
-                    {
-                        return -1;
-                    }
-
-                    var position = offset + index;
-
-                    if (source[position + lastIndex] == endChar)
-                    {
-                        // could be part in the replacement as characters match both at start and end
-                        return position;
-                    }
-
-                    // Performance-Note:
-                    // - set offset to position here so the for-increment adds the +1,
-                    //   avoiding a separate variable and keeping the loop idiomatic
-                    offset = position;
-                }
-            }
-            else
-            {
-                var extraProbeChar = substring[QuickSubstringProbeLengthThreshold];
-
-                for (var offset = startIndex; offset <= effectiveDelta; offset++)
-                {
-                    var index = searchSpace.Slice(offset, effectiveDelta - offset + 1).IndexOf(startChar);
-
-                    if (index < 0)
-                    {
-                        return -1;
-                    }
-
-                    var position = offset + index;
-
-                    if (source[position + lastIndex] == endChar && source[position + QuickSubstringProbeLengthThreshold] == extraProbeChar)
-                    {
-                        // could be part in the replacement as characters match both at start and end
-                        return position;
-                    }
-
-                    // Performance-Note:
-                    // - set offset to position here so the for-increment adds the +1,
-                    //   avoiding a separate variable and keeping the loop idiomatic
-                    offset = position;
-                }
-            }
-
-            return -1;
         }
 
         /// <summary>

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -41,6 +41,11 @@ namespace MiKoSolutions.Analyzers
 
         private const int QuickStartSubstringProbeLengthThreshold = 4;
 
+        /// <summary>
+        /// The minimum length threshold used for optimized substring probing operations.
+        /// </summary>
+        private const int QuickSubstringProbeLengthThreshold = 8;
+
         private static readonly char[] GenericTypeArgumentSeparator = { ',' };
 
         private static readonly TimeSpan RegexTimeout = 250.Milliseconds();
@@ -1376,7 +1381,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if any of the phrases are found; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool ContainsAny(this in ReadOnlySpan<char> value, IEnumerable<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
+        public static bool ContainsAny(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (comparison is StringComparison.Ordinal)
             {
@@ -1427,7 +1432,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if any of the phrases are found; otherwise, <see langword="false"/>.
         /// </returns>
-        public static bool ContainsAny(this string value, IEnumerable<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
+        public static bool ContainsAny(this string value, in ReadOnlySpan<string> phrases, in StringComparison comparison = StringComparison.Ordinal)
         {
             if (comparison is StringComparison.Ordinal)
             {
@@ -1436,11 +1441,51 @@ namespace MiKoSolutions.Analyzers
 
             var span = value.AsSpan();
 
-            foreach (var phrase in phrases)
+            for (int index = 0, length = phrases.Length; index < length; index++)
             {
+                var phrase = phrases[index];
+
                 if (QuickContainsSubstringProbe(span, phrase.AsSpan(), comparison))
                 {
                     if (value.Contains(phrase, comparison))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="string"/> contains any of the specified phrases using <see cref="StringComparison.Ordinal"/> as comparison method.
+        /// </summary>
+        /// <param name="value">
+        /// The <see cref="string"/> to search in.
+        /// </param>
+        /// <param name="phrases">
+        /// The phrases to seek.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if any of the phrases are found; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool ContainsAnyOrdinal(this in ReadOnlySpan<char> value, in ReadOnlySpan<string> phrases)
+        {
+            if (value.Length > 0)
+            {
+                for (int index = 0, length = phrases.Length; index < length; index++)
+                {
+                    var phraseSpan = phrases[index].AsSpan();
+
+                    // Performance-Note: This is a hot-path, so we do a quick probe to see if the text is there
+                    var potentialStartPosition = value.QuickSubstringProbeOrdinal(phraseSpan);
+
+                    if (potentialStartPosition is -1)
+                    {
+                        continue;
+                    }
+
+                    if (value.Slice(potentialStartPosition).Contains(phraseSpan))
                     {
                         return true;
                     }
@@ -3200,6 +3245,133 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
+        /// Determines the starting position where the specified text could potentially occur within the given text, using a quick probe optimization.
+        /// </summary>
+        /// <param name="source">
+        /// The text to search within.
+        /// </param>
+        /// <param name="substring">
+        /// The text to search for.
+        /// </param>
+        /// <returns>
+        /// The zero-based starting position where the specified text might occur, or <c>-1</c> if it does not occur.
+        /// </returns>
+        public static int QuickSubstringProbeOrdinal(this in ReadOnlySpan<char> source, in ReadOnlySpan<char> substring)
+        {
+            if (substring.Length is 0)
+            {
+                // cannot be part in the replacement as the substring is zero
+                return -1;
+            }
+
+            var delta = source.Length - substring.Length;
+
+            if (delta < 0)
+            {
+                // cannot be part in the replacement as the substring is too long to fit within the source
+                return -1;
+            }
+
+            var startChar = substring[0];
+
+            // Performance-Note:
+            // - restrict the search space upfront so that IndexOf never overshoots delta
+            var searchSpace = source.Slice(0, delta + 1);
+
+            // Performance-Note:
+            // - fast-exit: if startChar is not present at all in the valid window,
+            //   there is no point iterating; IndexOf is a tight single-comparison loop even without SIMD
+            var startIndex = searchSpace.IndexOf(startChar);
+
+            if (startIndex < 0)
+            {
+                return -1;
+            }
+
+            // Performance-Note:
+            // - fast-exit: if the substring is below the threshold, it is short enough to still fit inside the source
+            if (substring.Length < QuickSubstringProbeLengthThreshold)
+            {
+                return startIndex;
+            }
+
+            var lastIndex = substring.Length - 1;
+            var endChar = substring[lastIndex];
+
+            // Performance-Note:
+            // - fast-exit: if endChar does not appear anywhere in the valid end-character window, no complete match is possible
+            var endCharLastIndex = source.Slice(startIndex + lastIndex, delta - startIndex + 1).LastIndexOf(endChar);
+
+            if (endCharLastIndex < 0)
+            {
+                return -1;
+            }
+
+            // Performance-Note:
+            // - tighten delta to the last position where endChar actually appears,
+            //   so the loop never scans positions that cannot possibly yield a match
+            var effectiveDelta = startIndex + endCharLastIndex;
+
+            // Performance-Note:
+            // - if the substring is short enough, we can skip checking an extra probe character and just check the start and end characters;
+            // - note that most times the else part is run as the substring is often long enough
+            if (substring.Length <= 2 * QuickSubstringProbeLengthThreshold)
+            {
+                for (var offset = startIndex; offset <= effectiveDelta; offset++)
+                {
+                    var index = searchSpace.Slice(offset, effectiveDelta - offset + 1).IndexOf(startChar);
+
+                    if (index < 0)
+                    {
+                        return -1;
+                    }
+
+                    var position = offset + index;
+
+                    if (source[position + lastIndex] == endChar)
+                    {
+                        // could be part in the replacement as characters match both at start and end
+                        return position;
+                    }
+
+                    // Performance-Note:
+                    // - set offset to position here so the for-increment adds the +1,
+                    //   avoiding a separate variable and keeping the loop idiomatic
+                    offset = position;
+                }
+            }
+            else
+            {
+                var extraProbeChar = substring[QuickSubstringProbeLengthThreshold];
+
+                for (var offset = startIndex; offset <= effectiveDelta; offset++)
+                {
+                    var index = searchSpace.Slice(offset, effectiveDelta - offset + 1).IndexOf(startChar);
+
+                    if (index < 0)
+                    {
+                        return -1;
+                    }
+
+                    var position = offset + index;
+
+                    if (source[position + lastIndex] == endChar && source[position + QuickSubstringProbeLengthThreshold] == extraProbeChar)
+                    {
+                        // could be part in the replacement as characters match both at start and end
+                        return position;
+                    }
+
+                    // Performance-Note:
+                    // - set offset to position here so the for-increment adds the +1,
+                    //   avoiding a separate variable and keeping the loop idiomatic
+                    offset = position;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
         /// Gets the second word from the <see cref="string"/>.
         /// </summary>
         /// <param name="value">
@@ -4214,40 +4386,6 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Determines whether the <see cref="string"/> contains any of the specified phrases using <see cref="StringComparison.Ordinal"/> as comparison method.
-        /// </summary>
-        /// <param name="value">
-        /// The <see cref="string"/> to search in.
-        /// </param>
-        /// <param name="phrases">
-        /// The phrases to seek.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if any of the phrases are found; otherwise, <see langword="false"/>.
-        /// </returns>
-        private static bool ContainsAnyOrdinal(ReadOnlySpan<char> value, IEnumerable<string> phrases)
-        {
-            if (value.Length > 0)
-            {
-                foreach (var phrase in phrases)
-                {
-                    var phraseSpan = phrase.AsSpan();
-
-                    if (QuickContainsSubstringProbe(value, phraseSpan, StringComparison.Ordinal))
-                    {
-                        // Performance-Note: This is a hot-path, so we do not use our extension method 'Contains' here, but instead we call it directly to avoid the cost of calling out method
-                        if (value.IndexOf(phraseSpan) >= 0)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Finds all indices of a substring in a span using ordinal comparison.
         /// </summary>
         /// <param name="span">
@@ -4471,7 +4609,6 @@ namespace MiKoSolutions.Analyzers
         {
             if (value.Length > other.Length)
             {
-                // continue to check
                 return true;
             }
 
@@ -4570,6 +4707,7 @@ namespace MiKoSolutions.Analyzers
 
             if (length < QuickStartSubstringProbeLengthThreshold)
             {
+                // continue to check
                 return true;
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
@@ -40,6 +40,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             return comment.Slice(indexAfterPhrase).StartsWithAny(Constants.Comments.Delimiters);
         }
 
-        internal static bool ContainsPhrases(IEnumerable<string> phrases, in ReadOnlySpan<char> comment) => comment.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
+        internal static bool ContainsPhrases(in ReadOnlySpan<string> phrases, in ReadOnlySpan<char> comment) => comment.ContainsAny(phrases, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2060_CodeFixProvider.cs
@@ -751,7 +751,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                               "es that returns ", "ethods that returns ", "es which returns ", "ethods which returns ",
                                               //// accept phrases such as "to provide that/which is/are" as they are unusual but valid texts
                                           };
-                var strangeTexts = new HashSet<string>(rawStrangeTexts);
+                var strangeTextsSet = new HashSet<string>(rawStrangeTexts);
 
                 foreach (var raw in rawStrangeTexts)
                 {
@@ -763,11 +763,13 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                           .Replace("ethod", "unction")
                                           .ToStringAndRelease();
 
-                        strangeTexts.Add(function);
+                        strangeTextsSet.Add(function);
                     }
                 }
 
-                results.RemoveWhere(_ => _.ContainsAny(strangeTexts));
+                var strangeTexts = strangeTextsSet.OrderDescendingByLengthAndText();
+
+                results.RemoveWhere(_ => _.AsSpan().ContainsAnyOrdinal(strangeTexts));
 
                 return results;
             }
@@ -971,7 +973,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                            "Function gets ", "Method gets ",
                                        };
 
-                results.RemoveWhere(_ => _.ContainsAny(strangeTexts));
+                results.RemoveWhere(_ => _.AsSpan().ContainsAnyOrdinal(strangeTexts));
 
                 return results;
             }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/OverallDocumentationAnalyzer.cs
@@ -81,7 +81,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         protected IReadOnlyList<Diagnostic> AnalyzeComment(
                                                        DocumentationCommentTriviaSyntax comment,
-                                                       IEnumerable<string> termsForText,
+                                                       in ReadOnlySpan<string> termsForText,
                                                        in ReadOnlySpan<string> termsForAllLocations,
                                                        string replacement = "",
                                                        in StringComparison comparison = StringComparison.OrdinalIgnoreCase,

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2060_FactoryAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -26,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 #if !NCRUNCH
 
         [OneTimeTearDown]
-        public static void CleanupTestEnvironment() => System.GC.Collect();
+        public static void CleanupTestEnvironment() => GC.Collect();
 
 #endif
 
@@ -862,9 +863,9 @@ internal interface IFactory
                                          "y that are capable",
                                          "y which are able",
                                          "y which are capable",
-                                     };
+                                     }.OrderDescendingByLengthAndText();
 
-            results.RemoveWhere(_ => _.ContainsAny(strangePhrases));
+            results.RemoveWhere(_ => _.AsSpan().ContainsAnyOrdinal(strangePhrases));
 
             results.Add("Implementations create");
             results.Add("Implementations construct");
@@ -971,7 +972,7 @@ internal interface IFactory
                                           "Function gets ", "Method gets ",
                                       ];
 
-            results.RemoveWhere(_ => _.ContainsAny(strangePhrases));
+            results.RemoveWhere(_ => _.AsSpan().ContainsAnyOrdinal(strangePhrases));
 
             return results;
         }


### PR DESCRIPTION
- Refactor `QuickSubstringProbe` logic into `StringExtensions` as `QuickSubstringProbeOrdinal` extension method

- Refactor `ContainsAny`/`ContainsAnyOrdinal` to use `ReadOnlySpan<string>` for improved performance

- Update related analyzer and test code to match new signatures and optimized phrase matching