### PR TITLE
MiKo_3130 now only reports on NUnit

### DIFF
--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3130_AssertFailInsideIfBlockAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3130_AssertFailInsideIfBlockAnalyzer.cs
@@ -18,7 +18,13 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override bool IsUnitTestAnalyzer => true;
 
-        protected override void InitializeCore(CompilationStartAnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
+        protected override void InitializeCore(CompilationStartAnalysisContext context)
+        {
+            if (ReferencesNUnit(context.Compilation))
+            {
+                context.RegisterSyntaxNodeAction(AnalyzeIfStatement, SyntaxKind.IfStatement);
+            }
+        }
 
         private static bool HasIssue(InvocationExpressionSyntax assertFail)
         {


### PR DESCRIPTION
This is done as currently the code fix only supports NUnit.