### PR TITLE
MiKo_6074 is now aware of expression bodies

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -3140,9 +3140,9 @@ namespace MiKoSolutions.Analyzers
         /// <see langword="true"/> if the type is a Prism event; otherwise, <see langword="false"/>.
         /// </returns>
         internal static bool IsPrismEvent(this ITypeSymbol value) => value.TypeKind is TypeKind.Class
-                                                                     && value.SpecialType is SpecialType.None
-                                                                     && value.ToString() != "Microsoft.Practices.Prism.Events.EventBase"
-                                                                     && value.InheritsFrom("Microsoft.Practices.Prism.Events.EventBase");
+                                                                  && value.SpecialType is SpecialType.None
+                                                                  && value.ToString() != "Microsoft.Practices.Prism.Events.EventBase"
+                                                                  && value.InheritsFrom("Microsoft.Practices.Prism.Events.EventBase");
 
         /// <summary>
         /// Determines whether a symbol is publicly visible.

--- a/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/DocumentationComment.cs
@@ -13,8 +13,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                  };
 
         internal static bool EndsWithPeriod(in ReadOnlySpan<char> comment) => comment.EndsWith('.')
-                                                                        && comment.EndsWith("...") is false
-                                                                        && comment.EndsWith("etc.", StringComparison.OrdinalIgnoreCase) is false;
+                                                                           && comment.EndsWith("...") is false
+                                                                           && comment.EndsWith("etc.", StringComparison.OrdinalIgnoreCase) is false;
 
         internal static bool ContainsDoublePeriod(in ReadOnlySpan<char> comment) => comment.Contains("..", _ => AllowedChars.Contains(_) is false)
                                                                                  && comment.EndsWith("...") is false;

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2023_BooleanParamDefaultPhraseAnalyzer.cs
@@ -20,8 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
         public MiKo_2023_BooleanParamDefaultPhraseAnalyzer() : base(Id) => IgnoreEmptyParameters = false;
 
         protected override bool ShallAnalyzeParameter(IParameterSymbol parameter) => parameter.Type.IsBoolean()
-                                                                                     && parameter.IsOut() is false
-                                                                                     && parameter.GetEnclosingMethod().Name != nameof(IDisposable.Dispose);
+                                                                                  && parameter.IsOut() is false
+                                                                                  && parameter.GetEnclosingMethod().Name != nameof(IDisposable.Dispose);
 
         protected override Diagnostic[] AnalyzeParameter(IParameterSymbol parameter, XmlElementSyntax parameterComment, string comment)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
@@ -31,8 +31,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
         private static bool IsAssertionMethod(MemberAccessExpressionSyntax node) => AssertionMethods.Contains(node.GetName())
-                                                                                    && node.Expression is IdentifierNameSyntax invokedType
-                                                                                    && Constants.Names.AssertionTypes.Contains(invokedType.GetName());
+                                                                                 && node.Expression is IdentifierNameSyntax invokedType
+                                                                                 && Constants.Names.AssertionTypes.Contains(invokedType.GetName());
 
         private static bool IsXUnitAssertTrueMethod(MemberAccessExpressionSyntax node, SemanticModel semanticModel)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -34,8 +34,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
         private static bool IsAssertionMethod(MemberAccessExpressionSyntax node) => AssertionMethods.Contains(node.GetName())
-                                                                                    && node.Expression is IdentifierNameSyntax invokedType
-                                                                                    && Constants.Names.AssertionTypes.Contains(invokedType.GetName());
+                                                                                 && node.Expression is IdentifierNameSyntax invokedType
+                                                                                 && Constants.Names.AssertionTypes.Contains(invokedType.GetName());
 
         private static bool IsFixableAssertionForLinqCall(InvocationExpressionSyntax invocation)
         {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs
@@ -99,6 +99,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         }
 
         private static bool IsApplicable(IfStatementSyntax node) => node.Else is null // do not invert in case of an else block
-                                                                    && node.ReturnsImmediately();
+                                                                 && node.ReturnsImmediately();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzer.cs
@@ -34,8 +34,8 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         protected override bool IsUnitTestAnalyzer => true;
 
         protected override bool ShallAnalyze(IMethodSymbol symbol) => base.ShallAnalyze(symbol)
-                                                                      && symbol.IsTestMethod()
-                                                                      && symbol.Name.Length >= 7; // consider only long names
+                                                                   && symbol.Name.Length >= 7 // consider only long names
+                                                                   && symbol.IsTestMethod();
 
         protected override IEnumerable<Diagnostic> AnalyzeName(IMethodSymbol symbol, Compilation compilation) => symbol.Name.ContainsAny(WrongTerms, StringComparison.OrdinalIgnoreCase)
                                                                                                                  ? new[] { Issue(symbol) }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/IndendedSpacingCodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/IndendedSpacingCodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             return Task.FromResult(updatedSyntax);
         }
 
-        protected virtual T GetUpdatedSyntax(T node, int spaces) => node.WithLeadingSpaces(spaces);
+        protected virtual T GetUpdatedSyntax(T node, in int spaces) => node.WithLeadingSpaces(spaces);
 
         private SyntaxNode GetUpdatedSyntax(SyntaxNode syntax, Diagnostic issue)
         {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6074_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6074_CodeFixProvider.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
     {
         public override string FixableDiagnosticId => "MiKo_6074";
 
-        protected override BinaryExpressionSyntax GetUpdatedSyntax(BinaryExpressionSyntax node, int spaces)
+        protected override BinaryExpressionSyntax GetUpdatedSyntax(BinaryExpressionSyntax node, in int spaces)
         {
             var operatorToken = node.OperatorToken;
             var rightOperand = node.Right;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzer.cs
@@ -39,6 +39,13 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
 
                         return new LinePosition(leftPosition.Line, leftPosition.Character - offset);
                     }
+
+                    case ArrowExpressionClauseSyntax clause:
+                    {
+                        var position = clause.ArrowToken.GetStartPosition();
+
+                        return new LinePosition(position.Line, position.Character + 1);
+                    }
                 }
             }
 
