### PR TITLE
Added new method 'GetEnclosingWithinMethod' and adjusted usages

### DIFF
--- a/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SymbolExtensions.cs
@@ -568,7 +568,7 @@ namespace MiKoSolutions.Analyzers
         /// A collection of argument syntaxes that contains arguments for the specified invocation.
         /// </returns>
         internal static SeparatedSyntaxList<ArgumentSyntax> GetInvocationArgumentsFrom(this IFieldSymbol value, string invocation) => value.GetAssignmentsVia(invocation)
-                                                                                                                                           .Select(_ => _.GetEnclosing<InvocationExpressionSyntax>())
+                                                                                                                                           .Select(_ => _.GetEnclosingWithinMethod<InvocationExpressionSyntax>())
                                                                                                                                            .Select(_ => _.ArgumentList.Arguments)
                                                                                                                                            .FirstOrDefault(_ => _.Count > 0);
 

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.Navigation.cs
@@ -46,6 +46,7 @@ namespace MiKoSolutions.Analyzers
         /// </returns>
         internal static IEnumerable<T> AllDescendantNodes<T>(this SyntaxNode value, SyntaxKind kind) where T : SyntaxNode
         {
+            // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var node in value.AllDescendantNodes())
             {
                 if (node.IsKind(kind))
@@ -97,26 +98,27 @@ namespace MiKoSolutions.Analyzers
             // ReSharper disable once LoopCanBePartlyConvertedToQuery
             foreach (var ancestor in value.Ancestors())
             {
-                if (ancestor is T t)
+                switch (ancestor)
                 {
-                    yield return t;
-                }
+                    case T t:
+                        yield return t;
 
-                if (ancestor is DocumentationCommentTriviaSyntax)
-                {
-                    yield break;
+                        break;
+
+                    case DocumentationCommentTriviaSyntax _:
+                        yield break;
                 }
             }
         }
 
         /// <summary>
-        /// Gets all ancestors of the specified syntax node that are within the scope of a method, local function, or property.
+        /// Gets all ancestors of the specified syntax node that are within the scope of a method, local function, property or event.
         /// </summary>
         /// <param name="value">
         /// The syntax node whose ancestors to retrieve.
         /// </param>
         /// <returns>
-        /// A sequence that contains all ancestors of the specified type that are within the method, local function, or property scope.
+        /// A sequence that contains all ancestors of the specified type that are within the method, local function, property or event scope.
         /// </returns>
         internal static IEnumerable<SyntaxNode> AncestorsWithinMethods(this SyntaxNode value)
         {
@@ -127,7 +129,7 @@ namespace MiKoSolutions.Analyzers
                 {
                     case BaseMethodDeclarationSyntax _: // found the surrounding method
                     case LocalFunctionStatementSyntax _: // found the surrounding local function
-                    case BasePropertyDeclarationSyntax _: // found the surrounding property, so we already skipped the getters or setters
+                    case BasePropertyDeclarationSyntax _: // found the surrounding property or event, so we already skipped the getters or setters
                     case TypeDeclarationSyntax _: // found the surrounding type
                         yield break;
                 }
@@ -137,7 +139,7 @@ namespace MiKoSolutions.Analyzers
         }
 
         /// <summary>
-        /// Gets all ancestors of the specified syntax node that are of type <typeparamref name="T"/> and are within the scope of a method, local function, or property.
+        /// Gets all ancestors of the specified syntax node that are of type <typeparamref name="T"/> and are within the scope of a method, local function, property or event.
         /// </summary>
         /// <typeparam name="T">
         /// The type of nodes to return.
@@ -146,25 +148,16 @@ namespace MiKoSolutions.Analyzers
         /// The syntax node whose ancestors to retrieve.
         /// </param>
         /// <returns>
-        /// A sequence that contains all ancestors of the specified type that are within the method, local function, or property scope.
+        /// A sequence that contains all ancestors of the specified type that are within the method, local function, property or event scope.
         /// </returns>
         internal static IEnumerable<T> AncestorsWithinMethods<T>(this SyntaxNode value) where T : SyntaxNode
         {
             // ReSharper disable once LoopCanBePartlyConvertedToQuery
-            foreach (var ancestor in value.Ancestors())
+            foreach (var ancestor in value.AncestorsWithinMethods())
             {
                 if (ancestor is T t)
                 {
                     yield return t;
-                }
-
-                switch (ancestor)
-                {
-                    case BaseMethodDeclarationSyntax _: // found the surrounding method
-                    case LocalFunctionStatementSyntax _: // found the surrounding local function
-                    case BasePropertyDeclarationSyntax _: // found the surrounding property, so we already skipped the getters or setters
-                    case TypeDeclarationSyntax _: // found the surrounding type
-                        yield break;
                 }
             }
         }
@@ -591,7 +584,7 @@ namespace MiKoSolutions.Analyzers
                 return m;
             }
 
