### PR TITLE
Relaxed MiKo_3008 to not report for arrays on 'ToArray' or 'GetAsArray'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
@@ -53,11 +53,22 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private Diagnostic AnalyzeReturnType(IMethodSymbol method, ITypeSymbol returnType)
         {
-            var returnTypeString = returnType.ToString();
-
-            if (returnTypeString is "byte[]")
+            if (returnType is IArrayTypeSymbol array)
             {
-                return null;
+                if (array.ElementType.IsByte())
+                {
+                    return null;
+                }
+
+                switch (method.Name)
+                {
+                    case nameof(Enumerable.ToArray):
+                    case "GetAsArray":
+                    {
+                        // accept special methods
+                        return null;
+                    }
+                }
             }
 
             if (ForbiddenTypes.Exists(returnType.ImplementsPotentialGeneric))

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzer.cs
@@ -53,13 +53,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private Diagnostic AnalyzeReturnType(IMethodSymbol method, ITypeSymbol returnType)
         {
-            if (returnType is IArrayTypeSymbol array)
+            if (returnType.IsByteArray())
             {
-                if (array.ElementType.IsByte())
-                {
-                    return null;
-                }
+                return null;
+            }
 
+            if (returnType.TypeKind is TypeKind.Array)
+            {
                 switch (method.Name)
                 {
                     case nameof(Enumerable.ToArray):

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3008_ListReturnValueAnalyzerTests.cs
@@ -42,6 +42,20 @@ public interface TestMe
 }
 ");
 
+        [TestCase("object[] ToArray()")]
+        [TestCase("object[] GetAsArray()")]
+        [TestCase("string[] ToArray(StringComparer comparer)")]
+        public void No_issue_is_reported_for_special_method_(string method) => No_issue_is_reported_for(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public interface TestMe
+{
+    public " + method + @";
+}
+");
+
         [Test]
         public void An_issue_is_reported_for_forbidden_type_([ValueSource(nameof(ForbiddenTypes))] string returnValue) => An_issue_is_reported_for(@"
 using System;


### PR DESCRIPTION
- Handle array return types by allowing byte arrays and methods named `ToArray` or `GetAsArray` to return arrays

- Add tests to verify correct behavior