### PR TITLE
Refactor Aho-Corasick to reduce memory usage, updated documentation

### DIFF
--- a/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
+++ b/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
@@ -21,15 +21,31 @@ namespace MiKoSolutions.Analyzers
     /// The full transition table is resolved once, up-front, during construction, so that <see cref="IsMatch"/> never
     /// mutates any state afterward; instances are therefore safe to share and to query concurrently from multiple threads.
     /// </remarks>
+    /// <seealso href="https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm"/>
     public sealed class AhoCorasickMatcher
     {
-        // sorted list of every character that occurs in any pattern; used to map a char to a dense alphabet index via binary search
+        /// <summary>
+        /// The sorted list of every character that occurs in any pattern; used to map a char to a dense alphabet index via binary search.
+        /// </summary>
         private readonly char[] m_alphabet;
 
-        // flattened deterministic transition table: m_transitions[(state * m_alphabet.Length) + alphabetIndex] = next state
-        private readonly int[] m_transitions;
+        /// <summary>
+        /// Contains the map for each state to the index of its (potentially shared) row within <see cref="m_transitionRows"/>.
+        /// </summary>
+        /// <remarks>
+        /// Many states end up with identical transition rows (e.g. deep fallback-only states), so sharing those rows
+        /// considerably shrinks memory compared to storing one dedicated row per state.
+        /// </remarks>
+        private readonly int[] m_stateToRow;
 
-        // m_isTerminal[state] indicates whether reaching that state means a pattern was matched
+        /// <summary>
+        /// The flattened deduplicated transition rows: <c>m_transitionRows[(rowIndex * m_alphabet.Length) + alphabetIndex] = next state</c>.
+        /// </summary>
+        private readonly int[] m_transitionRows;
+
+        /// <summary>
+        /// Contains the indicators about the terminal nodes where <c>m_isTerminal[state]</c> indicates whether reaching that state means a pattern was matched.
+        /// </summary>
         private readonly bool[] m_isTerminal;
 
         /// <summary>
@@ -79,7 +95,7 @@ namespace MiKoSolutions.Analyzers
 
             Array.Sort(m_alphabet);
 
-            CompileToArrays(root, m_alphabet, out m_transitions, out m_isTerminal);
+            CompileToArrays(root, m_alphabet, out m_stateToRow, out m_transitionRows, out m_isTerminal);
         }
 
         /// <summary>
@@ -115,7 +131,7 @@ namespace MiKoSolutions.Analyzers
                 var alphabetIndex = Array.BinarySearch(m_alphabet, text[index]);
 
                 // unknown character (not part of any pattern): simply stay at / return to the root
