### PR TITLE
Replaced 'PackageLicenseUrl' with 'PackageLicenseExpression'

### DIFF
--- a/MiKo.Analyzer.Package.2019/MiKo.Analyzer.Package.2019.csproj
+++ b/MiKo.Analyzer.Package.2019/MiKo.Analyzer.Package.2019.csproj
@@ -12,9 +12,8 @@
     <PackageId>MiKoSolutions.Analyzers</PackageId>
     <PackageVersion>0.0.51</PackageVersion>
     <Authors>Ralf Koban</Authors>
-    <PackageLicenseUrl>https://github.com/RalfKoban/MiKo-Analyzers/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RalfKoban/MiKo-Analyzers</PackageProjectUrl>
-    <!--PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl-->
     <RepositoryUrl>https://github.com/RalfKoban/MiKo-Analyzers</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>A diagnostic extension for the .NET Compiler Platform ("Roslyn") that checks for different metrics such as Lines of Code or Cyclomatic Complexity; in addition to several documentation, maintainability, naming, ordering and performance rules.</Description>

--- a/MiKo.Analyzer.Package.2022/MiKo.Analyzer.Package.2022.csproj
+++ b/MiKo.Analyzer.Package.2022/MiKo.Analyzer.Package.2022.csproj
@@ -12,9 +12,8 @@
     <PackageId>MiKoSolutions.Analyzers</PackageId>
     <PackageVersion>0.0.51</PackageVersion>
     <Authors>Ralf Koban</Authors>
-    <PackageLicenseUrl>https://github.com/RalfKoban/MiKo-Analyzers/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RalfKoban/MiKo-Analyzers</PackageProjectUrl>
-    <!--PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl-->
     <RepositoryUrl>https://github.com/RalfKoban/MiKo-Analyzers</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>A diagnostic extension for the .NET Compiler Platform ("Roslyn") that checks for different metrics such as Lines of Code or Cyclomatic Complexity; in addition to several documentation, maintainability, naming, ordering and performance rules.</Description>

--- a/MiKo.Analyzer.Package.2026/MiKo.Analyzer.Package.2026.csproj
+++ b/MiKo.Analyzer.Package.2026/MiKo.Analyzer.Package.2026.csproj
@@ -12,9 +12,8 @@
     <PackageId>MiKoSolutions.Analyzers</PackageId>
     <PackageVersion>0.0.51</PackageVersion>
     <Authors>Ralf Koban</Authors>
-    <PackageLicenseUrl>https://github.com/RalfKoban/MiKo-Analyzers/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RalfKoban/MiKo-Analyzers</PackageProjectUrl>
-    <!--PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl-->
     <RepositoryUrl>https://github.com/RalfKoban/MiKo-Analyzers</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>A diagnostic extension for the .NET Compiler Platform ("Roslyn") that checks for different metrics such as Lines of Code or Cyclomatic Complexity; in addition to several documentation, maintainability, naming, ordering and performance rules.</Description>


### PR DESCRIPTION
- Replace deprecated `<PackageLicenseUrl>` with `<PackageLicenseExpression>MIT</PackageLicenseExpression>`

- Remove commented-out `<PackageIconUrl>`