### PR TITLE
Add 'DisableImplicitNuGetFallbackFolder' and 'DisableImplicitLibraryPacksFolder'

### DIFF
--- a/MiKo.Analyzer.2019/MiKo.Analyzer.2019.csproj
+++ b/MiKo.Analyzer.2019/MiKo.Analyzer.2019.csproj
@@ -19,6 +19,8 @@
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
+++ b/MiKo.Analyzer.2022/MiKo.Analyzer.2022.csproj
@@ -20,6 +20,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2022</DefineConstants>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.2026/MiKo.Analyzer.2026.csproj
+++ b/MiKo.Analyzer.2026/MiKo.Analyzer.2026.csproj
@@ -20,6 +20,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2026</DefineConstants>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.Codefixes.2019/MiKo.Analyzer.CodeFixes.2019.csproj
+++ b/MiKo.Analyzer.Codefixes.2019/MiKo.Analyzer.CodeFixes.2019.csproj
@@ -17,6 +17,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
+++ b/MiKo.Analyzer.Codefixes.2022/MiKo.Analyzer.CodeFixes.2022.csproj
@@ -17,6 +17,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2022</DefineConstants>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.Codefixes.2026/MiKo.Analyzer.CodeFixes.2026.csproj
+++ b/MiKo.Analyzer.Codefixes.2026/MiKo.Analyzer.CodeFixes.2026.csproj
@@ -17,6 +17,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2026</DefineConstants>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
   
   <ItemGroup>

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.ForTests.csproj
@@ -14,7 +14,9 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VS2022;VS2026</DefineConstants>
-	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
+++ b/MiKo.Analyzer.Tests/MiKo.Analyzer.Tests.csproj
@@ -11,6 +11,8 @@
     <!-- we do not want to get informed about security vulnerabilities here because this is a test project that is not published to customers -->
     <NuGetAudit>false</NuGetAudit>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Add MSBuild properties to disable implicit NuGet fallback and library packs folders.

Improves build determinism and reduces unexpected dependencies.