### PR TITLE
MiKo_0008 now no longer considers using aliases as usings and reports correct number of usings (instead of usings above limit)

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzer.cs
@@ -29,14 +29,19 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
         protected override void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
         {
-            var usingDirectives = context.Node.ChildNodes<UsingDirectiveSyntax>().Skip(AllowedUsings).ToArray();
-            var usingsAboveLimit = usingDirectives.Length;
+            var usingsAboveLimit = context.Node
+                                          .ChildNodes<UsingDirectiveSyntax>()
+                                          .Where(_ => _.Alias is null) // we do not want to report aliases, even though they might be additional namespace dependencies
+                                          .Skip(AllowedUsings)
+                                          .ToArray();
 
-            if (usingsAboveLimit > 0)
+            if (usingsAboveLimit.Length > 0)
             {
-                foreach (var usingDirective in usingDirectives)
+                var countedUsings = AllowedUsings + usingsAboveLimit.Length;
+
+                foreach (var usingDirective in usingsAboveLimit)
                 {
-                    ReportDiagnostics(context, Issue(usingDirective, usingsAboveLimit, AllowedUsings));
+                    ReportDiagnostics(context, Issue(usingDirective, countedUsings, AllowedUsings));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzer.cs
@@ -37,11 +37,11 @@ namespace MiKoSolutions.Analyzers.Rules.Metrics
 
             if (usingsAboveLimit.Length > 0)
             {
-                var countedUsings = AllowedUsings + usingsAboveLimit.Length;
+                var totalUsings = AllowedUsings + usingsAboveLimit.Length;
 
                 foreach (var usingDirective in usingsAboveLimit)
                 {
-                    ReportDiagnostics(context, Issue(usingDirective, countedUsings, AllowedUsings));
+                    ReportDiagnostics(context, Issue(usingDirective, totalUsings, AllowedUsings));
                 }
             }
         }

--- a/MiKo.Analyzer.Tests/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Metrics/MiKo_0008_TooManyUsingsAnalyzerTests.cs
@@ -76,6 +76,50 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_using_directives_at_limit_in_compilation_unit_and_additional_using_alias() => No_issue_is_reported_for(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Integer32 = System.Int32;
+
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_using_directives_at_limit_in_file_scoped_namespace_and_additional_using_alias() => No_issue_is_reported_for(@"
+namespace Bla;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Integer32 = System.Int32;
+
+public class TestMe
+{
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_using_directives_at_limit_in_namespace_and_additional_using_alias() => No_issue_is_reported_for(@"
+namespace Bla
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    using Integer32 = System.Int32;
+
+    public class TestMe
+    {
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_using_directives_below_limit_in_compilation_unit() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Exclude using aliases (such as `using Xyz = System.IO.File;`)

- Add tests to verify aliases are ignored