### PR TITLE
Refactor code to use `Is` methods instead of `GetName() is ...`

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Naming.cs
@@ -1068,5 +1068,83 @@ namespace MiKoSolutions.Analyzers
 
             return false;
         }
+
+        /// <summary>
+        /// Determines whether the specified member has the given name.
+        /// </summary>
+        /// <param name="value">
+        /// The member access expression syntax.
+        /// </param>
+        /// <param name="name">
+        /// The name to check.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the member has the given name; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool Is(this MemberAccessExpressionSyntax value, string name) => value.GetName() == name;
+
+        /// <summary>
+        /// Determines whether the specified member has the given identifier name and name.
+        /// </summary>
+        /// <param name="value">
+        /// The member access expression syntax.
+        /// </param>
+        /// <param name="identifierName">
+        /// The name of the identifier to check.
+        /// </param>
+        /// <param name="name">
+        /// The name to check.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the member has the given identifier name and name; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool Is(this ExpressionSyntax value, string identifierName, string name)
+        {
+            switch (value)
+            {
+                case InvocationExpressionSyntax i:
+                    return i.Is(identifierName, name);
+
+                case MemberAccessExpressionSyntax maes:
+                    return maes.Is(identifierName, name);
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the specified member has the given identifier name and name.
+        /// </summary>
+        /// <param name="value">
+        /// The member access expression syntax.
+        /// </param>
+        /// <param name="identifierName">
+        /// The name of the identifier to check.
+        /// </param>
+        /// <param name="name">
+        /// The name to check.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the member has the given identifier name and name; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool Is(this InvocationExpressionSyntax value, string identifierName, string name) => value?.Expression.Is(identifierName, name) is true;
+
+        /// <summary>
+        /// Determines whether the specified member has the given identifier name and name.
+        /// </summary>
+        /// <param name="value">
+        /// The member access expression syntax.
+        /// </param>
+        /// <param name="identifierName">
+        /// The name of the identifier to check.
+        /// </param>
+        /// <param name="name">
+        /// The name to check.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the member has the given identifier name and name; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool Is(this MemberAccessExpressionSyntax value, string identifierName, string name) => value.GetIdentifierName() == identifierName && value.Is(name);
     }
 }

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -1886,9 +1886,7 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static bool IsMoqItIsConditionMatcher(this InvocationExpressionSyntax value) => value.Expression is MemberAccessExpressionSyntax maes
                                                                                               && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression)
-                                                                                              && maes.Expression is IdentifierNameSyntax invokedType
-                                                                                              && invokedType.GetName() is Constants.Moq.ConditionMatcher.It
-                                                                                              && maes.GetName() is Constants.Moq.ConditionMatcher.Is;
+                                                                                              && maes.Is(Constants.Moq.ConditionMatcher.It, Constants.Moq.ConditionMatcher.Is);
 
         /// <summary>
         /// Determines whether an expression syntax represents a nameof expression.
@@ -2348,7 +2346,7 @@ namespace MiKoSolutions.Analyzers
                                                                                    && maes.IsKind(SyntaxKind.SimpleMemberAccessExpression)
                                                                                    && maes.Expression is TypeSyntax invokedType
                                                                                    && invokedType.IsString()
-                                                                                   && maes.GetName() is nameof(string.Format);
+                                                                                   && maes.Is(nameof(string.Format));
 
         /// <summary>
         /// Determines whether an argument syntax represents a <see cref="string"/> literal.
@@ -2677,7 +2675,7 @@ namespace MiKoSolutions.Analyzers
         /// <returns>
         /// <see langword="true"/> if the return statement returns a completed task; otherwise, <see langword="false"/>.
         /// </returns>
-        internal static bool ReturnsCompletedTask(this ReturnStatementSyntax value) => value.Expression is MemberAccessExpressionSyntax maes && maes.Expression.GetName() is nameof(Task) && maes.GetName() is nameof(Task.CompletedTask);
+        internal static bool ReturnsCompletedTask(this ReturnStatementSyntax value) => value.Expression is MemberAccessExpressionSyntax maes && maes.Is(nameof(Task), nameof(Task.CompletedTask));
 
         /// <summary>
         /// Determines whether an if statement returns immediately.
