### PR TITLE
Dogfooding own rules

### DIFF
--- a/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
+++ b/MiKo.Analyzer.Shared/AhoCorasickMatcher.cs
@@ -234,7 +234,9 @@ namespace MiKoSolutions.Analyzers
 
             var queue = new Queue<Node>();
             queue.Enqueue(root);
+
             root.Id = 0;
+
             order.Add(root);
 
             while (queue.Count > 0)
@@ -246,6 +248,7 @@ namespace MiKoSolutions.Analyzers
                     if (child.Id < 0)
                     {
                         child.Id = order.Count;
+
                         order.Add(child);
 
                         queue.Enqueue(child);

--- a/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         {
             Assert.Multiple(() =>
                                  {
-                                     Assert.That(Array.Empty<string>().HumanizedConcatenated(), Is.EqualTo(string.Empty), "0 value");
+                                     Assert.That(Array.Empty<string>().HumanizedConcatenated(), Is.Empty, "0 value");
                                      Assert.That(new[] { "a" }.HumanizedConcatenated(), Is.EqualTo("'a'"), "1 value");
                                      Assert.That(new[] { "a", "b" }.HumanizedConcatenated(), Is.EqualTo("'a' or 'b'"), "2 values");
                                      Assert.That(new[] { "a", "b", "c" }.HumanizedConcatenated(), Is.EqualTo("'a', 'b' or 'c'"), "3 values");
@@ -272,8 +272,8 @@ namespace MiKoSolutions.Analyzers.Extensions
             Assert.Multiple(() =>
                                  {
                                      Assert.That(((string)null).LastWord(), Is.Null, "with null as text");
-                                     Assert.That(string.Empty.LastWord(), Is.EqualTo(string.Empty), "with empty text");
-                                     Assert.That("   ".LastWord(), Is.EqualTo(string.Empty), "with whitespace-only text");
+                                     Assert.That(string.Empty.LastWord(), Is.Empty, "with empty text");
+                                     Assert.That("   ".LastWord(), Is.Empty, "with whitespace-only text");
                                      Assert.That("bla".LastWord(), Is.EqualTo("bla"), "without whitespace");
                                      Assert.That("bla blubb".LastWord(), Is.EqualTo("blubb"), "without whitespace at end");
                                      Assert.That(" bla blubb ".LastWord(), Is.EqualTo("blubb"), "with single whitespace at end");

--- a/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
@@ -45,7 +45,7 @@ namespace MiKoSolutions.Analyzers.Extensions
                 foundLines.Add(line.ToString());
             }
 
-            Assert.That(foundLines.Count, Is.EqualTo(3));
+            Assert.That(foundLines, Has.Count.EqualTo(3));
             Assert.That(foundLines[0], Is.EqualTo(Line1));
             Assert.That(foundLines[1], Is.Empty); // line between \r and \n
             Assert.That(foundLines[2], Is.EqualTo(Line2));
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Extensions
                 foundLines.Add(line.ToString());
             }
 
-            Assert.That(foundLines.Count, Is.EqualTo(2));
+            Assert.That(foundLines, Has.Count.EqualTo(2));
             Assert.That(foundLines[0], Is.EqualTo(Line1));
             Assert.That(foundLines[1], Is.EqualTo(Line2));
         }
@@ -76,7 +76,7 @@ namespace MiKoSolutions.Analyzers.Extensions
         {
             var lines = "something text to split".AsSpan().SplitBy([" text "], options: StringSplitOptions.RemoveEmptyEntries);
 
-            Assert.That(lines.Count, Is.EqualTo(2));
+            Assert.That(lines, Has.Count.EqualTo(2));
             Assert.That(lines[0], Is.EqualTo("something"));
             Assert.That(lines[1], Is.EqualTo("to split"));
         }

--- a/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
+++ b/MiKo.Analyzer.Tests/Extensions/StringSplitExtensionsTests.cs
@@ -47,7 +47,7 @@ namespace MiKoSolutions.Analyzers.Extensions
 
             Assert.That(foundLines.Count, Is.EqualTo(3));
             Assert.That(foundLines[0], Is.EqualTo(Line1));
-            Assert.That(foundLines[1], Is.EqualTo(string.Empty)); // line between \r and \n
+            Assert.That(foundLines[1], Is.Empty); // line between \r and \n
             Assert.That(foundLines[2], Is.EqualTo(Line2));
         }
 

--- a/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/MiKo.Analyzer.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -195,12 +195,12 @@ namespace TestHelper
                 }
 
                 return diagnostics.Count is 1
-                           ? [diagnostics[0]]
-                           : [.. diagnostics.OrderBy(_ => _.Location.SourceSpan.Start)];
+                       ? [diagnostics[0]]
+                       : [.. diagnostics.OrderBy(_ => _.Location.SourceSpan.Start)];
             }
             finally
             {
-                if (counted > 0 && counted % TestLimitToRunGarbageCollection == 0)
+                if (counted > 0 && counted % TestLimitToRunGarbageCollection is 0)
                 {
                     GC.Collect();
                 }

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2012_MeaninglessSummaryAnalyzerTests.cs
@@ -446,7 +446,7 @@ public class TestMeCfg
         }
 
         [Test]
-        public void Code_gets_fixed_for_unfinished_XAML_like_code()
+        public void Code_gets_fixed_for_XAML_like_comment_on_class()
         {
             const string OriginalCode = @"
 /// <summary>
@@ -470,7 +470,7 @@ public class
         }
 
         [Test]
