### PR TITLE
Refactor 'Title' property of code fixes into 'GetTitle' method to be able to customize code fix title shown to users

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2013_CodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2013";
 
-        protected override string Title => Resources.MiKo_2013_CodeFixTitle.FormatWith(Phrase);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2013_CodeFixTitle.FormatWith(Phrase);
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2016_CodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2016";
 
-        protected override string Title => Resources.MiKo_2016_CodeFixTitle.FormatWith(Constants.Comments.AsynchronouslyStartingPhrase);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2016_CodeFixTitle.FormatWith(Constants.Comments.AsynchronouslyStartingPhrase);
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2018_CodeFixProvider.cs
@@ -20,7 +20,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2018";
 
-        protected override string Title => Resources.MiKo_2018_CodeFixTitle.FormatWith(StartingPhrase);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2018_CodeFixTitle.FormatWith(StartingPhrase);
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_DefaultFalse_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_DefaultFalse_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2036_DefaultFalse_CodeFixProvider)), Shared]
     public sealed class MiKo_2036_DefaultFalse_CodeFixProvider : MiKo_2036_CodeFixProvider
     {
-        protected override string Title => Resources.MiKo_2036_CodeFixTitle_DefaultFalse;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2036_CodeFixTitle_DefaultFalse;
 
         protected override Task<XmlNodeSyntax[]> GetDefaultCommentAsync(TypeSyntax returnType, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_DefaultTrue_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_DefaultTrue_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2036_DefaultTrue_CodeFixProvider)), Shared]
     public sealed class MiKo_2036_DefaultTrue_CodeFixProvider : MiKo_2036_CodeFixProvider
     {
-        protected override string Title => Resources.MiKo_2036_CodeFixTitle_DefaultTrue;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2036_CodeFixTitle_DefaultTrue;
 
         protected override Task<XmlNodeSyntax[]> GetDefaultCommentAsync(TypeSyntax returnType, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_Enum_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2036_Enum_CodeFixProvider)), Shared]
     public sealed class MiKo_2036_Enum_CodeFixProvider : MiKo_2036_CodeFixProvider
     {
-        protected override string Title => Resources.MiKo_2036_CodeFixTitle_Enum;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2036_CodeFixTitle_Enum;
 
         protected override bool IsApplicable(in ImmutableArray<Diagnostic> issues) => base.IsApplicable(issues) is false;
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_NoDefault_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2036_NoDefault_CodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_2036_NoDefault_CodeFixProvider)), Shared]
     public sealed class MiKo_2036_NoDefault_CodeFixProvider : MiKo_2036_CodeFixProvider
     {
-        protected override string Title => Resources.MiKo_2036_CodeFixTitle_NoDefault;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2036_CodeFixTitle_NoDefault;
 
         protected override bool IsApplicable(in ImmutableArray<Diagnostic> issues) => issues.Any();
 

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2048_CodeFixProvider.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2048";
 
-        protected override string Title => Resources.MiKo_2048_CodeFixTitle.FormatWith(Phrase);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2048_CodeFixTitle.FormatWith(Phrase);
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2075_CodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2075";
 
-        protected override string Title => Resources.MiKo_2075_CodeFixTitle.FormatWith(Constants.Comments.CallbackTerm);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2075_CodeFixTitle.FormatWith(Constants.Comments.CallbackTerm);
 
         protected override XmlTextSyntax GetUpdatedSyntax(Document document, XmlTextSyntax syntax, Diagnostic issue) => GetUpdatedSyntax(syntax, issue, ReplacementMap);
     }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2100_CodeFixProvider.cs
@@ -16,7 +16,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
 
         public override string FixableDiagnosticId => "MiKo_2100";
 
-        protected override string Title => Resources.MiKo_2100_CodeFixTitle.FormatWith(Phrase);
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_2100_CodeFixTitle.FormatWith(Phrase);
 
         protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2230_CodeFixProvider.cs
