### PR TITLE
MiKo_3038 now ignores methods ending with 'HashCode'

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzer.cs
@@ -292,7 +292,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             if (symbol is IMethodSymbol method)
             {
-                if (method.Name is nameof(GetHashCode))
+                if (method.Name.AsSpan().EndsWith("HashCode"))
                 {
                     // ignore hash calculation
                     return Array.Empty<Diagnostic>();

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3038_DoNotUseMagicNumbersAnalyzerTests.cs
@@ -400,6 +400,30 @@ namespace Bla
 ");
 
         [Test]
+        public void No_issue_is_reported_for_CalculateHashCode_method() => No_issue_is_reported_for(@"
+using System;
+
+namespace Bla
+{
+    public class TestMe
+    {
+        private static int CalculateHashCode(string a, string b, string c)
+        {
+            unchecked
+            {
+                var hashCode = a?.GetHashCode() ?? 0;
+
+                hashCode = (hashCode * 397) ^ (b?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (c?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_Version_ctor() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Relax method check to ignore all ending with `HashCode` as it is likely that they calculate hash codes that are using some prime numbers for the hashes.