### PR TITLE
Refactor 'FindBetterTestName' and 'AdjustWordAfter'

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -92,16 +92,39 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A <see cref="StringBuilder"/> where the word following the specified phrase is adjusted according to the specified adjustment.
         /// </returns>
-        public static StringBuilder AdjustWordAfter(this StringBuilder value, string phrase, in FirstWordAdjustment adjustment)
+        public static StringBuilder AdjustWordAfter(this StringBuilder value, string phrase, in FirstWordAdjustment adjustment) => value.AdjustWordAfter(phrase.AsSpan(), adjustment);
+
+        /// <summary>
+        /// Gets a <see cref="StringBuilder"/> where the word following the specified phrase is adjusted according to the specified adjustment.
+        /// </summary>
+        /// <param name="value">
+        /// The original text.
+        /// </param>
+        /// <param name="phrase">
+        /// The phrase after which the word gets adjusted.
+        /// </param>
+        /// <param name="adjustment">
+        /// A bitwise combination of the enumeration members that specifies the adjustment to apply to the word following the phrase.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StringBuilder"/> where the word following the specified phrase is adjusted according to the specified adjustment.
+        /// </returns>
+        public static StringBuilder AdjustWordAfter(this StringBuilder value, in ReadOnlySpan<char> phrase, in FirstWordAdjustment adjustment)
         {
-            if (phrase.IsNullOrEmpty())
+            if (phrase.IsEmpty)
             {
                 return value;
             }
 
-            var phraseStartCharacter = phrase[0];
+            var length = value.Length;
+            var buffer = SharedPool.Rent(length);
 
-            var phraseStartIndex = IndexOf(value, phraseStartCharacter);
+            value.CopyTo(0, buffer, 0, length);
+
+            ReadOnlySpan<char> bufferSpan = buffer.AsSpan(0, length);
+
+            var phraseStartCharacter = phrase[0];
+            var phraseStartIndex = bufferSpan.IndexOf(phraseStartCharacter);
 
             if (phraseStartIndex <= -1)
             {
@@ -111,43 +134,53 @@ namespace MiKoSolutions.Analyzers
             var phraseLength = phrase.Length;
             var phraseEndCharacter = phrase[phraseLength - 1];
 
-            for (int index = phraseStartIndex, length = value.Length; index < length; index++)
+            for (var index = phraseStartIndex; index < length; index++)
             {
-                if (value[index] != phraseStartCharacter)
+                if (bufferSpan[index] != phraseStartCharacter)
                 {
                     continue;
                 }
 
                 var phraseEndIndex = index + phraseLength - 1;
 
-                if (phraseEndIndex >= length || value[phraseEndIndex] != phraseEndCharacter)
+                if (phraseEndIndex >= length || bufferSpan[phraseEndIndex] != phraseEndCharacter)
                 {
                     continue;
                 }
 
-                if (value.ToString(index, phraseLength).Equals(phrase, StringComparison.Ordinal))
+                if (bufferSpan.Slice(index, phraseLength).SequenceEqual(phrase))
                 {
                     // get next word (separated by '_', or by ' ' for sentences)
                     var nextWordStartIndex = phraseEndIndex + 1;
-                    var nextWordEndIndex = value.IndexOf(Constants.Underscore, Constants.Space, nextWordStartIndex) - 1;
 
-                    if (nextWordEndIndex > 0)
+                    // index is relative to the slice, so it needs to be checked for '-1' (not found) before it can be converted into an absolute index
+                    var nextWordEndIndex = bufferSpan.Slice(nextWordStartIndex).IndexOfAny(Constants.Underscore, Constants.Space);
+
+                    if (nextWordEndIndex >= 0)
                     {
-                        var nextWordLength = nextWordEndIndex - nextWordStartIndex + 1;
+                        // convert to an absolute index; '-1' is done here (not above) so the 'not found' case stays clearly separated
+                        nextWordEndIndex += nextWordStartIndex - 1;
 
-                        var nextWord = value.ToString(nextWordStartIndex, nextWordLength);
-                        var adjustedWord = nextWord.AdjustFirstWord(adjustment);
+                        if (nextWordEndIndex > 0)
+                        {
+                            var nextWordLength = nextWordEndIndex - nextWordStartIndex + 1;
 
-                        // cut it out
-                        value.Remove(nextWordStartIndex, nextWordLength);
+                            var nextWord = bufferSpan.Slice(nextWordStartIndex, nextWordLength);
+                            var adjustedWord = nextWord.AdjustFirstWord(adjustment);
 
-                        // insert word adjusted by 'handling' using 'AdjustFirstWord'
-                        value.Insert(nextWordStartIndex, adjustedWord);
+                            // cut it out
+                            value.Remove(nextWordStartIndex, nextWordLength);
 
-                        return value;
+                            // insert word adjusted by 'handling' using 'AdjustFirstWord'
+                            value.Insert(nextWordStartIndex, adjustedWord);
+
+                            break;
+                        }
                     }
                 }
             }
+
+            SharedPool.Return(buffer);
 
             return value;
         }
@@ -1180,69 +1213,6 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Finds the first occurrence of the specified character in the text.
-        /// </summary>
-        /// <param name="value">
-        /// The text to search.
-        /// </param>
-        /// <param name="c">
-        /// The character to search for.
-        /// </param>
-        /// <param name="start">
-        /// The zero-based starting position to begin searching.
-        /// The default is <c>0</c>.
-        /// </param>
-        /// <returns>
-        /// The zero-based index of the first occurrence of the specified character, or <c>-1</c> if it is not found.
-        /// </returns>
-        private static int IndexOf(this StringBuilder value, in char c, in int start = 0)
-        {
-            for (int index = start, length = value.Length; index < length; index++)
-            {
-                if (value[index] == c)
-                {
-                    return index;
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
-        /// Finds the first occurrence of either of the specified characters in the text.
-        /// </summary>
-        /// <param name="value">
-        /// The text to search.
-        /// </param>
-        /// <param name="c1">
-        /// The first character to search for.
-        /// </param>
-        /// <param name="c2">
-        /// The second character to search for.
-        /// </param>
-        /// <param name="start">
-        /// The zero-based starting position to begin searching.
-        /// The default is <c>0</c>.
-        /// </param>
-        /// <returns>
-        /// The zero-based index of the first occurrence of either specified character, or <c>-1</c> if neither is found.
-        /// </returns>
-        private static int IndexOf(this StringBuilder value, in char c1, in char c2, in int start = 0)
-        {
-            for (int index = start, length = value.Length; index < length; index++)
-            {
-                var c = value[index];
-
-                if (c == c1 || c == c2)
-                {
-                    return index;
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
         /// Converts the first word in the text to its infinite verb form.
         /// </summary>
         /// <param name="value">
@@ -1250,7 +1220,7 @@ namespace MiKoSolutions.Analyzers
         /// </param>
         private static void MakeInfinite(this StringBuilder value)
         {
-            var word = FirstWord(value, out var whitespacesBefore);
+            var word = value.FirstWord(out var whitespacesBefore);
 
             value.Remove(whitespacesBefore, word.Length);
 
@@ -1267,7 +1237,7 @@ namespace MiKoSolutions.Analyzers
         /// </param>
         private static void MakePlural(this StringBuilder value)
         {
-            var word = FirstWord(value, out var whitespacesBefore);
+            var word = value.FirstWord(out var whitespacesBefore);
 
             value.Remove(whitespacesBefore, word.Length);
 
@@ -1284,7 +1254,7 @@ namespace MiKoSolutions.Analyzers
         /// </param>
         private static void MakeThirdPersonSingular(this StringBuilder value)
         {
-            var word = FirstWord(value, out var whitespacesBefore);
+            var word = value.FirstWord(out var whitespacesBefore);
 
             value.Remove(whitespacesBefore, word.Length);
 

--- a/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringExtensions.cs
@@ -77,13 +77,28 @@ namespace MiKoSolutions.Analyzers
                 return value;
             }
 
-            var valueSpan = value.AsSpan();
+            return AdjustFirstWord(value.AsSpan(), adjustment);
+        }
 
+        /// <summary>
+        /// Adjusts the first word of the value according to the specified adjustment options.
+        /// </summary>
+        /// <param name="value">
+        /// The original value.
+        /// </param>
+        /// <param name="adjustment">
+        /// A bitwise combination of enumeration values that specifies the adjustment options for the first word.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> that contains the adjusted first word.
+        /// </returns>
+        public static string AdjustFirstWord(this in ReadOnlySpan<char> value, in FirstWordAdjustment adjustment)
+        {
             string word;
 
             if (adjustment.HasSet(FirstWordAdjustment.StartLowerCase))
             {
-                var firstWord = valueSpan.FirstWord();
+                var firstWord = value.FirstWord();
 
                 // only make lower case in case we have a word that is not all in upper case
                 word = firstWord.Length > 1 && firstWord.IsAllUpperCase()
@@ -92,7 +107,7 @@ namespace MiKoSolutions.Analyzers
             }
             else
             {
-                var firstWord = valueSpan.FirstWord();
+                var firstWord = value.FirstWord();
 
                 word = adjustment.HasSet(FirstWordAdjustment.StartUpperCase)
                        ? firstWord.ToUpperCaseAt(0)
@@ -100,7 +115,7 @@ namespace MiKoSolutions.Analyzers
             }
 
             // build continuation here because the word length may change based on the infinite term
-            var continuation = valueSpan.TrimStart().Slice(word.Length);
+            var continuation = value.TrimStart().Slice(word.Length);
 
             if (adjustment.HasSet(FirstWordAdjustment.MakeInfinite))
             {

--- a/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/NamesFinder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
@@ -280,26 +279,32 @@ namespace MiKoSolutions.Analyzers.Linguistics
             var betterName = FindBetterTestName(name);
 
             // let's see if the test name starts with any method/property/event/field name that shall be kept
-            var symbolName = symbol.Name;
+            var symbolName = symbol.Name.AsSpan();
 
             var index = symbolName.IndexOf(Constants.Underscore);
 
             if (index > 0)
             {
-                var methodName = symbolName.Substring(0, index);
+                var methodNameSpan = symbolName.Slice(0, index);
 
-                if (symbol.GetSyntax().DescendantNodes<IdentifierNameSyntax>().Any(_ => _.GetName() == methodName))
+                foreach (var identifier in symbol.GetSyntax().DescendantNodes<IdentifierNameSyntax>())
                 {
-                    var betterNamePrefix = FindBetterTestName(methodName);
-
-                    if (betterName.StartsWith(betterNamePrefix, StringComparison.Ordinal))
+                    if (identifier.GetName().Equals(methodNameSpan))
                     {
-                        var fixedBetterName = betterName.AsCachedBuilder()
-                                                        .TrimStartBy(betterNamePrefix.Length)
-                                                        .Insert(0, methodName)
-                                                        .ToStringAndRelease();
+                        var methodName = methodNameSpan.ToString();
+                        var betterNamePrefix = FindBetterTestName(methodName);
 
-                        return fixedBetterName;
+                        if (betterName.StartsWith(betterNamePrefix, StringComparison.Ordinal))
+                        {
+                            var fixedBetterName = betterName.AsCachedBuilder()
+                                                            .TrimStartBy(betterNamePrefix.Length)
+                                                            .Insert(0, methodName)
+                                                            .ToStringAndRelease();
+
+                            return fixedBetterName;
+                        }
+
+                        break;
                     }
                 }
             }
@@ -625,12 +630,12 @@ namespace MiKoSolutions.Analyzers.Linguistics
                   .ReplaceWithProbe("_will_be_", "_is_")
                   .ReplaceWithProbe("_will_", "_does_")
                   .Replace("__", "_")
-                  .AdjustWordAfter("_does_not_", FirstWordAdjustment.MakeInfinite)
+                  .AdjustWordAfter("_does_not_".AsSpan(), FirstWordAdjustment.MakeInfinite)
                   .ReplaceWithProbe("_does_not_", "<4>")
-                  .AdjustWordAfter("_does_", FirstWordAdjustment.MakeThirdPersonSingular)
+                  .AdjustWordAfter("_does_".AsSpan(), FirstWordAdjustment.MakeThirdPersonSingular)
                   .Replace("_does_", "_")
                   .ReplaceWithProbe("<4>", "_does_not_")
-                  .AdjustWordAfter("_to_", FirstWordAdjustment.MakeInfinite);
+                  .AdjustWordAfter("_to_".AsSpan(), FirstWordAdjustment.MakeInfinite);
 
                 return sb.ToStringAndRelease();
             }


### PR DESCRIPTION
- Refactor `StringBuilderExtensions` to add `ReadOnlySpan<char>` overloads for `AdjustWordAfter` and `AdjustFirstWord`

- Improve performance by using span-based methods

- Perform minor code cleanups