@@ -2821,7 +2819,7 @@ namespace MiKoSolutions.Analyzers
         {
             result = null;
 
-            if (value.GetName() is Constants.Moq.Object)
+            if (value.Is(Constants.Moq.Object))
             {
                 var expression = value.Expression.WithoutParenthesis(); // let's see if we can fix it in case we remove the surrounding parenthesis
 

--- a/MiKo.Analyzer.Shared/Rules/Analyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Analyzer.cs
@@ -224,7 +224,7 @@ namespace MiKoSolutions.Analyzers.Rules
         /// <see langword="true"/> if xUnit is references; otherwise, <see langword="false"/>.
         /// </returns>
         protected static bool ReferencesXUnit(Compilation compilation) => compilation.GetTypeByMetadataName("Xunit." + Constants.Names.FactAttributeFullName) != null
-                                                                          || compilation.GetTypeByMetadataName("Xunit." + Constants.Names.TheoryAttributeFullName) != null;
+                                                                       || compilation.GetTypeByMetadataName("Xunit." + Constants.Names.TheoryAttributeFullName) != null;
 
         /// <summary>
         /// Determines whether MSTest is referenced within the compilation.

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CompletedTaskAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CompletedTaskAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         protected override IEnumerable<Diagnostic> Analyze(IMethodSymbol symbol, Compilation compilation)
         {
             foreach (var invocation in symbol.GetSyntax()
-                                             .DescendantNodes<MemberAccessExpressionSyntax>(_ => _.IsKind(SyntaxKind.SimpleMemberAccessExpression) && _.Expression.GetName() is nameof(Task) && _.GetName() is nameof(Task.FromResult))
+                                             .DescendantNodes<MemberAccessExpressionSyntax>(_ => _ is MemberAccessExpressionSyntax maes && maes.Is(nameof(Task), nameof(Task.FromResult)))
                                              .Select(_ => _.GetEnclosing<InvocationExpressionSyntax>()))
             {
                 switch (invocation.Parent?.Kind())

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
@@ -38,7 +38,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             {
                 switch (node)
                 {
-                    case MemberAccessExpressionSyntax maes when maes.Expression.GetName() is nameof(Task) && maes.GetName() is nameof(Task.Run):
+                    case MemberAccessExpressionSyntax maes when maes.Is(nameof(Task), nameof(Task.Run)):
                         taskRunExpressions.Add(maes);
 
                         break;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3035_WaitOneHasTimeoutAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3035_WaitOneHasTimeoutAnalyzer.cs
@@ -14,18 +14,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
-        private static bool NodeHasIssue(MemberAccessExpressionSyntax node, SemanticModel semanticModel)
+        private static bool NodeHasIssue(InvocationExpressionSyntax node, SemanticModel semanticModel)
         {
-            if (node.GetName() != "WaitOne")
+            if (node.Expression is MemberAccessExpressionSyntax maes && maes.Is("WaitOne"))
             {
-                return false;
-            }
-
-            if (node.Parent is InvocationExpressionSyntax i)
-            {
-                var arguments = i.ArgumentList.Arguments;
+                var arguments = node.ArgumentList.Arguments;
                 var argumentsCount = arguments.Count;
 
                 if (argumentsCount > 0)
@@ -41,14 +36,16 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         }
                     }
                 }
+
+                return true;
             }
 
-            return true;
+            return false;
         }
 
-        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            var node = (MemberAccessExpressionSyntax)context.Node;
+            var node = (InvocationExpressionSyntax)context.Node;
 
             if (NodeHasIssue(node, context.SemanticModel))
             {
@@ -56,7 +53,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 if (methodSymbol is null)
                 {
-                    // nameof() is also a SimpleMemberAccessExpression, so assignments of lists etc. may cause an NRE to be thrown
+                    // nameof() is also a InvocationExpression, so assignments of lists etc. may cause an NRE to be thrown
                     return;
                 }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3037_DoNotUseMagicNumbersForTimeoutsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3037_DoNotUseMagicNumbersForTimeoutsAnalyzer.cs
@@ -31,13 +31,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
-        private Diagnostic[] AnalyzeIssue(MemberAccessExpressionSyntax node, ISymbol method)
+        private Diagnostic[] AnalyzeIssue(InvocationExpressionSyntax node, ISymbol method)
         {
-            if (node.Parent is InvocationExpressionSyntax i && Names.Contains(node.GetName()))
+            if (Names.Contains(node.GetName()))
             {
-                var argument = i.ArgumentList?.Arguments.FirstOrDefault(_ => _.Expression.IsKind(SyntaxKind.NumericLiteralExpression));
+                var argument = node.ArgumentList?.Arguments.FirstOrDefault(_ => _.Expression.IsKind(SyntaxKind.NumericLiteralExpression));
 
                 if (argument != null)
                 {
@@ -48,18 +48,17 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return Array.Empty<Diagnostic>();
         }
 
-        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            var node = (MemberAccessExpressionSyntax)context.Node;
-
             var methodSymbol = context.GetEnclosingMethod();
 
             if (methodSymbol is null)
             {
-                // nameof() is also a SimpleMemberAccessExpression, so assignments of lists etc. may cause an NRE to be thrown
+                // nameof() is also a InvocationExpressionSyntax, so assignments of lists etc. may cause an NRE to be thrown
                 return;
             }
 
+            var node = (InvocationExpressionSyntax)context.Node;
             var issues = AnalyzeIssue(node, methodSymbol);
 
             if (issues.Length > 0)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3043_WeakEventManagerHandlerUsesNameofAnalyzer.cs
@@ -16,56 +16,39 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
-        private Diagnostic[] AnalyzeIssue(MemberAccessExpressionSyntax node, ISymbol method)
+        private Diagnostic[] AnalyzeIssue(InvocationExpressionSyntax invocation, ISymbol method)
         {
-            var name = node.GetName();
-
-            switch (name)
+            if (invocation.Is("WeakEventManager", "AddHandler") || invocation.Is("WeakEventManager", "RemoveHandler"))
             {
-                case "AddHandler":
-                case "RemoveHandler":
+                var arguments = invocation.ArgumentList.Arguments;
+
+                if (arguments.Count >= 2)
                 {
-                    if (node.Parent is InvocationExpressionSyntax invocation)
+                    var argument = arguments[1];
+
+                    if (argument.Expression.IsKind(SyntaxKind.StringLiteralExpression))
                     {
-                        var typeName = invocation.GetIdentifierName();
-
-                        if (typeName is "WeakEventManager")
-                        {
-                            var arguments = invocation.ArgumentList.Arguments;
-
-                            if (arguments.Count >= 2)
-                            {
-                                var argument = arguments[1];
-
-                                if (argument.Expression.IsKind(SyntaxKind.StringLiteralExpression))
-                                {
-                                    return new[] { Issue(method.Name, argument) };
-                                }
-                            }
-                        }
+                        return new[] { Issue(method.Name, argument) };
                     }
-
-                    break;
                 }
             }
 
             return Array.Empty<Diagnostic>();
         }
 
-        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            var node = (MemberAccessExpressionSyntax)context.Node;
-
             var methodSymbol = context.GetEnclosingMethod();
 
             if (methodSymbol is null)
             {
-                // nameof() is also a SimpleMemberAccessExpression, so assignments of lists etc. may cause an NRE to be thrown
+                // nameof() is also a InvocationExpressionSyntax, so assignments of lists etc. may cause an NRE to be thrown
                 return;
             }
 
+            var node = (InvocationExpressionSyntax)context.Node;
             var issues = AnalyzeIssue(node, methodSymbol);
 
             if (issues.Length > 0)

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_PropertyChangeEventArgsUsageUsesNameofAnalyzer.cs
@@ -87,12 +87,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return name is "PropertyName";
         }
 
-        private static bool IsPropertyName(MemberAccessExpressionSyntax expression)
-        {
-            var name = expression.GetName();
-
-            return name is "PropertyName";
-        }
+        private static bool IsPropertyName(MemberAccessExpressionSyntax expression) => expression.Is("PropertyName");
 
         private static bool IsPropertyNameAccess(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax syntax && syntax.IsKind(SyntaxKind.SimpleMemberAccessExpression) && IsPropertyName(syntax);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3060_DebugTraceAssertAnalyzer.cs
@@ -28,19 +28,14 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             foreach (var methodCall in syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
             {
-                if (methodCall.GetName() is nameof(Debug.Assert))
+                if (methodCall.Is(nameof(Debug), nameof(Debug.Assert)) || methodCall.Is(nameof(Trace), nameof(Trace.Assert)))
                 {
-                    var identifierName = methodCall.GetIdentifierName();
-
-                    if (identifierName is nameof(Debug) || identifierName is nameof(Trace))
+                    if (issues is null)
                     {
-                        if (issues is null)
-                        {
-                            issues = new List<Diagnostic>(1);
-                        }
-
-                        issues.Add(Issue(symbol.Name, methodCall, methodCall.ToCleanedUpString()));
+                        issues = new List<Diagnostic>(1);
                     }
+
+                    issues.Add(Issue(symbol.Name, methodCall, methodCall.ToCleanedUpString()));
                 }
             }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3061_LoggerHasCategoryAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3061_LoggerHasCategoryAnalyzer.cs
@@ -18,28 +18,25 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsApplicable(Compilation compilation) => compilation.GetTypeByMetadataName(Constants.ILog.FullTypeName) != null;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
-        private static bool IsLogManagerGetLoggerCall(MemberAccessExpressionSyntax node) => node.GetName() is "GetLogger"
+        private static bool IsLogManagerGetLoggerCall(MemberAccessExpressionSyntax node) => node.Is("GetLogger")
                                                                                          && node.Expression is IdentifierNameSyntax i
                                                                                          && i.GetName().EndsWith("LogManager", StringComparison.Ordinal);
 
-        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            var node = (MemberAccessExpressionSyntax)context.Node;
+            var node = (InvocationExpressionSyntax)context.Node;
 
-            if (node.Parent is InvocationExpressionSyntax s)
+            var arguments = node.ArgumentList.Arguments;
+
+            if (arguments.Count is 1 && node.Expression is MemberAccessExpressionSyntax maes && IsLogManagerGetLoggerCall(maes))
             {
-                var arguments = s.ArgumentList.Arguments;
+                var argument = arguments[0];
 
-                if (arguments.Count is 1 && IsLogManagerGetLoggerCall(node))
+                if (argument.IsString(context.SemanticModel) is false)
                 {
-                    var argument = arguments[0];
-
-                    if (argument.IsString(context.SemanticModel) is false)
-                    {
-                        ReportDiagnostics(context, Issue(context.ContainingSymbol?.Name, argument));
-                    }
+                    ReportDiagnostics(context, Issue(context.ContainingSymbol?.Name, argument));
                 }
             }
         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_CodeFixProvider.cs
@@ -48,9 +48,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected virtual Guid CreateGuid() => System.Guid.NewGuid();
 
-        private static bool IsToStringCall(SyntaxNode node) => node is MemberAccessExpressionSyntax m
-                                                            && m.IsKind(SyntaxKind.SimpleMemberAccessExpression)
-                                                            && m.GetName() is nameof(ToString);
+        private static bool IsToStringCall(SyntaxNode node) => node is MemberAccessExpressionSyntax m && m.Is(nameof(ToString));
 
         private static InvocationExpressionSyntax GuidParse(ExpressionSyntax literal) => Invocation(nameof(System.Guid), nameof(System.Guid.Parse), Argument(literal));
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_TestMethodsDoNotUseGuidNewGuidAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3103_TestMethodsDoNotUseGuidNewGuidAnalyzer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -35,7 +34,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             var symbolName = symbol.Name;
 
             return symbol.GetSyntax()
-                         .DescendantNodes<MemberAccessExpressionSyntax>(_ => _.IsKind(SyntaxKind.SimpleMemberAccessExpression) && _.Expression.GetName() is nameof(Guid) && _.GetName() is nameof(Guid.NewGuid))
+                         .DescendantNodes<MemberAccessExpressionSyntax>(_ => _.Is(nameof(Guid), nameof(Guid.NewGuid)))
                          .Select(_ => Issue(symbolName, _));
         }
     }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3106_TestAssertsDoNotUseOperatorsAnalyzer.cs
@@ -36,7 +36,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsXUnitAssertTrueMethod(MemberAccessExpressionSyntax node, SemanticModel semanticModel)
         {
-            if (node.GetName() is "True" && node.Expression is IdentifierNameSyntax invokedType && invokedType.GetName() is "Assert")
+            if (node.Is("Assert", "True") && node.Expression is IdentifierNameSyntax invokedType)
             {
                 var symbol = invokedType.GetTypeSymbol(semanticModel);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3108_TestMethodsContainAssertsAnalyzer.cs
@@ -145,7 +145,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                             var mockName = ins.GetName();
 
                             // no arguments, so check for a 'Verifiable' call on the same mock object
-                            return nodes.Where(_ => _.GetName() is Constants.Moq.Verifiable && _.Parent is InvocationExpressionSyntax)
+                            return nodes.Where(_ => _.Is(Constants.Moq.Verifiable) && _.Parent is InvocationExpressionSyntax)
                                         .SelectMany(_ => _.DescendantNodes<MemberAccessExpressionSyntax>())
                                         .Any(_ => _.Expression is IdentifierNameSyntax e && e.GetName() == mockName);
                         }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3109_CodeFixProvider.cs
@@ -59,9 +59,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ArgumentListSyntax UpdatedSyntax(MemberAccessExpressionSyntax syntax, ArgumentListSyntax args)
         {
-            var methodName = syntax.GetName();
-
-            switch (methodName)
+            switch (syntax.GetName())
             {
                 case "Fail":
                 case "Inconclusive":

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3110_TestAssertsDoNotUseCountAnalyzer.cs
@@ -31,26 +31,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
         private static bool IsAssertionMethod(MemberAccessExpressionSyntax node) => AssertionMethods.Contains(node.GetName())
                                                                                  && node.Expression is IdentifierNameSyntax invokedType
                                                                                  && Constants.Names.AssertionTypes.Contains(invokedType.GetName());
 
-        private static bool IsFixableAssertionForLinqCall(InvocationExpressionSyntax invocation)
-        {
-            if (invocation.GetIdentifierName() is "Is")
-            {
-                switch (invocation.GetName())
-                {
-                    case "EqualTo":
-                    case "Zero":
-                        return true;
-                }
-            }
-
-            return false;
-        }
+        private static bool IsFixableAssertionForLinqCall(InvocationExpressionSyntax invocation) => invocation.Is("Is", "EqualTo") || invocation.Is("Is", "Zero");
 
         private static bool HasIssue(MemberAccessExpressionSyntax expression, out SyntaxToken token)
         {
@@ -70,26 +57,26 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return false;
         }
 
-        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
+        private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is MemberAccessExpressionSyntax maes)
+            if (context.Node is InvocationExpressionSyntax invocation)
             {
-                var issues = AnalyzeSimpleMemberAccessExpression(maes);
+                var issues = AnalyzeInvocationExpression(invocation);
 
                 ReportDiagnostics(context, issues);
             }
         }
 
-        private IEnumerable<Diagnostic> AnalyzeSimpleMemberAccessExpression(MemberAccessExpressionSyntax node)
+        private IEnumerable<Diagnostic> AnalyzeInvocationExpression(InvocationExpressionSyntax node)
         {
-            if (IsAssertionMethod(node) && node.Parent is InvocationExpressionSyntax methodCall)
+            if (node.Expression is MemberAccessExpressionSyntax maes && IsAssertionMethod(maes))
             {
-                var arguments = methodCall.ArgumentList.Arguments;
+                var arguments = node.ArgumentList.Arguments;
 
                 // keep in local variable to avoid multiple requests (see Roslyn implementation)
                 for (int index = 0, argumentsCount = arguments.Count; index < argumentsCount; index++)
                 {
-                    var issue = AnalyzeArgument(node, arguments[index], arguments);
+                    var issue = AnalyzeArgument(maes, arguments[index], arguments);
 
                     if (issue != null)
                     {
@@ -121,16 +108,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                         case "That" when arguments.Count >= 2:
                         {
-                            var expression = arguments[1].Expression;
-
-                            switch (expression)
+                            switch (arguments[1].Expression)
                             {
-                                case InvocationExpressionSyntax ai when IsFixableAssertionForLinqCall(ai):
-                                    // we can only fix "Assert.That(xyz.Count(), Is.EqualTo(42)"
-                                    return Issue(token);
-
-                                case MemberAccessExpressionSyntax am when am.GetName() is "Zero":
-                                    // we can only fix "Assert.That(xyz.Count(), Is.Zero"
+                                case InvocationExpressionSyntax ai when IsFixableAssertionForLinqCall(ai): // we can only fix "Assert.That(xyz.Count(), Is.EqualTo(42)"
+                                case MemberAccessExpressionSyntax am when am.Is("Zero"): // we can only fix "Assert.That(xyz.Count(), Is.Zero"
                                     return Issue(token);
                             }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseSpecificConstraintInsteadOfEqualToAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3111_TestAssertsUseSpecificConstraintInsteadOfEqualToAnalyzer.cs
@@ -66,10 +66,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                                 case LiteralExpressionSyntax literal when ConstraintMap.TryGetValue(literal.Token.ValueText, out var constraint):
                                     return Issue(constraint);
 
-                                case MemberAccessExpressionSyntax m when m.GetName() is NaN:
+                                case MemberAccessExpressionSyntax m when m.Is(NaN):
                                     return Issue(NaN);
 
-                                case MemberAccessExpressionSyntax m when m.GetName() is Empty && (m.GetIdentifierName() is "string" || m.GetIdentifierName() is "String"):
+                                case MemberAccessExpressionSyntax m when m.Is("string", Empty) || m.Is("String", Empty):
                                     return Issue(Empty);
                             }
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3112_TestAssertsUseIsEmptyInsteadOfHasCountZeroAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3112_TestAssertsUseIsEmptyInsteadOfHasCountZeroAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -40,16 +38,10 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var node = (MemberAccessExpressionSyntax)context.Node;
 
-            var issues = Analyze(node);
-
-            if (issues.Length > 0)
+            if (HasIssue(node))
             {
-                ReportDiagnostics(context, issues);
+                ReportDiagnostics(context, Issue(node));
             }
         }
-
-        private Diagnostic[] Analyze(MemberAccessExpressionSyntax node) => HasIssue(node)
-                                                                           ? new[] { Issue(node) }
-                                                                           : Array.Empty<Diagnostic>();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3113_CodeFixProvider.cs
@@ -48,9 +48,8 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private static async Task<ExpressionStatementSyntax> ConvertAsync(ExpressionStatementSyntax statement, Document document, CancellationToken cancellationToken)
         {
             var shouldNode = statement.GetFluentAssertionShouldNode();
-            var shouldName = shouldNode.GetName();
 
-            var assertThat = shouldName is Constants.FluentAssertions.ShouldBeEquivalentTo
+            var assertThat = shouldNode.Is(Constants.FluentAssertions.ShouldBeEquivalentTo)
                              ? ConvertShouldBeEquivalentTo(shouldNode)
                              : await ConvertShouldAsync(shouldNode, document, cancellationToken).ConfigureAwait(false);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3114_UseMockOfInsteadMockObjectAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3114_UseMockOfInsteadMockObjectAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -25,16 +23,11 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
         {
             var node = (MemberAccessExpressionSyntax)context.Node;
-            var issues = AnalyzeSimpleMemberAccessExpression(node);
 
-            if (issues.Length > 0)
+            if (node.TryGetMoqTypes(out _))
             {
-                ReportDiagnostics(context, issues);
+                ReportDiagnostics(context, Issue(node));
             }
         }
-
-        private Diagnostic[] AnalyzeSimpleMemberAccessExpression(MemberAccessExpressionSyntax node) => node.TryGetMoqTypes(out _)
-                                                                                                       ? new[] { Issue(node) }
-                                                                                                       : Array.Empty<Diagnostic>();
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3119_TestMethodsDoNotReturnCompletedTaskAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3119_TestMethodsDoNotReturnCompletedTaskAnalyzer.cs
@@ -55,6 +55,6 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return returnStatements.Any(_ => _.ReturnsCompletedTask());
         }
 
-        private static bool HasIssue(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax maes && maes.Expression.GetName() is nameof(Task) && maes.GetName() is nameof(Task.CompletedTask);
+        private static bool HasIssue(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax maes && maes.Is(nameof(Task), nameof(Task.CompletedTask));
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3123_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3123_CodeFixProvider.cs
@@ -340,7 +340,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         var a0 = arguments[0];
                         var a1 = arguments[1];
 
-                        if (a0.Expression is TypeOfExpressionSyntax t0 && a1.Expression is InvocationExpressionSyntax i1 && i1.GetName() is nameof(GetType) && i1.GetIdentifierName() == exceptionIdentifier)
+                        if (a0.Expression is TypeOfExpressionSyntax t0 && a1.Expression.Is(exceptionIdentifier, nameof(GetType)))
                         {
                             // !!! Side effect !!! : remove first assert as we handled that already
                             exceptionSpecificAsserts.Remove(assert);
@@ -350,7 +350,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                         }
 
                         // maybe arguments are switched
-                        if (a1.Expression is TypeOfExpressionSyntax t1 && a0.Expression is InvocationExpressionSyntax i0 && i0.GetName() is nameof(GetType) && i0.GetIdentifierName() == exceptionIdentifier)
+                        if (a1.Expression is TypeOfExpressionSyntax t1 && a0.Expression.Is(exceptionIdentifier, nameof(GetType)))
                         {
                             // !!! Side effect !!! : remove first assert as we handled that already
                             exceptionSpecificAsserts.Remove(assert);

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_AssertThatDoesNotUseLiteralForActualAnalyzer.cs
@@ -22,13 +22,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         // Otherwise, when we would register for the SimpleMemberAccessExpression, the argument would not belong to that access (it belongs to the invocation), and therefore it will be ignored by Visual Studio.
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);
 
-        private static bool IsAssertThat(InvocationExpressionSyntax node) => node.Expression is MemberAccessExpressionSyntax maes && IsAssertThat(maes);
-
-        private static bool IsAssertThat(MemberAccessExpressionSyntax node) => node.GetIdentifierName() is "Assert" && node.GetName() is "That";
-
         private void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node is InvocationExpressionSyntax invocation && IsAssertThat(invocation))
+            if (context.Node is InvocationExpressionSyntax invocation && invocation.Is("Assert", "That"))
             {
                 var issue = AnalyzeInvocationExpression(invocation, context.SemanticModel);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3127_CodeFixProvider.cs
@@ -68,7 +68,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static ArgumentSyntax FindIllPlacedActualArgument(ArgumentSyntax constraint)
         {
-            var invocation = constraint.FirstDescendant<InvocationExpressionSyntax>(_ => _.Expression is MemberAccessExpressionSyntax maes && maes.GetName() is "EqualTo");
+            var invocation = constraint.FirstDescendant<InvocationExpressionSyntax>(_ => _.Expression is MemberAccessExpressionSyntax maes && maes.Is("EqualTo"));
 
             if (invocation?.ArgumentList is ArgumentListSyntax list && list.Arguments is SeparatedSyntaxList<ArgumentSyntax> arguments && arguments.Count > 0)
             {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3221_GetHashCodeAnalyzer.cs
@@ -31,11 +31,9 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
                 foreach (var expression in method.DescendantNodes<MemberAccessExpressionSyntax>())
                 {
-                    switch (expression.GetName())
+                    if (expression.Is(ToHashCode) || expression.Is(HashCode, Combine))
                     {
-                        case ToHashCode:
-                        case Combine when expression.Expression.GetName() == HashCode:
-                            yield break;
+                        yield break;
                     }
 
                     expressionsCount++;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3231_UseIsPatternStringEqualsInvocationAnalyzer.cs
@@ -18,9 +18,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
 
-        private static bool IsStringComparisonOrdinal(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax m
-                                                                                   && m.GetIdentifierName() is nameof(StringComparison)
-                                                                                   && m.GetName() is nameof(StringComparison.Ordinal);
+        private static bool IsStringComparisonOrdinal(ExpressionSyntax expression) => expression is MemberAccessExpressionSyntax m && m.Is(nameof(StringComparison), nameof(StringComparison.Ordinal));
 
         private static bool IsStringComparisonOrdinal(in SeparatedSyntaxList<ArgumentSyntax> arguments, in SyntaxNodeAnalysisContext context)
         {
@@ -37,7 +35,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool HasIssue(InvocationExpressionSyntax invocation, in SyntaxNodeAnalysisContext context)
         {
-            if (invocation.Expression is MemberAccessExpressionSyntax maes && maes.GetName() is nameof(Equals))
+            if (invocation.Expression is MemberAccessExpressionSyntax maes && maes.Is(nameof(Equals)))
             {
                 var arguments = invocation.ArgumentList.Arguments;
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3235_DoNotConvertEnumerableParameterToListAnalyzer.cs
@@ -55,9 +55,15 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         private static bool IsCall(MemberAccessExpressionSyntax syntax)
         {
-            var name = syntax.GetName();
+            switch (syntax.GetName())
+            {
+                case nameof(Enumerable.ToList):
+                case nameof(Enumerable.ToArray):
+                    return true;
 
-            return name is nameof(Enumerable.ToList) || name is nameof(Enumerable.ToArray);
+                default:
+                    return false;
+            }
         }
 
         private static bool IsIEnumerable(IParameterSymbol parameter) => parameter.Type.OriginalDefinition.SpecialType is SpecialType.System_Collections_Generic_IEnumerable_T;

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3237_DoNotUseQualifiedNamesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3237_DoNotUseQualifiedNamesAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeQualifiedName, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
         private static bool HasIssue(MemberAccessExpressionSyntax node, in SyntaxNodeAnalysisContext context)
         {
@@ -54,7 +54,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             return false;
         }
 
-        private void AnalyzeQualifiedName(SyntaxNodeAnalysisContext context)
+        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
         {
             if (context.Node is MemberAccessExpressionSyntax node && HasIssue(node, context))
             {

--- a/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Performance/MiKo_5016_RemoveAllUsesContainsOfHashSetAnalyzer.cs
@@ -27,15 +27,13 @@ namespace MiKoSolutions.Analyzers.Rules.Performance
 
             foreach (var node in syntax.DescendantNodes<MemberAccessExpressionSyntax>(SyntaxKind.SimpleMemberAccessExpression))
             {
-                var name = node.GetName();
-
-                if (name != nameof(List<object>.RemoveAll))
+                if (node.Is(nameof(List<object>.RemoveAll)) is false)
                 {
                     continue;
                 }
 
                 // inspect for 'Contains' inside lambda or method group
-                foreach (var maes in node.Parent.DescendantNodes<MemberAccessExpressionSyntax>(_ => _.GetName() is nameof(Enumerable.Contains)))
+                foreach (var maes in node.Parent.DescendantNodes<MemberAccessExpressionSyntax>(_ => _.Is(nameof(Enumerable.Contains))))
                 {
                     if (semanticModel is null)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6021_ArgumentNullExceptionThrowIfNullStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6021_ArgumentNullExceptionThrowIfNullStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,8 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name is nameof(ArgumentNullException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIfNull" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.Is("ThrowIfNull") && base.IsCall(syntax, semanticModel);
 
-        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
+        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName().AsSpan().StartsWith("ThrowIf");
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6022_ArgumentExceptionThrowIfNullOrEmptyStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6022_ArgumentExceptionThrowIfNullOrEmptyStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,8 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name is nameof(ArgumentException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIfNullOrEmpty" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.Is("ThrowIfNullOrEmpty") && base.IsCall(syntax, semanticModel);
 
-        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
+        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName().AsSpan().StartsWith("ThrowIf");
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6023_ArgumentOutOfRangeExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6023_ArgumentOutOfRangeExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,8 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name is nameof(ArgumentOutOfRangeException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName().AsSpan().StartsWith("ThrowIf") && base.IsCall(syntax, semanticModel);
 
-        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
+        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName().AsSpan().StartsWith("ThrowIf");
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6024_ObjectDisposedExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6024_ObjectDisposedExceptionThrowIfStatementSurroundedByBlankLinesAnalyzer.cs
@@ -20,8 +20,8 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         // it may happen that in some broken code Roslyn is unable to detect a type (e.g. due to missing code paths), hence 'type' could be null here
         protected override bool IsCall(ITypeSymbol type) => type?.Name is nameof(ObjectDisposedException);
 
-        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName() is "ThrowIf" && base.IsCall(syntax, semanticModel);
+        protected override bool IsCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.Is("ThrowIf") && base.IsCall(syntax, semanticModel);
 
-        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName()?.StartsWith("ThrowIf", StringComparison.Ordinal) is true;
+        protected override bool IsAlsoCall(MemberAccessExpressionSyntax syntax, SemanticModel semanticModel) => syntax.GetName().AsSpan().StartsWith("ThrowIf");
     }
 }

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6034_DotsAreOnSameLineAsInvokedMemberAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6034_DotsAreOnSameLineAsInvokedMemberAnalyzer.cs
@@ -14,9 +14,9 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
         {
             var maes = (MemberAccessExpressionSyntax)context.Node;
             var operatorToken = maes.OperatorToken;

--- a/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Spacing/MiKo_6064_PropertyInvocationIsOnSameLineAnalyzer.cs
@@ -14,7 +14,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
         {
         }
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);
+        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccessExpression, SyntaxKind.SimpleMemberAccessExpression);
 
         private static bool HasIssue(MemberAccessExpressionSyntax member)
         {
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Spacing
                 && name.IsOnSameLineAs(expression) is false;
         }
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        private void AnalyzeSimpleMemberAccessExpression(SyntaxNodeAnalysisContext context)
         {
             if (context.Node is MemberAccessExpressionSyntax member && HasIssue(member))
             {


### PR DESCRIPTION
- Introduce `Is` extension methods for syntax nodes to simplify member and invocation name checks

- Refactor analyzers and code fix providers to use these methods

- Update syntax node registrations and remove redundant helpers

- Add provisional fixes for code fixes in case the issues are reported for arguments