### PR TITLE
Disabled IDE warnings for specific code as they do not make sense there

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -1879,6 +1879,7 @@ namespace MiKoSolutions.Analyzers.Rules
 
             var immutableProperties = ImmutableDictionary<string, string>.Empty;
 
+#pragma warning disable IDE0045 // Convert to conditional expression
             if (properties.Length is 1)
             {
                 immutableProperties = immutableProperties.Add(properties[0].Key, properties[0].Value);
@@ -1887,6 +1888,7 @@ namespace MiKoSolutions.Analyzers.Rules
             {
                 immutableProperties = immutableProperties.AddRange(properties.Select(_ => new KeyValuePair<string, string>(_.Key, _.Value)));
             }
+#pragma warning restore IDE0045 // Convert to conditional expression
 
             return Diagnostic.Create(m_rule, location, immutableProperties, args);
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3078_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3078_CodeFixProvider.cs
@@ -34,6 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 ExpressionSyntax expression;
 
+#pragma warning disable IDE0045 // Convert to conditional expression
                 if (isFlags && position > 0)
                 {
                     expression = SyntaxFactory.BinaryExpression(SyntaxKind.LeftShiftExpression, Literal(1), Literal(position - 1));
@@ -42,6 +43,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                 {
                     expression = Literal(position);
                 }
+#pragma warning restore IDE0045 // Convert to conditional expression
 
                 return member.WithEqualsValue(SyntaxFactory.EqualsValueClause(expression));
             }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzer.cs
@@ -59,6 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                    ? methodName.AsSpan(Prefix.Length)
                                    : methodName.AsSpan();
 
+#pragma warning disable IDE0045 // Convert to conditional expression
                 if (adjustedName.EndsWith(OnCanExecuteSuffix))
                 {
                     name = "CanExecute".ConcatenatedWith(adjustedName.Slice(0, adjustedName.Length - OnCanExecuteSuffix.Length));
@@ -73,6 +74,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                            ? methodName
                            : adjustedName.ToString();
                 }
+#pragma warning restore IDE0045 // Convert to conditional expression
             }
 
             return name.AsCachedBuilder()

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.EqualsAny.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.EqualsAny.cs
@@ -33,14 +33,17 @@ namespace MiKoSolutions.Analyzers.Extensions
         [Test]
         public static void EqualsAny_with_IEnumerable_returns_true_for_different_casing_with_OrdinalIgnoreCase_comparison() => Assert.That("abc".EqualsAny(new List<string> { "ABC" }, StringComparison.OrdinalIgnoreCase), Is.True);
 
+#pragma warning disable IDE0300 // Simplify collection initialization
         [Test]
         public static void EqualsAny_with_array_returns_false_for_null_value() => Assert.That(((string)null).EqualsAny(new[] { "abc" }), Is.False);
 
         [Test]
         public static void EqualsAny_with_array_returns_false_for_empty_value() => Assert.That(string.Empty.EqualsAny(new[] { "abc" }), Is.False);
 
+#pragma warning disable IDE0301 // Simplify collection initialization
         [Test]
         public static void EqualsAny_with_array_returns_false_for_empty_phrases() => Assert.That("abc".EqualsAny(Array.Empty<string>()), Is.False);
+#pragma warning restore IDE0301 // Simplify collection initialization
 
         [Test]
         public static void EqualsAny_with_array_returns_false_when_no_phrase_matches() => Assert.That("abc".EqualsAny(new[] { "xyz", "def" }), Is.False);
@@ -56,6 +59,7 @@ namespace MiKoSolutions.Analyzers.Extensions
 
         [Test]
         public static void EqualsAny_with_array_returns_true_for_different_casing_with_OrdinalIgnoreCase_comparison() => Assert.That("abc".EqualsAny(new[] { "ABC" }, StringComparison.OrdinalIgnoreCase), Is.True);
+#pragma warning restore IDE0300 // Simplify collection initialization
 
         [Test]
         public static void EqualsAny_with_collection_expression_returns_false_for_null_value() => Assert.That(((string)null).EqualsAny(["abc"]), Is.False);


### PR DESCRIPTION
- Suppress `IDE0045` and `IDE0300`/`IDE0301` code style warnings using `#pragma` directives around affected code blocks to prevent automatic suggestions

- No functional changes made