-                state = alphabetIndex < 0 ? 0 : m_transitions[(state * alphabetLength) + alphabetIndex];
+                state = alphabetIndex < 0 ? 0 : m_transitionRows[(m_stateToRow[state] * alphabetLength) + alphabetIndex];
 
                 if (m_isTerminal[state])
                 {
@@ -180,7 +196,13 @@ namespace MiKoSolutions.Analyzers
         /// Flattens the resolved <see cref="Node"/> graph (states, terminal flags, and per-character transitions)
         /// into plain arrays so that <see cref="IsMatch"/> only ever performs array indexing at query time.
         /// </summary>
-        private static void CompileToArrays(Node root, char[] alphabet, out int[] transitions, out bool[] isTerminal)
+        /// <remarks>
+        /// Many states (especially deep, fallback-only ones) end up with an identical row of per-character transitions.
+        /// Instead of storing one dedicated row per state (<c>stateCount * alphabetLength</c> entries), identical rows
+        /// are stored once and shared via <paramref name="stateToRow"/>, which considerably reduces memory for pattern
+        /// sets with many states but comparatively few distinct transition behaviors.
+        /// </remarks>
+        private static void CompileToArrays(Node root, char[] alphabet, out int[] stateToRow, out int[] transitionRows, out bool[] isTerminal)
         {
             // assign a stable, dense integer id to every reachable node (root is always state 0)
             var stateOf = new Dictionary<Node, int>();
@@ -210,23 +232,97 @@ namespace MiKoSolutions.Analyzers
             var alphabetLength = alphabet.Length;
             var stateCount = order.Count;
 
-            transitions = new int[stateCount * alphabetLength];
             isTerminal = new bool[stateCount];
+            stateToRow = new int[stateCount];
+
+            // deduplicate identical transition rows so that they are stored only once, keyed by their content
+            var rowIndexByContent = new Dictionary<RowKey, int>();
+            var uniqueRows = new List<int[]>();
 
             for (var state = 0; state < stateCount; state++)
             {
                 var node = order[state];
                 isTerminal[state] = node.IsTerminal;
 
-                var baseIndex = state * alphabetLength;
+                var row = new int[alphabetLength];
 
                 for (var alphabetIndex = 0; alphabetIndex < alphabetLength; alphabetIndex++)
                 {
                     // after 'BuildDeterministicTransitions', every node has an edge for every alphabet character
                     var next = node.Children[alphabet[alphabetIndex]];
 
-                    transitions[baseIndex + alphabetIndex] = stateOf[next];
+                    row[alphabetIndex] = stateOf[next];
                 }
+
+                var key = new RowKey(row);
+
+                if (rowIndexByContent.TryGetValue(key, out var rowIndex) is false)
+                {
+                    rowIndex = uniqueRows.Count;
+
+                    uniqueRows.Add(row);
+                    rowIndexByContent[key] = rowIndex;
+                }
+
+                stateToRow[state] = rowIndex;
+            }
+
+            transitionRows = new int[uniqueRows.Count * alphabetLength];
+
+            for (var rowIndex = 0; rowIndex < uniqueRows.Count; rowIndex++)
+            {
+                Array.Copy(uniqueRows[rowIndex], 0, transitionRows, rowIndex * alphabetLength, alphabetLength);
+            }
+        }
+
+        // wraps a transition row so that it can be used as a dictionary key based on its content rather than its reference identity
+        private readonly struct RowKey : IEquatable<RowKey>
+        {
+            private readonly int[] m_row;
+            private readonly int m_hashCode;
+
+            public RowKey(int[] row)
+            {
+                m_row = row;
+
+                var hashCode = 17;
+
+                foreach (var value in row)
+                {
+                    hashCode = (hashCode * 31) + value;
+                }
+
+                m_hashCode = hashCode;
+            }
+
+            public override int GetHashCode() => m_hashCode;
+
+            public override bool Equals(object obj) => obj is RowKey other && Equals(other);
+
+            public bool Equals(RowKey other)
+            {
+                if (m_hashCode != other.m_hashCode)
+                {
+                    return false;
+                }
+
+                var row = m_row;
+                var otherRow = other.m_row;
+
+                if (row.Length != otherRow.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < row.Length; i++)
+                {
+                    if (row[i] != otherRow[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
 

--- a/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
+++ b/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
@@ -21,7 +21,7 @@ namespace MiKoSolutions.Analyzers
     /// The full transition table is resolved once, up-front, during construction, so that <see cref="IsMatch"/> never
     /// mutates any state afterward; instances are therefore safe to share and to query concurrently from multiple threads.
     /// </remarks>
-    internal sealed class AhoCorasickMatcher
+    public sealed class AhoCorasickMatcher
     {
         // sorted list of every character that occurs in any pattern; used to map a char to a dense alphabet index via binary search
         private readonly char[] m_alphabet;

--- a/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
+++ b/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 //// ncrunch: rdi off
@@ -8,45 +9,68 @@ using System.Collections.Generic;
 namespace MiKoSolutions.Analyzers
 {
     /// <summary>
-    /// Provides a reusable multi-pattern matcher based on the Aho-Corasick algorithm that determines,
-    /// in a single pass over the searched text, whether any of a fixed set of patterns is contained within it.
+    /// Provides a reusable multi-pattern matcher based on the Aho-Corasick algorithm that determines whether any of a fixed set of patterns is contained within it.
+    /// This is done in a single pass over the searched text.
     /// </summary>
     /// <remarks>
-    /// The matcher is built once from a set of patterns and can then be queried many times,
-    /// each query costing <c>O(text length)</c> regardless of the number of patterns,
-    /// instead of <c>O(patterns count * text length)</c> as with a naive per-pattern <see cref="string.IndexOf(string)"/> loop.
-    /// <para />
-    /// Matching is performed using <see cref="StringComparison.Ordinal"/> semantics.
-    /// <para />
-    /// The full transition table is resolved once, up-front, during construction, so that <see cref="IsMatch"/> never
-    /// mutates any state afterward; instances are therefore safe to share and to query concurrently from multiple threads.
+    /// <para>
+    /// Calling <see cref="string.IndexOf(string)"/> once per pattern scans the text once for every pattern.
+    /// This matcher builds a small state machine once from all patterns instead.
+    /// It then scans the text only once, no matter how many patterns exist.
+    /// </para>
+    /// <para>
+    /// Internally, patterns are combined into a trie (a tree of shared prefixes).
+    /// "Failure links" let the matcher jump directly to the correct spot on a mismatch.
+    /// This avoids restarting from scratch and turns the trie into a fast, deterministic state machine.
+    /// </para>
+    /// <para>
+    /// To save memory, the transition table is not stored as one full row per state.
+    /// Instead, each state only stores its most common target as a "default", plus a short list of "exceptions" for the few characters that behave differently.
+    /// See <see cref="m_defaultTransition"/> for details.
+    /// </para>
+    /// <para>
+    /// Matching uses <see cref="StringComparison.Ordinal"/> semantics (exact, case-sensitive).
+    /// The whole table is built once during construction and never changes afterward, so instances are safe to share and query concurrently.
+    /// </para>
     /// </remarks>
     /// <seealso href="https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm"/>
     public sealed class AhoCorasickMatcher
     {
         /// <summary>
-        /// The sorted list of every character that occurs in any pattern; used to map a char to a dense alphabet index via binary search.
+        /// The sorted list of every character that occurs in any pattern.
+        /// Used to map a char to a dense alphabet index via binary search.
         /// </summary>
         private readonly char[] m_alphabet;
 
         /// <summary>
-        /// Contains the map for each state to the index of its (potentially shared) row within <see cref="m_transitionRows"/>.
+        /// For each state, the "default" target used by most alphabet characters.
+        /// Characters that behave differently are stored separately as exceptions (see <see cref="m_exceptionChars"/> and <see cref="m_exceptionTargets"/>).
+        /// This keeps memory usage low.
         /// </summary>
-        /// <remarks>
-        /// Many states end up with identical transition rows (e.g. deep fallback-only states), so sharing those rows
-        /// considerably shrinks memory compared to storing one dedicated row per state.
-        /// </remarks>
-        private readonly int[] m_stateToRow;
+        private readonly int[] m_defaultTransition;
 
         /// <summary>
-        /// The flattened deduplicated transition rows: <c>m_transitionRows[(rowIndex * m_alphabet.Length) + alphabetIndex] = next state</c>.
+        /// For each state, the start index into <see cref="m_exceptionChars"/> / <see cref="m_exceptionTargets"/>.
+        /// A state's exceptions span from <see cref="m_exceptionOffsets"/><c>[state]</c> to <see cref="m_exceptionOffsets"/><c>[state + 1]</c> (exclusive).
         /// </summary>
-        private readonly int[] m_transitionRows;
+        private readonly int[] m_exceptionOffsets;
 
         /// <summary>
-        /// Contains the indicators about the terminal nodes where <c>m_isTerminal[state]</c> indicates whether reaching that state means a pattern was matched.
+        /// The characters that do not use <see cref="m_defaultTransition"/> for their state.
+        /// Sorted per state (see <see cref="m_exceptionOffsets"/>) so they can be binary-searched.
         /// </summary>
-        private readonly bool[] m_isTerminal;
+        private readonly char[] m_exceptionChars;
+
+        /// <summary>
+        /// The transition target for the corresponding entry in <see cref="m_exceptionChars"/>.
+        /// </summary>
+        private readonly int[] m_exceptionTargets;
+
+        /// <summary>
+        /// <c>m_isTerminal[state]</c> indicates whether reaching that state means a pattern was matched.
+        /// Stored as a <see cref="BitArray"/> (1 bit per state) instead of <c>bool[]</c> (1 byte per state) to reduce memory usage.
+        /// </summary>
+        private readonly BitArray m_isTerminal;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AhoCorasickMatcher"/> class for the specified patterns.
@@ -88,14 +112,14 @@ namespace MiKoSolutions.Analyzers
             // resolve the whole transition table once, up-front, based on the mutable 'Node' graph
             BuildDeterministicTransitions(root, alphabet);
 
-            // compile the resolved 'Node' graph into flat arrays so that 'IsMatch' operates on cheap array indexing only
-            // (no dictionary lookups, no pointer chasing) and never mutates any state afterward;
-            // instances are therefore safe to share and to query concurrently from multiple threads.
+            // compile the resolved 'Node' graph into flat arrays so that 'IsMatch' operates on cheap array indexing only.
+            // No dictionary lookups, no pointer chasing.
+            // The result never mutates any state afterward, so instances are safe to share and to query concurrently from multiple threads.
             m_alphabet = alphabet.ToArray();
 
             Array.Sort(m_alphabet);
 
-            CompileToArrays(root, m_alphabet, out m_stateToRow, out m_transitionRows, out m_isTerminal);
+            CompileToArrays(root, m_alphabet, out m_defaultTransition, out m_exceptionOffsets, out m_exceptionChars, out m_exceptionTargets, out m_isTerminal);
         }
 
         /// <summary>
@@ -122,16 +146,14 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         public bool IsMatch(in ReadOnlySpan<char> text)
         {
-            var alphabetLength = m_alphabet.Length;
-
             var state = 0; // root
 
             for (int index = 0, length = text.Length; index < length; index++)
             {
-                var alphabetIndex = Array.BinarySearch(m_alphabet, text[index]);
+                var c = text[index];
 
                 // unknown character (not part of any pattern): simply stay at / return to the root
-                state = alphabetIndex < 0 ? 0 : m_transitionRows[(m_stateToRow[state] * alphabetLength) + alphabetIndex];
+                state = Array.BinarySearch(m_alphabet, c) < 0 ? 0 : NextState(state, c);
 
                 if (m_isTerminal[state])
                 {
@@ -142,6 +164,14 @@ namespace MiKoSolutions.Analyzers
             return false;
         }
 
+        /// <summary>
+        /// Resolves the trie into a deterministic state machine, so every node has an edge for every alphabet character.
+        /// Each edge is either a real trie edge or a computed fallback via failure links.
+        /// </summary>
+        /// <remarks>
+        /// This is the classic Aho-Corasick "failure link" construction.
+        /// It is processed breadth-first, so each node's failure link (<see cref="Node.Fail"/>) is already fully resolved by the time it is needed.
+        /// </remarks>
         private static void BuildDeterministicTransitions(Node root, HashSet<char> alphabet)
         {
             // snapshot the root's genuine trie edges before extending them with fallback shortcuts
@@ -173,7 +203,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     if (realChildren.TryGetValue(c, out var child))
                     {
-                        // 'current.Fail' was processed earlier (shallower BFS level) or is the root, so its transition table is already complete
+                        // 'current.Fail' was processed earlier (shallower BFS level) or is the root. Its transition table is already complete.
                         child.Fail = current.Fail.Children[c];
 
                         if (child.Fail.IsTerminal)
@@ -193,24 +223,18 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Flattens the resolved <see cref="Node"/> graph (states, terminal flags, and per-character transitions)
-        /// into plain arrays so that <see cref="IsMatch"/> only ever performs array indexing at query time.
+        /// Flattens the resolved <see cref="Node"/> graph into plain arrays (states, terminal flags, transitions).
+        /// This uses the default/exception split described on <see cref="m_defaultTransition"/>.
         /// </summary>
-        /// <remarks>
-        /// Many states (especially deep, fallback-only ones) end up with an identical row of per-character transitions.
-        /// Instead of storing one dedicated row per state (<c>stateCount * alphabetLength</c> entries), identical rows
-        /// are stored once and shared via <paramref name="stateToRow"/>, which considerably reduces memory for pattern
-        /// sets with many states but comparatively few distinct transition behaviors.
-        /// </remarks>
-        private static void CompileToArrays(Node root, char[] alphabet, out int[] stateToRow, out int[] transitionRows, out bool[] isTerminal)
+        private static void CompileToArrays(Node root, char[] alphabet, out int[] defaultTransition, out int[] exceptionOffsets, out char[] exceptionChars, out int[] exceptionTargets, out BitArray isTerminal)
         {
-            // assign a stable, dense integer id to every reachable node (root is always state 0)
-            var stateOf = new Dictionary<Node, int>();
+            // assign a stable, dense integer id to every reachable node (root is always state 0).
+            // it is stored directly on the node. This makes resolving a child's state later on a cheap field read instead of a dictionary lookup.
             var order = new List<Node>();
 
             var queue = new Queue<Node>();
             queue.Enqueue(root);
-            stateOf[root] = 0;
+            root.Id = 0;
             order.Add(root);
 
             while (queue.Count > 0)
@@ -219,9 +243,9 @@ namespace MiKoSolutions.Analyzers
 
                 foreach (var child in current.Children.Values)
                 {
-                    if (stateOf.ContainsKey(child) is false)
+                    if (child.Id < 0)
                     {
-                        stateOf[child] = order.Count;
+                        child.Id = order.Count;
                         order.Add(child);
 
                         queue.Enqueue(child);
@@ -232,108 +256,149 @@ namespace MiKoSolutions.Analyzers
             var alphabetLength = alphabet.Length;
             var stateCount = order.Count;
 
-            isTerminal = new bool[stateCount];
-            stateToRow = new int[stateCount];
+            isTerminal = new BitArray(stateCount);
+            defaultTransition = new int[stateCount];
+            exceptionOffsets = new int[stateCount + 1];
 
-            // deduplicate identical transition rows so that they are stored only once, keyed by their content
-            var rowIndexByContent = new Dictionary<RowKey, int>();
-            var uniqueRows = new List<int[]>();
+            var allExceptionChars = new List<char>();
+            var allExceptionTargets = new List<int>();
+
+            var rowTargets = new int[alphabetLength];
+            var sortedTargets = new int[alphabetLength];
 
             for (var state = 0; state < stateCount; state++)
             {
                 var node = order[state];
                 isTerminal[state] = node.IsTerminal;
 
-                var row = new int[alphabetLength];
-
                 for (var alphabetIndex = 0; alphabetIndex < alphabetLength; alphabetIndex++)
                 {
-                    // after 'BuildDeterministicTransitions', every node has an edge for every alphabet character
-                    var next = node.Children[alphabet[alphabetIndex]];
+                    // after 'BuildDeterministicTransitions', every node has an edge for every alphabet character.
+                    // 'Id' was assigned during the BFS above. This is a cheap field read instead of a dictionary lookup.
+                    var target = node.Children[alphabet[alphabetIndex]].Id;
 
-                    row[alphabetIndex] = stateOf[next];
+                    rowTargets[alphabetIndex] = target;
                 }
 
-                var key = new RowKey(row);
+                // find the target that this state jumps to most often across the whole alphabet.
+                // That target becomes the "default". Only the (comparatively few) deviating characters need to be stored explicitly as exceptions.
+                // This is done by sorting a scratch copy of the row, so that identical values end up next to each other.
+                // Then scan for the longest run of equal values.
+                // This is considerably cheaper than tallying occurrences via a dictionary. It matters since this runs once per state.
+                var defaultTarget = 0; // no alphabet characters at all (e.g. no patterns were provided): fall back to root
 
-                if (rowIndexByContent.TryGetValue(key, out var rowIndex) is false)
+                if (alphabetLength > 0)
                 {
-                    rowIndex = uniqueRows.Count;
+                    Array.Copy(rowTargets, sortedTargets, alphabetLength);
+                    Array.Sort(sortedTargets);
 
-                    uniqueRows.Add(row);
-                    rowIndexByContent[key] = rowIndex;
-                }
+                    defaultTarget = sortedTargets[0];
 
-                stateToRow[state] = rowIndex;
-            }
+                    var bestOccurrences = 1;
+                    var runTarget = sortedTargets[0];
+                    var runLength = 1;
 
-            transitionRows = new int[uniqueRows.Count * alphabetLength];
-
-            for (var rowIndex = 0; rowIndex < uniqueRows.Count; rowIndex++)
-            {
-                Array.Copy(uniqueRows[rowIndex], 0, transitionRows, rowIndex * alphabetLength, alphabetLength);
-            }
-        }
-
-        // wraps a transition row so that it can be used as a dictionary key based on its content rather than its reference identity
-        private readonly struct RowKey : IEquatable<RowKey>
-        {
-            private readonly int[] m_row;
-            private readonly int m_hashCode;
-
-            public RowKey(int[] row)
-            {
-                m_row = row;
-
-                var hashCode = 17;
-
-                foreach (var value in row)
-                {
-                    hashCode = (hashCode * 31) + value;
-                }
-
-                m_hashCode = hashCode;
-            }
-
-            public override int GetHashCode() => m_hashCode;
-
-            public override bool Equals(object obj) => obj is RowKey other && Equals(other);
-
-            public bool Equals(RowKey other)
-            {
-                if (m_hashCode != other.m_hashCode)
-                {
-                    return false;
-                }
-
-                var row = m_row;
-                var otherRow = other.m_row;
-
-                if (row.Length != otherRow.Length)
-                {
-                    return false;
-                }
-
-                for (var i = 0; i < row.Length; i++)
-                {
-                    if (row[i] != otherRow[i])
+                    for (var i = 1; i < alphabetLength; i++)
                     {
-                        return false;
+                        if (sortedTargets[i] == runTarget)
+                        {
+                            runLength++;
+                        }
+                        else
+                        {
+                            runTarget = sortedTargets[i];
+                            runLength = 1;
+                        }
+
+                        if (runLength > bestOccurrences)
+                        {
+                            bestOccurrences = runLength;
+                            defaultTarget = runTarget;
+                        }
                     }
                 }
 
-                return true;
+                defaultTransition[state] = defaultTarget;
+
+                exceptionOffsets[state] = allExceptionChars.Count;
+
+                for (var alphabetIndex = 0; alphabetIndex < alphabetLength; alphabetIndex++)
+                {
+                    var target = rowTargets[alphabetIndex];
+
+                    if (target != defaultTarget)
+                    {
+                        // 'alphabet' is sorted. Appending in increasing 'alphabetIndex' order keeps each state's exception range sorted as well.
+                        // That sorted order is required for the binary search in 'NextState'.
+                        allExceptionChars.Add(alphabet[alphabetIndex]);
+                        allExceptionTargets.Add(target);
+                    }
+                }
             }
+
+            exceptionOffsets[stateCount] = allExceptionChars.Count;
+
+            exceptionChars = allExceptionChars.ToArray();
+            exceptionTargets = allExceptionTargets.ToArray();
+        }
+
+        /// <summary>
+        /// Determines the next state to move to from <paramref name="state"/> when the next character in the text is <paramref name="c"/>.
+        /// </summary>
+        /// <param name="state">
+        /// The current state.
+        /// </param>
+        /// <param name="c">
+        /// The next character in the text.
+        /// </param>
+        /// <returns>
+        /// The state to move to.
+        /// </returns>
+        private int NextState(int state, char c)
+        {
+            var start = m_exceptionOffsets[state];
+            var count = m_exceptionOffsets[state + 1] - start;
+
+            if (count > 0)
+            {
+                var exceptionIndex = Array.BinarySearch(m_exceptionChars, start, count, c);
+
+                if (exceptionIndex >= 0)
+                {
+                    return m_exceptionTargets[exceptionIndex];
+                }
+            }
+
+            return m_defaultTransition[state];
         }
 
 #pragma warning disable SA1401 // Fields should be private
+        /// <summary>
+        /// Represents a single node (a "state") of the trie, corresponding to one prefix shared by one or more patterns.
+        /// </summary>
         private sealed class Node
         {
+            /// <summary>
+            /// The outgoing edges of this node.
+            /// Initially only real trie edges; after <see cref="BuildDeterministicTransitions"/>, computed fallback edges are added too.
+            /// </summary>
             public readonly Dictionary<char, Node> Children = new Dictionary<char, Node>();
 
+            /// <summary>
+            /// The "failure link": the node for the longest proper suffix of this node's prefix that is also a prefix of some pattern.
+            /// </summary>
             public Node Fail;
 
+            /// <summary>
+            /// Indicates whether reaching this node means that a whole pattern was matched.
+            /// </summary>
             public bool IsTerminal;
+
+            /// <summary>
+            /// The dense integer id assigned to this node (see <see cref="CompileToArrays"/>). <c>-1</c> means "not yet assigned".
+            /// Storing it directly on the node avoids a separate <c>Dictionary&lt;Node, int&gt;</c> lookup.
+            /// </summary>
+            public int Id = -1;
         }
 #pragma warning restore SA1401 // Fields should be private
     }

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -359,7 +359,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// A <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
         /// </returns>
-        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<Pair> replacementPairs, in AhoCorasickMatcher matcher = null)
+        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<Pair> replacementPairs, AhoCorasickMatcher matcher = null)
         {
             if (value.IsNullOrEmpty())
             {

--- a/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/StringBuilderExtensions.cs
@@ -342,7 +342,7 @@ namespace MiKoSolutions.Analyzers
         /// A <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, ReplacementMap map) => value.ReplaceAllWithProbe(map.Pairs);
+        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, ReplacementMap map) => value.ReplaceAllWithProbe(map.Pairs, map.Matcher);
 
         /// <summary>
         /// Gets a <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
@@ -353,10 +353,13 @@ namespace MiKoSolutions.Analyzers
         /// <param name="replacementPairs">
         /// The key-value pairs for replacement.
         /// </param>
+        /// <param name="matcher">
+        /// The (optional) matcher to invoke to see if the text contains a specific text pattern.
+        /// </param>
         /// <returns>
         /// A <see cref="StringBuilder"/> where all occurrences of the specified keys are replaced with their corresponding values.
         /// </returns>
-        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<Pair> replacementPairs)
+        public static StringBuilder ReplaceAllWithProbe(this StringBuilder value, in ReadOnlySpan<Pair> replacementPairs, in AhoCorasickMatcher matcher = null)
         {
             if (value.IsNullOrEmpty())
             {
@@ -366,28 +369,31 @@ namespace MiKoSolutions.Analyzers
             char[] text = null;
             var textSpan = GetTextAsRentedArray(ref value, ref text);
 
-            for (int index = 0, count = replacementPairs.Length; index < count; index++)
+            if (matcher is null || matcher.IsMatch(textSpan))
             {
-                var pair = replacementPairs[index];
-
-                if (textSpan.Length < pair.Key.Length)
+                for (int index = 0, count = replacementPairs.Length; index < count; index++)
                 {
-                    // cannot be part in the replacement as the substring is too long and cannot fit
-                    continue;
+                    var pair = replacementPairs[index];
+
+                    if (textSpan.Length < pair.Key.Length)
+                    {
+                        // cannot be part in the replacement as the substring is too long and cannot fit
+                        continue;
+                    }
+
+                    var replaceStartIndex = textSpan.QuickSubstringProbeOrdinal(pair.Key.AsSpan());
+
+                    if (replaceStartIndex is -1)
+                    {
+                        continue;
+                    }
+
+                    // can be part in the replacement as value seems to fit
+                    value.Replace(pair.Key, pair.Value, replaceStartIndex, value.Length - replaceStartIndex);
+
+                    // re-assign text as we might have replaced the string, but use a different array
+                    textSpan = GetTextAsRentedArray(ref value, ref text);
                 }
-
-                var replaceStartIndex = textSpan.QuickSubstringProbeOrdinal(pair.Key.AsSpan());
-
-                if (replaceStartIndex is -1)
-                {
-                    continue;
-                }
-
-                // can be part in the replacement as value seems to fit
-                value.Replace(pair.Key, pair.Value, replaceStartIndex, value.Length - replaceStartIndex);
-
-                // re-assign text as we might have replaced the string, but use a different array
-                textSpan = GetTextAsRentedArray(ref value, ref text);
             }
 
             if (text != null)

--- a/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
+++ b/MiKo.Analyzer.Shared/Linguistics/AbbreviationFinder.cs
@@ -813,6 +813,10 @@ namespace MiKoSolutions.Analyzers.Linguistics
                                                       new Pair("yntaxc", "ync"), // 'syn' within 'sync' / 'async'
                                                   };
 
+        private static readonly string[] CleanupKeys = Cleanups.ToArray(_ => _.Key);
+
+        private static readonly ReplacementMap CleanupMap = new ReplacementMap("Abbreviations", Cleanups, CleanupKeys) { Matcher = AhoCorasickMatcher.For(CleanupKeys) };
+
         private static readonly AhoCorasickMatcher MidTermMatcher = AhoCorasickMatcher.For(MidTerms.Select(_ => _.Key));
 
         /// <summary>
@@ -896,7 +900,7 @@ namespace MiKoSolutions.Analyzers.Linguistics
             if (findings.Length > 0)
             {
                 value.ReplaceAllWithProbe(findings);
-                value.ReplaceAllWithProbe(Cleanups);
+                value.ReplaceAllWithProbe(CleanupMap);
             }
 
             return value;

--- a/MiKo.Analyzer.Shared/ReplacementMap.cs
+++ b/MiKo.Analyzer.Shared/ReplacementMap.cs
@@ -19,6 +19,22 @@ namespace MiKoSolutions.Analyzers
         /// <param name="pairs">
         /// The map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
         /// </param>
+        public ReplacementMap(string id, Pair[] pairs)
+        {
+            Id = id;
+            Pairs = pairs;
+            Keys = pairs.ToArray(_ => _.Key);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplacementMap"/> class with an identifier and the terms to replace.
+        /// </summary>
+        /// <param name="id">
+        /// The identifier of the replacement map.
+        /// </param>
+        /// <param name="pairs">
+        /// The map of terms to their replacements (<see cref="Pair.Key"/> = original, <see cref="Pair.Value"/> = replacement).
+        /// </param>
         /// <param name="keys">
         /// The keys to look up the corresponding replacements in <paramref name="pairs"/> (see <see cref="Keys"/>).
         /// </param>
@@ -75,6 +91,14 @@ namespace MiKoSolutions.Analyzers
         /// The keys do not need to contain all keys of <see cref="Pairs"/>. Instead, they can contain the most common sub-sequences of those keys to optimize searching.
         /// </remarks>
         public string[] Keys { get; set; }
+
+        /// <summary>
+        /// Gets or sets the matcher to check if a text could fit.
+        /// </summary>
+        /// <value>
+        /// A matcher to check if a text could fit.
+        /// </value>
+        public AhoCorasickMatcher Matcher { get; set; }
 #pragma warning restore CA1819
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Documentation/MiKo_2012_CodeFixProvider.cs
@@ -65,8 +65,22 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
                                                                                                     .Except(new[] { "Gets or sets a value ", "Gets or sets ", "Gets a value ", "Sets a value ", "gets a value ", "sets a value " })
                                                                                                     .OrderDescendingByLengthAndText();
 
+        private static readonly ReplacementMap GetSetReplacementMap = new ReplacementMap("MiKo_2012_GetSet", GetSetReplacementPhrases.ToArray(_ => new Pair(_, Constants.SingleSpace)), GetSetReplacementPhrases)
+                                                                          {
+                                                                              Matcher = AhoCorasickMatcher.For(GetSetReplacementPhrases),
+                                                                          };
+
+        private static readonly Pair[] GetSetReplacementCleanups = CreateGetSetReplacementCleanups();
+
+        private static readonly string[] GetSetReplacementCleanupKeys = GetSetReplacementCleanups.ToArray(_ => _.Key);
+
+        private static readonly ReplacementMap GetSetReplacementCleanupMap = new ReplacementMap("MiKo_2012_GetSetCleanup", GetSetReplacementCleanups, GetSetReplacementCleanupKeys)
+                                                                                 {
+                                                                                     Matcher = AhoCorasickMatcher.For(GetSetReplacementCleanupKeys),
+                                                                                 };
+
         private static readonly ReplacementMap PreparationMap = new ReplacementMap(
-                                                                               "MiKo_2012_Replacement",
+                                                                               "MiKo_2012_Preparation",
                                                                                new[]
                                                                                    {
                                                                                        new Pair(Constants.Comments.SealedClassPhrase, "##SEALED##"),
@@ -310,107 +324,8 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             var builder = StringBuilderCache.Acquire(startingPhrase.Length + remainingText.Length)
                                             .Append(startingPhrase)
                                             .Append(remainingText.ToLowerCaseAt(0))
-                                            .ReplaceAllWithProbe(GetSetReplacementPhrases, Constants.SingleSpace);
-
-            builder.ReplaceWithProbe(" only if ", " if ");
-            builder.ReplaceWithProbe(" only when ", " when ");
-            builder.ReplaceWithProbe(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace);
-            builder.ReplaceWithProbe("indicating describes ", "indicating ");
-            builder.ReplaceWithProbe("indicating describe ", "indicating ");
-            builder.ReplaceWithProbe("indicating specifies ", "indicating ");
-            builder.ReplaceWithProbe("indicating specify ", "indicating ");
-            builder.ReplaceWithProbe("indicating indicates ", "indicating ");
-            builder.ReplaceWithProbe("indicating indicate ", "indicating ");
-            builder.ReplaceWithProbe("indicating returns ", "indicating ");
-            builder.ReplaceWithProbe("indicating return ", "indicating ");
-            builder.ReplaceWithProbe("indicating indicating", "indicating");
-            builder.ReplaceWithProbe("indicating for ", "indicating whether the ");
-            builder.ReplaceWithProbe("indicating property for ", "indicating whether ");
-            builder.ReplaceWithProbe("bool indicating", "value indicating");
-            builder.ReplaceWithProbe("bool that indicates", "value indicating");
-            builder.ReplaceWithProbe("bool which indicates", "value indicating");
-            builder.ReplaceWithProbe("boolean indicating", "value indicating");
-            builder.ReplaceWithProbe("boolean that indicates", "value indicating");
-            builder.ReplaceWithProbe("boolean which indicates", "value indicating");
-            builder.ReplaceWithProbe("value that indicates", "value indicating");
-            builder.ReplaceWithProbe("value which indicates", "value indicating");
-            builder.ReplaceWithProbe("value indicating whether value indicating", "value indicating");
-            builder.ReplaceWithProbe("value indicating value indicating", "value indicating");
-            builder.ReplaceWithProbe("the value indicat", "a value indicat");
-            builder.ReplaceWithProbe(" value indicating whether a value indicating", " value indicating");
-            builder.ReplaceWithProbe(" value indicating gets a value indicating", " value indicating");
-            builder.ReplaceWithProbe(" value indicating sets a value indicating", " value indicating");
-            builder.ReplaceWithProbe(" value indicating gets or sets a value indicating", " value indicating");
-            builder.ReplaceWithProbe(" value indicating a value indicating", " value indicating");
-            builder.ReplaceWithProbe("whether value indicating whether", "whether");
-            builder.ReplaceWithProbe("a value indicating get ", "a value indicating ");
-            builder.ReplaceWithProbe("a value indicating set ", "a value indicating ");
-            builder.ReplaceWithProbe("indicating that indicates if", "indicating whether");
-            builder.ReplaceWithProbe("indicating which indicates if", "indicating whether");
-            builder.ReplaceWithProbe("indicating that indicates that", "indicating whether");
-            builder.ReplaceWithProbe("indicating which indicates that", "indicating whether");
-            builder.ReplaceWithProbe("indicating that indicates whether", "indicating whether");
-            builder.ReplaceWithProbe("indicating which indicates whether", "indicating whether");
-            builder.ReplaceWithProbe("indicating that", "indicating whether");
-            builder.ReplaceWithProbe("indicating flag ", "indicating whether ");
-            builder.ReplaceWithProbe("indicating if ", "indicating whether ");
-            builder.ReplaceWithProbe("indicating to", "indicating whether to");
-            builder.ReplaceWithProbe("whether to true if to", "whether to");
-            builder.ReplaceWithProbe("whether to true to", "whether to");
-            builder.ReplaceWithProbe("whether to true, to", "whether to");
-            builder.ReplaceWithProbe("whether describe if", "whether");
-            builder.ReplaceWithProbe("whether describe that", "whether");
-            builder.ReplaceWithProbe("whether describe whether", "whether");
-            builder.ReplaceWithProbe("whether describes if", "whether");
-            builder.ReplaceWithProbe("whether describes that", "whether");
-            builder.ReplaceWithProbe("whether describes whether", "whether");
-            builder.ReplaceWithProbe("whether indicate if", "whether");
-            builder.ReplaceWithProbe("whether indicate that", "whether ");
-            builder.ReplaceWithProbe("whether indicate whether", "whether");
-            builder.ReplaceWithProbe("whether indicates if", "whether");
-            builder.ReplaceWithProbe("whether indicates that", "whether ");
-            builder.ReplaceWithProbe("whether indicates whether", "whether");
-            builder.ReplaceWithProbe("whether specifies if", "whether");
-            builder.ReplaceWithProbe("whether specifies that", "whether");
-            builder.ReplaceWithProbe("whether specifies whether", "whether");
-            builder.ReplaceWithProbe("whether specify if", "whether");
-            builder.ReplaceWithProbe("whether specify that", "whether");
-            builder.ReplaceWithProbe("whether specify whether", "whether");
-            builder.ReplaceWithProbe("whether whether", "whether");
-            builder.ReplaceWithProbe("whether set to true then", "whether");
-            builder.ReplaceWithProbe("whether set to true, then", "whether");
-            builder.ReplaceWithProbe("whether set to True then", "whether");
-            builder.ReplaceWithProbe("whether set to True, then", "whether");
-            builder.ReplaceWithProbe("whether set to TRUE then", "whether");
-            builder.ReplaceWithProbe("whether set to TRUE, then", "whether");
-            builder.ReplaceWithProbe("ets get ", "ets ");
-            builder.ReplaceWithProbe("ets set ", "ets ");
-            builder.ReplaceWithProbe("gets returns", "gets");
-            builder.ReplaceWithProbe("Gets returns", "Gets");
-            builder.ReplaceWithProbe("sets returns", "sets");
-            builder.ReplaceWithProbe("Sets returns", "Sets");
-            builder.ReplaceWithProbe("Gets or sets property for ", "Gets or sets ");
-            builder.ReplaceWithProbe("Gets or sets property ", "Gets or sets ");
-            builder.ReplaceWithProbe("Gets property for ", "Gets ");
-            builder.ReplaceWithProbe("Sets property for ", "Sets ");
-            builder.ReplaceWithProbe(" the the ", " the ");
-            builder.ReplaceWithProbe(" the an ", " an ");
-            builder.ReplaceWithProbe(" the a ", " a ");
-            builder.ReplaceWithProbe(" to the ", " the ");
-            builder.ReplaceWithProbe(" to an ", " an ");
-            builder.ReplaceWithProbe(" to a ", " a ");
-            builder.ReplaceWithProbe(" true if ", " whether ");
-            builder.ReplaceWithProbe(" tRUE if ", " whether ");
-            builder.ReplaceWithProbe(" true when ", " whether ");
-            builder.ReplaceWithProbe(" tRUE when ", " whether ");
-            builder.ReplaceWithProbe(" when set to true then ", " whether ");
-            builder.ReplaceWithProbe(" when set to true, then ", " whether ");
-            builder.ReplaceWithProbe(" when set to True then ", " whether ");
-            builder.ReplaceWithProbe(" when set to True, then ", " whether ");
-            builder.ReplaceWithProbe(" when set to TRUE then ", " whether ");
-            builder.ReplaceWithProbe(" when set to TRUE, then ", " whether ");
-            builder.ReplaceWithProbe(" only whether ", " whether ");
-            builder.ReplaceWithProbe(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace);
+                                            .ReplaceAllWithProbe(GetSetReplacementMap)
+                                            .ReplaceAllWithProbe(GetSetReplacementCleanupMap);
 
             var replacedFixedText = builder.ToStringAndRelease();
 
@@ -1194,6 +1109,112 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
             }
         }
 
-//// ncrunch: rdi default
-    }
+        private static Pair[] CreateGetSetReplacementCleanups()
+        {
+            return new[]
+                       {
+                           new Pair(" only if ", " if "),
+                           new Pair(" only when ", " when "),
+                           new Pair(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace),
+                           new Pair("indicating describes ", "indicating "),
+                           new Pair("indicating describe ", "indicating "),
+                           new Pair("indicating specifies ", "indicating "),
+                           new Pair("indicating specify ", "indicating "),
+                           new Pair("indicating indicates ", "indicating "),
+                           new Pair("indicating indicate ", "indicating "),
+                           new Pair("indicating returns ", "indicating "),
+                           new Pair("indicating return ", "indicating "),
+                           new Pair("indicating indicating", "indicating"),
+                           new Pair("indicating for ", "indicating whether the "),
+                           new Pair("indicating property for ", "indicating whether "),
+                           new Pair("bool indicating", "value indicating"),
+                           new Pair("bool that indicates", "value indicating"),
+                           new Pair("bool which indicates", "value indicating"),
+                           new Pair("boolean indicating", "value indicating"),
+                           new Pair("boolean that indicates", "value indicating"),
+                           new Pair("boolean which indicates", "value indicating"),
+                           new Pair("value that indicates", "value indicating"),
+                           new Pair("value which indicates", "value indicating"),
+                           new Pair("value indicating whether value indicating", "value indicating"),
+                           new Pair("value indicating value indicating", "value indicating"),
+                           new Pair("the value indicat", "a value indicat"),
+                           new Pair(" value indicating whether a value indicating", " value indicating"),
+                           new Pair(" value indicating gets a value indicating", " value indicating"),
+                           new Pair(" value indicating sets a value indicating", " value indicating"),
+                           new Pair(" value indicating gets or sets a value indicating", " value indicating"),
+                           new Pair(" value indicating a value indicating", " value indicating"),
+                           new Pair("whether value indicating whether", "whether"),
+                           new Pair("a value indicating get ", "a value indicating "),
+                           new Pair("a value indicating set ", "a value indicating "),
+                           new Pair("indicating that indicates if", "indicating whether"),
+                           new Pair("indicating which indicates if", "indicating whether"),
+                           new Pair("indicating that indicates that", "indicating whether"),
+                           new Pair("indicating which indicates that", "indicating whether"),
+                           new Pair("indicating that indicates whether", "indicating whether"),
+                           new Pair("indicating which indicates whether", "indicating whether"),
+                           new Pair("indicating that", "indicating whether"),
+                           new Pair("indicating flag ", "indicating whether "),
+                           new Pair("indicating if ", "indicating whether "),
+                           new Pair("indicating to", "indicating whether to"),
+                           new Pair("whether to true if to", "whether to"),
+                           new Pair("whether to true to", "whether to"),
+                           new Pair("whether to true, to", "whether to"),
+                           new Pair("whether describe if", "whether"),
+                           new Pair("whether describe that", "whether"),
+                           new Pair("whether describe whether", "whether"),
+                           new Pair("whether describes if", "whether"),
+                           new Pair("whether describes that", "whether"),
+                           new Pair("whether describes whether", "whether"),
+                           new Pair("whether indicate if", "whether"),
+                           new Pair("whether indicate that", "whether "),
+                           new Pair("whether indicate whether", "whether"),
+                           new Pair("whether indicates if", "whether"),
+                           new Pair("whether indicates that", "whether "),
+                           new Pair("whether indicates whether", "whether"),
+                           new Pair("whether specifies if", "whether"),
+                           new Pair("whether specifies that", "whether"),
+                           new Pair("whether specifies whether", "whether"),
+                           new Pair("whether specify if", "whether"),
+                           new Pair("whether specify that", "whether"),
+                           new Pair("whether specify whether", "whether"),
+                           new Pair("whether whether", "whether"),
+                           new Pair("whether set to true then", "whether"),
+                           new Pair("whether set to true, then", "whether"),
+                           new Pair("whether set to True then", "whether"),
+                           new Pair("whether set to True, then", "whether"),
+                           new Pair("whether set to TRUE then", "whether"),
+                           new Pair("whether set to TRUE, then", "whether"),
+                           new Pair("ets get ", "ets "),
+                           new Pair("ets set ", "ets "),
+                           new Pair("gets returns", "gets"),
+                           new Pair("Gets returns", "Gets"),
+                           new Pair("sets returns", "sets"),
+                           new Pair("Sets returns", "Sets"),
+                           new Pair("Gets or sets property for ", "Gets or sets "),
+                           new Pair("Gets or sets property ", "Gets or sets "),
+                           new Pair("Gets property for ", "Gets "),
+                           new Pair("Sets property for ", "Sets "),
+                           new Pair(" the the ", " the "),
+                           new Pair(" the an ", " an "),
+                           new Pair(" the a ", " a "),
+                           new Pair(" to the ", " the "),
+                           new Pair(" to an ", " an "),
+                           new Pair(" to a ", " a "),
+                           new Pair(" true if ", " whether "),
+                           new Pair(" tRUE if ", " whether "),
+                           new Pair(" true when ", " whether "),
+                           new Pair(" tRUE when ", " whether "),
+                           new Pair(" when set to true then ", " whether "),
+                           new Pair(" when set to true, then ", " whether "),
+                           new Pair(" when set to True then ", " whether "),
+                           new Pair(" when set to True, then ", " whether "),
+                           new Pair(" when set to TRUE then ", " whether "),
+                           new Pair(" when set to TRUE, then ", " whether "),
+                           new Pair(" only whether ", " whether "),
+                           new Pair(Constants.SingleSpace + Constants.SingleSpace, Constants.SingleSpace),
+                       };
+        }
+
+    //// ncrunch: rdi default
+}
 }

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1049_RequirementTermAnalyzer.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     {
         public const string Id = "MiKo_1049";
 
-        private static readonly Pair[] ReplacementMap = CreateReplacementMapEntries().Distinct().ToArray();
+        private static readonly ReplacementMap ReplacementMap = new ReplacementMap(Id, CreateReplacementMapEntries().Distinct().ToArray());
 
         private static readonly ConcurrentDictionary<string, string> AnalyzeNameCache = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
 

--- a/MiKo.Analyzer.Tests/AhoCorasickMatcherTests.cs
+++ b/MiKo.Analyzer.Tests/AhoCorasickMatcherTests.cs
@@ -246,5 +246,75 @@ namespace MiKoSolutions.Analyzers
                 Assert.That(matcher.IsMatch("no matching text here".AsSpan()), Is.False);
             }
         }
+
+        [Test]
+        public static void IsMatch_finds_every_pattern_when_many_states_share_an_identical_transition_row()
+        {
+            // every pattern only differs in its first character and shares the exact same single-character suffix,
+            // so the intermediate nodes (reached right after the first character) all end up with an identical
+            // transition row (real edge on '1' towards the terminal state, fallback to root for everything else);
+            // this specifically exercises the transition-row deduplication introduced to shrink the transition table.
+            var patterns = Enumerable.Range(0, 10).Select(_ => $"{_}1").ToArray();
+
+            var matcher = AhoCorasickMatcher.For(patterns);
+
+            using (Assert.EnterMultipleScope())
+            {
+                foreach (var pattern in patterns)
+                {
+                    Assert.That(matcher.IsMatch($"contains {pattern} somewhere".AsSpan()), Is.True, $"Failed for pattern '{pattern}'");
+                }
+
+                Assert.That(matcher.IsMatch("contains no matching digits".AsSpan()), Is.False);
+                Assert.That(matcher.IsMatch("12345".AsSpan()), Is.False); // shares digits with the patterns but never followed by the required '1' suffix at the right spot
+            }
+        }
+
+        [Test]
+        public static void IsMatch_finds_every_pattern_when_many_states_share_an_identical_transition_row_but_differ_in_terminal_state()
+        {
+            // 'a1', 'b1', ... are terminal only right after their second character, whereas the intermediate,
+            // non-terminal node reached after the first character shares its transition row content with other,
+            // unrelated terminal leaf states (e.g. the single-character pattern "z"); deduplicating rows purely by
+            // their transition content must not accidentally also merge the (separately tracked) terminal flag.
+            var matcher = AhoCorasickMatcher.For(["a1", "b1", "c1", "z"]);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(matcher.IsMatch("a1".AsSpan()), Is.True);
+                Assert.That(matcher.IsMatch("b1".AsSpan()), Is.True);
+                Assert.That(matcher.IsMatch("c1".AsSpan()), Is.True);
+                Assert.That(matcher.IsMatch("z".AsSpan()), Is.True);
+
+                // reaching the intermediate (non-terminal) state alone, without completing any full pattern, must not match
+                Assert.That(matcher.IsMatch("a".AsSpan()), Is.False);
+                Assert.That(matcher.IsMatch("b".AsSpan()), Is.False);
+                Assert.That(matcher.IsMatch("c".AsSpan()), Is.False);
+            }
+        }
+
+        [Test]
+        public static void IsMatch_produces_correct_results_for_a_large_number_of_overlapping_patterns()
+        {
+            // simulates a realistic large phrase set (similar in spirit to the replacement phrases used by code fixes)
+            // with lots of shared prefixes and suffixes, which is exactly the scenario that produces many states and,
+            // consequently, many opportunities for the transition table to contain duplicate rows.
+            var prefixes = new[] { "Gets ", "Sets ", "Gets or sets ", "gets ", "sets " };
+            var suffixes = new[] { "a value ", "the value ", "an instance ", "a flag ", "the flag " };
+
+            var patterns = prefixes.SelectMany(prefix => suffixes.Select(suffix => prefix + suffix)).ToArray();
+
+            var matcher = AhoCorasickMatcher.For(patterns);
+
+            using (Assert.EnterMultipleScope())
+            {
+                foreach (var pattern in patterns)
+                {
+                    Assert.That(matcher.IsMatch($"Summary: {pattern}indicating something.".AsSpan()), Is.True, $"Failed for pattern '{pattern}'");
+                }
+
+                Assert.That(matcher.IsMatch("Summary: Provides access to something.".AsSpan()), Is.False);
+            }
+        }
     }
 }

--- a/MiKo.Analyzer.Tests/AhoCorasickMatcherTests.cs
+++ b/MiKo.Analyzer.Tests/AhoCorasickMatcherTests.cs
@@ -253,7 +253,8 @@ namespace MiKoSolutions.Analyzers
             // every pattern only differs in its first character and shares the exact same single-character suffix,
             // so the intermediate nodes (reached right after the first character) all end up with an identical
             // transition row (real edge on '1' towards the terminal state, fallback to root for everything else);
-            // this specifically exercises the transition-row deduplication introduced to shrink the transition table.
+            // this specifically exercises the per-state default/exception compression introduced to shrink the transition table,
+            // where the shared fallback target becomes the default and only the '1' edge is stored as an exception.
             var patterns = Enumerable.Range(0, 10).Select(_ => $"{_}1").ToArray();
 
             var matcher = AhoCorasickMatcher.For(patterns);
@@ -275,8 +276,8 @@ namespace MiKoSolutions.Analyzers
         {
             // 'a1', 'b1', ... are terminal only right after their second character, whereas the intermediate,
             // non-terminal node reached after the first character shares its transition row content with other,
-            // unrelated terminal leaf states (e.g. the single-character pattern "z"); deduplicating rows purely by
-            // their transition content must not accidentally also merge the (separately tracked) terminal flag.
+            // unrelated terminal leaf states (e.g. the single-character pattern "z"); compressing per-state transitions
+            // into a default plus exceptions must not accidentally also merge the (separately tracked) terminal flag.
             var matcher = AhoCorasickMatcher.For(["a1", "b1", "c1", "z"]);
 
             using (Assert.EnterMultipleScope())
@@ -298,7 +299,7 @@ namespace MiKoSolutions.Analyzers
         {
             // simulates a realistic large phrase set (similar in spirit to the replacement phrases used by code fixes)
             // with lots of shared prefixes and suffixes, which is exactly the scenario that produces many states and,
-            // consequently, many opportunities for the transition table to contain duplicate rows.
+            // consequently, many opportunities for states to share the same default transition target.
             var prefixes = new[] { "Gets ", "Sets ", "Gets or sets ", "gets ", "sets " };
             var suffixes = new[] { "a value ", "the value ", "an instance ", "a flag ", "the flag " };
 


### PR DESCRIPTION
Refactor Aho-Corasick matcher to
- reduce memory usage by storing only default transitions and exceptions per state
- replace bool[] with BitArray for terminal flags
- clarify comments and docs
- store state ID in node structure
- and update IsMatch to use new transition logic