@@ -49,10 +56,10 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
             var node = (BinaryExpressionSyntax)context.Node;
 
-            var leftOperand = node.Left;
-            var rightOperand = node.Right;
+            var left = node.Left;
+            var right = node.Right;
 
-            if (rightOperand.IsOnSameLineAsEndOf(leftOperand))
+            if (right.IsOnSameLineAsEndOf(left))
             {
                 // we do not need to report anything when placed on same line
                 return;
@@ -62,7 +69,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
             {
                 var operatorToken = node.OperatorToken;
 
-                if (operatorToken.IsOnSameLineAs(rightOperand))
+                if (operatorToken.IsOnSameLineAs(right))
                 {
                     // operator is at begin of line
                     var position = FindOrientationPosition(node);
@@ -74,14 +81,14 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 }
                 else
                 {
-                    if (operatorToken.IsOnSameLineAsEndOf(leftOperand))
+                    if (operatorToken.IsOnSameLineAsEndOf(left))
                     {
                         // operator is at end of line
-                        var position = leftOperand.GetStartPosition();
+                        var position = left.GetStartPosition();
 
-                        if (NotVerticallyAligned(rightOperand.GetStartPosition(), position))
+                        if (NotVerticallyAligned(right.GetStartPosition(), position))
                         {
-                            ReportDiagnostics(context, Issue(rightOperand, CreateProposalForSpaces(position.Character)));
+                            ReportDiagnostics(context, Issue(right, CreateProposalForSpaces(position.Character)));
                         }
                     }
                 }

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.HumanizedTakeFirst.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.HumanizedTakeFirst.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+
+using NUnit.Framework;
 
 //// ncrunch: rdi off
 namespace MiKoSolutions.Analyzers.Extensions
@@ -31,6 +33,6 @@ namespace MiKoSolutions.Analyzers.Extensions
         [TestCase("hello   ", 5, ExpectedResult = "hello")]
         [TestCase("hello   ", 3, ExpectedResult = "hel...")]
         [TestCase("hi  there", 4, ExpectedResult = "hi...")]
-        public static string HumanizedTakeFirst_ReadOnlySpan_returns_correct_result_(string value, in int maximum) => ((System.ReadOnlySpan<char>)value).HumanizedTakeFirst(maximum);
+        public static string HumanizedTakeFirst_ReadOnlySpan_returns_correct_result_(string value, in int maximum) => value.AsSpan().HumanizedTakeFirst(maximum);
     }
 }

--- a/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Spacing/MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzerTests.cs
@@ -1747,6 +1747,93 @@ public class TestMe
             VerifyCSharpFix(OriginalCode, FixedCode);
         }
 
+        [Test]
+        public void No_issue_is_reported_if_add_operation_of_string_constants_is_placed_on_single_line_for_expression_bodied_property() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private string SomeText => ""some text"" + ""with some other text"" + ""and even more text"";
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_add_operation_of_string_constants_spans_multiple_lines_and_is_vertically_aligned_for_expression_bodied_property() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private string SomeText => ""some text""
+                             + ""with some other text""
+                             + ""and even more text"";
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_if_add_operation_of_string_constants_spans_multiple_lines_and_is_vertically_aligned_and_operator_is_at_end_of_line_for_expression_bodied_property() => No_issue_is_reported_for(@"
+using System;
+
+public class TestMe
+{
+    private string SomeText => ""some text"" +
+                               ""with some other text"" +
+                               ""and even more text"";
+}
+");
+
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = Justifications.StyleCop.SA1118)]
+        [Test]
+        public void An_issue_is_reported_if_add_operation_of_single_line_string_values_spans_multiple_lines_and_is_aligned_more_to_the_left_for_expression_bodied_property() => An_issue_is_reported_for(2, @"
+using System;
+
+public class TestMe
+{
+    private string SomeData { get; set; }
+
+    private string GetSomeOtherData() => string.Empty;
+
+    private string SomeText => SomeData
+        + Environment.NewLine +
+        GetSomeOtherData();
+}
+");
+
+        [Test]
+        public void Code_is_fixed_if_add_operation_of_single_line_string_values_spans_multiple_lines_and_is_aligned_more_to_the_left_for_expression_bodied_property()
+        {
+            const string OriginalCode = @"
+using System;
+
+public class TestMe
+{
+    private string SomeData { get; set; }
+
+    private string GetSomeOtherData() => string.Empty;
+
+    private string SomeText => SomeData
+        + Environment.NewLine +
+        GetSomeOtherData();
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+public class TestMe
+{
+    private string SomeData { get; set; }
+
+    private string GetSomeOtherData() => string.Empty;
+
+    private string SomeText => SomeData
+                             + Environment.NewLine +
+                               GetSomeOtherData();
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_6074_StringConcatenationsAreVerticallyAlignedAnalyzer();


### PR DESCRIPTION
- Add support to detect expression bodies (`=>` arrow clauses) to MiKo_6074

Unrelated:
- Apply own rules about indenting operators to the correct position

- Add `[in]` modifier to applicable methods

- Add use of `AsSpan()` instead of casting to `ReadOnlySpan<char>`