### PR TITLE
Add check for generated code, so that 'GetMethods' no longer returns generated methods

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -787,7 +787,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     var method = methods[index];
 
-                    if (method.MethodKind == kind)
+                    if (method.MethodKind == kind && method.IsGenerated() is false)
                     {
                         yield return method;
                     }
@@ -2656,6 +2656,17 @@ namespace MiKoSolutions.Analyzers
                     return false;
             }
         }
+
+        /// <summary>
+        /// Determines whether a method is generated.
+        /// </summary>
+        /// <param name="value">
+        /// The method to inspect.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the method is generated; otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool IsGenerated(this IMethodSymbol value) => value != null && value.HasAttribute(Constants.Names.GeneratedAttributeNames);
 
         /// <summary>
         /// Determines whether a type is generated.

--- a/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3128_TestMethodsHaveNoTestAttributeAnalyzerTests.cs
+++ b/MiKo.Analyzer.Tests/Rules/Maintainability/MiKo_3128_TestMethodsHaveNoTestAttributeAnalyzerTests.cs
@@ -24,6 +24,20 @@ public class TestMe
 ");
 
         [Test]
+        public void No_issue_is_reported_for_generated_method() => No_issue_is_reported_for(@"
+using System;
+
+public partial class App : System.Windows.Application
+{
+    [System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute(""PresentationBuildTasks"", ""10.0.11.0"")]
+    public void InitializeComponent()
+    {
+    }
+}
+");
+
+        [Test]
         public void No_issue_is_reported_for_test_method_marked_as_test() => No_issue_is_reported_for(@"
 using System;
 


### PR DESCRIPTION
- Introduce `IsGenerated` extension method to detect generated code attribute

- Exclude generated methods from processing by adding `IsGenerated` check

- Add unit test to ensure generated methods are ignored