-            return GetEnclosingMethod(value.Node, value.SemanticModel);
+            return value.Node.GetEnclosingMethod(value.SemanticModel);
         }
 
         /// <summary>
@@ -676,6 +669,28 @@ namespace MiKoSolutions.Analyzers
         /// The enclosing syntax node, or <see langword="null"/> if no enclosing node exists.
         /// </returns>
         internal static SyntaxNode GetEnclosingSyntaxNode(this XmlNodeSyntax value) => value?.FirstAncestor<DocumentationCommentTriviaSyntax>().GetEnclosingSyntaxNode();
+
+        /// <summary>
+        /// Gets the nearest enclosing node of type <typeparamref name="T"/> that contains the specified syntax node.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of node to return.
+        /// </typeparam>
+        /// <param name="value">
+        /// The syntax node whose enclosing node to retrieve.
+        /// </param>
+        /// <returns>
+        /// The enclosing node of the specified type, or <see langword="null"/> if no such node exists.
+        /// </returns>
+        internal static T GetEnclosingWithinMethod<T>(this SyntaxNode value) where T : SyntaxNode
+        {
+            if (value is T t)
+            {
+                return t;
+            }
+
+            return value.AncestorsWithinMethods<T>().FirstOrDefault();
+        }
 
         /// <summary>
         /// Gets the last child node of the specified syntax node that is of type <typeparamref name="T"/>.

--- a/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
+++ b/MiKo.Analyzer.Shared/Extensions/SyntaxNodeExtensions.cs
@@ -363,7 +363,7 @@ namespace MiKoSolutions.Analyzers
             }
 
             // most probably it's a if/else, but it might be a switch statement as well
-            var condition = value.GetRelatedIfStatement()?.Condition ?? value.GetEnclosing<SwitchStatementSyntax>()?.Expression;
+            var condition = value.GetRelatedIfStatement()?.Condition ?? value.GetEnclosingWithinMethod<SwitchStatementSyntax>()?.Expression;
 
             return condition;
         }