-        public void Code_gets_fixed_for_XAML_like_comment()
+        public void Code_gets_fixed_for_XAML_like_comment_on_interface()
         {
             const string OriginalCode = @"
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2100_ExampleDefaultPhraseAnalyzerTests.cs
@@ -52,7 +52,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_documented_items_with_correct_example_docu() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documented_items_with_expected_example_phrase() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2205_DocumentationShallUseNoteAnalyzerTests.cs
@@ -47,7 +47,7 @@ public sealed class TestMe { }
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correct_comment_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [Values("caution", "important")] string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_using_a_note_tag_in_XML_tag_([ValueSource(nameof(XmlTags))] string xmlTag, [Values("caution", "important")] string type) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// <note type=""" + type + @""" >
 /// The something.

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2206_FlagAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2206_FlagAnalyzerTests.cs
@@ -27,7 +27,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_that_does_not_mention_the_term_flag() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>Does something.</summary>
@@ -53,7 +53,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_class_that_mentions_the_term_flag_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">Its flag.</" + tag + @">
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_method_that_mentions_the_term_flag_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_property_that_mentions_the_term_flag_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_event_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_event_that_mentions_the_term_flag_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -96,7 +96,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_field_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_field_that_mentions_the_term_flag_([ValueSource(nameof(XmlTags))] string tag) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2208_DocumentationDoesNotUseAnInstanceOfAnalyzerTests.cs
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_a_type_instance_reference() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>Does something.</summary>
@@ -86,7 +86,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_documentation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">" + phrase + "something.</" + tag + @">
@@ -96,7 +96,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_method_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_documentation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -107,7 +107,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_property_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_documentation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -118,7 +118,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_event_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_documentation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -129,7 +129,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_field_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_documentation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -140,7 +140,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_documented_factory_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_method_documentation_with_a_type_instance_reference() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2210_DocumentationUsesInformationInsteadOfInfoAnalyzerTests.cs
@@ -26,7 +26,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_term_in_commented_class_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_commented_class_using_the_term_information_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The information something.
 /// </" + xmlTag + @">

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2212_DocumentationContainsWasNotSuccessfulAnalyzerTests.cs
@@ -18,7 +18,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_the_phrase_was_not_successful() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some summary.
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2213_DocumentationContainsNtContractionAnalyzerTests.cs
@@ -19,7 +19,7 @@ public class TestMe
 
         [TestCase("Some summary.")]
         [TestCase("Some parent.")]
-        public void No_issue_is_reported_for_correct_comment_(string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_an_nt_contraction_(string text) => No_issue_is_reported_for(@"
 /// <summary>
 /// " + text + @"
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2214_DocumentationContainsEmptyLinesAnalyzerTests.cs
@@ -28,7 +28,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_empty_lines() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some summary.
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2216_ParamInsteadOfParamRefAnalyzerTests.cs
@@ -31,7 +31,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_used_param_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_param_tag_used_in_param_element() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -44,7 +44,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_used_paramref_tag() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_paramref_tag_used_in_summary() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_used_param_tag_in_summary() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_param_tag_used_in_summary_instead_of_paramref() => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>
@@ -72,7 +72,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_used_param_tag_in_param() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_param_tag_used_in_param_element_instead_of_paramref() => An_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2218_DocumentationShouldNotContainUsedToAnalyzerTests.cs
@@ -262,7 +262,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_used_to_phrase() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some summary.
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2219_DocumentationContainsNoQuestionOrExclamationMarkAnalyzerTests.cs
@@ -21,7 +21,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_documentation_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_question_or_exclamation_mark_([ValueSource(nameof(XmlTags))] string tag) => No_issue_is_reported_for(@"
 /// <" + tag + ">Some text.</" + tag + @">
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2220_DocumentationShouldUseToSeekAnalyzerTests.cs
@@ -35,7 +35,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_to_seek_phrase() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some summary.
 /// </summary>
@@ -44,7 +44,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment_with_to_inspect_for() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_with_the_phrase_to_inspect_for_more_details() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some summary to inspect for more details.
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2221_DocumentationIsNotEmptyAnalyzerTests.cs
@@ -30,7 +30,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_empty_comment_([ValueSource(nameof(Tags))] string tag) => No_issue_is_reported_for(@"
 /// <" + tag + @">
 /// Some summary.
 /// </" + tag + @">

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2222_DocumentationUsesIdentificationInsteadOfIdentAnalyzerTests.cs
@@ -26,7 +26,7 @@ public sealed class TestMe { }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_term_in_commented_class_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_commented_class_using_the_term_identification_([ValueSource(nameof(XmlTags))] string xmlTag) => No_issue_is_reported_for(@"
 /// <" + xmlTag + @">
 /// The identification something.
 /// </" + xmlTag + @">

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2226_DocumentationContainsIntentionallyAnalyzerTests.cs
@@ -41,7 +41,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_an_intentional_phrase() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2227_DocumentationDoesNotContainReSharperMarkerAnalyzerTests.cs
@@ -27,7 +27,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_ReSharper_marker() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2229_XmlFragmentAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Documentation
     public sealed class MiKo_2229_XmlFragmentAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correct_XML() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_valid_XML_fragment() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some text
 /// </summary>
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_XML_with_CDataSection() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_valid_XML_fragment_with_CDataSection() => No_issue_is_reported_for(@"
 /// <summary>
 /// Some text
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2230_ReturnValueUsesListAnalyzerTests.cs
@@ -55,7 +55,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_text_list_in_returns() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_list_tag_used_in_returns() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <returns>
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_text_list_in_value() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_list_tag_used_in_value() => No_issue_is_reported_for(@"
 public class TestMe
 {
     /// <value>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2234_DocumentationShouldUseToAnalyzerTests.cs
@@ -21,7 +21,7 @@ public class TestMe
 
         [TestCase("Some summary.")]
         [TestCase("Some parent.")]
-        public void No_issue_is_reported_for_correct_comment_(string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_which_is_to_phrase_(string text) => No_issue_is_reported_for(@"
 /// <summary>
 /// " + text + @"
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2235_GoingToPhraseAnalyzerTests.cs
@@ -38,7 +38,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_a_going_to_phrase() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>Will be something.</summary>
@@ -64,7 +64,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_class_with_a_going_to_phrase_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">" + phrase + "</" + tag + @">

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2236_ExampleAbbreviationAnalyzerTests.cs
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_documentation_without_an_example_abbreviation() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>It is for example something.</summary>
@@ -67,7 +67,7 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_incorrectly_documented_class_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_documented_class_with_an_example_abbreviation_([ValueSource(nameof(XmlTags))] string tag, [ValueSource(nameof(Phrases))] string phrase) => An_issue_is_reported_for(@"
 using System;
 
 /// <" + tag + ">" + phrase + "</" + tag + @">

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2237_MultipleDocumentationAnalyzerTests.cs
@@ -28,7 +28,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items_with_multiple_elements() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_items_with_a_single_documentation_comment_per_multiple_xml_elements() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>This is some text.</summary>
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_documented_items_with_single_elements() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_items_with_a_single_documentation_comment_per_single_xml_element() => No_issue_is_reported_for(@"
 using System;
 
 /// <summary>This is some text.</summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2238_MakeSureToCallThisAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2238_MakeSureToCallThisAnalyzerTests.cs
@@ -51,7 +51,7 @@ public class TestMe
 
         [TestCase("Some summary.")]
         [TestCase("Some parent.")]
-        public void No_issue_is_reported_for_correct_comment_(string text) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_make_sure_to_call_this_phrase_(string text) => No_issue_is_reported_for(@"
 /// <summary>
 /// " + text + @"
 /// </summary>

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2301_TestArrangeActAssertCommentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2301_TestArrangeActAssertCommentAnalyzerTests.cs
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_test_method_([ValueSource(nameof(Tests))] string test) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_method_with_a_regular_comment_([ValueSource(nameof(Tests))] string test) => No_issue_is_reported_for(@"
 using NUnit.Framework;
 
 public class TestMe
@@ -115,10 +115,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_test_method_(
-                                                                            [ValueSource(nameof(Tests))] string test,
-                                                                            [ValueSource(nameof(Comments))] string comment,
-                                                                            [ValueSource(nameof(Gaps))] string gap)
+        public void An_issue_is_reported_for_test_method_with_arrange_act_assert_comment_(
+                                                                                      [ValueSource(nameof(Tests))] string test,
+                                                                                      [ValueSource(nameof(Comments))] string comment,
+                                                                                      [ValueSource(nameof(Gaps))] string gap)
             => An_issue_is_reported_for(@"
 using NUnit.Framework;
 
@@ -133,10 +133,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_non_test_method_in_test_class_(
-                                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                              [ValueSource(nameof(Comments))] string comment,
-                                                                                              [ValueSource(nameof(Gaps))] string gap)
+        public void An_issue_is_reported_for_non_test_method_in_test_class_with_arrange_act_assert_comment_(
+                                                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                                        [ValueSource(nameof(Comments))] string comment,
+                                                                                                        [ValueSource(nameof(Gaps))] string gap)
             => An_issue_is_reported_for(@"
 using NUnit.Framework;
 
@@ -151,10 +151,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_commented_non_test_method_in_test_class_with_visual_separators_(
-                                                                                                                     [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                                                     [ValueSource(nameof(Comments))] string comment,
-                                                                                                                     [ValueSource(nameof(Gaps))] string gap)
+        public void An_issue_is_reported_for_non_test_method_in_test_class_with_arrange_act_assert_comment_surrounded_by_visual_separators_(
+                                                                                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                                                                        [ValueSource(nameof(Comments))] string comment,
+                                                                                                                                        [ValueSource(nameof(Gaps))] string gap)
             => An_issue_is_reported_for(@"
 using NUnit.Framework;
 

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2302_CommentedOutCodeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2302_CommentedOutCodeAnalyzerTests.cs
@@ -53,7 +53,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_a_regular_comment() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -65,7 +65,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_method_that_contains_a_triple_slash() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_a_regular_comment_that_contains_a_triple_slash() => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2307_CommentContainsWasNotSuccessfulAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2307_CommentContainsWasNotSuccessfulAnalyzerTests.cs
@@ -18,7 +18,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_the_phrase() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2309_CommentContainsNtContractionAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2309_CommentContainsNtContractionAnalyzerTests.cs
@@ -23,7 +23,7 @@ public class TestMe
         [TestCase("some parent")]
         [TestCase("some insignificant comment")]
         [TestCase("some significant comment")]
-        public void No_issue_is_reported_for_correct_single_line_comment_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_single_line_comment_without_an_nt_contraction_(string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -34,7 +34,7 @@ public class TestMe
 
         [TestCase("some comment")]
         [TestCase("some parent")]
-        public void No_issue_is_reported_for_correct_multi_line_comment_(string comment) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_multi_line_comment_without_an_nt_contraction_(string comment) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2310_CommentContainsIntentionallyAnalyzerTests.cs
@@ -67,7 +67,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_an_intentional_phrase() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2311_CommentIsSeparatorAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_commented_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_a_regular_comment() => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Documentation/MiKo_2312_CommentShouldUseToAnalyzerTests.cs
@@ -20,7 +20,7 @@ public class TestMe
 }");
 
         [Test]
-        public void No_issue_is_reported_for_correct_comment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_comment_without_a_which_is_to_phrase() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1000_EventArgsTypeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1000_EventArgsTypeAnalyzerTests.cs
@@ -21,7 +21,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_EventArgs_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs
@@ -30,7 +30,7 @@ public class MyEventArgs : EventArgs
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_EventArgs() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventArgs_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe : EventArgs

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1001_EventArgsParameterAnalyzerTests.cs
@@ -93,7 +93,7 @@ public class TestMe
         [TestCase("DependencyPropertyChangedEventArgs e")]
         [TestCase("DependencyPropertyChangedEventArgs e, string a")]
         [TestCase("DependencyPropertyChangedEventArgs e0, DependencyPropertyChangedEventArgs e1")]
-        public void No_issue_is_reported_for_correctly_named_parameters_on_method_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_parameters_named_(string parameters) => No_issue_is_reported_for(@"
 using System;
 using System.Windows;
 
@@ -109,7 +109,7 @@ public class TestMe
         [TestCase("DependencyPropertyChangedEventArgs e")]
         [TestCase("DependencyPropertyChangedEventArgs e, string a")]
         [TestCase("DependencyPropertyChangedEventArgs e0, DependencyPropertyChangedEventArgs e1")]
-        public void No_issue_is_reported_for_correctly_named_parameters_on_local_function_(string parameters) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_parameters_named_(string parameters) => No_issue_is_reported_for(@"
 using System;
 using System.Windows;
 
@@ -135,7 +135,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_local_function_if_surrounding_method_contains_parameter_names() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_wrong_name_if_surrounding_method_contains_parameter_names() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -150,7 +150,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_local_function_if_surrounding_method_is_event_handling_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_wrong_name_if_surrounding_method_is_event_handling_method() => No_issue_is_reported_for(@"
 using System;
 using System.Windows;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1002_EventHandlingMethodParametersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1002_EventHandlingMethodParametersAnalyzerTests.cs
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_expected_name() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_expected_name() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_local_function_if_surrounding_method_contains_parameter_names() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_wrong_name_if_surrounding_method_contains_parameter_names() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -90,7 +90,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_sender() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_sender_with_wrong_name() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_sender_on_overridden_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_sender_with_wrong_name_on_overridden_method() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -112,7 +112,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_sender_on_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_sender_with_wrong_name_on_local_function() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -128,7 +128,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_EventArgs() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventArgs_with_wrong_name() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -139,7 +139,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_EventArgs_on_overridden_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventArgs_with_wrong_name_on_overridden_method() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -150,7 +150,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_correctly_named_EventArgs_on_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_EventArgs_with_expected_name_on_local_function() => An_issue_is_reported_for(@"
 
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1003_EventHandlingMethodNamePrefixAnalyzerTests.cs
@@ -23,7 +23,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_expected_name() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_expected_name() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_overridden_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overridden_method_with_wrong_name() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -59,7 +59,7 @@ public class TestMe : BaseClass
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_wrong_name() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -70,7 +70,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method_with_own_event_assignment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_wrong_name_and_own_event_assignment() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method_with_other_event_assignment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_wrong_name_and_other_event_assignment() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -107,7 +107,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method_with_other_event_assignment() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_expected_name_and_other_event_assignment() => No_issue_is_reported_for(@"
 
 using System;
 
@@ -129,7 +129,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method_with_underscore_inside_other_event_assignment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_wrong_name_containing_underscore_inside_other_event_assignment() => An_issue_is_reported_for(@"
 
 using System;
 
@@ -151,7 +151,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_local_function_with_other_event_assignment() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_with_wrong_name_and_other_event_assignment() => An_issue_is_reported_for(@"
 
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1004_EventNameSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1004_EventNameSuffixAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1004_EventNameSuffixAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_event() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -23,7 +23,7 @@ public class TestMe
 
         [TestCase("interface", "MyEvent")]
         [TestCase("class", "MyEvent")]
-        public void An_issue_is_reported_for_incorrectly_named_event_(string type, string eventName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_with_wrong_name_(string type, string eventName) => An_issue_is_reported_for(@"
 using System;
 
 public " + type + @" TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1005_EventArgsLocalVariableAnalyzerTests.cs
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_EventArgs_variable_with_correct_name_([Values("e", "args")] string variableName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_EventArgs_variable_named_([Values("e", "args")] string variableName) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -50,7 +50,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_var_EventArgs_variable_with_correct_name_([Values("e", "args")] string variableName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_var_EventArgs_variable_named_([Values("e", "args")] string variableName) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_EventArgs_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_EventArgs_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -76,7 +76,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_EventArgs_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_var_EventArgs_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -89,7 +89,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_inherited_EventArgs_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_inherited_EventArgs_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -104,7 +104,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_inherited_EventArgs_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_var_inherited_EventArgs_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -119,7 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_field_with_incorrect_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_with_wrong_name() => No_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -135,7 +135,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_EventArgs_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_EventArgs_variable_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -154,7 +154,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_EventArgs_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_EventArgs_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -173,7 +173,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_inherited_EventArgs_variable_with_incorrect_name_and_Parameter_named_e() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_var_inherited_EventArgs_variable_with_wrong_name_and_Parameter_named_e() => An_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1006_EventArgsTypeUsageAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1006_EventArgsTypeUsageAnalyzerTests.cs
@@ -194,7 +194,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_event_with_generic_EventHandler_using_correct_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_with_generic_EventHandler_using_expected_EventArgs() => No_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }
@@ -218,7 +218,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_event_with_generic_EventHandler_using_incorrect_EventArgs() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_with_generic_EventHandler_using_different_EventArgs() => An_issue_is_reported_for(@"
 using System;
 
 public class MyEventArgs : EventArgs { }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1011_DoMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1011_DoMethodsAnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices")]
         [TestCase("Dogfood")]
         [TestCase("DontShowAgainCheckBox")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -60,7 +60,7 @@ public class TestMe
         [TestCase("CallsDownloadWorkflowForMultipleParameterDownloadDevices")]
         [TestCase("Dogfood")]
         [TestCase("DontShowAgainCheckBox")]
-        public void No_issue_is_reported_for_correctly_named_local_function_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()
@@ -119,7 +119,7 @@ public class TestMe
         [TestCase("DoDownload")]
         [TestCase("DoWhatever")]
         [TestCase("IsDoDown")]
-        public void An_issue_is_reported_for_wrong_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -146,7 +146,7 @@ public class TestMe
         [TestCase("DoDownload")]
         [TestCase("DoWhatever")]
         [TestCase("IsDoDown")]
-        public void An_issue_is_reported_for_wrong_named_local_function_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1012_FireMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1012_FireMethodsAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("Raise")]
         [TestCase("Firewall")]
         [TestCase("_firewall")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -26,7 +26,7 @@ public class TestMe
         [TestCase("Raise")]
         [TestCase("Firewall")]
         [TestCase("_firewall")]
-        public void No_issue_is_reported_for_correctly_named_local_function_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void SomeMethod()
@@ -42,7 +42,7 @@ public class TestMe
         [TestCase("IsFiringSomething")]
         [TestCase("_fire")]
         [TestCase("_firing")]
-        public void An_issue_is_reported_for_wrong_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -55,7 +55,7 @@ public class TestMe
         [TestCase("IsFiringSomething")]
         [TestCase("_fire")]
         [TestCase("_firing")]
-        public void An_issue_is_reported_for_wrong_named_local_function_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void SomeMethod()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1013_NotifyMethodsAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("Raise")]
         [TestCase("OnSomething")]
         [TestCase("Notify")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -26,7 +26,7 @@ public class TestMe
         [TestCase("Raise")]
         [TestCase("OnSomething")]
         [TestCase("Notify")]
-        public void No_issue_is_reported_for_correctly_named_local_function_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()
@@ -39,7 +39,7 @@ public class TestMe
         [TestCase("NotifySomething")]
         [TestCase("OnNotify")]
         [TestCase("OnNotifySomething")]
-        public void An_issue_is_reported_for_wrong_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -49,7 +49,7 @@ public class TestMe
         [TestCase("NotifySomething")]
         [TestCase("OnNotify")]
         [TestCase("OnNotifySomething")]
-        public void An_issue_is_reported_for_wrong_named_local_function_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1014_CheckMethodsAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("CheckIn")]
         [TestCase("CheckOut")]
         [TestCase("CheckAccess")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -26,7 +26,7 @@ public class TestMe
         [TestCase("CheckIn")]
         [TestCase("CheckOut")]
         [TestCase("CheckAccess")]
-        public void No_issue_is_reported_for_correctly_named_local_function_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()
@@ -41,7 +41,7 @@ public class TestMe
         [TestCase("CheckConnection")]
         [TestCase("CheckOnline")]
         [TestCase("Check")]
-        public void An_issue_is_reported_for_wrong_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -53,7 +53,7 @@ public class TestMe
         [TestCase("CheckConnection")]
         [TestCase("CheckOnline")]
         [TestCase("Check")]
-        public void An_issue_is_reported_for_wrong_named_local_function_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1015_InitMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1015_InitMethodsAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("DoSomething")]
         [TestCase("Initialize")]
         [TestCase("InitializeSomething")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -24,7 +24,7 @@ public class TestMe
         [TestCase("DoSomething")]
         [TestCase("Initialize")]
         [TestCase("InitializeSomething")]
-        public void No_issue_is_reported_for_correctly_named_local_function_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()
@@ -37,7 +37,7 @@ public class TestMe
         [TestCase("Init")]
         [TestCase("Init2")]
         [TestCase("InitSomething")]
-        public void An_issue_is_reported_for_wrong_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -47,7 +47,7 @@ public class TestMe
         [TestCase("Init")]
         [TestCase("Init2")]
         [TestCase("InitSomething")]
-        public void An_issue_is_reported_for_wrong_named_local_function_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void Something()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1016_FactoryMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1016_FactoryMethodsAnalyzerTests.cs
@@ -79,7 +79,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_factory_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_factory_method_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMeFactory
@@ -109,7 +109,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_factory_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_factory_method_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMeFactory
@@ -119,7 +119,7 @@ public class TestMeFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_but_overridden_factory_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_overridden_factory_method_with_wrong_name() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMeFactory : BaseFactory
@@ -129,7 +129,7 @@ public class TestMeFactory : BaseFactory
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_local_function_inside_factory_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_with_wrong_name_inside_factory_method() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMeFactory

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1037_TypeSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1037_TypeSuffixAnalyzerTests.cs
@@ -20,14 +20,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] AllowedEnumNames = ["Interface", "Class"];
 
         [Test]
-        public void No_issue_is_reported_for_correct_name_on_enum() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_expected_name_on_enum() => No_issue_is_reported_for(@"
 public enum TestMe
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_name_on_([ValueSource(nameof(NonEnumTypes))] string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_expected_name_on_([ValueSource(nameof(NonEnumTypes))] string type) => No_issue_is_reported_for(@"
 public " + type + @" TestMe
 {
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1038_ExtensionMethodsClassSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1038_ExtensionMethodsClassSuffixAnalyzerTests.cs
@@ -46,7 +46,7 @@ public static class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_extension_class_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_class_with_expected_name() => No_issue_is_reported_for(@"
 public static class TestMeExtensions
 {
     public static void DoSomething(this int value) { }
@@ -54,7 +54,7 @@ public static class TestMeExtensions
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_class_with_incorrect_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_class_named_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 public static class " + name + @"
 {
     public static void DoSomething(this int value) { }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1039_ExtensionMethodsParameterAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_normal_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_plain_method() => No_issue_is_reported_for(@"
 public static class TestMe
 {
     public static void DoSomething(int i) { }
@@ -34,7 +34,7 @@ public static class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_extension_method_with_correct_parameter_name_([ValueSource(nameof(CorrectParameterNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_method_with_parameter_named_([ValueSource(nameof(CorrectParameterNames))] string name) => No_issue_is_reported_for(@"
 public static class TestMeExtensions
 {
     public static void DoSomething(this int " + name + @") { }
@@ -42,10 +42,10 @@ public static class TestMeExtensions
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_extension_method_with_correct_parameter_name_(
-                                                                                       [ValueSource(nameof(ConversionMethodPrefixes))] string prefix,
-                                                                                       [Values("Something", "")] string methodName,
-                                                                                       [ValueSource(nameof(CorrectConversionParameterNames))] string name)
+        public void No_issue_is_reported_for_extension_method_conversion_with_parameter_named_(
+                                                                                           [ValueSource(nameof(ConversionMethodPrefixes))] string prefix,
+                                                                                           [Values("Something", "")] string methodName,
+                                                                                           [ValueSource(nameof(CorrectConversionParameterNames))] string name)
             => No_issue_is_reported_for(@"
 public static class TestMeExtensions
 {
@@ -62,7 +62,7 @@ public static class TestMeExtensions
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_method_with_incorrect_parameter_name_([ValueSource(nameof(WrongParameterNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_method_with_parameter_named_([ValueSource(nameof(WrongParameterNames))] string name) => An_issue_is_reported_for(@"
 public static class TestMeExtensions
 {
     public static void DoSomething(this int " + name + @") { }
@@ -70,10 +70,10 @@ public static class TestMeExtensions
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_extension_method_with_incorrect_parameter_name_(
-                                                                                         [ValueSource(nameof(ConversionMethodPrefixes))] string prefix,
-                                                                                         [Values("Something", "2D", "")] string methodName,
-                                                                                         [ValueSource(nameof(WrongConversionParameterNames))] string name)
+        public void An_issue_is_reported_for_extension_method_with_parameter_named_(
+                                                                                [ValueSource(nameof(ConversionMethodPrefixes))] string prefix,
+                                                                                [Values("Something", "2D", "")] string methodName,
+                                                                                [ValueSource(nameof(WrongConversionParameterNames))] string name)
             => An_issue_is_reported_for(@"
 public static class TestMeExtensions
 {
@@ -98,7 +98,7 @@ public static class TestMeExtensions
         }
 
         [Test]
-        public void Code_gets_fixed_for_normal_parameter()
+        public void Code_gets_fixed_for_plain_parameter()
         {
             const string Template = @"
 public static class TestMeExtensions

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1040_ParameterCollectionSuffixAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("IDictionary<string,string> dictionary")]
         [TestCase("Dictionary<string,int> requiredValuesByFeatureId")]
         [TestCase("IReadOnlyDictionary<string,int> requiredValuesByFeatureId")]
-        public void No_issue_is_reported_for_correctly_named_parameter_(string parameter) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_named_(string parameter) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -55,7 +55,7 @@ public class TestMe
         [TestCase("XmlNode node")]
         [TestCase("XNode myNode")]
         [TestCase("XNode node")]
-        public void No_issue_is_reported_for_correctly_named_XML_parameter_(string parameter) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_parameter_named_(string parameter) => No_issue_is_reported_for(@"
 using System;
 using System.Xml;
 using System.Xml.Linq;
@@ -68,7 +68,7 @@ public class TestMe
 ");
 
         [Test] // this situation is covered by CA 1725 so we do not report that as well
-        public void No_issue_is_reported_for_incorrectly_named_parameter_of_method_that_implements_interface() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_with_collection_suffix_on_method_that_implements_interface() => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 
@@ -217,7 +217,7 @@ public class TestMe
         [TestCase("string blaDictionary")]
         [TestCase("string blaDict")]
         [TestCase("string blaDic")]
-        public void An_issue_is_reported_for_incorrectly_named_parameter_(string parameter) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_named_(string parameter) => An_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1041_FieldCollectionSuffixAnalyzerTests.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly TestCaseData[] CodeFixData = [.. CreateCodeFixData()];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_with_expected_name() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -57,7 +57,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue", "replacementMap")] string field)
+        public void No_issue_is_reported_for_field_named_([ValueSource(nameof(FieldPrefixes))] string prefix, [Values("dictionary", "map", "array", "value", "myValue", "replacementMap")] string field)
             => No_issue_is_reported_for(@"
 
 public class TestMe
@@ -71,7 +71,7 @@ public class TestMe
         [TestCase("blaObservableCollection")]
         [TestCase("blaArray")]
         [TestCase("blaHashSet")]
-        public void No_issue_is_reported_for_incorrectly_named_field_in_enum_(string field) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_with_collection_suffix_in_enum_(string field) => No_issue_is_reported_for(@"
 
 public enum TestMe
 {
@@ -95,7 +95,7 @@ public enum TestMe
         [TestCase("XmlNode node")]
         [TestCase("XNode myNode")]
         [TestCase("XNode node")]
-        public void No_issue_is_reported_for_correctly_named_XML_field_(string field) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_XML_field_named_(string field) => No_issue_is_reported_for(@"
 using System;
 using System.Xml;
 using System.Xml.Linq;
@@ -179,7 +179,7 @@ public class TestMe
         [TestCase("string blaDictionary")]
         [TestCase("string blaDict")]
         [TestCase("string blaDic")]
-        public void An_issue_is_reported_for_incorrectly_named_field_(string field) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_named_(string field) => An_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1042_CancellationTokenParameterNameAnalyzerTests.cs
@@ -43,7 +43,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_CancellationToken_parameter_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_CancellationToken_parameter_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1043_CancellationTokenLocalVariableAnalyzerTests.cs
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_CancellationToken_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_CancellationToken_variable_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -51,7 +51,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_var_CancellationToken_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_var_CancellationToken_variable_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -65,7 +65,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_CancellationToken_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_CancellationToken_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -79,7 +79,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_var_CancellationToken_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_var_CancellationToken_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -93,7 +93,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_field_with_incorrect_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_with_wrong_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -108,7 +108,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_CancellationToken_variable_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_variable_declaration_pattern_for_CancellationToken_variable_with_expected_name() => No_issue_is_reported_for(@"
 using System;
 using System.Threading;
 
@@ -126,7 +126,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_CancellationToken_variable_with_incorrect_name() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_variable_declaration_pattern_for_CancellationToken_variable_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Threading;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1044_CommandSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1044_CommandSuffixAnalyzerTests.cs
@@ -87,7 +87,7 @@ public class TestMe
         [TestCase("m_command")]
         [TestCase("_myCommand")]
         [TestCase("m_myCommand")]
-        public void No_issue_is_reported_for_correctly_named_command_field_(string fieldName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_command_field_named_(string fieldName) => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -140,7 +140,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_class_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -155,7 +155,7 @@ public class TestMe : ICommand
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_interface() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_interface_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -165,7 +165,7 @@ public interface ITestMe : ICommand
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_method_with_wrong_name() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -176,7 +176,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_property_named_Bla() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -187,7 +187,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_field() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_field_named_m_bla() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1045_CommandInvokeMethodsSuffixAnalyzerTests.cs
@@ -25,7 +25,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_command_methods() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_command_method_invoked_with_matching_method_name() => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -52,7 +52,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_command_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_command_local_function_invoked_with_Core_suffixed_name() => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -81,7 +81,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_methods() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_method_invoked_with_non_matching_method_name() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 
@@ -110,7 +110,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_command_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_command_local_function_invoked_with_non_matching_function_name() => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Input;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1046_AsyncMethodsSuffixAnalyzerTests.cs
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -47,7 +47,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_core_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_core_method_with_AsyncCore_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -67,7 +67,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -77,7 +77,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_core_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_core_method_with_AsyncCore_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -122,7 +122,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -135,7 +135,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -148,7 +148,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_local_function_inside_test_method_([ValueSource(nameof(TestFixtures))] string fixture, [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_Task_local_function_with_Async_suffix_inside_test_method_([ValueSource(nameof(TestFixtures))] string fixture, [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 using NUnit;
 using System.Threading.Tasks;
@@ -182,7 +182,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_async_void_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_void_method_without_Async_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -192,7 +192,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_Task_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Task_method_without_Async_suffix() => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -202,7 +202,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_async_void_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_async_void_local_function_without_Async_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -215,7 +215,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_Task_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Task_local_function_without_Async_suffix() => An_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -228,7 +228,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_correctly_named_local_function_inside_test_method_([ValueSource(nameof(TestFixtures))] string fixture, [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_Task_local_function_without_Async_suffix_inside_test_method_([ValueSource(nameof(TestFixtures))] string fixture, [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 using NUnit;
 using System.Threading.Tasks;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1047_NonAsyncMethodsButAsyncSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1047_NonAsyncMethodsButAsyncSuffixAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1047_NonAsyncMethodsButAsyncSuffixAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_non_async_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_async_method_without_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -22,7 +22,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_non_async_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_async_local_function_without_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -45,7 +45,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_async_void_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_async_void_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_method_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -68,7 +68,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_Task_local_function() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Task_local_function_with_Async_suffix() => No_issue_is_reported_for(@"
 using System.Threading.Tasks;
 
 public class TestMe
@@ -81,7 +81,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_non_async_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_async_method_with_Async_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -91,7 +91,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_non_async_core_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_async_core_method_with_AsyncCore_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_non_async_local_function() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_async_local_function_with_Async_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1048_ValueConverterSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1048_ValueConverterSuffixAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_converter_class_([ValueSource(nameof(ConverterInterfaces))] string interfaceName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_converter_class_with_Converter_suffix_([ValueSource(nameof(ConverterInterfaces))] string interfaceName) => No_issue_is_reported_for(@"
 using System;
 using System.Windows.Data;
 
@@ -39,7 +39,7 @@ public class TestMeConverter : " + interfaceName + @"
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_converter_class_([ValueSource(nameof(ConverterInterfaces))] string interfaceName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_converter_class_without_Converter_suffix_([ValueSource(nameof(ConverterInterfaces))] string interfaceName) => An_issue_is_reported_for(@"
 using System;
 using System.Windows.Data;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1049_RequirementTermAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1049_RequirementTermAnalyzerTests.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] Marker = ["Must", "Need", "Shall", "Should", "Will", "Would"];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_symbols() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_symbols_without_requirement_term() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -33,7 +33,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method_([Values("RefreshAllChildren", "CreateShallowCopy", "NeedsLicense", "Something_needs_license")] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_that_only_contains_requirement_term_as_part_of_a_longer_word_([Values("RefreshAllChildren", "CreateShallowCopy", "NeedsLicense", "Something_needs_license")] string methodName) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -45,7 +45,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_type_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_prefixed_with_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class " + marker + @"TestMe
@@ -54,7 +54,7 @@ public class " + marker + @"TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_field_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_containing_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -64,7 +64,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_const_field_([ValueSource(nameof(Marker))] string marker) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_const_field_containing_requirement_term_([ValueSource(nameof(Marker))] string marker) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_event_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_containing_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -84,7 +84,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_property_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_prefixed_with_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -94,7 +94,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_prefixed_with_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -104,7 +104,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_local_function_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_prefixed_with_requirement_term_([ValueSource(nameof(Marker))] string marker) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1051_DelegateParameterNameSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1051_DelegateParameterNameSuffixAnalyzerTests.cs
@@ -66,9 +66,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correct_parameter_name_(
-                                                                 [ValueSource(nameof(DelegateTypes))] string type,
-                                                                 [ValueSource(nameof(CorrectDelegateNames))] string name)
+        public void No_issue_is_reported_for_delegate_parameter_with_suffix_(
+                                                                         [ValueSource(nameof(DelegateTypes))] string type,
+                                                                         [ValueSource(nameof(CorrectDelegateNames))] string name)
             => No_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1052_DelegateLocalVariableNameSuffixAnalyzerTests.cs
@@ -65,9 +65,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correct_variable_name_(
-                                                                [ValueSource(nameof(DelegateTypes))] string type,
-                                                                [ValueSource(nameof(CorrectDelegateNames))] string name)
+        public void No_issue_is_reported_for_delegate_local_variable_with_suffix_(
+                                                                              [ValueSource(nameof(DelegateTypes))] string type,
+                                                                              [ValueSource(nameof(CorrectDelegateNames))] string name)
             => No_issue_is_reported_for(@"
 using System;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1053_DelegateFieldNameSuffixAnalyzerTests.cs
@@ -60,10 +60,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_correct_field_name_(
-                                                             [ValueSource(nameof(DelegateTypes))] string type,
-                                                             [ValueSource(nameof(FieldPrefixes))] string prefix,
-                                                             [ValueSource(nameof(CorrectDelegateNames))] string name)
+        public void No_issue_is_reported_for_delegate_field_with_suffix_(
+                                                                     [ValueSource(nameof(DelegateTypes))] string type,
+                                                                     [ValueSource(nameof(FieldPrefixes))] string prefix,
+                                                                     [ValueSource(nameof(CorrectDelegateNames))] string name)
         {
             var code = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1054_HelperClassNameAnalyzerTests.cs
@@ -31,7 +31,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] CorrectNames = ["TestMe", "OnlineHelp", "SoftwareUtilization"];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_helper_term_in_name_([ValueSource(nameof(CorrectNames))] string name) => No_issue_is_reported_for(@"
 public class " + name + @"
 {
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1055_DependencyPropertyFieldSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1055_DependencyPropertyFieldSuffixAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyProperty_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_with_Property_suffix() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -38,7 +38,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyProperty_field() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyProperty_field_without_Property_suffix() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1056_DependencyPropertyFieldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1056_DependencyPropertyFieldPrefixAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_unassigned_correctly_named_DependencyProperty_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unassigned_DependencyProperty_field_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -40,7 +40,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyProperty_field_with_nameof() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_registered_with_nameof_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -55,7 +55,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyProperty_field_with_string() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_registered_with_string_literal_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -70,7 +70,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyProperty_field_for_DependencyPropertyKey() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyProperty_field_matching_its_DependencyPropertyKey_field() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -120,7 +120,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyProperty_field_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
+        public void An_issue_is_reported_for_DependencyProperty_field_not_matching_registered_property_name_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
             => An_issue_is_reported_for(@"
 using System.Windows;
 
@@ -136,7 +136,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_DependencyProperty_field_if_class_has_no_properties_(
+        public void No_issue_is_reported_for_DependencyProperty_field_not_matching_any_property_when_class_has_no_properties_(
                                                                                            [Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
             => No_issue_is_reported_for(@"
 using System.Windows;
@@ -151,7 +151,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyProperty_field_with_nameof() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyProperty_field_registered_with_nameof_of_different_property() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -167,7 +167,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyProperty_field_with_string() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyProperty_field_registered_with_string_literal_of_different_property() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1057_DependencyPropertyKeyFieldSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1057_DependencyPropertyKeyFieldSuffixAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyPropertyKey_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyPropertyKey_field_with_Key_suffix() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -38,7 +38,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyPropertyKey_field_without_Key_suffix() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1058_DependencyPropertyKeyFieldPrefixAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_unassigned_DependencyPropertyKey_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unassigned_DependencyPropertyKey_field_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -40,7 +40,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyPropertyKey_field_with_nameof() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyPropertyKey_field_registered_with_nameof_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -55,7 +55,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_DependencyPropertyKey_field_with_string() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_DependencyPropertyKey_field_registered_with_string_literal_matching_property_name() => No_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -105,7 +105,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyPropertyKey_field_with_extra_Property_suffix() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -120,7 +120,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
+        public void An_issue_is_reported_for_DependencyPropertyKey_field_not_matching_registered_property_name_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
             => An_issue_is_reported_for(@"
 using System.Windows;
 
@@ -136,7 +136,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field_if_class_has_no_properties_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
+        public void No_issue_is_reported_for_DependencyPropertyKey_field_not_matching_any_property_when_class_has_no_properties_([Values("m_field", "m_fieldKey", "m_fieldProperty", "Field", "FieldKey", "FieldProperty")] string fieldName)
             => No_issue_is_reported_for(@"
 using System.Windows;
 
@@ -150,7 +150,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field_with_nameof() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyPropertyKey_field_registered_with_nameof_of_different_property() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla
@@ -166,7 +166,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_DependencyPropertyKey_field_with_string() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_DependencyPropertyKey_field_registered_with_string_literal_of_different_property() => An_issue_is_reported_for(@"
 using System.Windows;
 
 namespace Bla

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1059_ImplClassNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1059_ImplClassNameAnalyzerTests.cs
@@ -25,7 +25,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] WrongNames = CreateWrongNames(WrongSuffixes);
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_impl_suffix() => No_issue_is_reported_for(@"
 public class TestMe
 {
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1060_UseNotFoundInsteadOfMissingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1060_UseNotFoundInsteadOfMissingAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1060_UseNotFoundInsteadOfMissingAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_normal_type() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_non_exception_type() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -27,7 +27,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_exception() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_exception_with_NotFound_suffix() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -42,7 +42,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_enum_member() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_enum_member_named_NotFound() => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla
@@ -57,7 +57,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_exception_([Values("TestMeMissingException", "GetTestMeFailedException")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_exception_using_Missing_or_Failed_term_([Values("TestMeMissingException", "GetTestMeFailedException")] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class " + name + @" : Exception
@@ -69,7 +69,7 @@ public class " + name + @" : Exception
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_enum_member_([Values("Missing", "GetFailed")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_enum_member_using_Missing_or_Failed_term_([Values("Missing", "GetFailed")] string name) => An_issue_is_reported_for(@"
 using System;
 
 public enum TestMe
@@ -81,7 +81,7 @@ public enum TestMe
 
         [TestCase("TestMeMissingException", "TestMeNotFoundException")]
         [TestCase("GetTestMeFailedException", "TestMeNotFoundException")]
-        public void Code_gets_fixed_for_incorrectly_named_exception_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_exception_using_Missing_or_Failed_term_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;
@@ -99,7 +99,7 @@ public class ### : Exception
 
         [TestCase("SomethingMissing", "SomethingNotFound")]
         [TestCase("GetSomethingFailed", "SomethingNotFound")]
-        public void Code_gets_fixed_for_incorrectly_named_enum_member_(string originalName, string fixedName)
+        public void Code_gets_fixed_for_enum_member_using_Missing_or_Failed_term_(string originalName, string fixedName)
         {
             const string Template = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1061_TryMethodOutParameterNameAnalyzerTests.cs
@@ -56,7 +56,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_Try_method_with_correctly_named_out_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Try_method_with_out_parameter_named_result() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_TryGet_method_with_correctly_named_out_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_TryGet_method_with_out_parameter_named_after_get_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -101,7 +101,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_Try_method_with_incorrectly_named_out_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Try_method_with_out_parameter_named_i() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -119,7 +119,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_TryGet_method_with_incorrectly_named_out_parameter() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_TryGet_method_with_out_parameter_named_i() => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -131,7 +131,7 @@ public class TestMe
         [TestCase("class TestMe { void TryGetWhatever(out int i) { } }", "class TestMe { void TryGetWhatever(out int whatever) { } }")]
         [TestCase("class TestMe { void TryParse(out int i) { } }", "class TestMe { void TryParse(out int result) { } }")]
         [TestCase("class TestMe { void TryGetObject(out object o) { } }", "class TestMe { void TryGetObject(out object result) { } }")]
-        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+        public void Code_gets_fixed_for_out_parameter_of_Try_method(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         protected override string GetDiagnosticId() => MiKo_1061_TryMethodOutParameterNameAnalyzer.Id;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1062_IsDetectionNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1062_IsDetectionNameAnalyzerTests.cs
@@ -24,7 +24,7 @@ public class TestMe
         [TestCase("CanSomethingThatFits")]
         [TestCase("HasSomethingThatFits")]
         [TestCase("ContainsSomethingStillFitting")]
-        public void No_issue_is_reported_for_correctly_named_method_(string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_(string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool " + methodName + @"() => true;
@@ -34,7 +34,7 @@ public class TestMe
         [TestCase("CanSomethingThatNotFits")]
         [TestCase("HasSomethingThatNotFits")]
         [TestCase("ContainsSomethingNotFittingAnymore")]
-        public void An_issue_is_reported_for_incorrectly_named_method_(string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_containing_negation_word_(string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public bool " + methodName + @"() => true;
@@ -55,7 +55,7 @@ public class TestMe
         [TestCase("CanSomethingFitting")]
         [TestCase("HasSomethingFitting")]
         [TestCase("ContainsSomethingFitting")]
-        public void No_issue_is_reported_for_correctly_named_property_(string propertyName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_named_(string propertyName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public bool " + propertyName + @" { get; set; }
@@ -65,7 +65,7 @@ public class TestMe
         [TestCase("CanSomethingNotFitting")]
         [TestCase("HasSomethingNotFitting")]
         [TestCase("ContainsSomethingNotFitting")]
-        public void An_issue_is_reported_for_incorrectly_named_property_(string propertyName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_named_(string propertyName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public bool " + propertyName + @" { get; set; }
@@ -75,7 +75,7 @@ public class TestMe
         [TestCase("CanSomething")]
         [TestCase("HasSomething")]
         [TestCase("ContainsSomething")]
-        public void No_issue_is_reported_for_correctly_named_field_(string fieldName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_named_(string fieldName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     private bool m_" + fieldName + @";
@@ -85,7 +85,7 @@ public class TestMe
         [TestCase("CanSomethingNotFitting")]
         [TestCase("HasSomethingNotFitting")]
         [TestCase("ContainsSomethingNotFitting")]
-        public void An_issue_is_reported_for_incorrectly_named_field_(string fieldName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_field_named_(string fieldName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     private bool m_" + fieldName + @";

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1064_ParameterNameMeaningAnalyzerTests.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1064_ParameterNameMeaningAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_with_meaningful_name() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething(TestMe culprit)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1065_OperatorParameterNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1065_OperatorParameterNameAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1065_OperatorParameterNameAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_unary_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_unary_operator_parameter_named_value() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static implicit operator string(TestMe value) => ""bla"";
@@ -28,7 +28,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_binary_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_binary_operator_parameters_named_left_and_right() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public static bool operator !=(TestMe left, TestMe right)  => false;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1066_CtorParametersNamedAsAssignedPropertiesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1066_CtorParametersNamedAsAssignedPropertiesAnalyzerTests.cs
@@ -17,7 +17,7 @@ public sealed record TestMe(int X, int Y, double Distance);
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ctor_parameter_named_after_assigned_property() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public TestMe(int someProperty) => SomeProperty = someProperty;
@@ -27,7 +27,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameters() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_ctor_parameters_each_named_after_assigned_property() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public TestMe(int someProperty1, double someProperty2, string someProperty3)

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1067_PerformMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1067_PerformMethodsAnalyzerTests.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                         ];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_method_([ValueSource(nameof(AllowedNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_named_([ValueSource(nameof(AllowedNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -35,7 +35,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_local_function_([ValueSource(nameof(AllowedNames))] string methodName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_local_function_named_([ValueSource(nameof(AllowedNames))] string methodName) => No_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()
@@ -46,7 +46,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_named_method_([ValueSource(nameof(WrongNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_([ValueSource(nameof(WrongNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void " + methodName + @"() { }
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_named_local_function_([ValueSource(nameof(WrongNames))] string methodName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_function_named_([ValueSource(nameof(WrongNames))] string methodName) => An_issue_is_reported_for(@"
 public class TestMe
 {
     public void DoSomething()

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1069_PropertyNameMeaningAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1069_PropertyNameMeaningAnalyzerTests.cs
@@ -20,7 +20,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_property() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_meaningful_name() => No_issue_is_reported_for(@"
 public class TestMe
 {
     public int X { get; set; }
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_property_with_exact_same_name_as_interface() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_named_exactly_like_its_interface_type() => An_issue_is_reported_for(@"
 
 public interface ISomeInterface
 
@@ -52,7 +52,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_property_without_interface_prefix_I() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_named_like_interface_type_without_leading_I() => An_issue_is_reported_for(@"
 
 public interface ISomeInterfaceExtended
 
@@ -63,7 +63,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_getter_only_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_getter_only_property_named_like_interface_type_without_leading_I() => An_issue_is_reported_for(@"
 
 public interface ISomeInterfaceExtended
 
@@ -74,7 +74,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_setter_only_property() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_setter_only_property_named_like_interface_type_without_leading_I() => An_issue_is_reported_for(@"
 
 public interface ISomeInterfaceExtended
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1074_LockIdentifiersAreSuffixedWithLockAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1074_LockIdentifiersAreSuffixedWithLockAnalyzerTests.cs
@@ -20,7 +20,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_lock_([Values("syncRoot", "MyLock")] string lockName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_lock_object_named_([Values("syncRoot", "MyLock")] string lockName) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_lock() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_lock_object_without_Lock_suffix_or_syncRoot_name() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1075_TypesSuffixedWithEventArgsInheritFromEventArgsAnalyzerTests.cs
@@ -42,7 +42,7 @@ public class TestMeEventArgs : EventArgs
         [TestCase("MyEventsArg")]
         [TestCase("MyEventArgs")]
         [TestCase("MyEventsArgs")]
-        public void An_issue_is_reported_for_non_EventArgs_type_incorrectly_named_(string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_non_EventArgs_type_named_(string name) => An_issue_is_reported_for(@"
 using System;
 
 public class " + name + @"
@@ -54,7 +54,7 @@ public class " + name + @"
         [TestCase("MyEventsArg")]
         [TestCase("MyEventArgs")]
         [TestCase("MyEventsArgs")]
-        public void An_issue_is_reported_for_Prism_event_type_incorrectly_named_(string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Prism_event_type_named_(string name) => An_issue_is_reported_for(@"
 
 namespace Microsoft.Practices.Prism.Events
 {
@@ -73,7 +73,7 @@ namespace MyNamespace
 
         [TestCase("using System; class TestMeEventArg { }", "using System; class TestMe { }")]
         [TestCase("using System; class TestMeEventArgs { }", "using System; class TestMe { }")]
-        public void Code_gets_fixed_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
+        public void Code_gets_fixed_for_(string originalCode, string fixedCode) => VerifyCSharpFix(originalCode, fixedCode);
 
         [TestCase("TestMeEventArg", "TestMeEvent")]
         [TestCase("TestMeEventsArg", "TestMeEvent")]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1076_PrismEventTypeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1076_PrismEventTypeAnalyzerTests.cs
@@ -21,7 +21,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_EventArgs() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_Prism_event_type_with_Event_suffix() => No_issue_is_reported_for(@"
 
 namespace Microsoft.Practices.Prism.Events
 {
@@ -39,7 +39,7 @@ namespace MyNamespace
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_EventArgs() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_Prism_event_type_with_EventArgs_suffix() => An_issue_is_reported_for(@"
 
 namespace Microsoft.Practices.Prism.Events
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1078_BuilderMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1078_BuilderMethodsAnalyzerTests.cs
@@ -43,7 +43,7 @@ public class TestMeBuilder
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_builder_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_builder_method_with_Build_prefix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMeBuilder
@@ -83,7 +83,7 @@ public class CreateTestMeBuilder
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_builder_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_builder_method_with_Create_prefix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMeBuilder

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1079_RepositorySuffixAnalyzerTests.cs
@@ -34,7 +34,7 @@ public class Repository
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_repository_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_Repository_suffix() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMeRepository

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1085_ParametersWithNumberSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1085_ParametersWithNumberSuffixAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_unfinished_parameter_in_code() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_missing_parameter_in_code() => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1087_CtorParameterNameAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1087_CtorParameterNameAnalyzerTests.cs
@@ -19,7 +19,7 @@ public sealed record TestMe(int X, int Y, double Distance);
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_ctor() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_derived_ctor_with_parameter_names_matching_base_ctor() => No_issue_is_reported_for(@"
 using System;
 
 public class BaseClass
@@ -46,7 +46,7 @@ public class ChildClass : BaseClass
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_ctor_when_multiple_ctors_are_available() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_derived_ctor_with_parameter_names_matching_one_of_multiple_base_ctors() => No_issue_is_reported_for(@"
 using System;
 
 public class BaseClass

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1089_GetByMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1089_GetByMethodsAnalyzerTests.cs
@@ -70,7 +70,7 @@ public static class TestMeExtensions
 ");
 
         [Test]
-        public void No_issue_is_reported_for_incorrectly_named_method_test_method() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_method_named_like_a_GetBy_violation() => No_issue_is_reported_for(@"
 using System;
 
 using NUnit;
@@ -85,7 +85,7 @@ public class TestMeRepository
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_method() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_named_like_a_GetBy_violation() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMeRepository

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1090_ParametersWrongSuffixedAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_properly_named_parameter_([Values("comparer", "view", "item", "entity", "oldView", "newView", "currentView", "xmlElement", "sourceView", "targetView", "sourceEntity", "targetEntity")] string name)
+        public void No_issue_is_reported_for_method_with_parameter_named_([Values("comparer", "view", "item", "entity", "oldView", "newView", "currentView", "xmlElement", "sourceView", "targetView", "sourceEntity", "targetEntity")] string name)
             => No_issue_is_reported_for(@"
 
 public class TestMe
@@ -39,7 +39,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_incorrectly_named_parameter_([Values("myComparer", "myView", "myItem", "myEntity", "myElement")] string name)
+        public void An_issue_is_reported_for_method_with_parameter_named_([Values("myComparer", "myView", "myItem", "myEntity", "myElement")] string name)
             => An_issue_is_reported_for(@"
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1091_VariableWrongSuffixedAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_properly_named_variable_([Values("comparer", "view", "item", "entity", "xmlElement", "oldView", "newView", "currentView", "sourceEntity", "targetEntity")] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_variable_without_suffix_([Values("comparer", "view", "item", "entity", "xmlElement", "oldView", "newView", "currentView", "sourceEntity", "targetEntity")] string name) => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -41,7 +41,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_method_with_properly_named_source_and_target_variable_([Values("Item", "View")] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_with_source_and_target_prefixed_variable_without_suffix_([Values("Item", "View")] string name) => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -54,7 +54,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_method_with_incorrectly_named_variable_([Values("myComparer", "myView", "myItem", "myEntity", "myElement")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_method_with_variable_prefixed_with_my_([Values("myComparer", "myView", "myItem", "myEntity", "myElement")] string name) => An_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1092_AbilityTypeWrongSuffixedAnalyzerTests.cs
@@ -22,7 +22,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                       ];
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_ability_type_wrong_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -30,7 +30,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_wrong_name_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_named_([ValueSource(nameof(WrongNames))] string name) => An_issue_is_reported_for(@"
 
 public class " + name + @"
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1093_ObjectSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1093_ObjectSuffixAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1093_ObjectSuffixAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_Object_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -28,7 +28,7 @@ public class MyObject
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_property() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_without_Object_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -46,7 +46,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_field() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_field_without_Object_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1094_NamespaceAsClassSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1094_NamespaceAsClassSuffixAnalyzerTests.cs
@@ -11,7 +11,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1094_NamespaceAsClassSuffixAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_namespace_like_suffix() => No_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -19,8 +19,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_type_with_wrong_name_([Values("Management", "Handling")] string suffix)
-            => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_type_named_([Values("Management", "Handling")] string suffix) => An_issue_is_reported_for(@"
 
 public class My" + suffix + @"
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1097_ParameterNameFollowsFieldNameSchemeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1097_ParameterNameFollowsFieldNameSchemeAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1097_ParameterNameFollowsFieldNameSchemeAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_parameter() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parameter_without_field_name_scheme_prefix() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1100_TestClassesPrefixAnalyzerTests.cs
@@ -46,7 +46,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_with_correct_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_class_with_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestMe
@@ -64,7 +64,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_type_starting_with_Testable_and_test_class_with_starting_with_correct_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_starting_with_Testable_and_test_class_with_starting_with_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestableTestMe
@@ -82,7 +82,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_of_generic_type_with_correct_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_class_of_generic_type_with_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class ATestMe<T>
@@ -100,7 +100,7 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_of_generic_type_and_where_clause_with_correct_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_class_of_generic_type_and_where_clause_with_prefix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class ATestMe
@@ -118,9 +118,9 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_of_generic_type_and_typed_where_clause_constraint_with_correct_prefix_(
-                                                                                                                           [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                                                           [Values("class", "struct")] string constraint)
+        public void No_issue_is_reported_for_test_class_of_generic_type_and_typed_where_clause_constraint_with_prefix_(
+                                                                                                                   [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                                                   [Values("class", "struct")] string constraint)
             => No_issue_is_reported_for(@"
 namespace Bla
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1101_TestClassesSuffixAnalyzerTests.cs
@@ -19,7 +19,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_with_correct_suffix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_test_class_with_suffix_([ValueSource(nameof(TestFixtures))]string fixture) => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMeTests
 {
@@ -28,7 +28,7 @@ public class TestMeTests
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_class_with_wrong_suffix_([ValueSource(nameof(TestFixtures))] string fixture) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_test_class_with_suffix_([ValueSource(nameof(TestFixtures))] string fixture) => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1102_TestMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1102_TestMethodsAnalyzerTests.cs
@@ -19,9 +19,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_without_Test_in_name_(
+                                                                           [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                           [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -32,9 +32,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_local_function_with_correct_name_inside_test_method_(
-                                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                              [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_local_function_without_Test_in_name_inside_test_method_(
+                                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                                 [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -48,9 +48,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_with_Test_in_name_(
+                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                        [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -61,9 +61,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_function_with_wrong_name_inside_test_method_(
-                                                                                            [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                            [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_local_function_with_Test_in_name_inside_test_method_(
+                                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                              [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1103_TestSetupMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1103_TestSetupMethodsAnalyzerTests.cs
@@ -45,9 +45,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_test_setup_method_with_correct_name_(
-                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                              [ValueSource(nameof(TestSetUps))] string test)
+        public void No_issue_is_reported_for_test_setup_method_named_(
+                                                                  [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                  [ValueSource(nameof(TestSetUps))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -73,9 +73,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_test_setup_method_with_wrong_name_(
-                                                                            [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                            [ValueSource(nameof(TestSetUps))] string test)
+        public void An_issue_is_reported_for_test_setup_method_named_(
+                                                                  [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                  [ValueSource(nameof(TestSetUps))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1104_TestTeardownMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1104_TestTeardownMethodsAnalyzerTests.cs
@@ -45,9 +45,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_test_teardown_method_with_correct_name_(
-                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                 [ValueSource(nameof(TestTearDowns))] string test)
+        public void No_issue_is_reported_for_test_teardown_method_named_(
+                                                                     [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                     [ValueSource(nameof(TestTearDowns))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -73,9 +73,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_teardown_method_with_wrong_name_(
-                                                                               [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                               [ValueSource(nameof(TestTearDowns))] string test)
+        public void An_issue_is_reported_for_test_teardown_method_named_(
+                                                                     [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                     [ValueSource(nameof(TestTearDowns))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1105_OneTimeTestSetupMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1105_OneTimeTestSetupMethodsAnalyzerTests.cs
@@ -71,9 +71,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_OneTimeSetUp_method_with_correct_name_(
-                                                                                [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
+        public void No_issue_is_reported_for_OneTimeSetUp_method_named_(
+                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                    [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -99,9 +99,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_OneTimeSetUp_method_with_wrong_name_(
-                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                              [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
+        public void An_issue_is_reported_for_OneTimeSetUp_method_named_(
+                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                    [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1106_OneTimeTestTeardownMethodsAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1106_OneTimeTestTeardownMethodsAnalyzerTests.cs
@@ -58,9 +58,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_OneTimeSetUp_method_with_correct_name_(
-                                                                                [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
+        public void No_issue_is_reported_for_OneTimeSetUp_method_named_(
+                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                    [ValueSource(nameof(TestOneTimeSetUps))] string oneTimeSetUp)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -71,9 +71,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_OneTimeTearDown_method_with_correct_name_(
-                                                                                   [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                   [ValueSource(nameof(TestOneTimeTearDowns))] string oneTimeTearDown)
+        public void No_issue_is_reported_for_OneTimeTearDown_method_named_(
+                                                                       [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                       [ValueSource(nameof(TestOneTimeTearDowns))] string oneTimeTearDown)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -99,9 +99,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_OneTimeTearDown_method_with_wrong_name_(
-                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                 [ValueSource(nameof(TestOneTimeTearDowns))] string oneTimeTearDown)
+        public void An_issue_is_reported_for_OneTimeTearDown_method_named_(
+                                                                       [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                       [ValueSource(nameof(TestOneTimeTearDowns))] string oneTimeTearDown)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1107_TestMethodsPascalCasingAnalyzerTests.cs
@@ -20,9 +20,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -34,9 +34,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_test_method_with_correct_upper_and_lower_case_name_(
-                                                                                             [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                             [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_with_upper_and_lower_case_name_(
+                                                                                     [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                     [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -63,10 +63,10 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test,
-                                                                      [Values("DoSomethingDoesSomething", "DoSomething_DoesSomething", "DoSomething_Expect_DoSomething")] string name)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test,
+                                                            [Values("DoSomethingDoesSomething", "DoSomething_DoesSomething", "DoSomething_Expect_DoSomething")] string name)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzerTests.cs
@@ -12,14 +12,14 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1109_TestableClassesShouldNotBeSuffixedWithUtAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_correctly_named_class() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_class_without_Ut_suffix() => No_issue_is_reported_for(@"
 public class TestMe
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_class() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_class_with_Ut_suffix() => An_issue_is_reported_for(@"
 public class TestMeUt
 {
 }

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1110_TestMethodsSuffixedWithUnderscoreAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1110_TestMethodsSuffixedWithUnderscoreAnalyzerTests.cs
@@ -22,9 +22,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_parameterless_test_method_with_correct_name_(
-                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                      [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_parameterless_test_method_named_(
+                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                          [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -36,9 +36,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_parameterized_test_method_with_correct_name_(
-                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                      [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_parameterized_test_method_named_(
+                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                          [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -65,9 +65,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1111_TestMethodsWithoutParametersNotSuffixedWithUnderscoreAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1111_TestMethodsWithoutParametersNotSuffixedWithUnderscoreAnalyzerTests.cs
@@ -22,9 +22,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_parameterless_test_method_with_correct_name_(
-                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                      [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_parameterless_test_method_named_(
+                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                          [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -36,9 +36,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void No_issue_is_reported_for_parameterized_test_method_with_correct_name_(
-                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                      [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_parameterized_test_method_named_(
+                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                          [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -65,9 +65,9 @@ public class TestMe
 ");
 
         [Test, Combinatorial]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1112_TestsShouldNotUseArbitraryIdentifiersAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_field_in_test_class_with_wrong_name_([ValueSource(nameof(TestFixtures))] string fixture)
+        public void An_issue_is_reported_for_field_in_test_class_named_([ValueSource(nameof(TestFixtures))] string fixture)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -37,7 +37,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_const_field_in_test_class_with_wrong_name_([ValueSource(nameof(TestFixtures))] string fixture)
+        public void An_issue_is_reported_for_const_field_in_test_class_named_([ValueSource(nameof(TestFixtures))] string fixture)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -48,7 +48,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_in_test_class_with_wrong_name_([ValueSource(nameof(TestFixtures))] string fixture)
+        public void An_issue_is_reported_for_property_in_test_class_named_([ValueSource(nameof(TestFixtures))] string fixture)
             => An_issue_is_reported_for(@"
 
 [" + fixture + @"]
@@ -59,9 +59,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_in_test_class_with_wrong_name_(
-                                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                    [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_in_test_class_named_(
+                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                          [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -72,9 +72,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_parameter_of_test_method_in_test_class_with_wrong_name_(
-                                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                                 [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_parameter_of_test_method_in_test_class_named_(
+                                                                                       [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                       [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -85,7 +85,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_parameter_of_test_method_in_non_test_class_with_wrong_name_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parameter_of_test_method_in_non_test_class_named_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -95,9 +95,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_const_in_test_method_in_test_class_with_wrong_name_(
-                                                                                             [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                             [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_const_in_test_method_in_test_class_named_(
+                                                                                   [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                   [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -111,7 +111,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_const_in_test_method_in_non_test_class_with_wrong_name_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_const_in_test_method_in_non_test_class_named_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
 
 public class TestMe
 {
@@ -124,9 +124,9 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_variable_in_test_method_in_test_class_with_wrong_name_(
-                                                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_local_variable_in_test_method_in_test_class_named_(
+                                                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -140,7 +140,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_local_variable_in_test_method_in_non_test_class_with_wrong_name_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_local_variable_in_test_method_in_non_test_class_named_([ValueSource(nameof(Tests))] string test) => An_issue_is_reported_for(@"
 
 public class TestMe
 {

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1113_TestMethodsShouldNotBeNamedGivenWhenThenAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1113_TestMethodsShouldNotBeNamedGivenWhenThenAnalyzerTests.cs
@@ -27,10 +27,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             ];
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(AcceptedMethodNames))] string methodName,
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(AcceptedMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -41,10 +41,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(WrongMethodNames))] string methodName,
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(WrongMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1114_TestMethodsShouldNotBeNamedBadOrHappyPathAnalyzerTests.cs
@@ -38,10 +38,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                             ];
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(AcceptedMethodNames))] string methodName,
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(AcceptedMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -52,10 +52,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(WrongMethodNames))] string methodName,
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(WrongMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1115_TestMethodsShouldNotBeNamedScenarioExpectedOutcomeAnalyzerTests.cs
@@ -39,10 +39,10 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(CorrectMethodNames))] string methodName,
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(CorrectMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
         => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -53,10 +53,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(WrongMethodNames))] string methodName,
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(WrongMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1117_TestMethodsShouldBeNamedMorePreciseAnalyzerTests.cs
@@ -138,10 +138,10 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(CorrectMethodNames))] string methodName,
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(CorrectMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
         => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -152,10 +152,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_with_wrong_name_(
-                                                                      [ValueSource(nameof(VagueMethodNames))] string methodName,
-                                                                      [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                      [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(VagueMethodNames))] string methodName,
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1119_TestMethodsWhenPresentAnalyzerTests.cs
@@ -54,10 +54,10 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                               ];
 
         [Test]
-        public void No_issue_is_reported_for_test_method_with_correct_name_(
-                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                        [ValueSource(nameof(Tests))] string test,
-                                                                        [ValueSource(nameof(UnproblematicNames))] string unproblematicTest)
+        public void No_issue_is_reported_for_test_method_named_(
+                                                            [ValueSource(nameof(TestFixtures))] string fixture,
+                                                            [ValueSource(nameof(Tests))] string test,
+                                                            [ValueSource(nameof(UnproblematicNames))] string unproblematicTest)
             => No_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe
@@ -68,10 +68,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_method_ending_with_incorrect_name_(
-                                                                                 [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                 [ValueSource(nameof(Tests))] string test,
-                                                                                 [ValueSource(nameof(ProblematicTexts))] string problematicTest)
+        public void An_issue_is_reported_for_test_method_ending_with_(
+                                                                  [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                  [ValueSource(nameof(Tests))] string test,
+                                                                  [ValueSource(nameof(ProblematicTexts))] string problematicTest)
             => An_issue_is_reported_for(@"
 [" + fixture + @"]
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1200_ExceptionCatchBlockAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1200_ExceptionCatchBlockAnalyzerTests.cs
@@ -58,7 +58,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_exception_in_catch_block() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_exception_named_ex_in_catch_block() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -76,7 +76,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_exception_in_catch_block() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_exception_named_exception_in_catch_block() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -94,7 +94,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_nested_exception_in_catch_block() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_exception_named_exception_in_nested_catch_block() => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -154,7 +154,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_nested_exception_in_catch_block() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_exception_named_inner_in_nested_catch_block() => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -183,7 +183,7 @@ public class TestMe
                                                      "class TestMe { void DoSomething() { try { } catch (System.Exception ex) { System.Diagnostics.Trace.Write(ex.Message); } } }");
 
         [Test]
-        public void Code_gets_fixed_for_incorrectly_named_nested_exception_in_catch_block()
+        public void Code_gets_fixed_for_exception_named_exception_in_nested_catch_block()
         {
             const string OriginalCode = @"
 using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1201_ExceptionParameterAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1201_ExceptionParameterAnalyzerTests.cs
@@ -34,7 +34,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correctly_named_exception_([Values("ex", "exception", "innerException")] string name) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_exception_parameter_named_([Values("ex", "exception", "innerException")] string name) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -46,7 +46,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_exception_([Values("e", "exc", "except")] string name) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_exception_parameter_named_([Values("e", "exc", "except")] string name) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1300_SimpleLambdaExpressionIdentifierAnalyzerTests.cs
@@ -32,7 +32,7 @@ public class TestMe
         [TestCase("_4")]
         [TestCase("_5")]
         [TestCase("failed")] // result to indicate an error in ASP .NET Core
-        public void No_issue_is_reported_for_correctly_named_simple_lambda_identifier_(string identifier) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_simple_lambda_identifier_named_(string identifier) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,7 +60,7 @@ public class TestMe
         [TestCase("_4")]
         [TestCase("_5")]
         [TestCase("failed")] // result to indicate an error in ASP .NET Core
-        public void No_issue_is_reported_for_correctly_named_parenthesized_lambda_identifier_(string identifier) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_parenthesized_lambda_identifier_named_(string identifier) => No_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -96,7 +96,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_simple_lambda_identifier() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_simple_lambda_identifier_named_s() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -114,7 +114,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_incorrectly_named_parenthesized_lambda_identifier() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_parenthesized_lambda_identifier_named_s() => An_issue_is_reported_for(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1400_NamespacesInPluralAnalyzerTests.cs
@@ -104,24 +104,24 @@ namespace Abc." + ns + @"
         public void No_issue_is_reported_for_combined_known_file_scoped_namespace_([ValueSource(nameof(WellKnownCompanyAndFrameworkNames))] string ns) => No_issue_is_reported_for("namespace Abc." + ns + ";");
 
         [Test]
-        public void No_issue_is_reported_for_proper_namespace_([ValueSource(nameof(AllowedNamespaceNames))]string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_([ValueSource(nameof(AllowedNamespaceNames))]string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_proper_file_scoped_namespace_([ValueSource(nameof(AllowedNamespaceNames))] string ns) => No_issue_is_reported_for("namespace " + ns + ";");
+        public void No_issue_is_reported_for_file_scoped_namespace_([ValueSource(nameof(AllowedNamespaceNames))] string ns) => No_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void No_issue_is_reported_for_combined_proper_namespace_([ValueSource(nameof(AllowedNamespaceNames))]string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_combined_namespace_([ValueSource(nameof(AllowedNamespaceNames))]string ns) => No_issue_is_reported_for(@"
 namespace Abc." + ns + @"
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_combined_proper_file_scoped_namespace_([ValueSource(nameof(AllowedNamespaceNames))] string ns) => No_issue_is_reported_for("namespace Abc." + ns + ";");
+        public void No_issue_is_reported_for_combined_file_scoped_namespace_([ValueSource(nameof(AllowedNamespaceNames))] string ns) => No_issue_is_reported_for("namespace Abc." + ns + ";");
 
         [Test]
         public void No_issue_is_reported_for_top_level_singular_namespace_([ValueSource(nameof(SingularNamespaceNames))] string ns) => No_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1401_TechnicalNamespacesAnalyzerTests.cs
@@ -149,7 +149,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("MiKoSolutions")]
         [TestCase("MiKoSolutions.Infrastructure")]
         [TestCase("MiKoSolutions.Core")]
-        public void No_issue_is_reported_for_proper_namespace_(string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_(string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
@@ -158,17 +158,17 @@ namespace " + ns + @"
         [TestCase("MiKoSolutions")]
         [TestCase("MiKoSolutions.Infrastructure")]
         [TestCase("MiKoSolutions.Core")]
-        public void No_issue_is_reported_for_proper_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
+        public void No_issue_is_reported_for_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
+        public void An_issue_is_reported_for_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
         public void An_issue_is_reported_for_namespace_that_starts_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1402_WpfTechnicalNamespacesAnalyzerTests.cs
@@ -24,64 +24,64 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                    ];
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_namespace_(string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_(string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
+        public void No_issue_is_reported_for_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
+        public void An_issue_is_reported_for_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_namespace_that_starts_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_that_starts_with_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @".ABCD.EFG
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_file_scoped_namespace_that_starts_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ".ABCD.EFG;");
+        public void An_issue_is_reported_for_file_scoped_namespace_that_starts_with_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ".ABCD.EFG;");
 
         [Test]
-        public void An_issue_is_reported_for_namespace_that_ends_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_that_ends_with_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace ABCD.EFG." + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_file_scoped_namespace_that_ends_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace ABCD.EFG." + ns + ";");
+        public void An_issue_is_reported_for_file_scoped_namespace_that_ends_with_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace ABCD.EFG." + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_namespace_that_contains_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_that_contains_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace ABCD.EFG." + ns + @".HIJK
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_file_scoped_namespace_that_contains_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace ABCD.EFG." + ns + ".HIJK;");
+        public void An_issue_is_reported_for_file_scoped_namespace_that_contains_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace ABCD.EFG." + ns + ".HIJK;");
 
         [Test]
-        public void No_issue_is_reported_for_namespace_that_contains_acceptable_sub_namespace_([Values(nameof(System.ComponentModel), "ServiceModel")] string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_that_contains_sub_namespace_([Values(nameof(System.ComponentModel), "ServiceModel")] string ns) => No_issue_is_reported_for(@"
 namespace ABCD.EFG." + ns + @".HIJK
 {
 }
 ");
 
         [Test]
-        public void No_issue_is_reported_for_file_scoped_namespace_that_contains_acceptable_sub_namespace_([Values(nameof(System.ComponentModel), "ServiceModel")] string ns) => No_issue_is_reported_for("namespace ABCD.EFG." + ns + ".HIJK;");
+        public void No_issue_is_reported_for_file_scoped_namespace_that_contains_sub_namespace_([Values(nameof(System.ComponentModel), "ServiceModel")] string ns) => No_issue_is_reported_for("namespace ABCD.EFG." + ns + ".HIJK;");
 
         protected override string GetDiagnosticId() => MiKo_1402_WpfTechnicalNamespacesAnalyzer.Id;
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1404_NonsenseNamespacesAnalyzerTests.cs
@@ -25,24 +25,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                    ];
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_namespace_(string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_(string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
+        public void No_issue_is_reported_for_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
+        public void An_issue_is_reported_for_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
         public void An_issue_is_reported_for_namespace_that_starts_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1405_LibraryNamespacesAnalyzerTests.cs
@@ -23,24 +23,24 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                                                                    ];
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_namespace_(string ns) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_namespace_(string ns) => No_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [TestCase("MiKoSolutions")]
-        public void No_issue_is_reported_for_proper_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
+        public void No_issue_is_reported_for_file_scoped_namespace_(string ns) => No_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"
 namespace " + ns + @"
 {
 }
 ");
 
         [Test]
-        public void An_issue_is_reported_for_wrong_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
+        public void An_issue_is_reported_for_file_scoped_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for("namespace " + ns + ";");
 
         [Test]
         public void An_issue_is_reported_for_namespace_that_starts_with_wrong_sub_namespace_([ValueSource(nameof(ForbiddenNamespaceNames))] string ns) => An_issue_is_reported_for(@"

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1406_ValueConvertersNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1406_ValueConvertersNamespaceAnalyzerTests.cs
@@ -42,7 +42,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_converter_class_in_correct_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_converter_class_in_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla.Blubb.Converters
@@ -54,7 +54,7 @@ namespace Bla.Blubb.Converters
 ");
 
         [Test]
-        public void No_issue_is_reported_for_converter_class_in_correct_file_scoped_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_converter_class_in_file_scoped_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => No_issue_is_reported_for(@"
 using System;
 
 namespace Bla.Blubb.Converters;
@@ -65,7 +65,7 @@ public class TestMe : " + interfaceName + @"
 ");
 
         [Test]
-        public void An_issue_is_reported_for_converter_class_in_wrong_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_converter_class_in_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla.Blubb
@@ -77,7 +77,7 @@ namespace Bla.Blubb
 ");
 
         [Test]
-        public void An_issue_is_reported_for_converter_class_in_wrong_file_scoped_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_converter_class_in_file_scoped_namespace_([ValueSource(nameof(ValidTypes))] string interfaceName) => An_issue_is_reported_for(@"
 using System;
 
 namespace Bla.Blubb;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1407_TestNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1407_TestNamespaceAnalyzerTests.cs
@@ -54,9 +54,9 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_with_correct_namespace_(
-                                                                            [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                            [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_class_with_namespace_(
+                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                    [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 namespace Bla
 {
@@ -70,9 +70,9 @@ namespace Bla
 ");
 
         [Test]
-        public void No_issue_is_reported_for_test_class_with_correct_file_scoped_namespace_(
-                                                                                        [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                        [ValueSource(nameof(Tests))] string test)
+        public void No_issue_is_reported_for_test_class_with_file_scoped_namespace_(
+                                                                                [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                [ValueSource(nameof(Tests))] string test)
             => No_issue_is_reported_for(@"
 namespace Bla;
 
@@ -85,10 +85,10 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_class_with_incorrect_namespace_(
-                                                                              [ValueSource(nameof(WrongNamespaceNames))] string namespaceName,
-                                                                              [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                              [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_class_with_namespace_(
+                                                                    [ValueSource(nameof(WrongNamespaceNames))] string namespaceName,
+                                                                    [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                    [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 namespace " + namespaceName + @"
 {
@@ -102,10 +102,10 @@ namespace " + namespaceName + @"
 ");
 
         [Test]
-        public void An_issue_is_reported_for_test_class_with_incorrect_file_scoped_namespace_(
-                                                                                          [ValueSource(nameof(WrongNamespaceNames))] string namespaceName,
-                                                                                          [ValueSource(nameof(TestFixtures))] string fixture,
-                                                                                          [ValueSource(nameof(Tests))] string test)
+        public void An_issue_is_reported_for_test_class_with_file_scoped_namespace_(
+                                                                                [ValueSource(nameof(WrongNamespaceNames))] string namespaceName,
+                                                                                [ValueSource(nameof(TestFixtures))] string fixture,
+                                                                                [ValueSource(nameof(Tests))] string test)
             => An_issue_is_reported_for(@"
 namespace " + namespaceName + @";
 

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1408_ExtensionMethodsNamespaceAnalyzerTests.cs
@@ -54,7 +54,7 @@ namespace System
 ");
 
         [Test]
-        public void No_issue_is_reported_for_extension_method_class_with_correct_namespace() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_method_class_with_fitting_namespace() => No_issue_is_reported_for(@"
 namespace System
 {
     public static class TestMe
@@ -65,7 +65,7 @@ namespace System
 ");
 
         [Test]
-        public void No_issue_is_reported_for_extension_method_class_with_correct_file_scoped_namespace() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_extension_method_class_with_fittingfile_scoped_namespace() => No_issue_is_reported_for(@"
 namespace System;
 
 public static class TestMe
@@ -136,7 +136,7 @@ public static class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_method_class_with_non_fitting_namespace() => An_issue_is_reported_for(@"
 namespace Bla
 {
     public static class TestMe
@@ -147,7 +147,7 @@ namespace Bla
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_method_class_with_incorrect_namespace_2() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_method_class_with_non_fitting_namespace_2() => An_issue_is_reported_for(@"
 namespace Blah.Blubb
 {
     public class TestMe
@@ -168,7 +168,7 @@ namespace Blubber.Bla.Blubbdiblubb
 ");
 
         [Test]
-        public void An_issue_is_reported_for_extension_method_class_with_incorrect_file_scoped_namespace() => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_extension_method_class_with_non_fitting_file_scoped_namespace() => An_issue_is_reported_for(@"
 namespace Bla;
 
 public static class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1523_HelperMethodAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1523_HelperMethodAnalyzerTests.cs
@@ -13,7 +13,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         private static readonly string[] WrongTerms = ["Helper", "HelpingMethod"];
 
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_helper_term() => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1524_MethodPrefixedWithSubAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1524_MethodPrefixedWithSubAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1524_MethodPrefixedWithSubAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_Sub_prefix() => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1526_DelegatePropertyNameSuffixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1526_DelegatePropertyNameSuffixAnalyzerTests.cs
@@ -33,7 +33,7 @@ public class TestMe
 ");
 
         [Test]
-        public void No_issue_is_reported_for_correct_property_name_([ValueSource(nameof(DelegateTypes))] string type) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_property_with_fitting_name_([ValueSource(nameof(DelegateTypes))] string type) => No_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -43,8 +43,7 @@ public class TestMe
 ");
 
         [Test]
-        public void An_issue_is_reported_for_property_with_non_fitting_name_([ValueSource(nameof(DelegateTypes))] string type)
-            => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_property_with_non_fitting_name_([ValueSource(nameof(DelegateTypes))] string type) => An_issue_is_reported_for(@"
 using System;
 
 public class TestMe
@@ -60,7 +59,7 @@ public class TestMe
         [TestCase("SomeDelegate", "SomeCallback")]
         [TestCase("SomeFunc", "SomeCallback")]
         [TestCase("Something", "SomethingCallback")]
-        public void Code_gets_fixed(string originalName, string fixedName)
+        public void Code_gets_fixed_for_(string originalName, string fixedName)
         {
             const string Template = """
                                     using System;

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1527_TypeSuffixedWithSubAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1527_TypeSuffixedWithSubAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1527_TypeSuffixedWithSubAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_type_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_type_without_Sub_suffix() => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1537_MethodPrefixedWithEventAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
     public sealed class MiKo_1537_MethodPrefixedWithEventAnalyzerTests : CodeFixVerifier
     {
         [Test]
-        public void No_issue_is_reported_for_method_with_correct_name() => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_method_without_Event_prefix() => No_issue_is_reported_for(@"
 namespace Bla
 {
     public class TestMe

--- a/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1538_EventNamePrefixAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Naming/MiKo_1538_EventNamePrefixAnalyzerTests.cs
@@ -19,7 +19,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
         [TestCase("interface", "Off")]
         [TestCase("interface", "On")]
         [TestCase("interface", "OnlineBlaBla")]
-        public void No_issue_is_reported_for_correctly_named_event_(string type, string eventName) => No_issue_is_reported_for(@"
+        public void No_issue_is_reported_for_event_without_On_prefix_(string type, string eventName) => No_issue_is_reported_for(@"
 using System;
 
 public " + type + @" TestMe
@@ -30,7 +30,7 @@ public " + type + @" TestMe
 
         [TestCase("class", "OnStuff")]
         [TestCase("interface", "OnStuff")]
-        public void An_issue_is_reported_for_incorrectly_named_event_(string type, string eventName) => An_issue_is_reported_for(@"
+        public void An_issue_is_reported_for_event_with_On_prefix_(string type, string eventName) => An_issue_is_reported_for(@"
 using System;
 
 public " + type + @" TestMe


### PR DESCRIPTION
- Apply minor style updates

- Improve test assertion clarity by replacing `Is.EqualTo(string.Empty)` with `Is.Empty`

- Improve test assertion clarity by replacing `.Count, Is.EqualTo` with `Has.Count`

- Rename tests to no longer contain vague terms such as 'correct'

