### PR TITLE
Add new rule MiKo_3127 that reports when actual and expected values are switched on 'Assert.That'

### DIFF
--- a/Documentation/MiKo_3127.md
+++ b/Documentation/MiKo_3127.md
@@ -1,0 +1,48 @@
+﻿# MiKo_3127: Assertions should not swap 'actual' and 'expected' values
+
+## Cause
+
+An `Assert.That(...)` call has the `actual` and `expected` values swapped.
+
+## Rule description
+
+NUnit's constraint model expects `Assert.That(actual, Is.EqualTo(expected))`, with `actual` first and `expected` second, unlike classic `Assert.AreEqual(expected, actual)`.
+
+When switching from `Assert.AreEqual` to `Assert.That`, developers sometimes keep the old order by mistake, swapping the two values.
+This leads to confusing failure messages that show the wrong value as "expected".
+
+### Rationale behind
+
+Keeping the arguments in the correct order matters more than it might seem at first.
+
+A swapped assertion still compiles and still fails when values do not match.
+The problem only shows up once a test fails, and by then the failure message is wrong.
+The message will claim a value was "expected" when it was actually the "actual" one, and this makes debugging much harder.
+
+Following this rule provides several important benefits:
+
+- **Correct Failure Messages**:
+  When a test fails, the reported "expected" and "actual" values match reality.
+  This avoids confusion when reading the test output.
+
+- **Faster Debugging**:
+  Developers do not waste time figuring out that the failure message is misleading.
+  The real cause of a failure becomes clear immediately.
+
+- **Consistent Test Style**:
+  All assertions across the codebase follow the same argument order.
+  This makes tests easier to read and review, as everyone can rely on the same pattern.
+
+- **Fewer Mistakes During Refactoring**:
+  When old-style assertions get migrated to the constraint model, keeping the correct order avoids introducing subtle bugs into otherwise working tests.
+
+## How to fix violations
+
+To fix a violation of this rule, swap the position of the `actual` and `expected` values inside the assertion call.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable MiKo_3127
+#pragma warning restore MiKo_3127
+```

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.CodeFixes.projitems
@@ -235,6 +235,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3125_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3126_CodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3127_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_CodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_CodeFixProvider.cs" />

--- a/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
+++ b/MiKo.Analyzer.Shared/MiKo.Analyzer.Shared.projitems
@@ -326,6 +326,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3124_TestMethodsDoNotAssertInFinallyClauseAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3125_TestMethodsDoNotHaveBothTestAndTestCaseAttributeAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3126_TheoryMethodsDoNotHaveTestAttributeAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3201_InvertIfWhenFollowedByFewCodeLinesAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3202_InvertNegativeIfWhenReturningOnAllPathsAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rules\Maintainability\MiKo_3203_InvertNegativeIfInsideBlockWhenFollowedBySingleCodeLinesAnalyzer.cs" />

--- a/MiKo.Analyzer.Shared/Resources.Designer.cs
+++ b/MiKo.Analyzer.Shared/Resources.Designer.cs
@@ -14561,6 +14561,44 @@ namespace MiKoSolutions.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Swap &apos;actual&apos; and &apos;expected&apos; values on assertion.
+        /// </summary>
+        internal static string MiKo_3127_CodeFixTitle {
+            get {
+                return ResourceManager.GetString("MiKo_3127_CodeFixTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NUnit&apos;s constraint model expects &apos;Assert.That(actual, Is.EqualTo(expected))&apos;, with actual first and expected second, unlike classic &apos;Assert.AreEqual(expected, actual)&apos;.
+        ///When switching from &apos;Assert.AreEqual&apos; to &apos;Assert.That&apos;, developers sometimes keep the old order by mistake, swapping the two values.
+        ///This leads to confusing failure messages that show the wrong value as &quot;expected&quot;..
+        /// </summary>
+        internal static string MiKo_3127_Description {
+            get {
+                return ResourceManager.GetString("MiKo_3127_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Swap &apos;actual&apos; and &apos;expected&apos; values on assertion.
+        /// </summary>
+        internal static string MiKo_3127_MessageFormat {
+            get {
+                return ResourceManager.GetString("MiKo_3127_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assertions should not swap &apos;actual&apos; and &apos;expected&apos; values.
+        /// </summary>
+        internal static string MiKo_3127_Title {
+            get {
+                return ResourceManager.GetString("MiKo_3127_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invert if to simplify.
         /// </summary>
         internal static string MiKo_3201_CodeFixTitle {

--- a/MiKo.Analyzer.Shared/Resources.resx
+++ b/MiKo.Analyzer.Shared/Resources.resx
@@ -5101,6 +5101,20 @@ Use either a test attribute or [Theory] to keep the intent of each test method c
   <data name="MiKo_3126_Title" xml:space="preserve">
     <value>Theories should not have test attributes applied</value>
   </data>
+  <data name="MiKo_3127_CodeFixTitle" xml:space="preserve">
+    <value>Swap 'actual' and 'expected' values on assertion</value>
+  </data>
+  <data name="MiKo_3127_Description" xml:space="preserve">
+    <value>NUnit's constraint model expects 'Assert.That(actual, Is.EqualTo(expected))', with actual first and expected second, unlike classic 'Assert.AreEqual(expected, actual)'.
+When switching from 'Assert.AreEqual' to 'Assert.That', developers sometimes keep the old order by mistake, swapping the two values.
+This leads to confusing failure messages that show the wrong value as "expected".</value>
+  </data>
+  <data name="MiKo_3127_MessageFormat" xml:space="preserve">
+    <value>Swap 'actual' and 'expected' values on assertion</value>
+  </data>
+  <data name="MiKo_3127_Title" xml:space="preserve">
+    <value>Assertions should not swap 'actual' and 'expected' values</value>
+  </data>
   <data name="MiKo_3201_CodeFixTitle" xml:space="preserve">
     <value>Invert if to simplify</value>
   </data>

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer : MaintainabilityAnalyzer
+    {
+        public const string Id = "MiKo_3127";
+
+        public MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer() : base(Id, (SymbolKind)(-1))
+        {
+        }
+
+        protected override bool IsUnitTestAnalyzer => true;
+
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+
+        private static bool IsAssertThat(MemberAccessExpressionSyntax node) => node.Expression is IdentifierNameSyntax invokedType
+                                                                            && invokedType.GetName() is "Assert"
+                                                                            && node.GetName() is "That";
+
+        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MemberAccessExpressionSyntax maes)
+            {
+                var issue = AnalyzeSimpleMemberAccessExpression(maes, context.SemanticModel);
+
+                if (issue != null)
+                {
+                    ReportDiagnostics(context, issue);
+                }
+            }
+        }
+
+        private Diagnostic AnalyzeSimpleMemberAccessExpression(MemberAccessExpressionSyntax node, SemanticModel semanticModel)
+        {
+            if (node.Parent is InvocationExpressionSyntax methodCall && IsAssertThat(node))
+            {
+                var arguments = methodCall.ArgumentList.Arguments;
+
+                if (arguments.Count > 0)
+                {
+                    var expression = arguments[0].Expression;
+
+                    switch (expression)
+                    {
+                        case PrefixUnaryExpressionSyntax unary when unary.Operand is LiteralExpressionSyntax:
+                        case LiteralExpressionSyntax _:
+                        case MemberAccessExpressionSyntax maes when maes.IsEnum(semanticModel):
+                            return Issue(expression);
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
@@ -33,13 +33,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 var arguments = list.Arguments;
 
-                if (arguments.Count > 1 && arguments[1].Expression is InvocationExpressionSyntax comparison)
+                if (arguments.Count > 1)
                 {
-                    var comparisonArguments = comparison.ArgumentList.Arguments;
-                    if (comparisonArguments.Any())
+                    var illPlacedActual = FindIllPlacedActualArgument(arguments[1]);
+
+                    if (illPlacedActual != null)
                     {
                         var illPlacedExpected = arguments[0]; // this is the actual "expected" parameter
-                        var illPlacedActual = comparisonArguments.First(); // this is the actual "actual" parameter
 
                         var fixedActual = illPlacedActual.WithTriviaFrom(illPlacedExpected);
                         var fixedExpected = illPlacedExpected.WithoutTrivia();
@@ -67,6 +67,18 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
 
             return syntax;
+        }
+
+        private static ArgumentSyntax FindIllPlacedActualArgument(ArgumentSyntax constraint)
+        {
+            var invocation = constraint.FirstDescendant<InvocationExpressionSyntax>(_ => _.Expression is MemberAccessExpressionSyntax maes && maes.GetName() == "EqualTo");
+
+            if (invocation?.ArgumentList is ArgumentListSyntax list && list.Arguments is SeparatedSyntaxList<ArgumentSyntax> arguments && arguments.Count > 0)
+            {
+                return arguments[0]; // this should be the ill-placed "actual" parameter
+            }
+
+            return null;
         }
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MiKo_3127_CodeFixProvider)), Shared]
+    public sealed class MiKo_3127_CodeFixProvider : UnitTestCodeFixProvider
+    {
+        public override string FixableDiagnosticId => "MiKo_3127";
+
+        protected override SyntaxNode GetSyntax(IEnumerable<SyntaxNode> syntaxNodes)
+        {
+            return syntaxNodes.OfType<ArgumentListSyntax>().First();
+        }
+
+        protected override Task<SyntaxNode> GetUpdatedSyntaxAsync(SyntaxNode syntax, Diagnostic issue, Document document, CancellationToken cancellationToken)
+        {
+            var updatedSyntax = GetUpdatedSyntax(syntax);
+
+            return Task.FromResult(updatedSyntax);
+        }
+
+        private static SyntaxNode GetUpdatedSyntax(SyntaxNode syntax)
+        {
+            if (syntax is ArgumentListSyntax list)
+            {
+                var arguments = list.Arguments;
+
+                if (arguments.Count > 1 && arguments[1].Expression is InvocationExpressionSyntax comparison)
+                {
+                    var comparisonArguments = comparison.ArgumentList.Arguments;
+                    if (comparisonArguments.Any())
+                    {
+                        var illPlacedExpected = arguments[0]; // this is the actual "expected" parameter
+                        var illPlacedActual = comparisonArguments.First(); // this is the actual "actual" parameter
+
+                        var fixedActual = illPlacedActual.WithTriviaFrom(illPlacedExpected);
+                        var fixedExpected = illPlacedExpected.WithoutTrivia();
+
+                        var illPlacedNodes = new[] { illPlacedExpected, illPlacedActual };
+
+                        return list.ReplaceNodes(
+                                             illPlacedNodes,
+                                             (o, r) =>
+                                                      {
+                                                          if (r.IsEquivalentTo(illPlacedExpected))
+                                                          {
+                                                              return fixedActual;
+                                                          }
+
+                                                          if (r.IsEquivalentTo(illPlacedActual))
+                                                          {
+                                                              return fixedExpected;
+                                                          }
+
+                                                          return r;
+                                                      });
+                    }
+                }
+            }
+
+            return syntax;
+        }
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzerTests.cs
@@ -1,0 +1,368 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using NUnit.Framework;
+
+using TestHelper;
+
+//// ncrunch: rdi off
+namespace MiKoSolutions.Analyzers.Rules.Maintainability
+{
+    [TestFixture]
+    public sealed class MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzerTests : CodeFixVerifier
+    {
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_parameter() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(42)] int value)
+        {
+            Assert.That(value, Is.EqualTo(4711));
+        }
+    }
+}
+");
+
+        [Test]
+        public void No_issue_is_reported_for_test_method_with_parameter_of_enum_type() => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(StringComparison.Ordinal)] StringComparison value)
+        {
+            Assert.That(value, Is.EqualTo(StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+");
+
+        [TestCase("42", "4711")]
+        [TestCase("-42", "-4711")]
+        [TestCase("42.0", "47.11")]
+        [TestCase("42f", "47.11f")]
+        [TestCase("0xBB", "0xAA")]
+        [TestCase("0b0000_0000", "0b1111_1111")]
+        [TestCase("'a'", "'b'")]
+        [TestCase("\"something\"", "\"some text\"")]
+        [TestCase("true", "false")]
+        [TestCase("StringComparison.Ordinal", "StringComparison.OrdinalIgnoreCase")]
+        public void No_issue_is_reported_for_test_method_with_variable_(string actual, string expected) => No_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(value, Is.EqualTo(" + expected + @"));
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_parameter_as_expected() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(42)] int value)
+        {
+            Assert.That(4711, Is.EqualTo(value));
+        }
+    }
+}
+");
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_parameter_of_enum_type_as_expected() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(StringComparison.Ordinal)] StringComparison value)
+        {
+            Assert.That(StringComparison.OrdinalIgnoreCase, Is.EqualTo(value));
+        }
+    }
+}
+");
+
+        [TestCase("42", "4711")]
+        [TestCase("-42", "-4711")]
+        [TestCase("42.0", "47.11")]
+        [TestCase("42f", "47.11f")]
+        [TestCase("0xBB", "0xAA")]
+        [TestCase("0b0000_0000", "0b1111_1111")]
+        [TestCase("'a'", "'b'")]
+        [TestCase("\"something\"", "\"some text\"")]
+        [TestCase("true", "false")]
+        [TestCase("StringComparison.Ordinal", "StringComparison.OrdinalIgnoreCase")]
+        public void An_issue_is_reported_for_test_method_with_variable_(string actual, string expected) => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(" + expected + @", Is.EqualTo(value));
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_parameter_as_expected()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(42)] int value)
+        {
+            Assert.That(4711, Is.EqualTo(value));
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(42)] int value)
+        {
+            Assert.That(value, Is.EqualTo(4711));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_parameter_of_enum_type_as_expected()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(StringComparison.Ordinal)] StringComparison value)
+        {
+            Assert.That(StringComparison.OrdinalIgnoreCase, Is.EqualTo(value));
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest([Values(StringComparison.Ordinal)] StringComparison value)
+        {
+            Assert.That(value, Is.EqualTo(StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [TestCase("42", "4711")]
+        [TestCase("-42", "-4711")]
+        [TestCase("42.0", "47.11")]
+        [TestCase("42f", "47.11f")]
+        [TestCase("0xBB", "0xAA")]
+        [TestCase("0b0000_0000", "0b1111_1111")]
+        [TestCase("'a'", "'b'")]
+        [TestCase("\"something\"", "\"some text\"")]
+        [TestCase("true", "false")]
+        [TestCase("StringComparison.Ordinal", "StringComparison.OrdinalIgnoreCase")]
+        public void Code_gets_fixed_for_test_method_with_variable_(string actual, string expected)
+        {
+            var originalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(" + expected + @", Is.EqualTo(value));
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(value, Is.EqualTo(" + expected + @"));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        [TestCase("42", "4711")]
+        [TestCase("-42", "-4711")]
+        [TestCase("42.0", "47.11")]
+        [TestCase("42f", "47.11f")]
+        [TestCase("0xBB", "0xAA")]
+        [TestCase("0b0000_0000", "0b1111_1111")]
+        [TestCase("'a'", "'b'")]
+        [TestCase("\"something\"", "\"some text\"")]
+        [TestCase("true", "false")]
+        [TestCase("StringComparison.Ordinal", "StringComparison.OrdinalIgnoreCase")]
+        public void Code_gets_fixed_for_test_method_with_variable_when_spanning_multiple_lines_(string actual, string expected)
+        {
+            var originalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(
+                     " + expected + @",
+                     Is.EqualTo(value));
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = " + actual + @";
+
+            Assert.That(
+                     value,
+                     Is.EqualTo(" + expected + @"));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(originalCode, fixedCode);
+        }
+
+        protected override string GetDiagnosticId() => MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.Id;
+
+        protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer();
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider() => new MiKo_3127_CodeFixProvider();
+    }
+}

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzerTests.cs
@@ -359,6 +359,320 @@ namespace Bla
             VerifyCSharpFix(originalCode, fixedCode);
         }
 
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_chained_IgnoreCase()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = ""something"";
+
+            Assert.That(""some text"", Is.EqualTo(value).IgnoreCase);
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = ""something"";
+
+            Assert.That(value, Is.EqualTo(""some text"").IgnoreCase);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_chained_Within()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(47.11, Is.EqualTo(value).Within(0.5));
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(value, Is.EqualTo(47.11).Within(0.5));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void An_issue_is_reported_for_test_method_with_variable_and_Is_Not_EqualTo() => An_issue_is_reported_for(@"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42;
+
+            Assert.That(4711, Is.Not.EqualTo(value));
+        }
+    }
+}
+");
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_Is_Not_EqualTo()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42;
+
+            Assert.That(4711, Is.Not.EqualTo(value));
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42;
+
+            Assert.That(value, Is.Not.EqualTo(4711));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_Is_Not_EqualTo_and_chained_IgnoreCase()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = ""something"";
+
+            Assert.That(""some text"", Is.Not.EqualTo(value).IgnoreCase);
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = ""something"";
+
+            Assert.That(value, Is.Not.EqualTo(""some text"").IgnoreCase);
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_Is_Not_EqualTo_and_chained_Within()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(47.11, Is.Not.EqualTo(value).Within(0.5));
+        }
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(value, Is.Not.EqualTo(47.11).Within(0.5));
+        }
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
+        [Test]
+        public void Code_gets_fixed_for_test_method_with_variable_and_Is_EqualTo_and_chained_Within_with_nested_invocation()
+        {
+            const string OriginalCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(47.11, Is.EqualTo(value).Within(GetTolerance()));
+        }
+
+        private double GetTolerance() => 0.5;
+    }
+}
+";
+
+            const string FixedCode = @"
+using System;
+
+using NUnit.Framework;
+
+namespace Bla
+{
+    [TestFixture]
+    public class TestMe
+    {
+        [Test]
+        public void SomeTest()
+        {
+            var value = 42.0;
+
+            Assert.That(value, Is.EqualTo(47.11).Within(GetTolerance()));
+        }
+
+        private double GetTolerance() => 0.5;
+    }
+}
+";
+
+            VerifyCSharpFix(OriginalCode, FixedCode);
+        }
+
         protected override string GetDiagnosticId() => MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.Id;
 
         protected override DiagnosticAnalyzer GetObjectUnderTest() => new MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer();

--- a/MiKo.Analyzer.sln
+++ b/MiKo.Analyzer.sln
@@ -536,6 +536,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3. Maintenance", "3. Mainte
 		Documentation\MiKo_3124.md = Documentation\MiKo_3124.md
 		Documentation\MiKo_3125.md = Documentation\MiKo_3125.md
 		Documentation\MiKo_3126.md = Documentation\MiKo_3126.md
+		Documentation\MiKo_3127.md = Documentation\MiKo_3127.md
 		Documentation\MiKo_3201.md = Documentation\MiKo_3201.md
 		Documentation\MiKo_3202.md = Documentation\MiKo_3202.md
 		Documentation\MiKo_3203.md = Documentation\MiKo_3203.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Screenshots on how to use such analyzers can be found [here](https://learn.micro
 
 ## Available Rules
 
-The following tables list all the 567 rules that are currently provided by the analyzer.
+The following tables list all the 568 rules that are currently provided by the analyzer.
 
 ### Metrics
 
@@ -468,6 +468,7 @@ The following tables list all the 567 rules that are currently provided by the a
 |[MiKo_3124](/Documentation/MiKo_3124.md)|Do not use assertions in finally blocks in test methods|&#x2713;|&#x2713;|
 |[MiKo_3125](/Documentation/MiKo_3125.md)|NUnit tests should not have both [Test] and [TestCase] applied|&#x2713;|&#x2713;|
 |[MiKo_3126](/Documentation/MiKo_3126.md)|Theories should not have test attributes applied|&#x2713;|&#x2713;|
+|[MiKo_3127](/Documentation/MiKo_3127.md)|Assertions should not swap 'actual' and 'expected' values|&#x2713;|&#x2713;|
 |[MiKo_3201](/Documentation/MiKo_3201.md)|Invert if statements in short methods|&#x2713;|&#x2713;|
 |[MiKo_3202](/Documentation/MiKo_3202.md)|Use positive conditions when returning in all paths|&#x2713;|&#x2713;|
 |[MiKo_3203](/Documentation/MiKo_3203.md)|Invert if-continue statements when followed by single line|&#x2713;|&#x2713;|


### PR DESCRIPTION
- Add analyzer incl. code fix provider

- Add unit tests

- Update documentation and Readme.md

(resolves #2169)