@@ -1718,13 +1718,13 @@ namespace MiKoSolutions.Analyzers
         {
             while (true)
             {
-                var ifStatement = value.GetEnclosing<IfStatementSyntax>();
+                var ifStatement = value.GetEnclosingWithinMethod<IfStatementSyntax>();
 
                 if (ifStatement != null)
                 {
                     if (ifStatement.IsCallTo(methodName))
                     {
-                        var elseStatement = value.GetEnclosing<ElseClauseSyntax>();
+                        var elseStatement = value.GetEnclosingWithinMethod<ElseClauseSyntax>();
 
                         if (elseStatement != null && ifStatement.Equals(elseStatement.Parent))
                         {
@@ -1741,7 +1741,7 @@ namespace MiKoSolutions.Analyzers
                 else
                 {
                     // maybe an else block
-                    var elseStatement = value.GetEnclosing<ElseClauseSyntax>();
+                    var elseStatement = value.GetEnclosingWithinMethod<ElseClauseSyntax>();
 
                     if (elseStatement != null)
                     {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3012_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3012_CodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
 
             // it might be a local variable inside a switch, so we have to find out which one
-            if (syntax.GetEnclosing<SwitchStatementSyntax>()?.Expression is IdentifierNameSyntax identifier)
+            if (syntax.GetEnclosingWithinMethod<SwitchStatementSyntax>()?.Expression is IdentifierNameSyntax identifier)
             {
                 var arguments = GetUpdatedArgumentListSyntaxForIdentifier(syntax, identifier);
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_ArgumentOutOfRangeExceptionSwitchStatementAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_ArgumentOutOfRangeExceptionSwitchStatementAnalyzer.cs
@@ -29,7 +29,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
         protected override IEnumerable<Diagnostic> AnalyzeObjectCreation(ObjectCreationExpressionSyntax node, SemanticModel semanticModel)
         {
-            var switchSection = node.GetEnclosing<SwitchSectionSyntax>();
+            var switchSection = node.GetEnclosingWithinMethod<SwitchSectionSyntax>();
 
             // we are in the 'default:' clause if there is a 'default' switch label in the specific switch section
             if (switchSection != null && switchSection.DescendantNodes<DefaultSwitchLabelSyntax>().Any())

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3013_CodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
             }
 
             // it might be a local variable inside a switch, so we have to find out which one
-            if (syntax.GetEnclosing<SwitchStatementSyntax>()?.Expression is IdentifierNameSyntax identifier)
+            if (syntax.GetEnclosingWithinMethod<SwitchStatementSyntax>()?.Expression is IdentifierNameSyntax identifier)
             {
                 return ArgumentList(ParamName(identifier), Argument(identifier), GetUpdatedErrorMessage(argumentList));
             }

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_ArgumentNullExceptionThrownAtWrongPlaceAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3016_ArgumentNullExceptionThrownAtWrongPlaceAnalyzer.cs
@@ -66,7 +66,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             if (identifier.Parent is SwitchStatementSyntax && identifier.GetName() == parameterName)
             {
-                var switchSection = node.GetEnclosing<SwitchSectionSyntax>();
+                var switchSection = node.GetEnclosingWithinMethod<SwitchSectionSyntax>();
 
                 if (switchSection != null && switchSection.DescendantNodes<CaseSwitchLabelSyntax>().Any(_ => _.Value.IsKind(SyntaxKind.NullLiteralExpression)))
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CompletedTaskAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3020_CompletedTaskAnalyzer.cs
@@ -27,7 +27,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             foreach (var invocation in symbol.GetSyntax()
                                              .DescendantNodes<MemberAccessExpressionSyntax>(_ => _ is MemberAccessExpressionSyntax maes && maes.Is(nameof(Task), nameof(Task.FromResult)))
-                                             .Select(_ => _.GetEnclosing<InvocationExpressionSyntax>()))
+                                             .Select(_ => _.GetEnclosingWithinMethod<InvocationExpressionSyntax>()))
             {
                 switch (invocation.Parent?.Kind())
                 {

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3021_TaskRunAnalyzer.cs
@@ -52,7 +52,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
 
             foreach (var taskRunExpression in taskRunExpressions)
             {
-                var expression = taskRunExpression.GetEnclosing<InvocationExpressionSyntax>();
+                var expression = taskRunExpression.GetEnclosingWithinMethod<InvocationExpressionSyntax>();
                 var node = expression.GetEnclosing(EnclosingInvocationSyntaxKinds);
                 var syntaxKind = node?.Kind();
 

--- a/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_CodeFixProvider.cs
+++ b/MiKo.Analyzer.Shared/Rules/Maintainability/MiKo_3044_CodeFixProvider.cs
@@ -32,7 +32,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
         {
             var identifierName = syntax.Token.ValueText;
 
-            var ifStatement = syntax.GetEnclosing<IfStatementSyntax>();
+            var ifStatement = syntax.GetEnclosingWithinMethod<IfStatementSyntax>();
 
             if (ifStatement != null)
             {
@@ -41,7 +41,7 @@ namespace MiKoSolutions.Analyzers.Rules.Maintainability
                     ?? await FindRelatedTypeAsync(ifStatement.Else, identifierName, document, cancellationToken).ConfigureAwait(false);
             }
 
-            var switchStatement = syntax.GetEnclosing<SwitchStatementSyntax>();
+            var switchStatement = syntax.GetEnclosingWithinMethod<SwitchStatementSyntax>();
 
             if (switchStatement != null)
             {

--- a/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
+++ b/MiKo.Analyzer.Shared/Rules/Naming/MiKo_1108_MockNamingAnalyzer.cs
@@ -153,7 +153,7 @@ namespace MiKoSolutions.Analyzers.Rules.Naming
                 var syntax = (ParameterSyntax)context.Node;
 
                 // ignore invocations e.g. in lambdas
-                if (syntax.GetEnclosing<InvocationExpressionSyntax>() is null)
+                if (syntax.GetEnclosingWithinMethod<InvocationExpressionSyntax>() is null)
                 {
                     AnalyzeIdentifiers(context, type, syntax.Identifier);
                 }


### PR DESCRIPTION
- Introduce `GetEnclosingWithinMethod<T>` extension method to restrict syntax node searches within method/property/event scopes

- Refactor analyzers and code fixes to use this method for faster context navigation

- Update related helper methods for clarity and improved implementation