@@ -16,8 +16,6 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     {
         public override string FixableDiagnosticId => "MiKo_2230";
 
-        protected override string Title => Resources.MiKo_2230_CodeFixTitle;
-
         protected override Task<DocumentationCommentTriviaSyntax> GetUpdatedSyntaxAsync(DocumentationCommentTriviaSyntax syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
         {
             var updatedSyntax = GetUpdatedSyntax(syntax, issue);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
@@ -18,8 +18,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         public override string FixableDiagnosticId => "MiKo_3103";
 
-        protected sealed override string Title => Resources.MiKo_3103_CodeFixTitle;
-
         protected sealed override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
         {
             foreach (var syntax in syntaxNodes)

--- a/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/MiKoCodeFixProvider.cs
@@ -22,8 +22,6 @@ namespace MiKoSolutions.Analyzers.Rules
 
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(FixableDiagnosticId);
 
-        protected virtual string Title => Resources.ResourceManager.GetString(FixableDiagnosticId + "_CodeFixTitle", Resources.Culture);
-
 //// ncrunch: rdi off
 
         protected virtual bool IsSolutionWide => false;
@@ -55,6 +53,8 @@ namespace MiKoSolutions.Analyzers.Rules
         }
 
 //// ncrunch: rdi default
+
+        protected internal virtual string GetTitle(Diagnostic issue) => Resources.ResourceManager.GetString(FixableDiagnosticId + "_CodeFixTitle", Resources.Culture);
 
         /// <summary>
         /// Gets an argument list containing the specified arguments.
@@ -833,7 +833,7 @@ namespace MiKoSolutions.Analyzers.Rules
             {
                 var trivia = root.FindTrivia(startPosition);
 
-                return CodeAction.Create(Title, cancellationToken => ApplyDocumentCodeFixAsync(document, root, trivia, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
+                return CodeAction.Create(GetTitle(issue), cancellationToken => ApplyDocumentCodeFixAsync(document, root, trivia, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
             }
 
             // TODO RKN
@@ -851,10 +851,10 @@ namespace MiKoSolutions.Analyzers.Rules
 
             if (IsSolutionWide)
             {
-                return CodeAction.Create(Title, cancellationToken => ApplySolutionCodeFixAsync(document, root, syntax, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
+                return CodeAction.Create(GetTitle(issue), cancellationToken => ApplySolutionCodeFixAsync(document, root, syntax, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
             }
 
-            return CodeAction.Create(Title, cancellationToken => ApplyDocumentCodeFixAsync(document, root, syntax, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
+            return CodeAction.Create(GetTitle(issue), cancellationToken => ApplyDocumentCodeFixAsync(document, root, syntax, issue, cancellationToken), m_equivalenceKey); // ncrunch: no coverage
         }
 
 //// ncrunch: rdi default

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1055_1056_CodeFixProvider.cs
@@ -13,6 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         public override string FixableDiagnosticId => "MiKo_1055_1056";
 
-        protected override string Title => Resources.MiKo_1055_CodeFixTitle;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_1055_CodeFixTitle;
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1057_1058_CodeFixProvider.cs
@@ -13,6 +13,6 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
 
         public override string FixableDiagnosticId => "MiKo_1057_1058";
 
-        protected override string Title => Resources.MiKo_1057_CodeFixTitle;
+        protected internal override string GetTitle(Diagnostic issue) => Resources.MiKo_1057_CodeFixTitle;
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/AnalyzerTests.cs
@@ -290,13 +290,13 @@ namespace MiKoSolutions.Analyzers.Rules
         {
             Assert.Multiple(() =>
                                  {
-                                     foreach (var provider in AllCodeFixProviders)
+                                     foreach (var provider in AllCodeFixProviders.Cast<MiKoCodeFixProvider>())
                                      {
                                          var resourceKey = CreateResourceKey(provider);
 
                                          var expectedTitle = Resources.ResourceManager.GetString(resourceKey, CultureInfo.InvariantCulture) ?? "< - missing title - >";
 
-                                         var codeFixTitle = provider.GetType().GetProperty("Title", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(provider)?.ToString();
+                                         var codeFixTitle = provider.GetTitle(null);
 
                                          var parts = expectedTitle.FormatWith("|").Split('|');
 


### PR DESCRIPTION
- Refactor `CodeFixProvider` classes to replace the `protected` `Title` property with a `protected internal virtual GetTitle(Diagnostic issue)` method

- Update all derived providers and usages to override and call `GetTitle`

- Adjust `AnalyzerTests` to use the new method

(part of #2123)